### PR TITLE
Add org-scoped tenancy across all layers (Phase 2+3)

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -23,6 +23,7 @@ import (
 type Claims struct {
 	jwt.RegisteredClaims
 	AgentID string          `json:"agent_id"`
+	OrgID   uuid.UUID       `json:"org_id"`
 	Role    model.AgentRole `json:"role"`
 }
 
@@ -95,6 +96,7 @@ func (m *JWTManager) IssueToken(agent model.Agent) (string, time.Time, error) {
 			ID:        uuid.New().String(),
 		},
 		AgentID: agent.AgentID,
+		OrgID:   agent.OrgID,
 		Role:    agent.Role,
 	}
 

--- a/internal/ctxutil/ctxutil.go
+++ b/internal/ctxutil/ctxutil.go
@@ -1,0 +1,45 @@
+// Package ctxutil provides shared context key accessors.
+//
+// This package exists to break the circular dependency between server and mcp:
+// server imports mcp for MCP server setup, and mcp needs to read JWT claims
+// from the context that server's auth middleware populates. Both packages
+// import ctxutil instead of each other.
+package ctxutil
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+
+	"github.com/ashita-ai/akashi/internal/auth"
+)
+
+type contextKey string
+
+const (
+	keyClaims contextKey = "claims"
+	keyOrgID  contextKey = "org_id"
+)
+
+// WithClaims returns a new context carrying the given claims.
+func WithClaims(ctx context.Context, claims *auth.Claims) context.Context {
+	ctx = context.WithValue(ctx, keyClaims, claims)
+	ctx = context.WithValue(ctx, keyOrgID, claims.OrgID)
+	return ctx
+}
+
+// ClaimsFromContext extracts the JWT claims from the context.
+func ClaimsFromContext(ctx context.Context) *auth.Claims {
+	if v, ok := ctx.Value(keyClaims).(*auth.Claims); ok {
+		return v
+	}
+	return nil
+}
+
+// OrgIDFromContext extracts the org_id from the context.
+func OrgIDFromContext(ctx context.Context) uuid.UUID {
+	if v, ok := ctx.Value(keyOrgID).(uuid.UUID); ok {
+		return v
+	}
+	return uuid.Nil
+}

--- a/internal/model/agent.go
+++ b/internal/model/agent.go
@@ -10,15 +10,18 @@ import (
 type AgentRole string
 
 const (
-	RoleAdmin  AgentRole = "admin"
-	RoleAgent  AgentRole = "agent"
-	RoleReader AgentRole = "reader"
+	RolePlatformAdmin AgentRole = "platform_admin"
+	RoleOrgOwner      AgentRole = "org_owner"
+	RoleAdmin         AgentRole = "admin"
+	RoleAgent         AgentRole = "agent"
+	RoleReader        AgentRole = "reader"
 )
 
 // Agent represents an agent identity with role assignment.
 type Agent struct {
 	ID         uuid.UUID      `json:"id"`
 	AgentID    string         `json:"agent_id"`
+	OrgID      uuid.UUID      `json:"org_id"`
 	Name       string         `json:"name"`
 	Role       AgentRole      `json:"role"`
 	APIKeyHash *string        `json:"-"`
@@ -30,6 +33,7 @@ type Agent struct {
 // AccessGrant represents a fine-grained access grant between agents.
 type AccessGrant struct {
 	ID           uuid.UUID  `json:"id"`
+	OrgID        uuid.UUID  `json:"org_id"`
 	GrantorID    uuid.UUID  `json:"grantor_id"`
 	GranteeID    uuid.UUID  `json:"grantee_id"`
 	ResourceType string     `json:"resource_type"`
@@ -55,3 +59,26 @@ const (
 	ResourceDecision    ResourceType = "decision"
 	ResourceRun         ResourceType = "run"
 )
+
+// RoleRank returns the numeric rank of a role (higher = more privileges).
+func RoleRank(r AgentRole) int {
+	switch r {
+	case RolePlatformAdmin:
+		return 100
+	case RoleOrgOwner:
+		return 4
+	case RoleAdmin:
+		return 3
+	case RoleAgent:
+		return 2
+	case RoleReader:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// RoleAtLeast returns true if role r has at least the privileges of minRole.
+func RoleAtLeast(r, minRole AgentRole) bool {
+	return RoleRank(r) >= RoleRank(minRole)
+}

--- a/internal/model/api.go
+++ b/internal/model/api.go
@@ -45,6 +45,7 @@ const (
 // CreateRunRequest is the request body for POST /v1/runs.
 type CreateRunRequest struct {
 	AgentID     string         `json:"agent_id"`
+	OrgID       uuid.UUID      `json:"-"` // Set from JWT claims, not from request body.
 	TraceID     *string        `json:"trace_id,omitempty"`
 	ParentRunID *uuid.UUID     `json:"parent_run_id,omitempty"`
 	Metadata    map[string]any `json:"metadata,omitempty"`
@@ -145,4 +146,34 @@ type HealthResponse struct {
 type SubscriptionEvent struct {
 	Event string `json:"event"`
 	Data  any    `json:"data"`
+}
+
+// Organization represents a tenant in the multi-tenancy model.
+type Organization struct {
+	ID                   uuid.UUID `json:"id"`
+	Name                 string    `json:"name"`
+	Slug                 string    `json:"slug"`
+	Plan                 string    `json:"plan"`
+	StripeCustomerID     *string   `json:"stripe_customer_id,omitempty"`
+	StripeSubscriptionID *string   `json:"stripe_subscription_id,omitempty"`
+	DecisionLimit        int       `json:"decision_limit"`
+	AgentLimit           int       `json:"agent_limit"`
+	Email                string    `json:"email"`
+	EmailVerified        bool      `json:"email_verified"`
+	CreatedAt            time.Time `json:"created_at"`
+	UpdatedAt            time.Time `json:"updated_at"`
+}
+
+// OrgUsage tracks decision counts per org per billing period.
+type OrgUsage struct {
+	OrgID         uuid.UUID `json:"org_id"`
+	Period        string    `json:"period"`
+	DecisionCount int       `json:"decision_count"`
+}
+
+// SignupRequest is the request body for POST /auth/signup.
+type SignupRequest struct {
+	Email    string `json:"email"`
+	Password string `json:"password"`
+	OrgName  string `json:"org_name"`
 }

--- a/internal/model/decision.go
+++ b/internal/model/decision.go
@@ -13,6 +13,7 @@ type Decision struct {
 	ID           uuid.UUID        `json:"id"`
 	RunID        uuid.UUID        `json:"run_id"`
 	AgentID      string           `json:"agent_id"`
+	OrgID        uuid.UUID        `json:"org_id"`
 	DecisionType string           `json:"decision_type"`
 	Outcome      string           `json:"outcome"`
 	Confidence   float32          `json:"confidence"`
@@ -78,6 +79,7 @@ type Evidence struct {
 type DecisionConflict struct {
 	DecisionAID  uuid.UUID `json:"decision_a_id"`
 	DecisionBID  uuid.UUID `json:"decision_b_id"`
+	OrgID        uuid.UUID `json:"org_id"`
 	AgentA       string    `json:"agent_a"`
 	AgentB       string    `json:"agent_b"`
 	RunA         uuid.UUID `json:"run_a"`
@@ -95,6 +97,7 @@ type DecisionConflict struct {
 // AgentCurrentState is a summary of an agent's latest activity.
 type AgentCurrentState struct {
 	AgentID         string     `json:"agent_id"`
+	OrgID           uuid.UUID  `json:"org_id"`
 	LatestRunID     uuid.UUID  `json:"latest_run_id"`
 	RunStatus       RunStatus  `json:"run_status"`
 	StartedAt       time.Time  `json:"started_at"`

--- a/internal/model/event.go
+++ b/internal/model/event.go
@@ -38,6 +38,7 @@ const (
 type AgentEvent struct {
 	ID          uuid.UUID      `json:"id"`
 	RunID       uuid.UUID      `json:"run_id"`
+	OrgID       uuid.UUID      `json:"org_id"`
 	EventType   EventType      `json:"event_type"`
 	SequenceNum int64          `json:"sequence_num"`
 	OccurredAt  time.Time      `json:"occurred_at"`

--- a/internal/model/run.go
+++ b/internal/model/run.go
@@ -25,6 +25,7 @@ const (
 type AgentRun struct {
 	ID          uuid.UUID      `json:"id"`
 	AgentID     string         `json:"agent_id"`
+	OrgID       uuid.UUID      `json:"org_id"`
 	TraceID     *string        `json:"trace_id,omitempty"`
 	ParentRunID *uuid.UUID     `json:"parent_run_id,omitempty"`
 	Status      RunStatus      `json:"status"`

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -54,7 +54,7 @@ func (h *Handlers) HandleAuthToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	agent, err := h.db.GetAgentByAgentID(r.Context(), req.AgentID)
+	agent, err := h.db.GetAgentByAgentIDGlobal(r.Context(), req.AgentID)
 	if err != nil {
 		writeError(w, r, http.StatusUnauthorized, model.ErrCodeUnauthorized, "invalid credentials")
 		return
@@ -150,7 +150,10 @@ func (h *Handlers) SeedAdmin(ctx context.Context, adminAPIKey string) error {
 		return nil
 	}
 
-	count, err := h.db.CountAgents(ctx)
+	// Default org UUID for the pre-migration seed admin.
+	defaultOrgID := uuid.Nil
+
+	count, err := h.db.CountAgents(ctx, defaultOrgID)
 	if err != nil {
 		return fmt.Errorf("seed admin: count agents: %w", err)
 	}
@@ -166,6 +169,7 @@ func (h *Handlers) SeedAdmin(ctx context.Context, adminAPIKey string) error {
 
 	_, err = h.db.CreateAgent(ctx, model.Agent{
 		AgentID:    "admin",
+		OrgID:      defaultOrgID,
 		Name:       "System Admin",
 		Role:       model.RoleAdmin,
 		APIKeyHash: &hash,

--- a/internal/server/handlers_export.go
+++ b/internal/server/handlers_export.go
@@ -14,6 +14,7 @@ import (
 // alternatives and evidence for each decision. Uses cursor-based
 // pagination to avoid loading all results into memory.
 func (h *Handlers) HandleExportDecisions(w http.ResponseWriter, r *http.Request) {
+	orgID := OrgIDFromContext(r.Context())
 	q := r.URL.Query()
 
 	filters := model.QueryFilters{}
@@ -52,7 +53,7 @@ func (h *Handlers) HandleExportDecisions(w http.ResponseWriter, r *http.Request)
 	flusher, _ := w.(http.Flusher)
 
 	for {
-		decisions, _, err := h.db.QueryDecisions(r.Context(), model.QueryRequest{
+		decisions, _, err := h.db.QueryDecisions(r.Context(), orgID, model.QueryRequest{
 			Filters:  filters,
 			Include:  []string{"alternatives", "evidence"},
 			OrderBy:  "valid_from",

--- a/internal/service/trace/buffer.go
+++ b/internal/service/trace/buffer.go
@@ -53,7 +53,7 @@ func (b *Buffer) Start(ctx context.Context) {
 // Append adds events to the buffer, assigning server-side sequence numbers.
 // Returns the assigned events with populated IDs and sequence numbers.
 // Returns an error if the buffer is at capacity (backpressure).
-func (b *Buffer) Append(ctx context.Context, runID uuid.UUID, agentID string, inputs []model.EventInput) ([]model.AgentEvent, error) {
+func (b *Buffer) Append(ctx context.Context, runID uuid.UUID, agentID string, orgID uuid.UUID, inputs []model.EventInput) ([]model.AgentEvent, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -80,6 +80,7 @@ func (b *Buffer) Append(ctx context.Context, runID uuid.UUID, agentID string, in
 		events[i] = model.AgentEvent{
 			ID:          uuid.New(),
 			RunID:       runID,
+			OrgID:       orgID,
 			EventType:   input.EventType,
 			SequenceNum: seqNums[i],
 			OccurredAt:  occurredAt,

--- a/internal/storage/conflicts.go
+++ b/internal/storage/conflicts.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/google/uuid"
+
 	"github.com/ashita-ai/akashi/internal/model"
 )
 
@@ -25,20 +27,20 @@ func (db *DB) RefreshAgentState(ctx context.Context) error {
 	return nil
 }
 
-// ListConflicts retrieves detected conflicts, optionally filtered by decision_type.
-func (db *DB) ListConflicts(ctx context.Context, decisionType *string, limit int) ([]model.DecisionConflict, error) {
+// ListConflicts retrieves detected conflicts within an org, optionally filtered by decision_type.
+func (db *DB) ListConflicts(ctx context.Context, orgID uuid.UUID, decisionType *string, limit int) ([]model.DecisionConflict, error) {
 	if limit <= 0 {
 		limit = 50
 	}
 
-	query := `SELECT decision_a_id, decision_b_id, agent_a, agent_b, run_a, run_b,
+	query := `SELECT decision_a_id, decision_b_id, org_id, agent_a, agent_b, run_a, run_b,
 		 decision_type, outcome_a, outcome_b, confidence_a, confidence_b,
 		 decided_at_a, decided_at_b, detected_at
-		 FROM decision_conflicts`
+		 FROM decision_conflicts WHERE org_id = $1`
 
-	var args []any
+	args := []any{orgID}
 	if decisionType != nil {
-		query += " WHERE decision_type = $1"
+		query += " AND decision_type = $2"
 		args = append(args, *decisionType)
 	}
 
@@ -55,7 +57,7 @@ func (db *DB) ListConflicts(ctx context.Context, decisionType *string, limit int
 	for rows.Next() {
 		var c model.DecisionConflict
 		if err := rows.Scan(
-			&c.DecisionAID, &c.DecisionBID, &c.AgentA, &c.AgentB, &c.RunA, &c.RunB,
+			&c.DecisionAID, &c.DecisionBID, &c.OrgID, &c.AgentA, &c.AgentB, &c.RunA, &c.RunB,
 			&c.DecisionType, &c.OutcomeA, &c.OutcomeB, &c.ConfidenceA, &c.ConfidenceB,
 			&c.DecidedAtA, &c.DecidedAtB, &c.DetectedAt,
 		); err != nil {

--- a/internal/storage/organizations.go
+++ b/internal/storage/organizations.go
@@ -1,0 +1,185 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/ashita-ai/akashi/internal/model"
+)
+
+// CreateOrganization inserts a new organization.
+func (db *DB) CreateOrganization(ctx context.Context, org model.Organization) (model.Organization, error) {
+	if org.ID == uuid.Nil {
+		org.ID = uuid.New()
+	}
+	now := time.Now().UTC()
+	if org.CreatedAt.IsZero() {
+		org.CreatedAt = now
+	}
+	org.UpdatedAt = now
+
+	_, err := db.pool.Exec(ctx,
+		`INSERT INTO organizations (id, name, slug, plan, stripe_customer_id, stripe_subscription_id,
+		 decision_limit, agent_limit, email, email_verified, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
+		org.ID, org.Name, org.Slug, org.Plan, org.StripeCustomerID, org.StripeSubscriptionID,
+		org.DecisionLimit, org.AgentLimit, org.Email, org.EmailVerified, org.CreatedAt, org.UpdatedAt,
+	)
+	if err != nil {
+		return model.Organization{}, fmt.Errorf("storage: create organization: %w", err)
+	}
+	return org, nil
+}
+
+// GetOrganization retrieves an org by ID.
+func (db *DB) GetOrganization(ctx context.Context, id uuid.UUID) (model.Organization, error) {
+	var org model.Organization
+	err := db.pool.QueryRow(ctx,
+		`SELECT id, name, slug, plan, stripe_customer_id, stripe_subscription_id,
+		 decision_limit, agent_limit, email, email_verified, created_at, updated_at
+		 FROM organizations WHERE id = $1`, id,
+	).Scan(
+		&org.ID, &org.Name, &org.Slug, &org.Plan, &org.StripeCustomerID, &org.StripeSubscriptionID,
+		&org.DecisionLimit, &org.AgentLimit, &org.Email, &org.EmailVerified, &org.CreatedAt, &org.UpdatedAt,
+	)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return model.Organization{}, fmt.Errorf("storage: organization not found: %s", id)
+		}
+		return model.Organization{}, fmt.Errorf("storage: get organization: %w", err)
+	}
+	return org, nil
+}
+
+// GetOrganizationBySlug retrieves an org by slug.
+func (db *DB) GetOrganizationBySlug(ctx context.Context, slug string) (model.Organization, error) {
+	var org model.Organization
+	err := db.pool.QueryRow(ctx,
+		`SELECT id, name, slug, plan, stripe_customer_id, stripe_subscription_id,
+		 decision_limit, agent_limit, email, email_verified, created_at, updated_at
+		 FROM organizations WHERE slug = $1`, slug,
+	).Scan(
+		&org.ID, &org.Name, &org.Slug, &org.Plan, &org.StripeCustomerID, &org.StripeSubscriptionID,
+		&org.DecisionLimit, &org.AgentLimit, &org.Email, &org.EmailVerified, &org.CreatedAt, &org.UpdatedAt,
+	)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return model.Organization{}, fmt.Errorf("storage: organization not found: %s", slug)
+		}
+		return model.Organization{}, fmt.Errorf("storage: get organization by slug: %w", err)
+	}
+	return org, nil
+}
+
+// UpdateOrganization updates org fields.
+func (db *DB) UpdateOrganization(ctx context.Context, org model.Organization) error {
+	org.UpdatedAt = time.Now().UTC()
+	tag, err := db.pool.Exec(ctx,
+		`UPDATE organizations SET name = $1, slug = $2, plan = $3, stripe_customer_id = $4,
+		 stripe_subscription_id = $5, decision_limit = $6, agent_limit = $7, email = $8,
+		 email_verified = $9, updated_at = $10 WHERE id = $11`,
+		org.Name, org.Slug, org.Plan, org.StripeCustomerID, org.StripeSubscriptionID,
+		org.DecisionLimit, org.AgentLimit, org.Email, org.EmailVerified, org.UpdatedAt, org.ID,
+	)
+	if err != nil {
+		return fmt.Errorf("storage: update organization: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("storage: organization not found: %s", org.ID)
+	}
+	return nil
+}
+
+// IncrementUsage atomically increments the decision count for an org's current period.
+// Returns the new count.
+func (db *DB) IncrementUsage(ctx context.Context, orgID uuid.UUID, period string) (int, error) {
+	var count int
+	err := db.pool.QueryRow(ctx,
+		`INSERT INTO org_usage (org_id, period, decision_count)
+		 VALUES ($1, $2, 1)
+		 ON CONFLICT (org_id, period) DO UPDATE SET decision_count = org_usage.decision_count + 1
+		 RETURNING decision_count`,
+		orgID, period,
+	).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("storage: increment usage: %w", err)
+	}
+	return count, nil
+}
+
+// GetUsage returns the current period's usage for an org.
+func (db *DB) GetUsage(ctx context.Context, orgID uuid.UUID, period string) (model.OrgUsage, error) {
+	var usage model.OrgUsage
+	err := db.pool.QueryRow(ctx,
+		`SELECT org_id, period, decision_count FROM org_usage WHERE org_id = $1 AND period = $2`,
+		orgID, period,
+	).Scan(&usage.OrgID, &usage.Period, &usage.DecisionCount)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return model.OrgUsage{OrgID: orgID, Period: period, DecisionCount: 0}, nil
+		}
+		return model.OrgUsage{}, fmt.Errorf("storage: get usage: %w", err)
+	}
+	return usage, nil
+}
+
+// CreateEmailVerification inserts a verification token for an org.
+func (db *DB) CreateEmailVerification(ctx context.Context, orgID uuid.UUID, token string, expiresAt time.Time) error {
+	_, err := db.pool.Exec(ctx,
+		`INSERT INTO email_verifications (org_id, token, expires_at) VALUES ($1, $2, $3)`,
+		orgID, token, expiresAt,
+	)
+	if err != nil {
+		return fmt.Errorf("storage: create email verification: %w", err)
+	}
+	return nil
+}
+
+// VerifyEmail marks a verification token as used and sets the org's email as verified.
+// Returns an error if the token is invalid, expired, or already used.
+func (db *DB) VerifyEmail(ctx context.Context, token string) error {
+	tx, err := db.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("storage: begin verify tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	var orgID uuid.UUID
+	var expiresAt time.Time
+	var usedAt *time.Time
+	err = tx.QueryRow(ctx,
+		`SELECT org_id, expires_at, used_at FROM email_verifications WHERE token = $1`,
+		token,
+	).Scan(&orgID, &expiresAt, &usedAt)
+	if err != nil {
+		return fmt.Errorf("storage: verification token not found")
+	}
+
+	if usedAt != nil {
+		return fmt.Errorf("storage: verification token already used")
+	}
+	if time.Now().After(expiresAt) {
+		return fmt.Errorf("storage: verification token expired")
+	}
+
+	now := time.Now().UTC()
+	if _, err := tx.Exec(ctx,
+		`UPDATE email_verifications SET used_at = $1 WHERE token = $2`,
+		now, token,
+	); err != nil {
+		return fmt.Errorf("storage: mark verification used: %w", err)
+	}
+
+	if _, err := tx.Exec(ctx,
+		`UPDATE organizations SET email_verified = true, updated_at = $1 WHERE id = $2`,
+		now, orgID,
+	); err != nil {
+		return fmt.Errorf("storage: verify org email: %w", err)
+	}
+
+	return tx.Commit(ctx)
+}

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -327,7 +327,7 @@ func TestQueryDecisions(t *testing.T) {
 
 	dType := "classification"
 	confMin := float32(0.5)
-	decisions, total, err := testDB.QueryDecisions(ctx, model.QueryRequest{
+	decisions, total, err := testDB.QueryDecisions(ctx, uuid.Nil, model.QueryRequest{
 		Filters: model.QueryFilters{
 			AgentIDs:      []string{"query-test"},
 			DecisionType:  &dType,
@@ -386,7 +386,7 @@ func TestSearchDecisionsByEmbedding(t *testing.T) {
 	queryVec[1] = 0.01
 	queryEmb := pgvector.NewVector(queryVec)
 
-	results, err := testDB.SearchDecisionsByEmbedding(ctx, queryEmb, model.QueryFilters{}, 10)
+	results, err := testDB.SearchDecisionsByEmbedding(ctx, uuid.Nil, queryEmb, model.QueryFilters{}, 10)
 	require.NoError(t, err)
 	require.GreaterOrEqual(t, len(results), 2)
 	// The first result should be more similar (outcome="similar").
@@ -409,7 +409,7 @@ func TestTemporalQuery(t *testing.T) {
 	require.NoError(t, err)
 
 	// Query as of now should see the decision.
-	decisions, err := testDB.QueryDecisionsTemporal(ctx, model.TemporalQueryRequest{
+	decisions, err := testDB.QueryDecisionsTemporal(ctx, uuid.Nil, model.TemporalQueryRequest{
 		AsOf: time.Now().UTC().Add(time.Second),
 		Filters: model.QueryFilters{
 			AgentIDs: []string{"temporal-test"},
@@ -419,7 +419,7 @@ func TestTemporalQuery(t *testing.T) {
 	assert.GreaterOrEqual(t, len(decisions), 1)
 
 	// Query as of yesterday should see nothing.
-	decisions, err = testDB.QueryDecisionsTemporal(ctx, model.TemporalQueryRequest{
+	decisions, err = testDB.QueryDecisionsTemporal(ctx, uuid.Nil, model.TemporalQueryRequest{
 		AsOf: time.Now().UTC().Add(-24 * time.Hour),
 		Filters: model.QueryFilters{
 			AgentIDs: []string{"temporal-test"},
@@ -442,7 +442,7 @@ func TestAgentCRUD(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "crud-agent", agent.AgentID)
 
-	got, err := testDB.GetAgentByAgentID(ctx, "crud-agent")
+	got, err := testDB.GetAgentByAgentID(ctx, uuid.Nil, "crud-agent")
 	require.NoError(t, err)
 	assert.Equal(t, agent.ID, got.ID)
 
@@ -479,12 +479,12 @@ func TestAccessGrants(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check access.
-	has, err := testDB.HasAccess(ctx, grantee.ID, "agent_traces", "underwriting-agent", "read")
+	has, err := testDB.HasAccess(ctx, uuid.Nil, grantee.ID, "agent_traces", "underwriting-agent", "read")
 	require.NoError(t, err)
 	assert.True(t, has)
 
 	// Check no access for different resource.
-	has, err = testDB.HasAccess(ctx, grantee.ID, "agent_traces", "other-agent", "read")
+	has, err = testDB.HasAccess(ctx, uuid.Nil, grantee.ID, "agent_traces", "other-agent", "read")
 	require.NoError(t, err)
 	assert.False(t, has)
 
@@ -492,7 +492,7 @@ func TestAccessGrants(t *testing.T) {
 	err = testDB.DeleteGrant(ctx, grant.ID)
 	require.NoError(t, err)
 
-	has, err = testDB.HasAccess(ctx, grantee.ID, "agent_traces", "underwriting-agent", "read")
+	has, err = testDB.HasAccess(ctx, uuid.Nil, grantee.ID, "agent_traces", "underwriting-agent", "read")
 	require.NoError(t, err)
 	assert.False(t, has)
 }
@@ -506,7 +506,7 @@ func TestListRunsByAgent(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	runs, total, err := testDB.ListRunsByAgent(ctx, agentID, 10, 0)
+	runs, total, err := testDB.ListRunsByAgent(ctx, uuid.Nil, agentID, 10, 0)
 	require.NoError(t, err)
 	assert.Equal(t, 3, total)
 	assert.Len(t, runs, 3)


### PR DESCRIPTION
## Summary

- Threads `org_id` through every layer: models, auth, storage, services, handlers, MCP tools/resources
- All data access is now scoped to the caller's organization via JWT claims
- Introduces `ctxutil` package to break server↔mcp circular dependency
- Adds `organizations.go` with full org CRUD, usage tracking, and email verification
- Implements 5-role RBAC hierarchy (`platform_admin > org_owner > admin > agent > reader`) with `RoleAtLeast` helper
- `requireRole` middleware simplified from role-set to single minimum role parameter
- Storage layer: every query now includes `org_id` in WHERE clauses
- New `GetAgentByAgentIDGlobal` for auth token issuance (where org isn't known yet)

## Files changed (29)

**New files:**
- `internal/ctxutil/ctxutil.go` — shared context key accessors
- `internal/storage/organizations.go` — org CRUD, usage, email verification

**Modified layers:**
- Models (5 files): OrgID on all tenant structs, new Organization/OrgUsage types, role hierarchy
- Auth: OrgID in JWT claims
- Storage (8 files): org-scoped queries everywhere
- Service (2 files): orgID parameter on all methods
- Handlers (7 files): extract orgID from context, pass through
- MCP (2 files): extract orgID via ctxutil
- Tests: updated for new function signatures

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] All server integration tests pass (57 tests)
- [x] All storage integration tests pass
- [x] Existing data uses default org UUID (`00000000-...`) via migration 014
- [ ] CI pipeline validates on push