### PR TITLE
Implement specs 17-22: security, correctness, performance, design, SDK, CI hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,3 +61,69 @@ jobs:
         with:
           files: coverage.out
           fail_ci_if_error: false
+
+  build-ui:
+    name: Build with UI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Set up Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
+
+      - name: Build frontend
+        run: cd ui && npm ci && npm run build
+
+      - name: Build Go binary with UI embed
+        run: go build -tags ui -ldflags "-X main.version=ci" -o /dev/null ./cmd/akashi
+
+  test-go-sdk:
+    name: Test Go SDK
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: '1.22'
+          cache: true
+
+      - name: Run Go SDK tests
+        run: cd sdk/go && go test -race -count=1 ./...
+
+  test-python-sdk:
+    name: Test Python SDK
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies and run tests
+        run: cd sdk/python && pip install -e ".[dev]" && pytest
+
+  test-typescript-sdk:
+    name: Test TypeScript SDK
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
+
+      - name: Install dependencies and run tests
+        run: cd sdk/typescript && npm ci && npm test

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: all build build-ui build-with-ui test lint fmt vet clean docker-up docker-down ci security tidy \
-       dev-ui migrate-apply migrate-lint migrate-hash migrate-diff migrate-status
+       dev-ui migrate-apply migrate-lint migrate-hash migrate-diff migrate-status migrate-validate
 
 BINARY := bin/akashi
 GO := go
@@ -10,7 +10,7 @@ LDFLAGS := -ldflags "-X main.version=$(VERSION)"
 all: fmt lint vet test build
 
 # Run the full CI pipeline locally (mirrors .github/workflows/ci.yml)
-ci: tidy build lint vet security test
+ci: tidy build lint vet security test migrate-validate
 	@echo "CI passed"
 
 build:
@@ -31,6 +31,8 @@ dev-ui:
 test:
 	$(GO) test $(GOFLAGS) ./... -v
 
+# NOTE: CI uses golangci-lint v2.8.0. Install locally with:
+#   go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.8.0
 lint:
 	golangci-lint run ./...
 
@@ -84,3 +86,6 @@ migrate-diff: ## Generate a new migration from schema changes (usage: make migra
 
 migrate-status: ## Show migration status
 	$(ATLAS) migrate status --env local
+
+migrate-validate: ## Validate migration file integrity (checksums + SQL)
+	$(ATLAS) migrate validate --dir file://migrations

--- a/README.md
+++ b/README.md
@@ -88,8 +88,10 @@ Every decision trace records:
 | Language | Path | Install |
 |----------|------|---------|
 | Go | [`sdk/go/`](sdk/go/) | `go get github.com/ashita-ai/akashi/sdk/go/akashi` |
-| Python | [`sdk/python/`](sdk/python/) | `pip install akashi` |
-| TypeScript | [`sdk/typescript/`](sdk/typescript/) | `npm install @akashi/sdk` |
+| Python | [`sdk/python/`](sdk/python/) | `pip install git+https://github.com/ashita-ai/akashi.git#subdirectory=sdk/python` |
+| TypeScript | [`sdk/typescript/`](sdk/typescript/) | `npm install github:ashita-ai/akashi#path:sdk/typescript` |
+
+Package registry publication is planned for the 1.0 release. Install from source for now.
 
 All SDKs provide: `Check`, `Trace`, `Query`, `Search`, `Recent`. Auth token management is automatic.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -91,7 +91,7 @@ A recovery middleware wraps all HTTP handlers. If a handler panics, the stack tr
 
 All data is scoped by `org_id`. Every database query includes an `org_id` WHERE clause. SSE event subscriptions are org-scoped. The storage layer enforces org boundaries independently of the handler layer (defense-in-depth).
 
-PostgreSQL row-level security (RLS) policies exist on tenant-scoped tables as an additional layer. Application-level WHERE clauses are the primary enforcement mechanism.
+Tenant isolation is enforced via `org_id` WHERE clauses on every query. All storage-layer functions require `org_id` as a parameter and include it in query predicates.
 
 Access grants are org-scoped: a grant in one organization cannot authorize access to data in another organization. The `access_grants` table includes `org_id` in all queries, and grant lookups enforce both `org_id` and `grantee_id`.
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1693,15 +1693,13 @@ components:
 
     SourceType:
       type: string
-      enum:
-        - document
-        - api_response
-        - agent_output
-        - user_input
-        - search_result
-        - tool_output
-        - memory
-        - database_query
+      pattern: '^[a-z][a-z0-9_]*$'
+      description: |
+        Type of evidence source. Common values: document, api_response,
+        agent_output, user_input, search_result, tool_output, memory,
+        database_query. Any lowercase alphanumeric string with underscores
+        is accepted.
+      example: "document"
 
     Evidence:
       type: object

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.40.0
 	go.opentelemetry.io/otel/trace v1.40.0
 	golang.org/x/crypto v0.47.0
+	golang.org/x/sync v0.19.0
 )
 
 require (
@@ -85,7 +86,6 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.40.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
 	golang.org/x/net v0.49.0 // indirect
-	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.40.0 // indirect
 	golang.org/x/text v0.33.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260128011058-8636f8732409 // indirect

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,134 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestEnvIntValid(t *testing.T) {
+	t.Setenv("TEST_INT", "42")
+	v, err := envInt("TEST_INT", 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v != 42 {
+		t.Fatalf("expected 42, got %d", v)
+	}
+}
+
+func TestEnvIntFallback(t *testing.T) {
+	// TEST_INT_MISSING is not set.
+	v, err := envInt("TEST_INT_MISSING", 99)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v != 99 {
+		t.Fatalf("expected fallback 99, got %d", v)
+	}
+}
+
+func TestEnvIntInvalid(t *testing.T) {
+	t.Setenv("TEST_INT_BAD", "abc")
+	_, err := envInt("TEST_INT_BAD", 0)
+	if err == nil {
+		t.Fatal("expected error for non-integer value, got nil")
+	}
+	if got := err.Error(); got != `TEST_INT_BAD="abc" is not a valid integer` {
+		t.Fatalf("unexpected error message: %s", got)
+	}
+}
+
+func TestEnvBoolValid(t *testing.T) {
+	t.Setenv("TEST_BOOL", "true")
+	v, err := envBool("TEST_BOOL", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !v {
+		t.Fatal("expected true")
+	}
+}
+
+func TestEnvBoolInvalid(t *testing.T) {
+	t.Setenv("TEST_BOOL_BAD", "maybe")
+	_, err := envBool("TEST_BOOL_BAD", false)
+	if err == nil {
+		t.Fatal("expected error for non-boolean value, got nil")
+	}
+	if got := err.Error(); got != `TEST_BOOL_BAD="maybe" is not a valid boolean` {
+		t.Fatalf("unexpected error message: %s", got)
+	}
+}
+
+func TestEnvDurationValid(t *testing.T) {
+	t.Setenv("TEST_DUR", "5s")
+	v, err := envDuration("TEST_DUR", 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v.Seconds() != 5 {
+		t.Fatalf("expected 5s, got %s", v)
+	}
+}
+
+func TestEnvDurationInvalid(t *testing.T) {
+	t.Setenv("TEST_DUR_BAD", "five-seconds")
+	_, err := envDuration("TEST_DUR_BAD", 0)
+	if err == nil {
+		t.Fatal("expected error for invalid duration, got nil")
+	}
+	if got := err.Error(); got != `TEST_DUR_BAD="five-seconds" is not a valid duration` {
+		t.Fatalf("unexpected error message: %s", got)
+	}
+}
+
+func TestLoadFailsOnInvalidPort(t *testing.T) {
+	t.Setenv("AKASHI_PORT", "abc")
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected Load() to fail with invalid AKASHI_PORT")
+	}
+	// Error should mention the variable name and value.
+	if got := err.Error(); !contains(got, "AKASHI_PORT") || !contains(got, "abc") {
+		t.Fatalf("error should mention AKASHI_PORT and value 'abc', got: %s", got)
+	}
+}
+
+func TestLoadFailsOnMultipleInvalid(t *testing.T) {
+	t.Setenv("AKASHI_PORT", "abc")
+	t.Setenv("AKASHI_SMTP_PORT", "xyz")
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected Load() to fail with multiple invalid vars")
+	}
+	got := err.Error()
+	if !contains(got, "AKASHI_PORT") {
+		t.Fatalf("error should mention AKASHI_PORT, got: %s", got)
+	}
+	if !contains(got, "AKASHI_SMTP_PORT") {
+		t.Fatalf("error should mention AKASHI_SMTP_PORT, got: %s", got)
+	}
+}
+
+func TestLoadSucceedsWithDefaults(t *testing.T) {
+	// With no env vars set, Load should succeed using all defaults.
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("expected Load() to succeed with defaults, got: %v", err)
+	}
+	if cfg.Port != 8080 {
+		t.Fatalf("expected default port 8080, got %d", cfg.Port)
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && searchSubstring(s, substr)
+}
+
+func searchSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/integrity/integrity.go
+++ b/internal/integrity/integrity.go
@@ -4,18 +4,43 @@ package integrity
 
 import (
 	"crypto/sha256"
+	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
 )
 
-// ComputeContentHash produces a SHA-256 hex digest from the canonical decision fields.
-// The canonical form is: id|decision_type|outcome|confidence|reasoning|valid_from
-// where reasoning defaults to empty string if nil, and valid_from is RFC 3339 UTC.
+// Hash version prefixes. New hashes get v2 (length-prefixed encoding).
+// Old hashes (no prefix) are treated as v1 (pipe-delimited) for backward compatibility.
+const (
+	hashV2Prefix = "v2:"
+)
+
+// ComputeContentHash produces a versioned SHA-256 hex digest from the canonical decision fields.
+// New hashes use the v2 format (length-prefixed binary encoding) and carry a "v2:" prefix.
 func ComputeContentHash(id uuid.UUID, decisionType, outcome string, confidence float32, reasoning *string, validFrom time.Time) string {
+	return hashV2Prefix + computeV2Hash(id, decisionType, outcome, confidence, reasoning, validFrom)
+}
+
+// VerifyContentHash checks whether a stored hash matches the recomputed hash.
+// It detects the hash version from the prefix and uses the appropriate algorithm:
+//   - "v2:" prefix -> length-prefixed binary encoding (current)
+//   - no prefix   -> pipe-delimited encoding (legacy v1)
+func VerifyContentHash(stored string, id uuid.UUID, decisionType, outcome string, confidence float32, reasoning *string, validFrom time.Time) bool {
+	if strings.HasPrefix(stored, hashV2Prefix) {
+		return stored == hashV2Prefix+computeV2Hash(id, decisionType, outcome, confidence, reasoning, validFrom)
+	}
+	// Legacy v1 hashes (pipe-delimited, no version prefix).
+	return stored == computeV1Hash(id, decisionType, outcome, confidence, reasoning, validFrom)
+}
+
+// computeV1Hash produces the legacy pipe-delimited SHA-256 hex digest.
+// Kept for backward compatibility with hashes created before the v2 format.
+func computeV1Hash(id uuid.UUID, decisionType, outcome string, confidence float32, reasoning *string, validFrom time.Time) string {
 	r := ""
 	if reasoning != nil {
 		r = *reasoning
@@ -28,9 +53,28 @@ func ComputeContentHash(id uuid.UUID, decisionType, outcome string, confidence f
 	return hex.EncodeToString(sum[:])
 }
 
-// VerifyContentHash recomputes the content hash and compares it to the stored value.
-func VerifyContentHash(stored string, id uuid.UUID, decisionType, outcome string, confidence float32, reasoning *string, validFrom time.Time) bool {
-	return stored == ComputeContentHash(id, decisionType, outcome, confidence, reasoning, validFrom)
+// computeV2Hash produces a length-prefixed SHA-256 hex digest.
+// Each field is encoded as a 4-byte big-endian length prefix followed by the field bytes.
+// This avoids delimiter collisions when freeform text fields contain pipe characters.
+func computeV2Hash(id uuid.UUID, decisionType, outcome string, confidence float32, reasoning *string, validFrom time.Time) string {
+	h := sha256.New()
+	writeField := func(s string) {
+		var lenBuf [4]byte
+		binary.BigEndian.PutUint32(lenBuf[:], uint32(len(s))) //nolint:gosec // field lengths are bounded by HTTP request body limits (~1MB)
+		h.Write(lenBuf[:])
+		h.Write([]byte(s))
+	}
+	writeField(id.String())
+	writeField(decisionType)
+	writeField(outcome)
+	writeField(strconv.FormatFloat(float64(confidence), 'f', 10, 32))
+	writeField(validFrom.UTC().Format(time.RFC3339Nano))
+	r := ""
+	if reasoning != nil {
+		r = *reasoning
+	}
+	writeField(r)
+	return hex.EncodeToString(h.Sum(nil))
 }
 
 // hashPair produces SHA-256(a || b) as a hex string.

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -46,7 +46,7 @@ func ReScore(results []Result, decisions map[uuid.UUID]model.Decision, limit int
 			continue
 		}
 
-		ageDays := now.Sub(d.ValidFrom).Hours() / 24.0
+		ageDays := math.Max(0, now.Sub(d.ValidFrom).Hours()/24.0)
 		qualityBonus := 0.6 + 0.3*float64(d.QualityScore)
 		recencyDecay := 1.0 / (1.0 + ageDays/90.0)
 		relevance := float64(r.Score) * qualityBonus * recencyDecay

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -286,6 +286,11 @@ func (h *Handlers) SeedAdmin(ctx context.Context, adminAPIKey string) error {
 
 // HandleSignup handles POST /auth/signup.
 func (h *Handlers) HandleSignup(w http.ResponseWriter, r *http.Request) {
+	if h.signupSvc == nil {
+		writeError(w, r, http.StatusNotFound, model.ErrCodeNotFound, "signup is not enabled")
+		return
+	}
+
 	var req model.SignupRequest
 	if err := decodeJSON(r, &req, h.maxRequestBodyBytes); err != nil {
 		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "invalid request body")
@@ -304,7 +309,7 @@ func (h *Handlers) HandleSignup(w http.ResponseWriter, r *http.Request) {
 			errors.Is(err, signup.ErrOrgNameRequired):
 			writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, err.Error())
 		default:
-			h.logger.Error("signup failed", "error", err, "email", req.Email)
+			h.logger.Error("signup failed", "error", err)
 			writeError(w, r, http.StatusInternalServerError, model.ErrCodeInternalError, "signup failed")
 		}
 		return
@@ -317,6 +322,11 @@ func (h *Handlers) HandleSignup(w http.ResponseWriter, r *http.Request) {
 // Accepts {"token": "..."} in the request body (not as a query parameter)
 // to avoid token exposure in server/proxy logs and browser history.
 func (h *Handlers) HandleVerifyEmail(w http.ResponseWriter, r *http.Request) {
+	if h.signupSvc == nil {
+		writeError(w, r, http.StatusNotFound, model.ErrCodeNotFound, "signup is not enabled")
+		return
+	}
+
 	var req struct {
 		Token string `json:"token"`
 	}

--- a/internal/server/handlers_export.go
+++ b/internal/server/handlers_export.go
@@ -26,17 +26,25 @@ func (h *Handlers) HandleExportDecisions(w http.ResponseWriter, r *http.Request)
 		filters.DecisionType = &dt
 	}
 	if fromStr := q.Get("from"); fromStr != "" {
-		if t, err := time.Parse(time.RFC3339, fromStr); err == nil {
-			filters.TimeRange = &model.TimeRange{From: &t}
+		t, err := time.Parse(time.RFC3339, fromStr)
+		if err != nil {
+			writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput,
+				"invalid 'from' parameter: must be RFC 3339 format (e.g., 2025-01-01T00:00:00Z)")
+			return
 		}
+		filters.TimeRange = &model.TimeRange{From: &t}
 	}
 	if toStr := q.Get("to"); toStr != "" {
-		if t, err := time.Parse(time.RFC3339, toStr); err == nil {
-			if filters.TimeRange == nil {
-				filters.TimeRange = &model.TimeRange{}
-			}
-			filters.TimeRange.To = &t
+		t, err := time.Parse(time.RFC3339, toStr)
+		if err != nil {
+			writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput,
+				"invalid 'to' parameter: must be RFC 3339 format (e.g., 2025-12-31T23:59:59Z)")
+			return
 		}
+		if filters.TimeRange == nil {
+			filters.TimeRange = &model.TimeRange{}
+		}
+		filters.TimeRange.To = &t
 	}
 
 	// Filename with timestamp.

--- a/internal/service/trace/buffer_test.go
+++ b/internal/service/trace/buffer_test.go
@@ -1,0 +1,33 @@
+package trace
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestBufferDoubleStartIsNoop(t *testing.T) {
+	// Buffer.Start() must be idempotent — a second call logs a warning and returns
+	// without spawning a second flush goroutine or panicking on double close(b.done).
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	buf := NewBuffer(nil, logger, 100, 50*time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	buf.Start(ctx) // First call — should work.
+	buf.Start(ctx) // Second call — should be a no-op, no panic.
+
+	// Verify started is true.
+	if !buf.started.Load() {
+		t.Fatal("expected started to be true after Start()")
+	}
+
+	// Clean shutdown.
+	cancel()
+	drainCtx, drainCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer drainCancel()
+	buf.Drain(drainCtx)
+}

--- a/internal/storage/delete.go
+++ b/internal/storage/delete.go
@@ -10,7 +10,8 @@ import (
 )
 
 // ErrAgentNotFound is returned when an agent doesn't exist.
-var ErrAgentNotFound = errors.New("storage: agent not found")
+// It wraps ErrNotFound so callers can use errors.Is(err, ErrNotFound) generically.
+var ErrAgentNotFound = fmt.Errorf("storage: agent: %w", ErrNotFound)
 
 // DeleteAgentResult contains the count of rows deleted per table.
 type DeleteAgentResult struct {

--- a/internal/storage/errors.go
+++ b/internal/storage/errors.go
@@ -1,0 +1,6 @@
+package storage
+
+import "errors"
+
+// ErrNotFound is returned when a requested entity does not exist.
+var ErrNotFound = errors.New("storage: not found")

--- a/internal/storage/grants.go
+++ b/internal/storage/grants.go
@@ -43,7 +43,7 @@ func (db *DB) DeleteGrant(ctx context.Context, orgID, id uuid.UUID) error {
 		return fmt.Errorf("storage: delete grant: %w", err)
 	}
 	if tag.RowsAffected() == 0 {
-		return fmt.Errorf("storage: grant not found: %s", id)
+		return fmt.Errorf("storage: grant %s: %w", id, ErrNotFound)
 	}
 	return nil
 }
@@ -63,7 +63,7 @@ func (db *DB) GetGrant(ctx context.Context, orgID uuid.UUID, id uuid.UUID) (mode
 	)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return model.AccessGrant{}, fmt.Errorf("storage: grant not found: %s", id)
+			return model.AccessGrant{}, fmt.Errorf("storage: grant %s: %w", id, ErrNotFound)
 		}
 		return model.AccessGrant{}, fmt.Errorf("storage: get grant: %w", err)
 	}

--- a/internal/storage/runs.go
+++ b/internal/storage/runs.go
@@ -54,7 +54,7 @@ func (db *DB) GetRun(ctx context.Context, orgID, id uuid.UUID) (model.AgentRun, 
 	)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return model.AgentRun{}, fmt.Errorf("storage: run not found: %s", id)
+			return model.AgentRun{}, fmt.Errorf("storage: run %s: %w", id, ErrNotFound)
 		}
 		return model.AgentRun{}, fmt.Errorf("storage: get run: %w", err)
 	}
@@ -76,7 +76,7 @@ func (db *DB) CompleteRun(ctx context.Context, orgID, id uuid.UUID, status model
 		return fmt.Errorf("storage: complete run: %w", err)
 	}
 	if tag.RowsAffected() == 0 {
-		return fmt.Errorf("storage: run not found or already completed: %s", id)
+		return fmt.Errorf("storage: run %s (or already completed): %w", id, ErrNotFound)
 	}
 	return nil
 }

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -167,7 +167,7 @@ func TestInsertAndGetEvents(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int64(2), count)
 
-	got, err := testDB.GetEventsByRun(ctx, run.OrgID, run.ID)
+	got, err := testDB.GetEventsByRun(ctx, run.OrgID, run.ID, 0)
 	require.NoError(t, err)
 	assert.Len(t, got, 2)
 	assert.Equal(t, model.EventDecisionStarted, got[0].EventType)
@@ -199,7 +199,7 @@ func TestInsertEventsCOPY(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int64(100), count)
 
-	got, err := testDB.GetEventsByRun(ctx, run.OrgID, run.ID)
+	got, err := testDB.GetEventsByRun(ctx, run.OrgID, run.ID, 0)
 	require.NoError(t, err)
 	assert.Len(t, got, 100)
 }
@@ -396,7 +396,7 @@ func TestAgentCRUD(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, agent.ID, got.ID)
 
-	gotByID, err := testDB.GetAgentByID(ctx, agent.ID)
+	gotByID, err := testDB.GetAgentByID(ctx, agent.ID, agent.OrgID)
 	require.NoError(t, err)
 	assert.Equal(t, "crud-agent", gotByID.AgentID)
 }
@@ -516,7 +516,7 @@ func TestAgentTagsPersistence(t *testing.T) {
 	assert.Equal(t, []string{"finance", "compliance"}, got.Tags)
 
 	// Also test GetAgentByID.
-	gotByID, err := testDB.GetAgentByID(ctx, agent.ID)
+	gotByID, err := testDB.GetAgentByID(ctx, agent.ID, agent.OrgID)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"finance", "compliance"}, gotByID.Tags)
 }
@@ -666,11 +666,11 @@ func TestListAgentsIncludesTags(t *testing.T) {
 	require.NoError(t, err)
 
 	// Retrieve individually to verify tags are present in list results.
-	got1, err := testDB.GetAgentByID(ctx, a1.ID)
+	got1, err := testDB.GetAgentByID(ctx, a1.ID, a1.OrgID)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"team-a"}, got1.Tags)
 
-	got2, err := testDB.GetAgentByID(ctx, a2.ID)
+	got2, err := testDB.GetAgentByID(ctx, a2.ID, a2.OrgID)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"team-b", "team-c"}, got2.Tags)
 }

--- a/migrations/023_hash_verification_tokens.sql
+++ b/migrations/023_hash_verification_tokens.sql
@@ -1,0 +1,5 @@
+-- Rename the token column to token_hash to reflect that only SHA-256 hashes
+-- are stored, not raw verification tokens. Any existing plaintext tokens become
+-- invalid (acceptable for pre-launch; no orgs are stuck mid-verification in prod).
+
+ALTER TABLE email_verifications RENAME COLUMN token TO token_hash;

--- a/migrations/atlas.sum
+++ b/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:zgXN1TE8qBhIxXs17pa8E0VjCDU+ZKapod8zYPEyCO0=
+h1:Z/oLwvN0UuWaBF1AFya1mYpu7Jzii87u9uNKlie/MWg=
 001_create_agent_runs.sql h1:kt1hhf4ttnT0iglMXihEJCZtiKBhSYli5HeMcFaKGl0=
 002_create_agent_events.sql h1:teJwKwJaghjyJj9JYW/KgD8tCMZm9h1IqAUPLtmvqmA=
 003_create_decisions.sql h1:/uCnEUGTvX6VRfOtLygpUXpx/JJ58uijEAm0mQt0MNA=
@@ -19,3 +19,4 @@ h1:zgXN1TE8qBhIxXs17pa8E0VjCDU+ZKapod8zYPEyCO0=
 020_revision_chain.sql h1:8vsQ3FSUAZCSTjfR7dXae10+BWx7v+Y3ZA4E4ePQWIM=
 021_remove_unused_rls.sql h1:t6TRfph0JLYI0O6YGKWP61J+vbRCSH2Jh5wvG0wfpZg=
 022_agent_tags.sql h1:ptl5K6k5jKlLPdLWtiB36FNk7oQ0uIpRbeMpdw16F4M=
+023_hash_verification_tokens.sql h1:BCwY1Rf1WqMEoZxPuF1F9kIMS/WSlHNsvqtlPFtAAhw=

--- a/sdk/python/src/akashi/types.py
+++ b/sdk/python/src/akashi/types.py
@@ -15,11 +15,17 @@ class Decision(BaseModel):
     id: UUID
     run_id: UUID
     agent_id: str
+    org_id: UUID
     decision_type: str
     outcome: str
     confidence: float = Field(ge=0.0, le=1.0)
     reasoning: str | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
+    quality_score: float = 0.0
+    precedent_ref: UUID | None = None
+    supersedes_id: UUID | None = None
+    content_hash: str = ""
+    tags: list[str] = Field(default_factory=list)
     valid_from: datetime
     valid_to: datetime | None = None
     transaction_time: datetime
@@ -59,6 +65,7 @@ class DecisionConflict(BaseModel):
 
     decision_a_id: UUID
     decision_b_id: UUID
+    org_id: UUID
     agent_a: str
     agent_b: str
     run_a: UUID
@@ -68,6 +75,8 @@ class DecisionConflict(BaseModel):
     outcome_b: str
     confidence_a: float
     confidence_b: float
+    reasoning_a: str | None = None
+    reasoning_b: str | None = None
     decided_at_a: datetime
     decided_at_b: datetime
     detected_at: datetime
@@ -93,10 +102,13 @@ class AgentEvent(BaseModel):
 
     id: UUID
     run_id: UUID
+    org_id: UUID
     event_type: str
     sequence_num: int
     occurred_at: datetime
     agent_id: str
+    trace_id: str = ""
+    span_id: str = ""
     payload: dict[str, Any] = Field(default_factory=dict)
     created_at: datetime
 
@@ -109,6 +121,7 @@ class Agent(BaseModel):
     org_id: UUID
     name: str
     role: str
+    tags: list[str] = Field(default_factory=list)
     metadata: dict[str, Any] = Field(default_factory=dict)
     created_at: datetime
 
@@ -271,6 +284,7 @@ class QueryResponse(BaseModel):
 
     decisions: list[Decision]
     total: int
+    count: int = 0
     limit: int
     offset: int = 0
 

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -84,6 +84,7 @@ def _decision_json(decision_id: str | None = None, run_id: str | None = None) ->
         "id": decision_id or DECISION_ID,
         "run_id": run_id or RUN_ID,
         "agent_id": "test-agent",
+        "org_id": ORG_ID,
         "decision_type": "architecture",
         "outcome": "chose event sourcing",
         "confidence": 0.9,
@@ -137,6 +138,7 @@ def _conflict_json() -> dict:
     return {
         "decision_a_id": str(uuid.uuid4()),
         "decision_b_id": str(uuid.uuid4()),
+        "org_id": ORG_ID,
         "agent_a": "planner",
         "agent_b": "coder",
         "run_a": str(uuid.uuid4()),
@@ -166,6 +168,7 @@ class TestCheck:
                             "id": DECISION_ID,
                             "run_id": RUN_ID,
                             "agent_id": "other-agent",
+                            "org_id": ORG_ID,
                             "decision_type": "deployment",
                             "outcome": "approved",
                             "confidence": 0.95,

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -3,11 +3,17 @@ export interface Decision {
   id: string;
   run_id: string;
   agent_id: string;
+  org_id: string;
   decision_type: string;
   outcome: string;
   confidence: number;
   reasoning?: string;
   metadata: Record<string, unknown>;
+  quality_score: number;
+  precedent_ref?: string;
+  supersedes_id?: string;
+  content_hash?: string;
+  tags?: string[];
   valid_from: string;
   valid_to?: string;
   transaction_time: string;
@@ -44,6 +50,7 @@ export interface Evidence {
 export interface DecisionConflict {
   decision_a_id: string;
   decision_b_id: string;
+  org_id: string;
   agent_a: string;
   agent_b: string;
   run_a: string;
@@ -53,6 +60,8 @@ export interface DecisionConflict {
   outcome_b: string;
   confidence_a: number;
   confidence_b: number;
+  reasoning_a?: string;
+  reasoning_b?: string;
   decided_at_a: string;
   decided_at_b: string;
   detected_at: string;
@@ -76,10 +85,13 @@ export interface AgentRun {
 export interface AgentEvent {
   id: string;
   run_id: string;
+  org_id: string;
   event_type: string;
   sequence_num: number;
   occurred_at: string;
   agent_id: string;
+  trace_id?: string;
+  span_id?: string;
   payload: Record<string, unknown>;
   created_at: string;
 }
@@ -91,6 +103,7 @@ export interface Agent {
   org_id: string;
   name: string;
   role: string;
+  tags: string[];
   metadata: Record<string, unknown>;
   created_at: string;
 }
@@ -215,6 +228,7 @@ export interface CheckResponse {
 export interface QueryResponse {
   decisions: Decision[];
   total: number;
+  count: number;
   limit: number;
   offset: number;
 }


### PR DESCRIPTION
## Summary

Comprehensive hardening pass implementing six specs that address findings from the 2026-02-09 codebase audit. 48 files changed, +1605/-363 lines.

- **Spec 17 (Security):** MCP total info leak, webhook retry storm, nil signupSvc panics, grant validation, SHA-256 token hashing (migration 023), auth allowlist, internal URL blocking, PII removal, JWT key pair check
- **Spec 18 (Correctness):** Buffer double-start guard, GetRun 10K limit with truncation flag, revision CTE deep-chain fix, pagination `has_more` semantics, export date validation, verify decision three-state status, config fail-fast
- **Spec 19 (Performance):** OTEL cardinality fix via `r.Pattern`, statusWriter dedup, Qdrant `singleflight` health check, bounded conflict/event queries, outbox metric O(1) estimation, ReScore ageDays clamp
- **Spec 20 (Design):** `ErrNotFound` sentinel error, org_id defense-in-depth on secondary queries, broker Listen retry, content hash v2 with length-prefix encoding
- **Spec 21 (SDK & Docs):** Go SDK +8 fields and 3 methods, constructor validation, full README, Python/TS alignment, SECURITY.md fix, OpenAPI pattern, install instructions
- **Spec 22 (CI):** UI build job, SDK test jobs, Makefile atlas target, Dockerfile HEALTHCHECK

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] `atlas migrate validate` — OK
- [x] `go test -race -count=1 ./...` — 18/18 packages pass
- [ ] CI pipeline passes (build, lint, vet, test, migration validation)
- [ ] New CI jobs run successfully (build-ui, test-go-sdk, test-python-sdk, test-typescript-sdk)
- [ ] Verify migration 023 applies cleanly against staging DB