### PR TITLE
Fix P0/P1 security and correctness issues from code review

### DIFF
--- a/cmd/akashi/main.go
+++ b/cmd/akashi/main.go
@@ -223,6 +223,7 @@ func run(ctx context.Context, logger *slog.Logger) error {
 		MCPServer:           mcpSrv.MCPServer(),
 		Version:             version,
 		MaxRequestBodyBytes: cfg.MaxRequestBodyBytes,
+		CORSAllowedOrigins:  cfg.CORSAllowedOrigins,
 		UIFS:                uiFS,
 		OpenAPISpec:         api.OpenAPISpec,
 	})

--- a/docker/docker-compose.cloud.yml
+++ b/docker/docker-compose.cloud.yml
@@ -1,9 +1,10 @@
-# Cloud deployment: PgBouncer → TimescaleDB Cloud, Redis local, Qdrant Cloud.
+# Cloud deployment: PgBouncer → TimescaleDB Cloud, Qdrant Cloud, Ollama local.
 #
 # Usage:
 #   cp docker/env.cloud.example docker/.env.cloud
 #   # Edit docker/.env.cloud with your cloud credentials
 #   docker compose -f docker/docker-compose.cloud.yml --env-file docker/.env.cloud up -d
+#   docker exec akashi-cloud-ollama ollama pull mxbai-embed-large   # first run only
 #
 # No local Postgres or Qdrant — both are managed cloud services.
 # PgBouncer is local because the app's dual-connection architecture needs
@@ -56,6 +57,21 @@ services:
       timeout: 5s
       retries: 5
 
+  ollama:
+    image: ollama/ollama:latest
+    container_name: akashi-cloud-ollama
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:11434:11434"
+    volumes:
+      - ollama_data:/root/.ollama
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://127.0.0.1:11434/api/tags || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
   akashi:
     build:
       context: ..
@@ -83,15 +99,15 @@ services:
       QDRANT_API_KEY: ${QDRANT_API_KEY}
       QDRANT_COLLECTION: ${QDRANT_COLLECTION:-akashi_decisions}
 
-      # Embedding provider — cloud mode typically uses OpenAI.
-      AKASHI_EMBEDDING_PROVIDER: ${AKASHI_EMBEDDING_PROVIDER:-auto}
-      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
-      AKASHI_EMBEDDING_MODEL: ${AKASHI_EMBEDDING_MODEL:-text-embedding-3-small}
+      # Ollama for embeddings (running in the stack).
+      AKASHI_EMBEDDING_PROVIDER: ${AKASHI_EMBEDDING_PROVIDER:-ollama}
+      OLLAMA_URL: http://ollama:11434
+      OLLAMA_MODEL: ${OLLAMA_MODEL:-mxbai-embed-large}
       AKASHI_EMBEDDING_DIMENSIONS: ${AKASHI_EMBEDDING_DIMENSIONS:-1024}
 
-      # Ollama (alternative to OpenAI — only if you have a host-accessible instance).
-      OLLAMA_URL: ${OLLAMA_URL:-}
-      OLLAMA_MODEL: ${OLLAMA_MODEL:-mxbai-embed-large}
+      # OpenAI (alternative to Ollama — set AKASHI_EMBEDDING_PROVIDER=openai).
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      AKASHI_EMBEDDING_MODEL: ${AKASHI_EMBEDDING_MODEL:-text-embedding-3-small}
 
       # Stripe billing (optional).
       STRIPE_SECRET_KEY: ${STRIPE_SECRET_KEY:-}
@@ -120,6 +136,9 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+      ollama:
+        condition: service_healthy
 
 volumes:
   redisdata:
+  ollama_data:

--- a/docker/docker-compose.local.yml
+++ b/docker/docker-compose.local.yml
@@ -1,13 +1,13 @@
-# Local development: fully self-contained stack with no cloud dependencies.
+# Local development: self-contained stack, pgvector fallback (no Qdrant).
 #
 # Usage:
 #   docker compose -f docker/docker-compose.local.yml up -d
+#   docker exec akashi-local-ollama ollama pull mxbai-embed-large   # first run only
 #   curl http://localhost:8080/health
 #
-# Postgres (pgvector + TimescaleDB) runs locally. No Qdrant — semantic search
-# falls back to pgvector. Embedding provider defaults to noop (no external
-# service required). Override AKASHI_EMBEDDING_PROVIDER=auto if Ollama is
-# running on the host.
+# Postgres (pgvector + TimescaleDB) and Ollama run locally. No Qdrant — semantic
+# search falls back to pgvector. No PgBouncer — single-user local dev doesn't
+# need connection pooling.
 
 services:
   postgres:
@@ -37,28 +37,6 @@ services:
       timeout: 5s
       retries: 5
 
-  pgbouncer:
-    # Pinned 2026-02-08. Check for updates: https://hub.docker.com/r/edoburu/pgbouncer/tags
-    image: edoburu/pgbouncer:v1.25.1-p0
-    container_name: akashi-local-pgbouncer
-    restart: unless-stopped
-    ports:
-      - "127.0.0.1:6432:5432"
-    environment:
-      DATABASE_URL: postgres://akashi:${POSTGRES_PASSWORD:-akashi}@postgres:5432/akashi
-      POOL_MODE: transaction
-      AUTH_TYPE: scram-sha-256
-      MAX_CLIENT_CONN: 1000
-      DEFAULT_POOL_SIZE: 50
-    depends_on:
-      postgres:
-        condition: service_healthy
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -p 5432"]
-      interval: 5s
-      timeout: 5s
-      retries: 5
-
   redis:
     image: redis:7.4-alpine
     container_name: akashi-local-redis
@@ -79,6 +57,21 @@ services:
       timeout: 5s
       retries: 5
 
+  ollama:
+    image: ollama/ollama:latest
+    container_name: akashi-local-ollama
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:11434:11434"
+    volumes:
+      - ollama_data:/root/.ollama
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://127.0.0.1:11434/api/tags || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
   akashi:
     build:
       context: ..
@@ -88,9 +81,8 @@ services:
     ports:
       - "127.0.0.1:8080:8080"
     environment:
-      # Database: queries go through PgBouncer; NOTIFY goes direct to Postgres.
-      # sslmode=disable — no TLS between local containers.
-      DATABASE_URL: postgres://akashi:${POSTGRES_PASSWORD:-akashi}@pgbouncer:5432/akashi?sslmode=disable
+      # Database: no PgBouncer — both URLs go direct to Postgres.
+      DATABASE_URL: postgres://akashi:${POSTGRES_PASSWORD:-akashi}@postgres:5432/akashi?sslmode=disable
       NOTIFY_URL: postgres://akashi:${POSTGRES_PASSWORD:-akashi}@postgres:5432/akashi?sslmode=disable
       REDIS_URL: redis://default:${REDIS_PASSWORD:-akashi}@redis:6379/0
 
@@ -103,14 +95,15 @@ services:
       QDRANT_URL: ""
       QDRANT_API_KEY: ""
 
-      # Noop embedding by default (no external service needed for local dev).
-      # Set to "auto" if Ollama is running on the host.
-      AKASHI_EMBEDDING_PROVIDER: ${AKASHI_EMBEDDING_PROVIDER:-noop}
+      # Ollama for embeddings (running in the stack).
+      AKASHI_EMBEDDING_PROVIDER: ${AKASHI_EMBEDDING_PROVIDER:-ollama}
+      OLLAMA_URL: http://ollama:11434
+      OLLAMA_MODEL: ${OLLAMA_MODEL:-mxbai-embed-large}
+      AKASHI_EMBEDDING_DIMENSIONS: ${AKASHI_EMBEDDING_DIMENSIONS:-1024}
+
+      # OpenAI (unused by default, set AKASHI_EMBEDDING_PROVIDER=openai to enable).
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       AKASHI_EMBEDDING_MODEL: ${AKASHI_EMBEDDING_MODEL:-text-embedding-3-small}
-      AKASHI_EMBEDDING_DIMENSIONS: ${AKASHI_EMBEDDING_DIMENSIONS:-1024}
-      OLLAMA_URL: ${OLLAMA_URL:-http://host.docker.internal:11434}
-      OLLAMA_MODEL: ${OLLAMA_MODEL:-mxbai-embed-large}
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8080/health || exit 1"]
       interval: 10s
@@ -118,13 +111,14 @@ services:
       retries: 5
       start_period: 15s
     depends_on:
-      pgbouncer:
-        condition: service_healthy
       postgres:
         condition: service_healthy
       redis:
+        condition: service_healthy
+      ollama:
         condition: service_healthy
 
 volumes:
   pgdata:
   redisdata:
+  ollama_data:

--- a/internal/server/broker.go
+++ b/internal/server/broker.go
@@ -69,6 +69,10 @@ func (b *Broker) Start(ctx context.Context) {
 
 		// Extract org_id from the notification payload for tenant isolation.
 		orgID := extractOrgID(payload)
+		if orgID == uuid.Nil {
+			b.logger.Warn("broker: could not extract org_id from notification payload",
+				"channel", channel)
+		}
 
 		// Format as SSE event.
 		event := formatSSE(channel, payload)

--- a/internal/service/trace/buffer.go
+++ b/internal/service/trace/buffer.go
@@ -235,6 +235,11 @@ func (b *Buffer) Len() int {
 	return len(b.events)
 }
 
+// Capacity returns the hard upper limit on buffered events.
+func (b *Buffer) Capacity() int {
+	return maxBufferCapacity
+}
+
 // DroppedEvents returns the total number of events dropped due to buffer capacity
 // exhaustion after a flush failure. A non-zero value indicates data loss.
 func (b *Buffer) DroppedEvents() int64 {

--- a/internal/storage/errors.go
+++ b/internal/storage/errors.go
@@ -4,3 +4,7 @@ import "errors"
 
 // ErrNotFound is returned when a requested entity does not exist.
 var ErrNotFound = errors.New("storage: not found")
+
+// ErrQuotaExceeded is returned when a transactional quota check determines
+// that the org has exceeded its decision limit for the current billing period.
+var ErrQuotaExceeded = errors.New("storage: quota exceeded")


### PR DESCRIPTION
## Summary

Fixes all critical and high-priority issues identified during the 87/100 codebase review. Changes span security hardening, correctness improvements, and design cleanup across 15 files.

### P0 Security
- **Authz error propagation**: `CanAccessAgent` and `LoadGrantedSet` now propagate real DB errors instead of silently degrading to no-access on transient failures. `storage.ErrNotFound` is still treated as "skip" (correct behavior).
- **CORS origin allowlist**: Replaced unconditional origin reflection with a configurable allowlist (`AKASHI_CORS_ALLOWED_ORIGINS`). Defaults to `["*"]` for backward compatibility; operators can lock down to specific origins in production.
- **API key auth in middleware**: Added `ApiKey agent_id:secret` scheme to `authMiddleware` for MCP clients and machine-to-machine integrations where JWT token refresh is impractical.

### P1 Correctness
- **Billing quota TOCTOU**: Moved quota check + usage increment inside `CreateTraceTx` using `INSERT...ON CONFLICT DO UPDATE...RETURNING` with a row-level lock. The pre-check remains as a fast reject before expensive embedding API calls, but the definitive enforcement is now atomic inside the transaction. Added `storage.ErrQuotaExceeded` sentinel.

### Design Improvements
- **NoopProvider zero-vector bloat**: Returns `ErrNoProvider` error instead of allocating and storing ~4KB zero vectors per decision when no embedding provider is configured. The service layer already handles embedding errors gracefully.
- **Health thresholds**: Derived from `buffer.Capacity()` instead of hardcoded 50K/75K magic numbers.
- **Verification logging**: Downgraded `HandleVerifyEmail` error log from `Error` to `Warn` (user-triggered failures aren't server errors).
- **Broker observability**: Added logging when `extractOrgID` fails to parse notification payloads.
- **Docker Compose**: Added Ollama to both local and cloud compose files; removed PgBouncer from local dev (single-user doesn't need connection pooling).

### Deferred (separate PRs)
- Keyset pagination for export endpoint (requires migration)
- Stripe webhook event ID dedup (requires migration)

## Test plan

- [x] `go mod tidy && git diff --exit-code go.mod go.sum` — no changes
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] `atlas migrate validate` — valid
- [x] `go test -race -count=1 ./...` — all pass, no races