### PR TITLE
Add self-serve signup with email verification (Phase 4)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,6 +42,14 @@ type Config struct {
 	OTELEndpoint string
 	ServiceName  string
 
+	// SMTP settings for email verification.
+	SMTPHost     string
+	SMTPPort     int
+	SMTPUser     string
+	SMTPPassword string
+	SMTPFrom     string
+	BaseURL      string // e.g., "https://akashi.example.com" for verification links.
+
 	// Operational settings.
 	LogLevel                string
 	ConflictRefreshInterval time.Duration
@@ -71,6 +79,12 @@ func Load() (Config, error) {
 		OllamaModel:             envStr("OLLAMA_MODEL", "mxbai-embed-large"),
 		OTELEndpoint:            envStr("OTEL_EXPORTER_OTLP_ENDPOINT", ""),
 		ServiceName:             envStr("OTEL_SERVICE_NAME", "akashi"),
+		SMTPHost:                envStr("AKASHI_SMTP_HOST", ""),
+		SMTPPort:                envInt("AKASHI_SMTP_PORT", 587),
+		SMTPUser:                envStr("AKASHI_SMTP_USER", ""),
+		SMTPPassword:            envStr("AKASHI_SMTP_PASSWORD", ""),
+		SMTPFrom:                envStr("AKASHI_SMTP_FROM", "noreply@akashi.dev"),
+		BaseURL:                 envStr("AKASHI_BASE_URL", "http://localhost:8080"),
 		LogLevel:                envStr("AKASHI_LOG_LEVEL", "info"),
 		ConflictRefreshInterval: envDuration("AKASHI_CONFLICT_REFRESH_INTERVAL", 30*time.Second),
 		EventBufferSize:         envInt("AKASHI_EVENT_BUFFER_SIZE", 1000),

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ashita-ai/akashi/internal/model"
 	"github.com/ashita-ai/akashi/internal/service/decisions"
 	"github.com/ashita-ai/akashi/internal/service/trace"
+	"github.com/ashita-ai/akashi/internal/signup"
 	"github.com/ashita-ai/akashi/internal/storage"
 )
 
@@ -24,6 +25,7 @@ type Handlers struct {
 	decisionSvc         *decisions.Service
 	buffer              *trace.Buffer
 	broker              *Broker
+	signupSvc           *signup.Service
 	logger              *slog.Logger
 	startedAt           time.Time
 	version             string
@@ -32,13 +34,15 @@ type Handlers struct {
 
 // NewHandlers creates a new Handlers with all dependencies.
 // broker may be nil if LISTEN/NOTIFY is not configured.
-func NewHandlers(db *storage.DB, jwtMgr *auth.JWTManager, decisionSvc *decisions.Service, buffer *trace.Buffer, broker *Broker, logger *slog.Logger, version string, maxRequestBodyBytes int64) *Handlers {
+// signupSvc may be nil if signup is not configured.
+func NewHandlers(db *storage.DB, jwtMgr *auth.JWTManager, decisionSvc *decisions.Service, buffer *trace.Buffer, broker *Broker, signupSvc *signup.Service, logger *slog.Logger, version string, maxRequestBodyBytes int64) *Handlers {
 	return &Handlers{
 		db:                  db,
 		jwtMgr:              jwtMgr,
 		decisionSvc:         decisionSvc,
 		buffer:              buffer,
 		broker:              broker,
+		signupSvc:           signupSvc,
 		logger:              logger,
 		startedAt:           time.Now(),
 		version:             version,
@@ -69,6 +73,19 @@ func (h *Handlers) HandleAuthToken(w http.ResponseWriter, r *http.Request) {
 	if err != nil || !valid {
 		writeError(w, r, http.StatusUnauthorized, model.ErrCodeUnauthorized, "invalid credentials")
 		return
+	}
+
+	// Reject unverified orgs (skip for the default org used by pre-migration seed admin).
+	if agent.OrgID != uuid.Nil {
+		org, err := h.db.GetOrganization(r.Context(), agent.OrgID)
+		if err != nil {
+			writeError(w, r, http.StatusInternalServerError, model.ErrCodeInternalError, "failed to look up organization")
+			return
+		}
+		if !org.EmailVerified {
+			writeError(w, r, http.StatusForbidden, model.ErrCodeForbidden, "email not verified — check your inbox or request a new verification link")
+			return
+		}
 	}
 
 	token, expiresAt, err := h.jwtMgr.IssueToken(agent)
@@ -180,6 +197,48 @@ func (h *Handlers) SeedAdmin(ctx context.Context, adminAPIKey string) error {
 
 	h.logger.Info("seeded initial admin agent")
 	return nil
+}
+
+// HandleSignup handles POST /auth/signup.
+func (h *Handlers) HandleSignup(w http.ResponseWriter, r *http.Request) {
+	var req model.SignupRequest
+	if err := decodeJSON(r, &req, h.maxRequestBodyBytes); err != nil {
+		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "invalid request body")
+		return
+	}
+
+	result, err := h.signupSvc.Signup(r.Context(), signup.SignupInput{
+		Email:    req.Email,
+		Password: req.Password,
+		OrgName:  req.OrgName,
+	})
+	if err != nil {
+		h.logger.Error("signup failed", "error", err, "email", req.Email)
+		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, err.Error())
+		return
+	}
+
+	writeJSON(w, r, http.StatusCreated, result)
+}
+
+// HandleVerifyEmail handles GET /auth/verify.
+func (h *Handlers) HandleVerifyEmail(w http.ResponseWriter, r *http.Request) {
+	token := r.URL.Query().Get("token")
+	if token == "" {
+		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "token is required")
+		return
+	}
+
+	if err := h.signupSvc.Verify(r.Context(), token); err != nil {
+		h.logger.Error("email verification failed", "error", err)
+		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, err.Error())
+		return
+	}
+
+	writeJSON(w, r, http.StatusOK, map[string]string{
+		"status":  "verified",
+		"message": "email verified successfully — you can now authenticate",
+	})
 }
 
 // --- Shared helpers ---

--- a/internal/signup/signup.go
+++ b/internal/signup/signup.go
@@ -1,0 +1,236 @@
+// Package signup implements self-serve organization signup with email verification.
+package signup
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/smtp"
+	"regexp"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/google/uuid"
+
+	"github.com/ashita-ai/akashi/internal/auth"
+	"github.com/ashita-ai/akashi/internal/model"
+	"github.com/ashita-ai/akashi/internal/storage"
+)
+
+// Sentinel errors returned by validation and signup logic.
+var (
+	ErrInvalidEmail    = errors.New("invalid email format")
+	ErrWeakPassword    = errors.New("password must be at least 12 characters with uppercase, lowercase, and digit")
+	ErrOrgNameRequired = errors.New("org_name is required")
+)
+
+// Service handles organization signup and email verification.
+type Service struct {
+	db       *storage.DB
+	logger   *slog.Logger
+	smtpHost string
+	smtpPort int
+	smtpUser string
+	smtpPass string
+	smtpFrom string
+	baseURL  string
+}
+
+// Config holds SMTP and base URL settings for the signup service.
+type Config struct {
+	SMTPHost string
+	SMTPPort int
+	SMTPUser string
+	SMTPPass string
+	SMTPFrom string
+	BaseURL  string
+}
+
+// New creates a signup service.
+func New(db *storage.DB, cfg Config, logger *slog.Logger) *Service {
+	return &Service{
+		db:       db,
+		logger:   logger,
+		smtpHost: cfg.SMTPHost,
+		smtpPort: cfg.SMTPPort,
+		smtpUser: cfg.SMTPUser,
+		smtpPass: cfg.SMTPPass,
+		smtpFrom: cfg.SMTPFrom,
+		baseURL:  strings.TrimRight(cfg.BaseURL, "/"),
+	}
+}
+
+// SignupInput is the validated input for a signup request.
+type SignupInput struct {
+	Email    string
+	Password string
+	OrgName  string
+}
+
+// SignupResult is returned on successful signup.
+type SignupResult struct {
+	OrgID   uuid.UUID `json:"org_id"`
+	AgentID string    `json:"agent_id"`
+	Message string    `json:"message"`
+}
+
+// Signup creates a new organization with an owner agent and sends a verification email.
+func (s *Service) Signup(ctx context.Context, input SignupInput) (SignupResult, error) {
+	if err := validateEmail(input.Email); err != nil {
+		return SignupResult{}, err
+	}
+	if err := validatePassword(input.Password); err != nil {
+		return SignupResult{}, err
+	}
+	if strings.TrimSpace(input.OrgName) == "" {
+		return SignupResult{}, ErrOrgNameRequired
+	}
+
+	slug := slugify(input.OrgName)
+
+	org, err := s.db.CreateOrganization(ctx, model.Organization{
+		Name:          input.OrgName,
+		Slug:          slug,
+		Plan:          "free",
+		DecisionLimit: 1000,
+		AgentLimit:    5,
+		Email:         input.Email,
+		EmailVerified: false,
+	})
+	if err != nil {
+		return SignupResult{}, fmt.Errorf("signup: create org: %w", err)
+	}
+
+	hash, err := auth.HashAPIKey(input.Password)
+	if err != nil {
+		return SignupResult{}, fmt.Errorf("signup: hash password: %w", err)
+	}
+
+	agentID := "owner@" + slug
+	_, err = s.db.CreateAgent(ctx, model.Agent{
+		AgentID:    agentID,
+		OrgID:      org.ID,
+		Name:       input.OrgName + " Owner",
+		Role:       model.RoleOrgOwner,
+		APIKeyHash: &hash,
+	})
+	if err != nil {
+		return SignupResult{}, fmt.Errorf("signup: create owner agent: %w", err)
+	}
+
+	token, err := generateToken(32)
+	if err != nil {
+		return SignupResult{}, fmt.Errorf("signup: generate token: %w", err)
+	}
+
+	if err := s.db.CreateEmailVerification(ctx, org.ID, token, time.Now().Add(24*time.Hour)); err != nil {
+		return SignupResult{}, fmt.Errorf("signup: create verification: %w", err)
+	}
+
+	verifyURL := fmt.Sprintf("%s/auth/verify?token=%s", s.baseURL, token)
+	if err := s.sendVerificationEmail(input.Email, verifyURL); err != nil {
+		// Log but don't fail — the user can request a resend later.
+		s.logger.Error("signup: send verification email failed", "error", err, "email", input.Email)
+	}
+
+	return SignupResult{
+		OrgID:   org.ID,
+		AgentID: agentID,
+		Message: "check your email to verify your account",
+	}, nil
+}
+
+// Verify validates a verification token and marks the org's email as verified.
+func (s *Service) Verify(ctx context.Context, token string) error {
+	return s.db.VerifyEmail(ctx, token)
+}
+
+func (s *Service) sendVerificationEmail(to, verifyURL string) error {
+	if s.smtpHost == "" {
+		s.logger.Info("signup: verification email (dev mode — SMTP not configured)",
+			"to", to,
+			"verify_url", verifyURL,
+		)
+		return nil
+	}
+
+	subject := "Verify your Akashi account"
+	body := fmt.Sprintf(
+		"Welcome to Akashi!\r\n\r\nClick the link below to verify your email:\r\n\r\n%s\r\n\r\nThis link expires in 24 hours.",
+		verifyURL,
+	)
+
+	msg := fmt.Sprintf(
+		"From: %s\r\nTo: %s\r\nSubject: %s\r\nMIME-Version: 1.0\r\nContent-Type: text/plain; charset=UTF-8\r\n\r\n%s",
+		s.smtpFrom, to, subject, body,
+	)
+
+	addr := fmt.Sprintf("%s:%d", s.smtpHost, s.smtpPort)
+	var smtpAuth smtp.Auth
+	if s.smtpUser != "" {
+		smtpAuth = smtp.PlainAuth("", s.smtpUser, s.smtpPass, s.smtpHost)
+	}
+
+	return smtp.SendMail(addr, smtpAuth, s.smtpFrom, []string{to}, []byte(msg))
+}
+
+// --- Validation helpers ---
+
+var emailRegex = regexp.MustCompile(`^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$`)
+
+func validateEmail(email string) error {
+	if !emailRegex.MatchString(email) {
+		return ErrInvalidEmail
+	}
+	return nil
+}
+
+func validatePassword(password string) error {
+	if len(password) < 12 {
+		return ErrWeakPassword
+	}
+	var hasUpper, hasLower, hasDigit bool
+	for _, c := range password {
+		switch {
+		case unicode.IsUpper(c):
+			hasUpper = true
+		case unicode.IsLower(c):
+			hasLower = true
+		case unicode.IsDigit(c):
+			hasDigit = true
+		}
+	}
+	if !hasUpper || !hasLower || !hasDigit {
+		return ErrWeakPassword
+	}
+	return nil
+}
+
+var multiHyphen = regexp.MustCompile(`-{2,}`)
+
+func slugify(name string) string {
+	s := strings.ToLower(name)
+	s = strings.Map(func(r rune) rune {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '-' {
+			return r
+		}
+		if r == ' ' || r == '_' {
+			return '-'
+		}
+		return -1
+	}, s)
+	s = multiHyphen.ReplaceAllString(s, "-")
+	return strings.Trim(s, "-")
+}
+
+func generateToken(length int) (string, error) {
+	b := make([]byte, length)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}

--- a/internal/signup/signup_test.go
+++ b/internal/signup/signup_test.go
@@ -1,0 +1,76 @@
+package signup
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateEmail(t *testing.T) {
+	tests := []struct {
+		email string
+		valid bool
+	}{
+		{"user@example.com", true},
+		{"user+tag@example.com", true},
+		{"user@sub.domain.com", true},
+		{"user.name@example.co.uk", true},
+		{"", false},
+		{"not-an-email", false},
+		{"@example.com", false},
+		{"user@", false},
+		{"user@.com", false},
+		{"user@example", false},
+	}
+	for _, tt := range tests {
+		err := validateEmail(tt.email)
+		if tt.valid {
+			assert.NoError(t, err, "expected %q to be valid", tt.email)
+		} else {
+			assert.ErrorIs(t, err, ErrInvalidEmail, "expected %q to be invalid", tt.email)
+		}
+	}
+}
+
+func TestValidatePassword(t *testing.T) {
+	tests := []struct {
+		password string
+		valid    bool
+	}{
+		{"StrongP@ss123", true},
+		{"Abcdefghij1x", true},
+		{"short1A", false},        // too short
+		{"alllowercase1", false},  // no uppercase
+		{"ALLUPPERCASE1", false},  // no lowercase
+		{"AllLettersNoDigit", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		err := validatePassword(tt.password)
+		if tt.valid {
+			assert.NoError(t, err, "expected %q to be valid", tt.password)
+		} else {
+			assert.ErrorIs(t, err, ErrWeakPassword, "expected %q to be rejected", tt.password)
+		}
+	}
+}
+
+func TestSlugify(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"My Org", "my-org"},
+		{"ACME Corp", "acme-corp"},
+		{"hello_world", "hello-world"},
+		{"  spaces  everywhere  ", "spaces-everywhere"},
+		{"Special!@#Chars", "specialchars"},
+		{"multiple---hyphens", "multiple-hyphens"},
+		{"Already-Good", "already-good"},
+		{"123 Numbers", "123-numbers"},
+	}
+	for _, tt := range tests {
+		result := slugify(tt.input)
+		assert.Equal(t, tt.expected, result, "slugify(%q)", tt.input)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `POST /auth/signup` for self-serve org creation with email verification
- Adds `GET /auth/verify` to validate email tokens and unlock authentication
- Gates `POST /auth/token` on `email_verified` for non-default orgs
- New `internal/signup` package with email/password validation, slug generation, SMTP (or dev-mode logging)
- SMTP config fields (`AKASHI_SMTP_HOST`, `AKASHI_SMTP_PORT`, `AKASHI_SMTP_USER`, `AKASHI_SMTP_PASSWORD`, `AKASHI_SMTP_FROM`, `AKASHI_BASE_URL`)

## Test plan

- [x] Unit tests for email validation, password validation, slugify (3 tests)
- [x] Integration: valid signup creates org + agent (201)
- [x] Integration: unverified org blocked from token issuance (403)
- [x] Integration: invalid email / weak password / missing org name rejected (400)
- [x] Integration: missing/invalid verification tokens rejected (400)
- [x] Integration: full end-to-end flow — signup → verify → authenticate → token reuse blocked
- [x] All existing tests pass (60+ server tests, storage, auth, quality)
- [ ] Pre-existing flaky `TestLimiterConcurrent` unrelated to these changes