### PR TITLE
Upgrade PostgreSQL 17 to 18

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,7 @@ go vet ./...
 # Build
 go build -o bin/akashi ./cmd/akashi
 
-# Docker — local stack (Postgres 17 + pgvector + TimescaleDB, no cloud deps)
+# Docker — local stack (Postgres 18 + pgvector + TimescaleDB, no cloud deps)
 docker compose -f docker/docker-compose.local.yml up -d
 docker compose -f docker/docker-compose.local.yml down
 
@@ -162,7 +162,7 @@ Gitignored. Use for temporary research, drafts, debugging notes, SQL experiments
 
 ### Storage
 
-Single PostgreSQL 17 instance with extensions:
+Single PostgreSQL 18 instance with extensions:
 - **pgvector** (HNSW indexes) for semantic search over decision traces
 - **TimescaleDB** for time-series event ingestion and partitioning
 - **JSONB** for facet-based extensibility (OpenLineage pattern)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # ashita-ai/akashi
 
-Decision trace layer for multi-agent AI systems. Go 1.25, PostgreSQL 17 + pgvector + TimescaleDB.
+Decision trace layer for multi-agent AI systems. Go 1.25, PostgreSQL 18 + pgvector + TimescaleDB.
 
 ## Before every commit
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ flowchart TD
     CONFLICT --> PG
     BILLING --> PG
 
-    PG[("PostgreSQL 17<br/>pgvector + TimescaleDB")]
+    PG[("PostgreSQL 18<br/>pgvector + TimescaleDB")]
 
     style C1 fill:#f0f4ff,stroke:#4a6fa5
     style C2 fill:#f0f4ff,stroke:#4a6fa5

--- a/adrs/ADR-002-unified-postgres-storage.md
+++ b/adrs/ADR-002-unified-postgres-storage.md
@@ -22,7 +22,7 @@ The storage architecture:
 
 | Concern | Technology | Deployment |
 |---------|-----------|------------|
-| Source of truth | PostgreSQL 17 | Always |
+| Source of truth | PostgreSQL 18 | Always |
 | Embeddings (source of truth) | pgvector column | Always (stored for Qdrant sync, not indexed for search) |
 | Vector search | Qdrant | Optional (cloud, multi-tenant) |
 | Time-series events | TimescaleDB | Always |
@@ -82,7 +82,7 @@ The vector search trigger from the original ADR has been exercised — Qdrant wa
 - Core storage in `internal/storage/`, search abstraction in `internal/search/`.
 - Migrations are forward-only SQL files in `migrations/`.
 - The `Searcher` interface abstracts vector search backend selection.
-- Docker Compose for OSS bundles Postgres 17 + pgvector + TimescaleDB. No Qdrant.
+- Docker Compose for OSS bundles Postgres 18 + pgvector + TimescaleDB. No Qdrant.
 - Cloud deployment adds Qdrant as a separate service with outbox-based sync.
 - The pgvector HNSW index on `decisions.embedding` was dropped in migration 017 (Qdrant replaces it). The `evidence.embedding` HNSW index remains. The `decisions.embedding` column is retained as source of truth for Qdrant outbox sync.
 

--- a/docker/docker-compose.local.yml
+++ b/docker/docker-compose.local.yml
@@ -11,7 +11,7 @@
 
 services:
   postgres:
-    image: timescale/timescaledb-ha:pg17
+    image: timescale/timescaledb-ha:pg18
     container_name: akashi-local-postgres
     restart: unless-stopped
     ports:

--- a/docs/technical-deep-dive.md
+++ b/docs/technical-deep-dive.md
@@ -60,7 +60,7 @@ Akashi is a decision audit layer for multi-agent AI systems. It captures, stores
                 │                              │
                 ▼                              ▼
 ┌─────────────────────────────────────────────────────────────────────┐
-│                    PostgreSQL 17                                     │
+│                    PostgreSQL 18                                     │
 │  ┌───────────────┐  ┌────────────────┐  ┌─────────────────────────┐ │
 │  │   pgvector    │  │  TimescaleDB   │  │    LISTEN/NOTIFY        │ │
 │  │ (similarity)  │  │ (time-series)  │  │  (real-time events)     │ │

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -44,7 +44,7 @@ func TestMain(m *testing.M) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	req := testcontainers.ContainerRequest{
-		Image:        "timescale/timescaledb:latest-pg17",
+		Image:        "timescale/timescaledb:latest-pg18",
 		ExposedPorts: []string{"5432/tcp"},
 		Env: map[string]string{
 			"POSTGRES_USER":     "akashi",

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -27,7 +27,7 @@ func TestMain(m *testing.M) {
 
 	// Start a TimescaleDB container with pgvector.
 	req := testcontainers.ContainerRequest{
-		Image:        "timescale/timescaledb:latest-pg17",
+		Image:        "timescale/timescaledb:latest-pg18",
 		ExposedPorts: []string{"5432/tcp"},
 		Env: map[string]string{
 			"POSTGRES_USER":     "akashi",


### PR DESCRIPTION
## Summary

- **Docker images**: `timescale/timescaledb-ha:pg17` → `pg18`, `timescale/timescaledb:latest-pg17` → `latest-pg18`
- **Testcontainers**: Both `storage_test.go` and `server_test.go` updated
- **Docs**: README, CLAUDE.md, AGENTS.md, `docs/technical-deep-dive.md`, `adrs/ADR-002` all updated from "PostgreSQL 17" to "PostgreSQL 18"

Matches TigerData production (PostgreSQL 18.1, TimescaleDB 2.24.0).

## Test plan

- [x] `go test -race ./...` passes with pg18 containers