### PR TITLE
Fix review findings: races, pagination, export, rate limiter

### DIFF
--- a/internal/ratelimit/ratelimit_test.go
+++ b/internal/ratelimit/ratelimit_test.go
@@ -70,7 +70,7 @@ func TestMain(m *testing.M) {
 func newTestLimiter(t *testing.T) *ratelimit.Limiter {
 	t.Helper()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
-	return ratelimit.New(testRedis, logger)
+	return ratelimit.New(testRedis, logger, false)
 }
 
 func TestLimiterAllow(t *testing.T) {
@@ -156,7 +156,7 @@ func TestLimiterNoopMode(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
 
 	// Noop mode: nil client allows all requests.
-	limiter := ratelimit.New(nil, logger)
+	limiter := ratelimit.New(nil, logger, false)
 
 	rule := ratelimit.Rule{
 		Prefix: "test-noop",

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -203,6 +203,7 @@ func New(cfg ServerConfig) *Server {
 			Handler:      handler,
 			ReadTimeout:  cfg.ReadTimeout,
 			WriteTimeout: cfg.WriteTimeout,
+			IdleTimeout:  2 * cfg.ReadTimeout, // Prevent accumulation of idle connections.
 		},
 		handler:  handler,
 		handlers: h,


### PR DESCRIPTION
## Summary

**P0 — correctness bugs:**
- **Pagination totals after access filtering**: `HandleQuery` and `HandleDecisionsRecent` returned the pre-filter DB `COUNT(*)` as `total`, lying to non-admin clients about how many results exist. Now adjusts `total` to `len(decisions)` when filtering removed items.
- **OutboxWorker.drainCtx data race**: `drainCtx` field written by `Drain()` on the main goroutine and read by `pollLoop()` on the background goroutine with no synchronization. Same pattern as the Buffer race fixed in 27a1900. Replaced with `chan context.Context` buffered channel.
- **Redundant sort in integrityProofLoop**: `sort.Strings(hashes)` called after SQL already `ORDER BY content_hash ASC`. Removed the sort and clarified the comment.

**P1 — edge case correctness:**
- **Rate limiter fail-open when RequireRedis**: `Allow()` was unconditionally fail-open on Redis errors, silently disabling rate limiting during Redis outages. When `RequireRedis` is set, runtime Redis failures now deny requests (fail-closed).

**P2 — design improvements:**
- **Export offset pagination → keyset cursor**: `HandleExportDecisions` used `OFFSET` which degrades to O(offset) per page. New `ExportDecisionsCursor` storage method uses `(valid_from, id)` keyset for O(1) per page at any position.
- **No IdleTimeout**: HTTP server lacked `IdleTimeout`, allowing idle connections to accumulate. Set to `2 * ReadTimeout`.
- **OTEL instruments created per-request**: `httpMeter.Int64Counter` / `Float64Histogram` called on every request (OTEL deduplicates but still allocates). Moved to package-level `init()`.

## Test plan

- [x] `go test -race -count=1 ./...` — all pass, no races
- [x] `go build ./...` / `go vet ./...` / `golangci-lint run ./...` — clean
- [x] `atlas migrate validate` — clean
- [ ] Verify pagination `total` is accurate for non-admin users with access grants
- [ ] Verify export streams correctly for large datasets (>1000 decisions)
- [ ] Verify rate limiting denies requests when `AKASHI_REQUIRE_REDIS=true` and Redis is down