### PR TITLE
Add tamper-evident integrity, revision chain, SSE conflicts, OTEL metrics

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,6 +67,7 @@ type Config struct {
 	// Operational settings.
 	LogLevel                string
 	ConflictRefreshInterval time.Duration
+	IntegrityProofInterval  time.Duration // How often to build Merkle tree proofs.
 	EventBufferSize         int
 	EventFlushTimeout       time.Duration
 	MaxRequestBodyBytes     int64 // Maximum request body size in bytes.
@@ -110,6 +111,7 @@ func Load() (Config, error) {
 		OutboxBatchSize:         envInt("AKASHI_OUTBOX_BATCH_SIZE", 100),
 		LogLevel:                envStr("AKASHI_LOG_LEVEL", "info"),
 		ConflictRefreshInterval: envDuration("AKASHI_CONFLICT_REFRESH_INTERVAL", 30*time.Second),
+		IntegrityProofInterval:  envDuration("AKASHI_INTEGRITY_PROOF_INTERVAL", 5*time.Minute),
 		EventBufferSize:         envInt("AKASHI_EVENT_BUFFER_SIZE", 1000),
 		EventFlushTimeout:       envDuration("AKASHI_EVENT_FLUSH_TIMEOUT", 100*time.Millisecond),
 		MaxRequestBodyBytes:     int64(envInt("AKASHI_MAX_REQUEST_BODY_BYTES", 1*1024*1024)), // 1 MB default

--- a/internal/integrity/integrity.go
+++ b/internal/integrity/integrity.go
@@ -1,0 +1,66 @@
+// Package integrity provides tamper-evident hashing and Merkle tree construction
+// for decision audit trails. All functions are pure and deterministic.
+package integrity
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ComputeContentHash produces a SHA-256 hex digest from the canonical decision fields.
+// The canonical form is: id|decision_type|outcome|confidence|reasoning|valid_from
+// where reasoning defaults to empty string if nil, and valid_from is RFC 3339 UTC.
+func ComputeContentHash(id uuid.UUID, decisionType, outcome string, confidence float32, reasoning *string, validFrom time.Time) string {
+	r := ""
+	if reasoning != nil {
+		r = *reasoning
+	}
+	canonical := fmt.Sprintf("%s|%s|%s|%g|%s|%s",
+		id.String(), decisionType, outcome, confidence, r, validFrom.UTC().Format(time.RFC3339Nano))
+	sum := sha256.Sum256([]byte(canonical))
+	return hex.EncodeToString(sum[:])
+}
+
+// VerifyContentHash recomputes the content hash and compares it to the stored value.
+func VerifyContentHash(stored string, id uuid.UUID, decisionType, outcome string, confidence float32, reasoning *string, validFrom time.Time) bool {
+	return stored == ComputeContentHash(id, decisionType, outcome, confidence, reasoning, validFrom)
+}
+
+// BuildMerkleRoot constructs a Merkle tree from leaf hashes and returns the root.
+// Leaves must be sorted lexicographically by the caller for determinism.
+// If leaves is empty, returns an empty string.
+// If leaves has one element, the root is that element.
+// Odd-length levels are handled by promoting the last node.
+func BuildMerkleRoot(leaves []string) string {
+	if len(leaves) == 0 {
+		return ""
+	}
+	if len(leaves) == 1 {
+		return leaves[0]
+	}
+
+	// Build tree bottom-up.
+	level := make([]string, len(leaves))
+	copy(level, leaves)
+
+	for len(level) > 1 {
+		var next []string
+		for i := 0; i < len(level); i += 2 {
+			if i+1 < len(level) {
+				combined := level[i] + level[i+1]
+				sum := sha256.Sum256([]byte(combined))
+				next = append(next, hex.EncodeToString(sum[:]))
+			} else {
+				// Odd node: promote without re-hashing.
+				next = append(next, level[i])
+			}
+		}
+		level = next
+	}
+
+	return level[0]
+}

--- a/internal/integrity/integrity_test.go
+++ b/internal/integrity/integrity_test.go
@@ -1,0 +1,118 @@
+package integrity
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func TestComputeContentHash_Deterministic(t *testing.T) {
+	id := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	validFrom := time.Date(2026, 1, 15, 10, 30, 0, 0, time.UTC)
+	reasoning := "chose microservices for scalability"
+
+	h1 := ComputeContentHash(id, "architecture", "microservices", 0.85, &reasoning, validFrom)
+	h2 := ComputeContentHash(id, "architecture", "microservices", 0.85, &reasoning, validFrom)
+
+	if h1 != h2 {
+		t.Fatalf("hash not deterministic: %q != %q", h1, h2)
+	}
+	if len(h1) != 64 {
+		t.Fatalf("expected 64-char hex SHA-256, got %d chars", len(h1))
+	}
+}
+
+func TestComputeContentHash_NilReasoning(t *testing.T) {
+	id := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	validFrom := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+
+	h1 := ComputeContentHash(id, "deploy", "production", 0.9, nil, validFrom)
+	reasoning := ""
+	h2 := ComputeContentHash(id, "deploy", "production", 0.9, &reasoning, validFrom)
+
+	if h1 != h2 {
+		t.Fatalf("nil reasoning and empty string reasoning should produce the same hash: %q != %q", h1, h2)
+	}
+}
+
+func TestComputeContentHash_DifferentInputs(t *testing.T) {
+	id := uuid.MustParse("33333333-3333-3333-3333-333333333333")
+	validFrom := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+
+	h1 := ComputeContentHash(id, "architecture", "monolith", 0.7, nil, validFrom)
+	h2 := ComputeContentHash(id, "architecture", "microservices", 0.7, nil, validFrom)
+
+	if h1 == h2 {
+		t.Fatal("different outcomes should produce different hashes")
+	}
+}
+
+func TestVerifyContentHash(t *testing.T) {
+	id := uuid.MustParse("44444444-4444-4444-4444-444444444444")
+	validFrom := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+	reasoning := "cost analysis favored option B"
+
+	hash := ComputeContentHash(id, "vendor", "option_b", 0.92, &reasoning, validFrom)
+
+	if !VerifyContentHash(hash, id, "vendor", "option_b", 0.92, &reasoning, validFrom) {
+		t.Fatal("verification should succeed for matching inputs")
+	}
+
+	if VerifyContentHash(hash, id, "vendor", "option_a", 0.92, &reasoning, validFrom) {
+		t.Fatal("verification should fail for different outcome")
+	}
+
+	if VerifyContentHash("tampered_hash", id, "vendor", "option_b", 0.92, &reasoning, validFrom) {
+		t.Fatal("verification should fail for tampered hash")
+	}
+}
+
+func TestBuildMerkleRoot_Empty(t *testing.T) {
+	root := BuildMerkleRoot(nil)
+	if root != "" {
+		t.Fatalf("empty input should produce empty root, got %q", root)
+	}
+}
+
+func TestBuildMerkleRoot_SingleLeaf(t *testing.T) {
+	leaf := "abc123"
+	root := BuildMerkleRoot([]string{leaf})
+	if root != leaf {
+		t.Fatalf("single leaf should be the root: got %q, want %q", root, leaf)
+	}
+}
+
+func TestBuildMerkleRoot_Deterministic(t *testing.T) {
+	leaves := []string{"hash_a", "hash_b", "hash_c", "hash_d"}
+
+	r1 := BuildMerkleRoot(leaves)
+	r2 := BuildMerkleRoot(leaves)
+
+	if r1 != r2 {
+		t.Fatalf("Merkle root not deterministic: %q != %q", r1, r2)
+	}
+	if len(r1) != 64 {
+		t.Fatalf("expected 64-char hex SHA-256 root, got %d chars", len(r1))
+	}
+}
+
+func TestBuildMerkleRoot_OrderMatters(t *testing.T) {
+	r1 := BuildMerkleRoot([]string{"a", "b", "c"})
+	r2 := BuildMerkleRoot([]string{"b", "a", "c"})
+
+	if r1 == r2 {
+		t.Fatal("different leaf ordering should produce different roots")
+	}
+}
+
+func TestBuildMerkleRoot_OddLeafCount(t *testing.T) {
+	// With 3 leaves: pair (0,1), promote (2). Then pair (hash01, leaf2) → root.
+	root := BuildMerkleRoot([]string{"x", "y", "z"})
+	if root == "" {
+		t.Fatal("odd leaf count should still produce a root")
+	}
+	if len(root) != 64 {
+		t.Fatalf("expected 64-char hex SHA-256 root, got %d chars", len(root))
+	}
+}

--- a/internal/model/decision.go
+++ b/internal/model/decision.go
@@ -27,6 +27,12 @@ type Decision struct {
 	// Precedent reference: decision that influenced this one.
 	PrecedentRef *uuid.UUID `json:"precedent_ref,omitempty"`
 
+	// Revision chain: ID of the decision this one supersedes.
+	SupersedesID *uuid.UUID `json:"supersedes_id,omitempty"`
+
+	// Tamper-evident SHA-256 content hash of canonical decision fields.
+	ContentHash string `json:"content_hash,omitempty"`
+
 	// Bi-temporal columns.
 	ValidFrom       time.Time  `json:"valid_from"`
 	ValidTo         *time.Time `json:"valid_to,omitempty"`

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -141,6 +141,12 @@ func New(cfg ServerConfig) *Server {
 	// Recent decisions (reader+).
 	mux.Handle("GET /v1/decisions/recent", queryRL(readRole(http.HandlerFunc(h.HandleDecisionsRecent))))
 
+	// Decision revision history (reader+).
+	mux.Handle("GET /v1/decisions/{id}/revisions", queryRL(readRole(http.HandlerFunc(h.HandleDecisionRevisions))))
+
+	// Integrity verification (reader+).
+	mux.Handle("GET /v1/verify/{id}", queryRL(readRole(http.HandlerFunc(h.HandleVerifyDecision))))
+
 	// Subscription endpoint (reader+, no rate limit — long-lived connection).
 	mux.Handle("GET /v1/subscribe", readRole(http.HandlerFunc(h.HandleSubscribe)))
 

--- a/internal/storage/integrity.go
+++ b/internal/storage/integrity.go
@@ -1,0 +1,102 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// IntegrityProof represents a Merkle tree batch proof for an organization.
+type IntegrityProof struct {
+	ID            uuid.UUID `json:"id"`
+	OrgID         uuid.UUID `json:"org_id"`
+	BatchStart    time.Time `json:"batch_start"`
+	BatchEnd      time.Time `json:"batch_end"`
+	DecisionCount int       `json:"decision_count"`
+	RootHash      string    `json:"root_hash"`
+	PreviousRoot  *string   `json:"previous_root,omitempty"`
+	CreatedAt     time.Time `json:"created_at"`
+}
+
+// GetLatestIntegrityProof returns the most recent integrity proof for an org.
+// Returns nil if no proofs exist.
+func (db *DB) GetLatestIntegrityProof(ctx context.Context, orgID uuid.UUID) (*IntegrityProof, error) {
+	var p IntegrityProof
+	err := db.pool.QueryRow(ctx,
+		`SELECT id, org_id, batch_start, batch_end, decision_count, root_hash, previous_root, created_at
+		 FROM integrity_proofs
+		 WHERE org_id = $1
+		 ORDER BY created_at DESC
+		 LIMIT 1`, orgID,
+	).Scan(&p.ID, &p.OrgID, &p.BatchStart, &p.BatchEnd, &p.DecisionCount, &p.RootHash, &p.PreviousRoot, &p.CreatedAt)
+	if err != nil {
+		if err.Error() == "no rows in result set" {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("storage: get latest integrity proof: %w", err)
+	}
+	return &p, nil
+}
+
+// CreateIntegrityProof inserts a new integrity proof.
+func (db *DB) CreateIntegrityProof(ctx context.Context, p IntegrityProof) error {
+	if p.ID == uuid.Nil {
+		p.ID = uuid.New()
+	}
+	_, err := db.pool.Exec(ctx,
+		`INSERT INTO integrity_proofs (id, org_id, batch_start, batch_end, decision_count, root_hash, previous_root, created_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+		p.ID, p.OrgID, p.BatchStart, p.BatchEnd, p.DecisionCount, p.RootHash, p.PreviousRoot, p.CreatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("storage: create integrity proof: %w", err)
+	}
+	return nil
+}
+
+// GetDecisionHashesForBatch returns content_hash values for decisions in an org
+// created between since (exclusive) and until (inclusive), ordered lexicographically.
+func (db *DB) GetDecisionHashesForBatch(ctx context.Context, orgID uuid.UUID, since, until time.Time) ([]string, error) {
+	rows, err := db.pool.Query(ctx,
+		`SELECT content_hash FROM decisions
+		 WHERE org_id = $1 AND created_at > $2 AND created_at <= $3
+		   AND content_hash IS NOT NULL AND content_hash != ''
+		 ORDER BY content_hash ASC`,
+		orgID, since, until,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("storage: get decision hashes for batch: %w", err)
+	}
+	defer rows.Close()
+
+	var hashes []string
+	for rows.Next() {
+		var h string
+		if err := rows.Scan(&h); err != nil {
+			return nil, fmt.Errorf("storage: scan decision hash: %w", err)
+		}
+		hashes = append(hashes, h)
+	}
+	return hashes, rows.Err()
+}
+
+// ListOrganizationIDs returns all active organization IDs.
+func (db *DB) ListOrganizationIDs(ctx context.Context) ([]uuid.UUID, error) {
+	rows, err := db.pool.Query(ctx, `SELECT id FROM organizations ORDER BY id`)
+	if err != nil {
+		return nil, fmt.Errorf("storage: list organization IDs: %w", err)
+	}
+	defer rows.Close()
+
+	var ids []uuid.UUID
+	for rows.Next() {
+		var id uuid.UUID
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("storage: scan organization ID: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}

--- a/migrations/020_revision_chain.sql
+++ b/migrations/020_revision_chain.sql
@@ -1,0 +1,21 @@
+-- Decision revision chain: links revised decisions to their predecessors.
+ALTER TABLE decisions ADD COLUMN supersedes_id UUID REFERENCES decisions(id);
+CREATE INDEX idx_decisions_supersedes ON decisions(supersedes_id) WHERE supersedes_id IS NOT NULL;
+
+-- Tamper-evident content hash: SHA-256 of canonical decision fields.
+ALTER TABLE decisions ADD COLUMN content_hash TEXT;
+CREATE INDEX idx_decisions_content_hash ON decisions(content_hash) WHERE content_hash IS NOT NULL;
+
+-- Merkle tree integrity proofs: periodic batch hashes for tamper detection.
+CREATE TABLE integrity_proofs (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    org_id          UUID NOT NULL REFERENCES organizations(id),
+    batch_start     TIMESTAMPTZ NOT NULL,
+    batch_end       TIMESTAMPTZ NOT NULL,
+    decision_count  INTEGER NOT NULL,
+    root_hash       TEXT NOT NULL,
+    previous_root   TEXT,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_integrity_proofs_org_time ON integrity_proofs(org_id, created_at DESC);

--- a/migrations/atlas.sum
+++ b/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:LiQ/JechJXRvAFKdpXSxVgcXRfjBqVCixbs1B+08mHE=
+h1:UpDp/k4k7XAFvDW18IqchcAMO45dqHYxKkahChYd2Ww=
 001_create_agent_runs.sql h1:kt1hhf4ttnT0iglMXihEJCZtiKBhSYli5HeMcFaKGl0=
 002_create_agent_events.sql h1:teJwKwJaghjyJj9JYW/KgD8tCMZm9h1IqAUPLtmvqmA=
 003_create_decisions.sql h1:/uCnEUGTvX6VRfOtLygpUXpx/JJ58uijEAm0mQt0MNA=
@@ -16,3 +16,4 @@ h1:LiQ/JechJXRvAFKdpXSxVgcXRfjBqVCixbs1B+08mHE=
 017_search_outbox.sql h1:/mr2WUe1WOxpdExx1fQPzol7hkZ9RLsGRwsy3JMdfU4=
 018_auth_lookup_index.sql h1:mWVyPxpborlQbm9+FwkzgO96DCW2hOYaIX0/HqsSBFI=
 019_text_search_index.sql h1:24xjvADSB+/E2O1uOPl8Yxw6SkfOwqravuOhQqURidM=
+020_revision_chain.sql h1:8vsQ3FSUAZCSTjfR7dXae10+BWx7v+Y3ZA4E4ePQWIM=


### PR DESCRIPTION
## Summary

- **Integrity layer**: SHA-256 content hashes on every decision at INSERT time, Merkle tree batch proofs via background goroutine, `GET /v1/verify/{id}` for cryptographic verification, `integrity_proofs` table with chained roots per org
- **Revision chain**: `supersedes_id` foreign key links revised decisions to predecessors, `GET /v1/decisions/{id}/revisions` returns full chain via recursive CTE
- **SSE conflict notifications**: `conflictRefreshLoop` detects new conflicts after each mat view refresh and sends `pg_notify` on `akashi_conflicts` channel
- **OTEL application metrics**: buffer depth/dropped gauges, embedding/search duration histograms, outbox depth gauge
- **Bug fix**: `HandleQuery` pagination was using `len(decisions)` instead of DB total count

Migration 020 adds `supersedes_id`, `content_hash` columns to decisions and creates `integrity_proofs` table.

## Test plan

- [ ] `go test ./...` passes (including 8 new integrity tests)
- [ ] `golangci-lint run ./...` — 0 issues
- [ ] `atlas migrate validate --dir file://migrations` passes
- [ ] Trace a decision via `POST /v1/trace` — verify `content_hash` is populated
- [ ] Call `GET /v1/verify/{id}` — verify `valid: true`
- [ ] Create two conflicting decisions — verify SSE delivers `akashi_conflicts` event within 30s
- [ ] Call `GET /v1/decisions/{id}/revisions` on a revised decision — verify chain returned