### PR TITLE
Add Stripe billing integration with quota enforcement (Phase 5)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -71,6 +71,7 @@ require (
 	github.com/shirou/gopsutil/v4 v4.25.6 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
+	github.com/stripe/stripe-go/v84 v84.3.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -155,6 +155,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/stripe/stripe-go/v84 v84.3.0 h1:77HH+ro7yzmyyF7Xkbkj6y5QtnU1WWHC6t2y4mq0Wvk=
+github.com/stripe/stripe-go/v84 v84.3.0/go.mod h1:Z4gcKw1zl4geDG2+cjpSaJES9jaohGX6n7FP8/kHIqw=
 github.com/testcontainers/testcontainers-go v0.40.0 h1:pSdJYLOVgLE8YdUY2FHQ1Fxu+aMnb6JfVz1mxk7OeMU=
 github.com/testcontainers/testcontainers-go v0.40.0/go.mod h1:FSXV5KQtX2HAMlm7U3APNyLkkap35zNLxukw9oBi/MY=
 github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFAEVmqU=

--- a/internal/billing/billing.go
+++ b/internal/billing/billing.go
@@ -1,0 +1,138 @@
+// Package billing integrates Stripe for subscription management, usage metering,
+// and quota enforcement. If Stripe is not configured (no secret key), billing
+// endpoints return 503 and quota enforcement is disabled.
+package billing
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	stripe "github.com/stripe/stripe-go/v84"
+
+	"github.com/ashita-ai/akashi/internal/storage"
+)
+
+// Sentinel errors for quota enforcement.
+var (
+	ErrQuotaExceeded      = errors.New("monthly decision quota exceeded")
+	ErrAgentLimitExceeded = errors.New("agent limit exceeded")
+	ErrBillingDisabled    = errors.New("billing not configured")
+)
+
+// Plan defines limits for an org's subscription tier.
+type Plan struct {
+	Name          string
+	PriceID       string // Stripe Price ID (empty for free/enterprise).
+	DecisionLimit int    // 0 = unlimited.
+	AgentLimit    int    // 0 = unlimited.
+}
+
+// Service wraps Stripe API calls and provides quota enforcement.
+type Service struct {
+	client        *stripe.Client
+	db            *storage.DB
+	logger        *slog.Logger
+	plans         map[string]Plan
+	webhookSecret string
+	proPriceID    string
+	enabled       bool
+}
+
+// Config holds Stripe configuration.
+type Config struct {
+	SecretKey      string
+	WebhookSecret  string
+	PriceIDPro     string
+}
+
+// New creates a billing service. If cfg.SecretKey is empty, the service
+// operates in disabled mode (no quota enforcement, billing endpoints 503).
+func New(db *storage.DB, cfg Config, logger *slog.Logger) *Service {
+	enabled := cfg.SecretKey != ""
+
+	var client *stripe.Client
+	if enabled {
+		client = stripe.NewClient(cfg.SecretKey)
+	}
+
+	return &Service{
+		client: client,
+		db:     db,
+		logger: logger,
+		plans: map[string]Plan{
+			"free": {
+				Name:          "Free",
+				DecisionLimit: 1_000,
+				AgentLimit:    5,
+			},
+			"pro": {
+				Name:          "Pro",
+				PriceID:       cfg.PriceIDPro,
+				DecisionLimit: 50_000,
+				AgentLimit:    0, // unlimited
+			},
+			"enterprise": {
+				Name:          "Enterprise",
+				DecisionLimit: 0, // custom per-org
+				AgentLimit:    0,
+			},
+		},
+		webhookSecret: cfg.WebhookSecret,
+		proPriceID:    cfg.PriceIDPro,
+		enabled:       enabled,
+	}
+}
+
+// Enabled returns true if Stripe is configured.
+func (s *Service) Enabled() bool { return s.enabled }
+
+// GetPlan returns the plan definition for a given plan name.
+func (s *Service) GetPlan(name string) (Plan, bool) {
+	p, ok := s.plans[name]
+	return p, ok
+}
+
+// CreateCheckoutSession creates a Stripe Checkout session for plan upgrade.
+func (s *Service) CreateCheckoutSession(ctx context.Context, orgID, orgEmail, successURL, cancelURL string) (string, error) {
+	if !s.enabled {
+		return "", ErrBillingDisabled
+	}
+
+	sess, err := s.client.V1CheckoutSessions.Create(ctx, &stripe.CheckoutSessionCreateParams{
+		Mode:          stripe.String(string(stripe.CheckoutSessionModeSubscription)),
+		CustomerEmail: stripe.String(orgEmail),
+		SuccessURL:    stripe.String(successURL),
+		CancelURL:     stripe.String(cancelURL),
+		LineItems: []*stripe.CheckoutSessionCreateLineItemParams{
+			{
+				Price:    stripe.String(s.proPriceID),
+				Quantity: stripe.Int64(1),
+			},
+		},
+		Metadata: map[string]string{
+			"org_id": orgID,
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("billing: create checkout session: %w", err)
+	}
+	return sess.URL, nil
+}
+
+// CreatePortalSession creates a Stripe billing portal session for subscription management.
+func (s *Service) CreatePortalSession(ctx context.Context, stripeCustomerID, returnURL string) (string, error) {
+	if !s.enabled {
+		return "", ErrBillingDisabled
+	}
+
+	sess, err := s.client.V1BillingPortalSessions.Create(ctx, &stripe.BillingPortalSessionCreateParams{
+		Customer:  stripe.String(stripeCustomerID),
+		ReturnURL: stripe.String(returnURL),
+	})
+	if err != nil {
+		return "", fmt.Errorf("billing: create portal session: %w", err)
+	}
+	return sess.URL, nil
+}

--- a/internal/billing/billing_test.go
+++ b/internal/billing/billing_test.go
@@ -1,0 +1,89 @@
+package billing
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewService_Enabled(t *testing.T) {
+	svc := New(nil, Config{
+		SecretKey:     "sk_test_xxx",
+		WebhookSecret: "whsec_xxx",
+		PriceIDPro:    "price_xxx",
+	}, nil)
+
+	assert.True(t, svc.Enabled())
+}
+
+func TestNewService_Disabled(t *testing.T) {
+	svc := New(nil, Config{}, nil)
+
+	assert.False(t, svc.Enabled())
+}
+
+func TestGetPlan(t *testing.T) {
+	svc := New(nil, Config{PriceIDPro: "price_xxx"}, nil)
+
+	tests := []struct {
+		name     string
+		planName string
+		wantOK   bool
+		wantPlan Plan
+	}{
+		{"free plan", "free", true, Plan{Name: "Free", DecisionLimit: 1_000, AgentLimit: 5}},
+		{"pro plan", "pro", true, Plan{Name: "Pro", PriceID: "price_xxx", DecisionLimit: 50_000, AgentLimit: 0}},
+		{"enterprise plan", "enterprise", true, Plan{Name: "Enterprise", DecisionLimit: 0, AgentLimit: 0}},
+		{"unknown plan", "platinum", false, Plan{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plan, ok := svc.GetPlan(tt.planName)
+			assert.Equal(t, tt.wantOK, ok)
+			if ok {
+				assert.Equal(t, tt.wantPlan.Name, plan.Name)
+				assert.Equal(t, tt.wantPlan.DecisionLimit, plan.DecisionLimit)
+				assert.Equal(t, tt.wantPlan.AgentLimit, plan.AgentLimit)
+				assert.Equal(t, tt.wantPlan.PriceID, plan.PriceID)
+			}
+		})
+	}
+}
+
+func TestCurrentPeriod(t *testing.T) {
+	period := CurrentPeriod()
+	require.NotEmpty(t, period)
+	// Period should be in YYYY-MM format.
+	assert.Regexp(t, `^\d{4}-\d{2}$`, period)
+}
+
+func TestCheckDecisionQuota_DisabledService(t *testing.T) {
+	svc := New(nil, Config{}, nil)
+
+	// Disabled service should always allow.
+	err := svc.CheckDecisionQuota(nil, [16]byte{})
+	assert.NoError(t, err)
+}
+
+func TestCheckAgentQuota_DisabledService(t *testing.T) {
+	svc := New(nil, Config{}, nil)
+
+	err := svc.CheckAgentQuota(nil, [16]byte{})
+	assert.NoError(t, err)
+}
+
+func TestCreateCheckoutSession_Disabled(t *testing.T) {
+	svc := New(nil, Config{}, nil)
+
+	_, err := svc.CreateCheckoutSession(nil, "org-id", "test@example.com", "https://ok", "https://cancel")
+	assert.ErrorIs(t, err, ErrBillingDisabled)
+}
+
+func TestCreatePortalSession_Disabled(t *testing.T) {
+	svc := New(nil, Config{}, nil)
+
+	_, err := svc.CreatePortalSession(nil, "cus_xxx", "https://return")
+	assert.ErrorIs(t, err, ErrBillingDisabled)
+}

--- a/internal/billing/metering.go
+++ b/internal/billing/metering.go
@@ -1,0 +1,77 @@
+package billing
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// CurrentPeriod returns the current billing period string (YYYY-MM).
+func CurrentPeriod() string {
+	return time.Now().UTC().Format("2006-01")
+}
+
+// CheckDecisionQuota checks if an org has exceeded its monthly decision limit.
+// Returns nil if allowed, ErrQuotaExceeded if the limit is reached,
+// or a wrapped error on storage failure.
+func (s *Service) CheckDecisionQuota(ctx context.Context, orgID uuid.UUID) error {
+	if !s.enabled {
+		return nil
+	}
+
+	org, err := s.db.GetOrganization(ctx, orgID)
+	if err != nil {
+		return fmt.Errorf("billing: get org for quota check: %w", err)
+	}
+
+	// Unlimited orgs (enterprise or decision_limit=0) skip the check.
+	if org.DecisionLimit == 0 {
+		return nil
+	}
+
+	usage, err := s.db.GetUsage(ctx, orgID, CurrentPeriod())
+	if err != nil {
+		return nil // No usage record = 0 decisions this period.
+	}
+
+	if usage.DecisionCount >= org.DecisionLimit {
+		return fmt.Errorf("%w: %d/%d decisions this period", ErrQuotaExceeded, usage.DecisionCount, org.DecisionLimit)
+	}
+	return nil
+}
+
+// CheckAgentQuota checks if an org has exceeded its agent limit.
+// Returns nil if allowed, ErrAgentLimitExceeded if the limit is reached.
+func (s *Service) CheckAgentQuota(ctx context.Context, orgID uuid.UUID) error {
+	if !s.enabled {
+		return nil
+	}
+
+	org, err := s.db.GetOrganization(ctx, orgID)
+	if err != nil {
+		return fmt.Errorf("billing: get org for agent quota: %w", err)
+	}
+
+	// Unlimited orgs skip the check.
+	if org.AgentLimit == 0 {
+		return nil
+	}
+
+	count, err := s.db.CountAgents(ctx, orgID)
+	if err != nil {
+		return fmt.Errorf("billing: count agents: %w", err)
+	}
+
+	if count >= org.AgentLimit {
+		return fmt.Errorf("%w: %d/%d agents", ErrAgentLimitExceeded, count, org.AgentLimit)
+	}
+	return nil
+}
+
+// IncrementDecisionCount atomically increments the usage counter after a successful trace.
+func (s *Service) IncrementDecisionCount(ctx context.Context, orgID uuid.UUID) error {
+	_, err := s.db.IncrementUsage(ctx, orgID, CurrentPeriod())
+	return err
+}

--- a/internal/billing/webhooks.go
+++ b/internal/billing/webhooks.go
@@ -1,0 +1,166 @@
+package billing
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/google/uuid"
+	stripe "github.com/stripe/stripe-go/v84"
+)
+
+// HandleWebhook processes a Stripe webhook event. Returns the HTTP status code
+// to respond with and any error. Verifies the webhook signature, then dispatches
+// to the appropriate handler based on event type.
+func (s *Service) HandleWebhook(ctx context.Context, body []byte, sigHeader string) (int, error) {
+	event, err := stripe.ConstructEvent(body, sigHeader, s.webhookSecret)
+	if err != nil {
+		return http.StatusBadRequest, fmt.Errorf("billing: invalid webhook signature: %w", err)
+	}
+
+	switch event.Type {
+	case "checkout.session.completed":
+		return s.handleCheckoutCompleted(ctx, event)
+	case "customer.subscription.updated":
+		return s.handleSubscriptionUpdated(ctx, event)
+	case "customer.subscription.deleted":
+		return s.handleSubscriptionDeleted(ctx, event)
+	case "invoice.payment_failed":
+		return s.handlePaymentFailed(ctx, event)
+	default:
+		return http.StatusOK, nil
+	}
+}
+
+func (s *Service) handleCheckoutCompleted(ctx context.Context, event stripe.Event) (int, error) {
+	var sess stripe.CheckoutSession
+	if err := json.Unmarshal(event.Data.Raw, &sess); err != nil {
+		return http.StatusBadRequest, fmt.Errorf("billing: unmarshal checkout session: %w", err)
+	}
+
+	orgIDStr, ok := sess.Metadata["org_id"]
+	if !ok {
+		return http.StatusBadRequest, fmt.Errorf("billing: missing org_id in checkout metadata")
+	}
+	orgID, err := uuid.Parse(orgIDStr)
+	if err != nil {
+		return http.StatusBadRequest, fmt.Errorf("billing: invalid org_id: %w", err)
+	}
+
+	org, err := s.db.GetOrganization(ctx, orgID)
+	if err != nil {
+		return http.StatusInternalServerError, fmt.Errorf("billing: get org: %w", err)
+	}
+
+	proPlan := s.plans["pro"]
+	org.Plan = "pro"
+	if sess.Customer != nil {
+		org.StripeCustomerID = &sess.Customer.ID
+	}
+	if sess.Subscription != nil {
+		org.StripeSubscriptionID = &sess.Subscription.ID
+	}
+	org.DecisionLimit = proPlan.DecisionLimit
+	org.AgentLimit = proPlan.AgentLimit
+
+	if err := s.db.UpdateOrganization(ctx, org); err != nil {
+		return http.StatusInternalServerError, fmt.Errorf("billing: update org: %w", err)
+	}
+
+	customerID := ""
+	if sess.Customer != nil {
+		customerID = sess.Customer.ID
+	}
+	s.logger.Info("billing: checkout completed, upgraded to pro",
+		"org_id", orgID,
+		"customer_id", customerID,
+	)
+	return http.StatusOK, nil
+}
+
+func (s *Service) handleSubscriptionUpdated(ctx context.Context, event stripe.Event) (int, error) {
+	var sub stripe.Subscription
+	if err := json.Unmarshal(event.Data.Raw, &sub); err != nil {
+		return http.StatusBadRequest, fmt.Errorf("billing: unmarshal subscription: %w", err)
+	}
+
+	customerID := ""
+	if sub.Customer != nil {
+		customerID = sub.Customer.ID
+	}
+	org, err := s.db.GetOrganizationByStripeCustomer(ctx, customerID)
+	if err != nil {
+		s.logger.Warn("billing: subscription updated for unknown customer", "customer_id", customerID)
+		return http.StatusOK, nil // Don't fail — might be a different product.
+	}
+
+	newPlan := "free"
+	for name, plan := range s.plans {
+		if plan.PriceID != "" && sub.Items != nil && len(sub.Items.Data) > 0 && sub.Items.Data[0].Price != nil && sub.Items.Data[0].Price.ID == plan.PriceID {
+			newPlan = name
+			break
+		}
+	}
+
+	plan := s.plans[newPlan]
+	org.Plan = newPlan
+	org.DecisionLimit = plan.DecisionLimit
+	org.AgentLimit = plan.AgentLimit
+
+	if err := s.db.UpdateOrganization(ctx, org); err != nil {
+		return http.StatusInternalServerError, fmt.Errorf("billing: update org plan: %w", err)
+	}
+
+	s.logger.Info("billing: subscription updated", "org_id", org.ID, "plan", newPlan)
+	return http.StatusOK, nil
+}
+
+func (s *Service) handleSubscriptionDeleted(ctx context.Context, event stripe.Event) (int, error) {
+	var sub stripe.Subscription
+	if err := json.Unmarshal(event.Data.Raw, &sub); err != nil {
+		return http.StatusBadRequest, fmt.Errorf("billing: unmarshal subscription: %w", err)
+	}
+
+	customerID := ""
+	if sub.Customer != nil {
+		customerID = sub.Customer.ID
+	}
+	org, err := s.db.GetOrganizationByStripeCustomer(ctx, customerID)
+	if err != nil {
+		s.logger.Warn("billing: subscription deleted for unknown customer", "customer_id", customerID)
+		return http.StatusOK, nil
+	}
+
+	freePlan := s.plans["free"]
+	org.Plan = "free"
+	org.DecisionLimit = freePlan.DecisionLimit
+	org.AgentLimit = freePlan.AgentLimit
+	org.StripeSubscriptionID = nil
+
+	if err := s.db.UpdateOrganization(ctx, org); err != nil {
+		return http.StatusInternalServerError, fmt.Errorf("billing: downgrade org: %w", err)
+	}
+
+	s.logger.Info("billing: subscription deleted, downgraded to free", "org_id", org.ID)
+	return http.StatusOK, nil
+}
+
+func (s *Service) handlePaymentFailed(ctx context.Context, event stripe.Event) (int, error) {
+	var invoice stripe.Invoice
+	if err := json.Unmarshal(event.Data.Raw, &invoice); err != nil {
+		return http.StatusBadRequest, fmt.Errorf("billing: unmarshal invoice: %w", err)
+	}
+
+	customerID := ""
+	if invoice.Customer != nil {
+		customerID = invoice.Customer.ID
+	}
+	s.logger.Warn("billing: payment failed",
+		"customer_id", customerID,
+		"amount_due", invoice.AmountDue,
+		"attempt_count", invoice.AttemptCount,
+	)
+
+	return http.StatusOK, nil
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,6 +42,11 @@ type Config struct {
 	OTELEndpoint string
 	ServiceName  string
 
+	// Stripe billing settings.
+	StripeSecretKey     string
+	StripeWebhookSecret string
+	StripePriceIDPro    string // Stripe Price ID for the Pro plan.
+
 	// SMTP settings for email verification.
 	SMTPHost     string
 	SMTPPort     int
@@ -79,6 +84,9 @@ func Load() (Config, error) {
 		OllamaModel:             envStr("OLLAMA_MODEL", "mxbai-embed-large"),
 		OTELEndpoint:            envStr("OTEL_EXPORTER_OTLP_ENDPOINT", ""),
 		ServiceName:             envStr("OTEL_SERVICE_NAME", "akashi"),
+		StripeSecretKey:         envStr("STRIPE_SECRET_KEY", ""),
+		StripeWebhookSecret:     envStr("STRIPE_WEBHOOK_SECRET", ""),
+		StripePriceIDPro:        envStr("STRIPE_PRO_PRICE_ID", ""),
 		SMTPHost:                envStr("AKASHI_SMTP_HOST", ""),
 		SMTPPort:                envInt("AKASHI_SMTP_PORT", 587),
 		SMTPUser:                envStr("AKASHI_SMTP_USER", ""),

--- a/internal/model/api.go
+++ b/internal/model/api.go
@@ -39,6 +39,7 @@ const (
 	ErrCodeNotFound      = "NOT_FOUND"
 	ErrCodeConflict      = "CONFLICT"
 	ErrCodeRateLimited   = "RATE_LIMITED"
+	ErrCodeQuotaExceeded = "QUOTA_EXCEEDED"
 	ErrCodeInternalError = "INTERNAL_ERROR"
 )
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/ashita-ai/akashi/internal/auth"
+	"github.com/ashita-ai/akashi/internal/billing"
 	"github.com/ashita-ai/akashi/internal/model"
 	"github.com/ashita-ai/akashi/internal/service/decisions"
 	"github.com/ashita-ai/akashi/internal/service/trace"
@@ -23,6 +24,7 @@ type Handlers struct {
 	db                  *storage.DB
 	jwtMgr              *auth.JWTManager
 	decisionSvc         *decisions.Service
+	billingSvc          *billing.Service
 	buffer              *trace.Buffer
 	broker              *Broker
 	signupSvc           *signup.Service
@@ -35,11 +37,13 @@ type Handlers struct {
 // NewHandlers creates a new Handlers with all dependencies.
 // broker may be nil if LISTEN/NOTIFY is not configured.
 // signupSvc may be nil if signup is not configured.
-func NewHandlers(db *storage.DB, jwtMgr *auth.JWTManager, decisionSvc *decisions.Service, buffer *trace.Buffer, broker *Broker, signupSvc *signup.Service, logger *slog.Logger, version string, maxRequestBodyBytes int64) *Handlers {
+// billingSvc may be nil if Stripe is not configured.
+func NewHandlers(db *storage.DB, jwtMgr *auth.JWTManager, decisionSvc *decisions.Service, billingSvc *billing.Service, buffer *trace.Buffer, broker *Broker, signupSvc *signup.Service, logger *slog.Logger, version string, maxRequestBodyBytes int64) *Handlers {
 	return &Handlers{
 		db:                  db,
 		jwtMgr:              jwtMgr,
 		decisionSvc:         decisionSvc,
+		billingSvc:          billingSvc,
 		buffer:              buffer,
 		broker:              broker,
 		signupSvc:           signupSvc,

--- a/internal/server/handlers_billing.go
+++ b/internal/server/handlers_billing.go
@@ -1,0 +1,148 @@
+package server
+
+import (
+	"io"
+	"net/http"
+
+	"github.com/ashita-ai/akashi/internal/billing"
+	"github.com/ashita-ai/akashi/internal/model"
+)
+
+// HandleBillingCheckout handles POST /billing/checkout (org_owner+).
+// Creates a Stripe Checkout session for upgrading to the Pro plan.
+func (h *Handlers) HandleBillingCheckout(w http.ResponseWriter, r *http.Request) {
+	claims := ClaimsFromContext(r.Context())
+	orgID := OrgIDFromContext(r.Context())
+
+	if h.billingSvc == nil || !h.billingSvc.Enabled() {
+		writeError(w, r, http.StatusServiceUnavailable, model.ErrCodeInternalError, "billing not configured")
+		return
+	}
+
+	org, err := h.db.GetOrganization(r.Context(), orgID)
+	if err != nil {
+		h.logger.Error("billing checkout: get org", "error", err, "org_id", claims.OrgID)
+		writeError(w, r, http.StatusInternalServerError, model.ErrCodeInternalError, "internal error")
+		return
+	}
+
+	var req struct {
+		SuccessURL string `json:"success_url"`
+		CancelURL  string `json:"cancel_url"`
+	}
+	if err := decodeJSON(r, &req, h.maxRequestBodyBytes); err != nil {
+		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "invalid request body")
+		return
+	}
+
+	if req.SuccessURL == "" || req.CancelURL == "" {
+		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "success_url and cancel_url are required")
+		return
+	}
+
+	url, err := h.billingSvc.CreateCheckoutSession(r.Context(), orgID.String(), org.Email, req.SuccessURL, req.CancelURL)
+	if err != nil {
+		h.logger.Error("billing checkout: create session", "error", err, "org_id", orgID)
+		writeError(w, r, http.StatusInternalServerError, model.ErrCodeInternalError, "failed to create checkout session")
+		return
+	}
+
+	writeJSON(w, r, http.StatusOK, map[string]string{"checkout_url": url})
+}
+
+// HandleBillingPortal handles POST /billing/portal (org_owner+).
+// Creates a Stripe Billing Portal session for managing an existing subscription.
+func (h *Handlers) HandleBillingPortal(w http.ResponseWriter, r *http.Request) {
+	claims := ClaimsFromContext(r.Context())
+	orgID := OrgIDFromContext(r.Context())
+
+	if h.billingSvc == nil || !h.billingSvc.Enabled() {
+		writeError(w, r, http.StatusServiceUnavailable, model.ErrCodeInternalError, "billing not configured")
+		return
+	}
+
+	org, err := h.db.GetOrganization(r.Context(), orgID)
+	if err != nil {
+		h.logger.Error("billing portal: get org", "error", err, "org_id", claims.OrgID)
+		writeError(w, r, http.StatusInternalServerError, model.ErrCodeInternalError, "internal error")
+		return
+	}
+
+	if org.StripeCustomerID == nil {
+		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "no active subscription")
+		return
+	}
+
+	var req struct {
+		ReturnURL string `json:"return_url"`
+	}
+	if err := decodeJSON(r, &req, h.maxRequestBodyBytes); err != nil {
+		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "invalid request body")
+		return
+	}
+
+	if req.ReturnURL == "" {
+		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "return_url is required")
+		return
+	}
+
+	url, err := h.billingSvc.CreatePortalSession(r.Context(), *org.StripeCustomerID, req.ReturnURL)
+	if err != nil {
+		h.logger.Error("billing portal: create session", "error", err, "org_id", orgID)
+		writeError(w, r, http.StatusInternalServerError, model.ErrCodeInternalError, "failed to create portal session")
+		return
+	}
+
+	writeJSON(w, r, http.StatusOK, map[string]string{"portal_url": url})
+}
+
+// HandleBillingWebhook handles POST /billing/webhooks.
+// This endpoint is NOT protected by JWT auth — Stripe signs the payload with
+// its webhook secret. The billing service verifies the signature.
+func (h *Handlers) HandleBillingWebhook(w http.ResponseWriter, r *http.Request) {
+	if h.billingSvc == nil || !h.billingSvc.Enabled() {
+		writeError(w, r, http.StatusServiceUnavailable, model.ErrCodeInternalError, "billing not configured")
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, h.maxRequestBodyBytes))
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "failed to read body")
+		return
+	}
+
+	sigHeader := r.Header.Get("Stripe-Signature")
+	status, whErr := h.billingSvc.HandleWebhook(r.Context(), body, sigHeader)
+	if whErr != nil {
+		h.logger.Error("billing webhook failed", "error", whErr, "status", status)
+		writeError(w, r, status, model.ErrCodeInternalError, whErr.Error())
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// HandleUsage handles GET /v1/usage.
+// Returns the current billing period's usage statistics for the caller's org.
+func (h *Handlers) HandleUsage(w http.ResponseWriter, r *http.Request) {
+	orgID := OrgIDFromContext(r.Context())
+
+	org, err := h.db.GetOrganization(r.Context(), orgID)
+	if err != nil {
+		h.logger.Error("usage: get org", "error", err, "org_id", orgID)
+		writeError(w, r, http.StatusInternalServerError, model.ErrCodeInternalError, "internal error")
+		return
+	}
+
+	period := billing.CurrentPeriod()
+	usage, _ := h.db.GetUsage(r.Context(), orgID, period)
+
+	writeJSON(w, r, http.StatusOK, map[string]any{
+		"org_id":         orgID,
+		"plan":           org.Plan,
+		"period":         period,
+		"decision_count": usage.DecisionCount,
+		"decision_limit": org.DecisionLimit,
+		"agent_limit":    org.AgentLimit,
+	})
+}

--- a/internal/server/handlers_decisions.go
+++ b/internal/server/handlers_decisions.go
@@ -1,8 +1,10 @@
 package server
 
 import (
+	"errors"
 	"net/http"
 
+	"github.com/ashita-ai/akashi/internal/billing"
 	"github.com/ashita-ai/akashi/internal/model"
 	"github.com/ashita-ai/akashi/internal/service/decisions"
 )
@@ -48,6 +50,10 @@ func (h *Handlers) HandleTrace(w http.ResponseWriter, r *http.Request) {
 		PrecedentRef: req.PrecedentRef,
 	})
 	if err != nil {
+		if errors.Is(err, billing.ErrQuotaExceeded) {
+			writeError(w, r, http.StatusTooManyRequests, model.ErrCodeQuotaExceeded, err.Error())
+			return
+		}
 		writeError(w, r, http.StatusInternalServerError, model.ErrCodeInternalError, "failed to create trace")
 		return
 	}

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -177,7 +177,8 @@ func authMiddleware(jwtMgr *auth.JWTManager, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Paths that don't require auth.
 		if r.URL.Path == "/health" || r.URL.Path == "/auth/token" ||
-			r.URL.Path == "/auth/signup" || r.URL.Path == "/auth/verify" {
+			r.URL.Path == "/auth/signup" || r.URL.Path == "/auth/verify" ||
+			r.URL.Path == "/billing/webhooks" {
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -96,7 +96,7 @@ func TestMain(m *testing.M) {
 
 	jwtMgr, _ := auth.NewJWTManager("", "", 24*time.Hour)
 	embedder := embedding.NewNoopProvider(1024)
-	decisionSvc := decisions.New(db, embedder, logger)
+	decisionSvc := decisions.New(db, embedder, nil, logger)
 	buf := trace.NewBuffer(db, logger, 1000, 50*time.Millisecond)
 	buf.Start(ctx)
 
@@ -105,7 +105,7 @@ func TestMain(m *testing.M) {
 		SMTPFrom: "test@akashi.dev",
 		BaseURL:  "http://localhost:8080",
 	}, logger)
-	srv := server.New(db, jwtMgr, decisionSvc, buf, nil, nil, signupSvc, logger, 0, 30*time.Second, 30*time.Second, mcpSrv.MCPServer(), "test", 1*1024*1024)
+	srv := server.New(db, jwtMgr, decisionSvc, nil, buf, nil, nil, signupSvc, logger, 0, 30*time.Second, 30*time.Second, mcpSrv.MCPServer(), "test", 1*1024*1024)
 
 	// Seed admin.
 	_ = srv.Handlers().SeedAdmin(ctx, "test-admin-key")
@@ -1113,6 +1113,154 @@ func TestSignupAndVerifyFullFlow(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = resp5.Body.Close() }()
 	assert.Equal(t, http.StatusBadRequest, resp5.StatusCode)
+}
+
+func TestUsageEndpoint(t *testing.T) {
+	t.Run("authenticated user can see usage", func(t *testing.T) {
+		resp, err := authedRequest("GET", testSrv.URL+"/v1/usage", adminToken, nil)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var result struct {
+			Data struct {
+				Plan          string `json:"plan"`
+				Period        string `json:"period"`
+				DecisionCount int    `json:"decision_count"`
+				DecisionLimit int    `json:"decision_limit"`
+				AgentLimit    int    `json:"agent_limit"`
+			} `json:"data"`
+		}
+		data, _ := io.ReadAll(resp.Body)
+		err = json.Unmarshal(data, &result)
+		require.NoError(t, err)
+		assert.NotEmpty(t, result.Data.Period)
+		assert.NotEmpty(t, result.Data.Plan)
+	})
+
+	t.Run("unauthenticated cannot see usage", func(t *testing.T) {
+		resp, err := http.Get(testSrv.URL + "/v1/usage")
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
+}
+
+func TestBillingWebhookEndpoint(t *testing.T) {
+	t.Run("webhook returns 503 when billing disabled", func(t *testing.T) {
+		body := []byte(`{"type":"checkout.session.completed"}`)
+		req, _ := http.NewRequest("POST", testSrv.URL+"/billing/webhooks", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+	})
+
+	t.Run("webhook does not require JWT auth", func(t *testing.T) {
+		// Verify the endpoint is reachable without Bearer token
+		// (it uses Stripe signature instead of JWT).
+		body := []byte(`{}`)
+		req, _ := http.NewRequest("POST", testSrv.URL+"/billing/webhooks", bytes.NewReader(body))
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		// Should NOT be 401 (auth middleware skipped). Returns 503 because billing is disabled.
+		assert.NotEqual(t, http.StatusUnauthorized, resp.StatusCode)
+		assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+	})
+}
+
+func TestBillingCheckoutEndpoint(t *testing.T) {
+	t.Run("billing not configured returns 503 for org_owner", func(t *testing.T) {
+		// Create an org_owner via signup + verify to get a proper token.
+		ownerToken := createVerifiedOrgOwner(t, "billing-checkout-test@example.com", "Str0ngPassw0rd!", "Billing Checkout Org")
+
+		resp, err := authedRequest("POST", testSrv.URL+"/billing/checkout", ownerToken,
+			map[string]string{"success_url": "https://ok", "cancel_url": "https://cancel"})
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+	})
+
+	t.Run("admin cannot access checkout (requires org_owner)", func(t *testing.T) {
+		resp, err := authedRequest("POST", testSrv.URL+"/billing/checkout", adminToken,
+			map[string]string{"success_url": "https://ok", "cancel_url": "https://cancel"})
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	})
+
+	t.Run("agent cannot access checkout", func(t *testing.T) {
+		resp, err := authedRequest("POST", testSrv.URL+"/billing/checkout", agentToken,
+			map[string]string{"success_url": "https://ok", "cancel_url": "https://cancel"})
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	})
+}
+
+func TestBillingPortalEndpoint(t *testing.T) {
+	t.Run("billing not configured returns 503 for org_owner", func(t *testing.T) {
+		ownerToken := createVerifiedOrgOwner(t, "billing-portal-test@example.com", "Str0ngPassw0rd!", "Billing Portal Org")
+
+		resp, err := authedRequest("POST", testSrv.URL+"/billing/portal", ownerToken,
+			map[string]string{"return_url": "https://return"})
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+	})
+
+	t.Run("admin cannot access portal (requires org_owner)", func(t *testing.T) {
+		resp, err := authedRequest("POST", testSrv.URL+"/billing/portal", adminToken,
+			map[string]string{"return_url": "https://return"})
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	})
+}
+
+// createVerifiedOrgOwner signs up a new org, verifies the email, and returns a JWT token
+// for the org_owner agent. This is a helper for tests that need an org_owner role.
+func createVerifiedOrgOwner(t *testing.T, email, password, orgName string) string {
+	t.Helper()
+	ctx := context.Background()
+
+	// 1. Sign up.
+	signupBody, _ := json.Marshal(model.SignupRequest{Email: email, Password: password, OrgName: orgName})
+	resp, err := http.Post(testSrv.URL+"/auth/signup", "application/json", bytes.NewReader(signupBody))
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	var signupResult struct {
+		Data signup.SignupResult `json:"data"`
+	}
+	data, _ := io.ReadAll(resp.Body)
+	require.NoError(t, json.Unmarshal(data, &signupResult))
+
+	// 2. Verify email directly via DB.
+	host, _ := testcontainer.Host(ctx)
+	port, _ := testcontainer.MappedPort(ctx, "5432")
+	dsn := fmt.Sprintf("postgres://akashi:akashi@%s:%s/akashi?sslmode=disable", host, port.Port())
+	conn, err := pgx.Connect(ctx, dsn)
+	require.NoError(t, err)
+	defer func() { _ = conn.Close(ctx) }()
+
+	var verifyToken string
+	err = conn.QueryRow(ctx,
+		"SELECT token FROM email_verifications WHERE org_id = $1 AND used_at IS NULL ORDER BY created_at DESC LIMIT 1",
+		signupResult.Data.OrgID,
+	).Scan(&verifyToken)
+	require.NoError(t, err)
+
+	resp2, err := http.Get(testSrv.URL + "/auth/verify?token=" + verifyToken)
+	require.NoError(t, err)
+	defer func() { _ = resp2.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp2.StatusCode)
+
+	// 3. Get token.
+	return getToken(testSrv.URL, signupResult.Data.AgentID, password)
 }
 
 func TestAccessGrantEnforcement(t *testing.T) {


### PR DESCRIPTION
## Summary

- Integrates Stripe (stripe-go/v84) for subscription billing, usage metering, and quota enforcement
- Creates `internal/billing/` package with plan definitions, webhook handling, metering, and checkout/portal session management
- Adds quota enforcement in the trace hot path (decision limit) and agent creation (agent limit) — returns 429 QUOTA_EXCEEDED when limits hit
- Adds 4 new HTTP endpoints: `/billing/checkout`, `/billing/portal`, `/billing/webhooks`, `/v1/usage`
- Billing is fully optional — disabled when `STRIPE_SECRET_KEY` is empty (quota checks bypassed, billing endpoints return 503)
- Plan limits: free = 1000 decisions/mo + 5 agents, pro = 50000 + unlimited, enterprise = custom per-org

## Test plan

- [x] Billing unit tests pass (8 tests: service enabled/disabled, plan lookup, period format, quota bypass when disabled, checkout/portal disabled errors)
- [x] Integration tests pass (usage endpoint returns 200 with correct shape, webhook returns 503 when disabled, webhook skips JWT auth, checkout/portal return 503 for org_owner when billing disabled, checkout/portal return 403 for non-owner roles)
- [x] All existing tests pass (38 server tests, all billing tests, signup tests, auth tests, MCP tests)
- [x] `go build ./...` clean
- [x] `go test -race ./internal/billing/...` clean
- [ ] Manual test with Stripe test keys (requires Stripe account)

🤖 Generated with [Claude Code](https://claude.com/claude-code)