### PR TITLE
Implement OTEL trace correlation (spec 14)

### DIFF
--- a/internal/model/query.go
+++ b/internal/model/query.go
@@ -30,6 +30,7 @@ type QueryRequest struct {
 	OrderDir string       `json:"order_dir,omitempty"`
 	Limit    int          `json:"limit,omitempty"`
 	Offset   int          `json:"offset,omitempty"`
+	TraceID  *string      `json:"trace_id,omitempty"` // Filter by OTEL trace ID (matches agent_runs.trace_id).
 }
 
 // TemporalQueryRequest is the request body for POST /v1/query/temporal.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -186,10 +186,11 @@ func New(cfg ServerConfig) *Server {
 	}
 
 	// Middleware chain (outermost executes first):
-	// request ID → security headers → CORS → tracing → logging → auth → recovery → handler.
+	// request ID → security headers → CORS → tracing → logging → baggage → auth → recovery → handler.
 	var handler http.Handler = mux
 	handler = recoveryMiddleware(cfg.Logger, handler)
 	handler = authMiddleware(cfg.JWTMgr, handler)
+	handler = baggageMiddleware(handler)
 	handler = loggingMiddleware(cfg.Logger, handler)
 	handler = tracingMiddleware(handler)
 	handler = corsMiddleware(handler)

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -10,6 +10,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/propagation"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -56,6 +57,16 @@ func Init(ctx context.Context, endpoint, serviceName, version string, insecure b
 		sdktrace.WithResource(res),
 	)
 	otel.SetTracerProvider(tp)
+
+	// Register W3C Trace Context and Baggage propagators.
+	// This enables automatic extraction of incoming traceparent/tracestate/baggage
+	// headers and injection into outgoing requests (e.g., embedding API calls).
+	otel.SetTextMapPropagator(
+		propagation.NewCompositeTextMapPropagator(
+			propagation.TraceContext{},
+			propagation.Baggage{},
+		),
+	)
 
 	// Metric exporter.
 	metricOpts := []otlpmetrichttp.Option{

--- a/sdk/python/src/akashi/__init__.py
+++ b/sdk/python/src/akashi/__init__.py
@@ -13,6 +13,7 @@ from akashi.exceptions import (
     ValidationError,
 )
 from akashi.middleware import AkashiMiddleware, AkashiSyncMiddleware
+from akashi.otel import trace_id_from_context
 from akashi.types import (
     Agent,
     AgentEvent,
@@ -76,6 +77,8 @@ __all__ = [
     "SearchResponse",
     "HealthResponse",
     "UsageResponse",
+    # OTEL helpers
+    "trace_id_from_context",
     # Exceptions
     "AkashiError",
     "AuthenticationError",

--- a/sdk/python/src/akashi/otel.py
+++ b/sdk/python/src/akashi/otel.py
@@ -1,0 +1,25 @@
+"""Optional OTEL trace context helpers for Akashi.
+
+These functions gracefully degrade when the opentelemetry-api package is not
+installed. They are convenience wrappers that extract the current OTEL trace ID
+so it can be passed to Akashi's trace_id field without manual header
+construction.
+"""
+
+
+def trace_id_from_context() -> str | None:
+    """Extract the current OTEL trace ID, if available.
+
+    Returns the 32-character lowercase hex trace ID from the active OTEL span,
+    or None if OTEL is not installed or no active span exists.
+    """
+    try:
+        from opentelemetry import trace as otel_trace
+
+        span = otel_trace.get_current_span()
+        ctx = span.get_span_context()
+        if ctx.is_valid:
+            return format(ctx.trace_id, "032x")
+    except ImportError:
+        pass
+    return None

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -1,6 +1,7 @@
 export { AkashiClient } from "./client.js";
 export { withAkashi } from "./middleware.js";
 export { TokenManager } from "./auth.js";
+export { traceIdFromContext } from "./otel.js";
 export {
   AkashiError,
   AuthenticationError,

--- a/sdk/typescript/src/otel.ts
+++ b/sdk/typescript/src/otel.ts
@@ -1,0 +1,31 @@
+/**
+ * Optional OTEL trace context helpers for Akashi.
+ *
+ * These functions gracefully degrade when @opentelemetry/api is not installed.
+ * They extract the current OTEL trace ID so it can be passed to Akashi's
+ * trace_id field without manual header construction.
+ */
+
+/**
+ * Extract the current OTEL trace ID from the active span, if available.
+ *
+ * Returns the 32-character lowercase hex trace ID, or undefined if
+ * @opentelemetry/api is not installed or no active span exists.
+ */
+export function traceIdFromContext(): string | undefined {
+  try {
+    // Dynamic require so this module doesn't hard-depend on @opentelemetry/api.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { trace } = require("@opentelemetry/api");
+    const span = trace.getActiveSpan();
+    if (span) {
+      const ctx = span.spanContext();
+      if (ctx.traceId !== "00000000000000000000000000000000") {
+        return ctx.traceId;
+      }
+    }
+  } catch {
+    // @opentelemetry/api not installed — that's fine.
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Summary

- Register W3C TraceContext + Baggage propagators at OTEL init time, enabling automatic extraction of incoming `traceparent`/`tracestate` headers and propagation to outgoing embedding API calls
- Inject `traceparent`/`tracestate` into response headers for client-side trace correlation
- Add `baggageMiddleware` that extracts `akashi.context_id` from OTEL baggage and sets it as a span attribute
- Set `akashi.trace_id`, `akashi.agent_id`, and `akashi.decision_type` as span attributes in `Trace()` and `HandleCreateRun`
- Add `trace_id` filter to `POST /v1/query` via `agent_runs` subquery
- Add SDK helpers: `trace_id_from_context()` (Python) and `traceIdFromContext()` (TypeScript) with graceful OTEL degradation

Closes ADR-010 OTEL integration gaps.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `golangci-lint run ./...` passes (0 issues)
- [x] `go test ./...` passes (all packages)
- [x] `atlas migrate validate` passes
- [ ] Manual: send request with `traceparent` header, verify response includes `traceparent`
- [ ] Manual: `POST /v1/trace` with `trace_id`, verify OTEL span has `akashi.trace_id` attribute
- [ ] Manual: `POST /v1/query` with `trace_id` filter, verify only matching decisions returned
- [ ] Manual: send request with `Baggage: akashi.context_id=abc`, verify span attribute set