### PR TITLE
Add Qdrant vector search, OpenAPI spec, and quality hardening

### DIFF
--- a/cmd/akashi/main.go
+++ b/cmd/akashi/main.go
@@ -182,9 +182,26 @@ func run(ctx context.Context, logger *slog.Logger) error {
 	}
 
 	// Create and start HTTP server (MCP mounted at /mcp).
-	srv := server.New(db, jwtMgr, decisionSvc, billingSvc, buf, limiter, broker, signupSvc, searcher, logger,
-		cfg.Port, cfg.ReadTimeout, cfg.WriteTimeout,
-		mcpSrv.MCPServer(), version, cfg.MaxRequestBodyBytes, uiFS, api.OpenAPISpec)
+	srv := server.New(server.ServerConfig{
+		DB:                  db,
+		JWTMgr:              jwtMgr,
+		DecisionSvc:         decisionSvc,
+		BillingSvc:          billingSvc,
+		Buffer:              buf,
+		Limiter:             limiter,
+		Broker:              broker,
+		SignupSvc:           signupSvc,
+		Searcher:            searcher,
+		Logger:              logger,
+		Port:                cfg.Port,
+		ReadTimeout:         cfg.ReadTimeout,
+		WriteTimeout:        cfg.WriteTimeout,
+		MCPServer:           mcpSrv.MCPServer(),
+		Version:             version,
+		MaxRequestBodyBytes: cfg.MaxRequestBodyBytes,
+		UIFS:                uiFS,
+		OpenAPISpec:         api.OpenAPISpec,
+	})
 
 	// Seed admin agent.
 	if err := srv.Handlers().SeedAdmin(ctx, cfg.AdminAPIKey); err != nil {

--- a/docs/TECHNICAL_DEEP_DIVE.md
+++ b/docs/TECHNICAL_DEEP_DIVE.md
@@ -370,11 +370,11 @@ func VerifyAPIKey(key, hash string) (bool, error) {
 
 ### Go Patterns Used
 
-#### 1. Functional Options (implicit via config)
+#### 1. Struct-Based Configuration
 ```go
 // config/config.go loads from environment
 cfg, _ := config.Load()
-srv := server.New(db, jwtMgr, decisionSvc, buffer, limiter, broker, ...)
+srv := server.New(server.ServerConfig{DB: db, JWTMgr: jwtMgr, DecisionSvc: decisionSvc, ...})
 ```
 
 #### 2. Context Propagation

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -38,27 +38,39 @@ type Handlers struct {
 	openapiSpec         []byte
 }
 
+// HandlersDeps holds all dependencies for constructing Handlers.
+// Optional (nil-safe): BillingSvc, Broker, SignupSvc, Searcher, OpenAPISpec.
+type HandlersDeps struct {
+	DB                  *storage.DB
+	JWTMgr              *auth.JWTManager
+	DecisionSvc         *decisions.Service
+	BillingSvc          *billing.Service
+	Buffer              *trace.Buffer
+	Broker              *Broker
+	SignupSvc           *signup.Service
+	Searcher            search.Searcher
+	Logger              *slog.Logger
+	Version             string
+	MaxRequestBodyBytes int64
+	OpenAPISpec         []byte
+}
+
 // NewHandlers creates a new Handlers with all dependencies.
-// broker may be nil if LISTEN/NOTIFY is not configured.
-// signupSvc may be nil if signup is not configured.
-// billingSvc may be nil if Stripe is not configured.
-// searcher may be nil if Qdrant is not configured.
-// openapiSpec may be nil if no OpenAPI spec is embedded.
-func NewHandlers(db *storage.DB, jwtMgr *auth.JWTManager, decisionSvc *decisions.Service, billingSvc *billing.Service, buffer *trace.Buffer, broker *Broker, signupSvc *signup.Service, searcher search.Searcher, logger *slog.Logger, version string, maxRequestBodyBytes int64, openapiSpec []byte) *Handlers {
+func NewHandlers(d HandlersDeps) *Handlers {
 	return &Handlers{
-		db:                  db,
-		jwtMgr:              jwtMgr,
-		decisionSvc:         decisionSvc,
-		billingSvc:          billingSvc,
-		buffer:              buffer,
-		broker:              broker,
-		signupSvc:           signupSvc,
-		searcher:            searcher,
-		logger:              logger,
+		db:                  d.DB,
+		jwtMgr:              d.JWTMgr,
+		decisionSvc:         d.DecisionSvc,
+		billingSvc:          d.BillingSvc,
+		buffer:              d.Buffer,
+		broker:              d.Broker,
+		signupSvc:           d.SignupSvc,
+		searcher:            d.Searcher,
+		logger:              d.Logger,
 		startedAt:           time.Now(),
-		version:             version,
-		maxRequestBodyBytes: maxRequestBodyBytes,
-		openapiSpec:         openapiSpec,
+		version:             d.Version,
+		maxRequestBodyBytes: d.MaxRequestBodyBytes,
+		openapiSpec:         d.OpenAPISpec,
 	}
 }
 

--- a/internal/server/handlers_decisions.go
+++ b/internal/server/handlers_decisions.go
@@ -43,6 +43,12 @@ func (h *Handlers) HandleTrace(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Verify the agent exists within the caller's org to prevent orphaned data.
+	if _, err := h.db.GetAgentByAgentID(r.Context(), orgID, req.AgentID); err != nil {
+		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "agent_id not found in this organization")
+		return
+	}
+
 	result, err := h.decisionSvc.Trace(r.Context(), orgID, decisions.TraceInput{
 		AgentID:      req.AgentID,
 		TraceID:      req.TraceID,


### PR DESCRIPTION
## Summary

- **Qdrant vector search (spec 07)**: Adds Qdrant Cloud as the primary semantic search index with an outbox-based sync pattern. Postgres remains source of truth; Qdrant is a derived, eventually-consistent index. Fallback chain: Qdrant → ILIKE text search. Drops the pgvector HNSW index on `decisions.embedding` (the whole point of Qdrant is that pgvector HNSW doesn't scale).
- **OpenAPI 3.1 spec**: Full API spec embedded and served at `GET /openapi.yaml`.
- **Query correctness**: `valid_to IS NULL` added to `QueryDecisions` and `GetDecisionsByAgent` to respect bi-temporal model on all non-temporal read paths.
- **Agent validation**: `HandleTrace` now validates `agent_id` exists in the caller's org before creating traces, preventing orphaned data.
- **API consistency**: Rate limiter 429 responses use the standard `APIError` envelope with `request_id` and timestamp instead of a bare JSON object.
- **Dead code removal**: `SearchDecisionsByEmbedding` removed (replaced by Qdrant).
- **Config struct refactor**: `server.New()` and `NewHandlers()` accept config structs instead of 18/12 positional parameters.

## New files

| File | Purpose |
|------|---------|
| `internal/search/search.go` | `Searcher` interface, `Result` type, `ReScore()` |
| `internal/search/qdrant.go` | `QdrantIndex` — Qdrant gRPC client, filter translation, health cache |
| `internal/search/qdrant_test.go` | Unit tests for filters, re-scoring, URL parsing |
| `internal/search/outbox.go` | `OutboxWorker` — polls outbox, syncs to Qdrant, dead-letter at 10 attempts |
| `internal/search/outbox_test.go` | Outbox worker tests |
| `migrations/017_search_outbox.sql` | Outbox table, drops pgvector HNSW index |
| `api/openapi.yaml` | OpenAPI 3.1 specification |
| `api/embed.go` | `go:embed` for the spec |

## Key design decisions

- **Shared collection with org_id payload filter** (no collection-per-tenant)
- **Outbox pattern** ensures Qdrant upserts are transactional with Postgres commits
- **Over-fetch 3x from Qdrant**, hydrate from Postgres, re-score with quality + recency weighting
- **5-second cached health check** avoids hammering Qdrant on every request
- **Graceful degradation**: Qdrant disabled → text search only. No silent failures.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `golangci-lint run ./...` — 0 issues
- [x] `atlas migrate validate` passes
- [x] `go test ./internal/search/... -v` passes
- [x] `go test ./internal/server/... -v` passes
- [ ] Integration: start with `QDRANT_URL` set → logs "qdrant: enabled"
- [ ] Integration: start without `QDRANT_URL` → logs "qdrant: disabled", search uses text fallback
- [ ] Integration: `POST /v1/trace` → decision appears in Qdrant within ~2s
- [ ] Integration: `POST /v1/search` with semantic → results from Qdrant