### PR TITLE
MCP: check-before-trace nudging and agent auto-registration

### DIFF
--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -7,6 +7,7 @@ package mcp
 
 import (
 	"log/slog"
+	"time"
 
 	mcplib "github.com/mark3labs/mcp-go/mcp"
 	mcpserver "github.com/mark3labs/mcp-go/server"
@@ -17,18 +18,20 @@ import (
 
 // Server wraps the MCP server with Akashi's service layer.
 type Server struct {
-	mcpServer   *mcpserver.MCPServer
-	db          *storage.DB        // for resources (read-only queries)
-	decisionSvc *decisions.Service // for tools (shared business logic)
-	logger      *slog.Logger
+	mcpServer    *mcpserver.MCPServer
+	db           *storage.DB        // for resources (read-only queries)
+	decisionSvc  *decisions.Service // for tools (shared business logic)
+	logger       *slog.Logger
+	checkTracker *checkTracker // tracks check-before-trace workflow compliance
 }
 
 // New creates and configures a new MCP server with all resources, tools, and prompts.
 func New(db *storage.DB, decisionSvc *decisions.Service, logger *slog.Logger, version string) *Server {
 	s := &Server{
-		db:          db,
-		decisionSvc: decisionSvc,
-		logger:      logger,
+		db:           db,
+		decisionSvc:  decisionSvc,
+		logger:       logger,
+		checkTracker: newCheckTracker(time.Hour),
 	}
 
 	s.mcpServer = mcpserver.NewMCPServer(

--- a/internal/mcp/tracker.go
+++ b/internal/mcp/tracker.go
@@ -1,0 +1,70 @@
+package mcp
+
+import (
+	"sync"
+	"time"
+)
+
+// checkTracker records recent akashi_check calls so handleTrace can detect
+// when a caller skips the check-before-trace workflow and nudge them.
+//
+// The tracker is keyed on (agentID, decisionType) with a configurable time
+// window. If a check was recorded within the window, WasChecked returns true.
+// This is an in-memory, per-process structure — it does not survive restarts,
+// which is acceptable because the nudge is advisory, not a hard gate.
+type checkTracker struct {
+	mu     sync.Mutex
+	checks map[checkKey]time.Time
+	window time.Duration // how long a check is considered "recent"
+}
+
+type checkKey struct {
+	agentID      string
+	decisionType string
+}
+
+func newCheckTracker(window time.Duration) *checkTracker {
+	return &checkTracker{
+		checks: make(map[checkKey]time.Time),
+		window: window,
+	}
+}
+
+// Record notes that the given agent checked for precedents of this decision type.
+func (t *checkTracker) Record(agentID, decisionType string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.checks[checkKey{agentID, decisionType}] = time.Now()
+
+	// Lazy cleanup: if the map has grown large, purge stale entries to prevent
+	// unbounded growth from many distinct (agent, type) pairs over time.
+	if len(t.checks) > 1000 {
+		t.purgeStale()
+	}
+}
+
+// WasChecked reports whether the given agent checked this decision type
+// within the configured time window.
+func (t *checkTracker) WasChecked(agentID, decisionType string) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	ts, ok := t.checks[checkKey{agentID, decisionType}]
+	if !ok {
+		return false
+	}
+	if time.Since(ts) > t.window {
+		delete(t.checks, checkKey{agentID, decisionType})
+		return false
+	}
+	return true
+}
+
+// purgeStale removes entries older than the window. Must be called with mu held.
+func (t *checkTracker) purgeStale() {
+	now := time.Now()
+	for k, ts := range t.checks {
+		if now.Sub(ts) > t.window {
+			delete(t.checks, k)
+		}
+	}
+}

--- a/internal/mcp/tracker_test.go
+++ b/internal/mcp/tracker_test.go
@@ -1,0 +1,103 @@
+package mcp
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCheckTracker_RecordAndCheck(t *testing.T) {
+	tracker := newCheckTracker(time.Hour)
+
+	// Not checked yet.
+	if tracker.WasChecked("agent-1", "architecture") {
+		t.Fatal("expected WasChecked to return false before any Record")
+	}
+
+	// Record a check.
+	tracker.Record("agent-1", "architecture")
+
+	// Now it should return true.
+	if !tracker.WasChecked("agent-1", "architecture") {
+		t.Fatal("expected WasChecked to return true after Record")
+	}
+}
+
+func TestCheckTracker_DifferentTypes(t *testing.T) {
+	tracker := newCheckTracker(time.Hour)
+
+	tracker.Record("agent-1", "architecture")
+
+	// Same agent, different type — should not count.
+	if tracker.WasChecked("agent-1", "security") {
+		t.Fatal("expected WasChecked to return false for unchecked decision type")
+	}
+}
+
+func TestCheckTracker_DifferentAgents(t *testing.T) {
+	tracker := newCheckTracker(time.Hour)
+
+	tracker.Record("agent-1", "architecture")
+
+	// Different agent, same type — should not count.
+	if tracker.WasChecked("agent-2", "architecture") {
+		t.Fatal("expected WasChecked to return false for different agent")
+	}
+}
+
+func TestCheckTracker_Expiry(t *testing.T) {
+	// Use a very short window so entries expire immediately.
+	tracker := newCheckTracker(time.Millisecond)
+
+	tracker.Record("agent-1", "architecture")
+	time.Sleep(5 * time.Millisecond)
+
+	if tracker.WasChecked("agent-1", "architecture") {
+		t.Fatal("expected WasChecked to return false after window expired")
+	}
+}
+
+func TestCheckTracker_UpdateTimestamp(t *testing.T) {
+	tracker := newCheckTracker(50 * time.Millisecond)
+
+	tracker.Record("agent-1", "architecture")
+	time.Sleep(30 * time.Millisecond)
+
+	// Re-record to refresh the timestamp.
+	tracker.Record("agent-1", "architecture")
+	time.Sleep(30 * time.Millisecond)
+
+	// Should still be valid because we refreshed.
+	if !tracker.WasChecked("agent-1", "architecture") {
+		t.Fatal("expected WasChecked to return true after timestamp refresh")
+	}
+}
+
+func TestCheckTracker_PurgeStale(t *testing.T) {
+	// Use a 100ms window so entries don't expire during the tight insert loop,
+	// then sleep long enough for all entries to go stale before triggering purge.
+	tracker := newCheckTracker(100 * time.Millisecond)
+
+	// Fill with >1000 entries.
+	for i := range 1100 {
+		tracker.Record("agent-1", string(rune('A'+i%26))+string(rune('0'+i/26)))
+	}
+
+	// Wait for all entries to become stale.
+	time.Sleep(150 * time.Millisecond)
+
+	// Record two fresh entries. The first one exceeds the 1000-entry threshold
+	// and triggers purgeStale, which should remove all 1100 stale entries.
+	tracker.Record("agent-fresh", "architecture")
+	tracker.Record("agent-trigger", "trigger")
+
+	if !tracker.WasChecked("agent-fresh", "architecture") {
+		t.Fatal("expected fresh entry to survive purge")
+	}
+
+	tracker.mu.Lock()
+	count := len(tracker.checks)
+	tracker.mu.Unlock()
+	if count > 10 {
+		t.Fatalf("expected stale entries to be purged, got %d entries", count)
+	}
+}


### PR DESCRIPTION
## Summary

- **Check-before-trace nudging**: `handleTrace` now detects when a caller records a decision without first calling `akashi_check` for the same `decision_type`. The trace still succeeds, but the response includes an advisory reminder to check for precedents first. Enforced in-product — every MCP client gets the nudge with zero configuration.
- **Agent auto-registration**: When an admin+ caller traces for an `agent_id` that doesn't exist yet, the agent is auto-registered (`role=agent`, no API key) instead of returning an error. Non-admin callers still get a clear error. `agent_id` defaults to the caller's authenticated identity when omitted.
- **Shared service method**: Both MCP and HTTP trace handlers use `ResolveOrCreateAgent` with race-safe duplicate key handling.

## Implementation

| File | Change |
|------|--------|
| `internal/mcp/tracker.go` | In-memory `checkTracker` with time-windowed `(agentID, decisionType)` tracking, lazy purge at >1000 entries |
| `internal/mcp/tracker_test.go` | 6 unit tests (record/check, different types/agents, expiry, timestamp refresh, stale purge) |
| `internal/mcp/mcp.go` | `checkTracker` added to Server struct, initialized with 1-hour window |
| `internal/mcp/tools.go` | `handleCheck` records checks; `handleTrace` nudges when check missing; `agent_id` defaults to caller; auto-registration via `ResolveOrCreateAgent`; tool description updated |
| `internal/service/decisions/service.go` | `ResolveOrCreateAgent` — admin+ auto-registers agents, race-safe `isDuplicateKey` handling |
| `internal/server/handlers_decisions.go` | `HandleTrace` uses `ResolveOrCreateAgent` instead of raw `GetAgentByAgentID` |
| `internal/server/server_test.go` | 3 integration tests — MCP default agent_id, MCP auto-register, HTTP auto-register |

## Test plan

- [x] `go test -race ./...` passes (unit + integration)
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go vet ./...` clean
- [x] `atlas migrate validate` clean
- [ ] Manual: call `akashi_trace` without prior `akashi_check` via MCP client → verify nudge appears in response
- [ ] Manual: admin traces for a new `agent_id` → verify agent auto-created, appears in `GET /v1/agents`
- [ ] Manual: non-admin traces for non-existent `agent_id` → verify 403 Forbidden