### PR TITLE
Fix migration 021 for managed PostgreSQL services

### DIFF
--- a/migrations/atlas.sum
+++ b/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:Oxk1uvgBDGS+/sqbaRDTSTqlVQXPGGWxQAXttjbx0FA=
+h1:zgXN1TE8qBhIxXs17pa8E0VjCDU+ZKapod8zYPEyCO0=
 001_create_agent_runs.sql h1:kt1hhf4ttnT0iglMXihEJCZtiKBhSYli5HeMcFaKGl0=
 002_create_agent_events.sql h1:teJwKwJaghjyJj9JYW/KgD8tCMZm9h1IqAUPLtmvqmA=
 003_create_decisions.sql h1:/uCnEUGTvX6VRfOtLygpUXpx/JJ58uijEAm0mQt0MNA=
@@ -17,5 +17,5 @@ h1:Oxk1uvgBDGS+/sqbaRDTSTqlVQXPGGWxQAXttjbx0FA=
 018_auth_lookup_index.sql h1:mWVyPxpborlQbm9+FwkzgO96DCW2hOYaIX0/HqsSBFI=
 019_text_search_index.sql h1:24xjvADSB+/E2O1uOPl8Yxw6SkfOwqravuOhQqURidM=
 020_revision_chain.sql h1:8vsQ3FSUAZCSTjfR7dXae10+BWx7v+Y3ZA4E4ePQWIM=
-021_remove_unused_rls.sql h1:TPRW1jP23Rbbpe+tcCBSBE/EkAiXsg67NQO9pQk/TR0=
-022_agent_tags.sql h1:jx5SVZthr/0Qu/v3MqdvW9tpIrBgVeG835vQxetYEWw=
+021_remove_unused_rls.sql h1:t6TRfph0JLYI0O6YGKWP61J+vbRCSH2Jh5wvG0wfpZg=
+022_agent_tags.sql h1:ptl5K6k5jKlLPdLWtiB36FNk7oQ0uIpRbeMpdw16F4M=


### PR DESCRIPTION
## Summary

- Wrap `DROP OWNED BY` / `DROP ROLE IF EXISTS` in a PL/pgSQL exception block
- Managed services (TigerData, Timescale Cloud) don't grant the privileges needed for these operations, causing the entire migration to fail and blocking all subsequent migrations (022+) and admin seeding

The unused `akashi_app` role is harmless if it remains — RLS policies and DISABLE RLS still execute successfully outside the exception block.

**Found during:** first cloud deploy against TigerData PostgreSQL 18.1.

## Test plan

- [x] `atlas migrate validate` passes
- [x] `go test -race ./...` passes (local testcontainers, where DROP ROLE succeeds)
- [x] Verified manually: migration runs clean on TigerData (exception caught, NOTICE logged, all subsequent migrations apply)