### PR TITLE
Fix search fallback and API key access filtering

### DIFF
--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -375,11 +375,15 @@ func verifyAPIKey(ctx context.Context, db *storage.DB, credential string) (*auth
 			continue
 		}
 		// Matched — synthesize claims equivalent to a JWT.
-		return &auth.Claims{
+		// Subject must be set to the agent's internal UUID so that
+		// authz.LoadGrantedSet can parse it for grant-based access filtering.
+		claims := &auth.Claims{
 			AgentID: a.AgentID,
 			OrgID:   a.OrgID,
 			Role:    a.Role,
-		}, nil
+		}
+		claims.Subject = a.ID.String()
+		return claims, nil
 	}
 
 	if !verified {


### PR DESCRIPTION
## Summary

- **Search fallback dead code**: When Qdrant is healthy but returns zero results (empty collection, outbox not synced), the ILIKE text search fallback was unreachable — `akashi_search` returned 0 results for every query. Now falls through to `SearchDecisionsByText` on empty Qdrant results.
- **API key auth missing Subject**: `verifyAPIKey` synthesized claims without `RegisteredClaims.Subject`, causing `authz.LoadGrantedSet` to fail `uuid.Parse("")` and return an empty granted set. All non-admin API key users silently got zero results from filtered endpoints (query, search, recent, conflicts). Now sets `claims.Subject = a.ID.String()`.

## Test plan

- [ ] Verify `akashi_search` returns results for queries that match existing decisions (e.g. "rate limiting")
- [ ] Verify non-admin API key user can see decisions via `POST /v1/query`
- [ ] Verify admin API key user behavior is unchanged
- [ ] All existing tests pass with `-race` (confirmed locally)