### PR TITLE
Fix correctness bugs, add panic recovery, remove dead code

### DIFF
--- a/cmd/akashi/main.go
+++ b/cmd/akashi/main.go
@@ -71,7 +71,7 @@ func run(ctx context.Context, logger *slog.Logger) error {
 	slog.Info("akashi starting", "version", version, "port", cfg.Port)
 
 	// Initialize OpenTelemetry.
-	otelShutdown, err := telemetry.Init(ctx, cfg.OTELEndpoint, cfg.ServiceName, version)
+	otelShutdown, err := telemetry.Init(ctx, cfg.OTELEndpoint, cfg.ServiceName, version, cfg.OTELInsecure)
 	if err != nil {
 		return fmt.Errorf("telemetry: %w", err)
 	}
@@ -227,7 +227,6 @@ func run(ctx context.Context, logger *slog.Logger) error {
 	}
 
 	// Graceful shutdown.
-	fmt.Println()
 	slog.Info("akashi shutting down")
 
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 15*time.Second)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,6 +40,7 @@ type Config struct {
 
 	// OTEL settings.
 	OTELEndpoint string
+	OTELInsecure bool // Use HTTP instead of HTTPS for OTEL exporter (default: false).
 	ServiceName  string
 
 	// Stripe billing settings.
@@ -90,6 +91,7 @@ func Load() (Config, error) {
 		OllamaURL:               envStr("OLLAMA_URL", "http://localhost:11434"),
 		OllamaModel:             envStr("OLLAMA_MODEL", "mxbai-embed-large"),
 		OTELEndpoint:            envStr("OTEL_EXPORTER_OTLP_ENDPOINT", ""),
+		OTELInsecure:            envBool("OTEL_EXPORTER_OTLP_INSECURE", false),
 		ServiceName:             envStr("OTEL_SERVICE_NAME", "akashi"),
 		StripeSecretKey:         envStr("STRIPE_SECRET_KEY", ""),
 		StripeWebhookSecret:     envStr("STRIPE_WEBHOOK_SECRET", ""),
@@ -143,6 +145,15 @@ func envInt(key string, defaultVal int) int {
 	if v := os.Getenv(key); v != "" {
 		if n, err := strconv.Atoi(v); err == nil {
 			return n
+		}
+	}
+	return defaultVal
+}
+
+func envBool(key string, defaultVal bool) bool {
+	if v := os.Getenv(key); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			return b
 		}
 	}
 	return defaultVal

--- a/internal/model/api.go
+++ b/internal/model/api.go
@@ -144,12 +144,6 @@ type HealthResponse struct {
 	Uptime   int64  `json:"uptime_seconds"`
 }
 
-// SubscriptionEvent is sent over SSE to subscribers.
-type SubscriptionEvent struct {
-	Event string `json:"event"`
-	Data  any    `json:"data"`
-}
-
 // Organization represents a tenant in the multi-tenancy model.
 type Organization struct {
 	ID                   uuid.UUID `json:"id"`

--- a/internal/model/decision.go
+++ b/internal/model/decision.go
@@ -99,15 +99,3 @@ type DecisionConflict struct {
 	DecidedAtB   time.Time `json:"decided_at_b"`
 	DetectedAt   time.Time `json:"detected_at"`
 }
-
-// AgentCurrentState is a summary of an agent's latest activity.
-type AgentCurrentState struct {
-	AgentID         string     `json:"agent_id"`
-	OrgID           uuid.UUID  `json:"org_id"`
-	LatestRunID     uuid.UUID  `json:"latest_run_id"`
-	RunStatus       RunStatus  `json:"run_status"`
-	StartedAt       time.Time  `json:"started_at"`
-	EventCount      int64      `json:"event_count"`
-	LastActivity    *time.Time `json:"last_activity,omitempty"`
-	ActiveDecisions int64      `json:"active_decisions"`
-}

--- a/internal/model/query.go
+++ b/internal/model/query.go
@@ -52,14 +52,6 @@ type SearchResult struct {
 	SimilarityScore float32  `json:"similarity_score"`
 }
 
-// PagedResult wraps paginated query results.
-type PagedResult[T any] struct {
-	Items  []T `json:"items"`
-	Total  int `json:"total"`
-	Limit  int `json:"limit"`
-	Offset int `json:"offset"`
-}
-
 // CheckRequest is the request body for POST /v1/check.
 // It supports a lightweight precedent lookup before making a decision.
 type CheckRequest struct {

--- a/internal/ratelimit/ratelimit_test.go
+++ b/internal/ratelimit/ratelimit_test.go
@@ -229,8 +229,6 @@ func TestLimiterConcurrent(t *testing.T) {
 	}
 
 	// Fire 200 concurrent requests with limit of 100.
-	// Due to microsecond-precision member IDs, requests in the same
-	// microsecond may share an ID, causing minor variance in counts.
 	results := make(chan ratelimit.Result, 200)
 	for i := 0; i < 200; i++ {
 		go func() {

--- a/internal/search/outbox.go
+++ b/internal/search/outbox.go
@@ -100,7 +100,9 @@ func (w *OutboxWorker) pollLoop(ctx context.Context) {
 			w.once.Do(func() { close(w.done) })
 			return
 		case <-ticker.C:
-			w.processBatch(ctx)
+			batchCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+			w.processBatch(batchCtx)
+			cancel()
 		}
 	}
 }

--- a/internal/service/trace/buffer.go
+++ b/internal/service/trace/buffer.go
@@ -112,7 +112,10 @@ func (b *Buffer) flushLoop(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
-			b.flush(context.Background()) // Final flush on shutdown.
+			// Final flush with bounded timeout so shutdown can't hang forever.
+			flushCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			b.flush(flushCtx)
+			cancel()
 			close(b.done)
 			return
 		case <-ticker.C:

--- a/internal/storage/alternatives.go
+++ b/internal/storage/alternatives.go
@@ -11,30 +11,6 @@ import (
 	"github.com/ashita-ai/akashi/internal/model"
 )
 
-// CreateAlternative inserts a single alternative for a decision.
-func (db *DB) CreateAlternative(ctx context.Context, alt model.Alternative) (model.Alternative, error) {
-	if alt.ID == uuid.Nil {
-		alt.ID = uuid.New()
-	}
-	if alt.CreatedAt.IsZero() {
-		alt.CreatedAt = time.Now().UTC()
-	}
-	if alt.Metadata == nil {
-		alt.Metadata = map[string]any{}
-	}
-
-	_, err := db.pool.Exec(ctx,
-		`INSERT INTO alternatives (id, decision_id, label, score, selected, rejection_reason, metadata, created_at)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
-		alt.ID, alt.DecisionID, alt.Label, alt.Score, alt.Selected,
-		alt.RejectionReason, alt.Metadata, alt.CreatedAt,
-	)
-	if err != nil {
-		return model.Alternative{}, fmt.Errorf("storage: create alternative: %w", err)
-	}
-	return alt, nil
-}
-
 // CreateAlternativesBatch inserts multiple alternatives using COPY.
 func (db *DB) CreateAlternativesBatch(ctx context.Context, alts []model.Alternative) error {
 	if len(alts) == 0 {

--- a/internal/storage/decisions.go
+++ b/internal/storage/decisions.go
@@ -429,6 +429,7 @@ func buildDecisionWhereClause(orgID uuid.UUID, f model.QueryFilters, startArgIdx
 		if f.TimeRange.To != nil {
 			conditions = append(conditions, fmt.Sprintf("valid_from <= $%d", idx))
 			args = append(args, *f.TimeRange.To)
+			idx++ //nolint:ineffassign // keep idx consistent so future additions don't miscount
 		}
 	}
 

--- a/internal/storage/delete.go
+++ b/internal/storage/delete.go
@@ -36,7 +36,7 @@ func (db *DB) DeleteAgentData(ctx context.Context, orgID uuid.UUID, agentID stri
 	var result DeleteAgentResult
 
 	// Look up the agent's internal UUID for grant deletion.
-	var agentUUID string
+	var agentUUID uuid.UUID
 	err = tx.QueryRow(ctx, `SELECT id FROM agents WHERE org_id = $1 AND agent_id = $2`, orgID, agentID).Scan(&agentUUID)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {

--- a/internal/storage/events.go
+++ b/internal/storage/events.go
@@ -3,7 +3,6 @@ package storage
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -96,22 +95,6 @@ func (db *DB) GetEventsByRun(ctx context.Context, runID uuid.UUID) ([]model.Agen
 	)
 	if err != nil {
 		return nil, fmt.Errorf("storage: get events by run: %w", err)
-	}
-	defer rows.Close()
-
-	return scanEvents(rows)
-}
-
-// GetEventsByRunBeforeTime retrieves events for a run that occurred before a given time.
-// Used for context replay.
-func (db *DB) GetEventsByRunBeforeTime(ctx context.Context, runID uuid.UUID, before time.Time) ([]model.AgentEvent, error) {
-	rows, err := db.pool.Query(ctx,
-		`SELECT id, run_id, org_id, event_type, sequence_num, occurred_at, agent_id, payload, created_at
-		 FROM agent_events WHERE run_id = $1 AND occurred_at <= $2
-		 ORDER BY sequence_num ASC`, runID, before,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("storage: get events before time: %w", err)
 	}
 	defer rows.Close()
 


### PR DESCRIPTION
## Summary

- **Rate limiter ZADD collision**: Under high concurrency, requests landing in the same microsecond got identical sorted set member IDs, causing Redis ZADD to silently deduplicate instead of counting. Fixed with an atomic counter for globally unique member IDs.
- **Panic recovery middleware**: Handler panics now return 500 instead of crashing the process.
- **Billing handler bugs**: `GetUsage` error was silently discarded (200 OK with zero data); billing error logs referenced wrong org_id variable.
- **Query parameter bug**: `buildDecisionWhereClause` missing `idx++` after `TimeRange.To` — latent misalignment if filters are ever extended.
- **Security**: `/auth/verify` now rate-limited; OTEL TLS is configurable instead of hardcoded insecure.
- **Robustness**: 30s timeout on outbox batch processing; 10s timeout on buffer final flush.
- **Dead code**: Removed 5 unused types/functions (zero callers confirmed via grep).

## Test plan

- [x] All Go tests pass (`go test ./... -count=1` — 11 packages, 0 failures)
- [x] `TestLimiterConcurrent` now passes reliably (was flaky due to the ZADD collision bug)
- [x] TypeScript SDK tests pass (23/23)
- [x] Python SDK tests pass (10/10)
- [x] Go SDK tests pass (5/5)
- [x] `golangci-lint` clean (0 issues)
- [x] `go vet` clean
- [x] `atlas migrate validate` clean