### PR TITLE
Add tag-based access control for agents

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -273,6 +273,38 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
+  /v1/agents/{agent_id}/tags:
+    patch:
+      operationId: updateAgentTags
+      tags: [Agents]
+      summary: Update an agent's tags
+      description: |
+        Replace the tags for an agent. Tags enable group-based access control:
+        agents sharing at least one tag can see each other's decisions without
+        explicit grants. Tags coexist with the existing grant system.
+        Requires `admin` role or higher.
+      parameters:
+        - $ref: "#/components/parameters/AgentIDPath"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateAgentTagsRequest"
+      responses:
+        "200":
+          description: Tags updated. Returns the updated agent.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/APIResponse_Agent"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
   # ── Runs ───────────────────────────────────────────────────────────
   /v1/runs:
     post:
@@ -1285,7 +1317,7 @@ components:
 
     Agent:
       type: object
-      required: [id, agent_id, org_id, name, role, metadata, created_at, updated_at]
+      required: [id, agent_id, org_id, name, role, tags, metadata, created_at, updated_at]
       properties:
         id:
           type: string
@@ -1299,6 +1331,13 @@ components:
           type: string
         role:
           $ref: "#/components/schemas/AgentRole"
+        tags:
+          type: array
+          items:
+            type: string
+          description: |
+            Tags for group-based access control. Agents sharing at least one
+            tag can see each other's decisions. Must match `^[a-z][a-z0-9_-]*$`.
         metadata:
           type: object
           additionalProperties: true
@@ -1321,9 +1360,26 @@ components:
           $ref: "#/components/schemas/AgentRole"
         api_key:
           type: string
+        tags:
+          type: array
+          items:
+            type: string
+          description: Optional tags for group-based access control.
         metadata:
           type: object
           additionalProperties: true
+
+    UpdateAgentTagsRequest:
+      type: object
+      required: [tags]
+      properties:
+        tags:
+          type: array
+          items:
+            type: string
+          description: |
+            New set of tags for the agent. Replaces existing tags entirely.
+            Each tag must match `^[a-z][a-z0-9_-]*$`.
 
     DeleteAgentResponse:
       type: object

--- a/internal/model/agent.go
+++ b/internal/model/agent.go
@@ -26,6 +26,7 @@ type Agent struct {
 	Name       string         `json:"name"`
 	Role       AgentRole      `json:"role"`
 	APIKeyHash *string        `json:"-"`
+	Tags       []string       `json:"tags"`
 	Metadata   map[string]any `json:"metadata"`
 	CreatedAt  time.Time      `json:"created_at"`
 	UpdatedAt  time.Time      `json:"updated_at"`
@@ -80,6 +81,31 @@ func RoleRank(r AgentRole) int {
 // RoleAtLeast returns true if role r has at least the privileges of minRole.
 func RoleAtLeast(r, minRole AgentRole) bool {
 	return RoleRank(r) >= RoleRank(minRole)
+}
+
+// ValidateTag checks that a tag conforms to the allowed format.
+// Tags must start with a lowercase letter and contain only lowercase
+// alphanumeric characters, hyphens, and underscores.
+func ValidateTag(tag string) error {
+	if len(tag) == 0 {
+		return fmt.Errorf("tag must not be empty")
+	}
+	if len(tag) > 64 {
+		return fmt.Errorf("tag must be at most 64 characters")
+	}
+	for i := 0; i < len(tag); i++ {
+		c := tag[i]
+		if i == 0 {
+			if c < 'a' || c > 'z' {
+				return fmt.Errorf("tag must start with a lowercase letter, got %q", c)
+			}
+			continue
+		}
+		if (c < 'a' || c > 'z') && (c < '0' || c > '9') && c != '-' && c != '_' {
+			return fmt.Errorf("tag contains invalid character at position %d: %q", i, c)
+		}
+	}
+	return nil
 }
 
 // ValidateAgentID checks that an agent ID conforms to the allowed format.

--- a/internal/model/api.go
+++ b/internal/model/api.go
@@ -123,7 +123,13 @@ type CreateAgentRequest struct {
 	Name     string         `json:"name"`
 	Role     AgentRole      `json:"role"`
 	APIKey   string         `json:"api_key"`
+	Tags     []string       `json:"tags,omitempty"`
 	Metadata map[string]any `json:"metadata,omitempty"`
+}
+
+// UpdateAgentTagsRequest is the request body for PATCH /v1/agents/{agent_id}/tags.
+type UpdateAgentTagsRequest struct {
+	Tags []string `json:"tags"`
 }
 
 // CreateGrantRequest is the request body for POST /v1/grants.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -115,6 +115,7 @@ func New(cfg ServerConfig) *Server {
 	adminOnly := requireRole(model.RoleAdmin)
 	mux.Handle("POST /v1/agents", adminOnly(http.HandlerFunc(h.HandleCreateAgent)))
 	mux.Handle("GET /v1/agents", adminOnly(http.HandlerFunc(h.HandleListAgents)))
+	mux.Handle("PATCH /v1/agents/{agent_id}/tags", adminOnly(http.HandlerFunc(h.HandleUpdateAgentTags)))
 	mux.Handle("DELETE /v1/agents/{agent_id}", adminOnly(http.HandlerFunc(h.HandleDeleteAgent)))
 	mux.Handle("GET /v1/export/decisions", adminOnly(http.HandlerFunc(h.HandleExportDecisions)))
 

--- a/migrations/022_agent_tags.sql
+++ b/migrations/022_agent_tags.sql
@@ -1,0 +1,8 @@
+-- Add tags to agents for group-based access control.
+-- Tags are string arrays; agents sharing at least one tag can see each other's decisions.
+-- Coexists with the existing per-agent grant system in access_grants.
+
+ALTER TABLE agents ADD COLUMN tags TEXT[] NOT NULL DEFAULT '{}';
+
+-- GIN index enables efficient && (overlap) queries for tag-based access lookups.
+CREATE INDEX idx_agents_tags ON agents USING GIN (tags);

--- a/migrations/atlas.sum
+++ b/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:X7VwaYIXHiwll+eimqLMoys2S9EyqcYYHGrimg8W74U=
+h1:Oxk1uvgBDGS+/sqbaRDTSTqlVQXPGGWxQAXttjbx0FA=
 001_create_agent_runs.sql h1:kt1hhf4ttnT0iglMXihEJCZtiKBhSYli5HeMcFaKGl0=
 002_create_agent_events.sql h1:teJwKwJaghjyJj9JYW/KgD8tCMZm9h1IqAUPLtmvqmA=
 003_create_decisions.sql h1:/uCnEUGTvX6VRfOtLygpUXpx/JJ58uijEAm0mQt0MNA=
@@ -18,3 +18,4 @@ h1:X7VwaYIXHiwll+eimqLMoys2S9EyqcYYHGrimg8W74U=
 019_text_search_index.sql h1:24xjvADSB+/E2O1uOPl8Yxw6SkfOwqravuOhQqURidM=
 020_revision_chain.sql h1:8vsQ3FSUAZCSTjfR7dXae10+BWx7v+Y3ZA4E4ePQWIM=
 021_remove_unused_rls.sql h1:TPRW1jP23Rbbpe+tcCBSBE/EkAiXsg67NQO9pQk/TR0=
+022_agent_tags.sql h1:jx5SVZthr/0Qu/v3MqdvW9tpIrBgVeG835vQxetYEWw=


### PR DESCRIPTION
## Summary

- Adds `tags TEXT[]` column to agents with a GIN index for efficient overlap queries
- Agents sharing at least one tag can see each other's decisions (any-overlap rule) without requiring explicit per-agent grants
- Tags coexist with the existing grant system — grants handle one-off exceptions, tags handle group access
- New `PATCH /v1/agents/{agent_id}/tags` endpoint (admin-only) for updating tags
- `LoadGrantedSet` and `CanAccessAgent` merge tag-based matches with grant-based matches; all downstream filters (decisions, search, conflicts, MCP) benefit automatically

## Motivation

The current per-agent grant model requires O(n²) rows for group access — 50 agents in a "finance" team all needing to see each other's traces requires 2,450 grant rows. Tags reduce this to 50 rows (one per agent) with a single tag value.

## Files changed

| File | Change |
|------|--------|
| `migrations/022_agent_tags.sql` | `tags TEXT[]` + GIN index |
| `internal/model/agent.go` | `Tags` field, `ValidateTag` |
| `internal/model/api.go` | `Tags` on `CreateAgentRequest`, `UpdateAgentTagsRequest` |
| `internal/storage/agents.go` | All scan helpers, `ListAgentIDsBySharedTags`, `UpdateAgentTags` |
| `internal/authz/authz.go` | `LoadGrantedSet` + `CanAccessAgent` tag merging |
| `internal/server/handlers_admin.go` | Tag validation on create, `HandleUpdateAgentTags` |
| `internal/server/server.go` | `PATCH /v1/agents/{agent_id}/tags` route |
| `api/openapi.yaml` | Schema + endpoint docs |
| `internal/storage/storage_test.go` | 5 integration tests |

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] `atlas migrate validate` — valid
- [x] `go test -race -count=1 ./...` — all pass
- [ ] Manual: create two agents with tag `["finance"]` → they see each other's decisions
- [ ] Manual: agent with `["legal"]` cannot see finance decisions
- [ ] Manual: add `"finance"` tag to legal agent → now sees finance decisions
- [ ] Manual: existing grant-based access still works alongside tags