### PR TITLE
Add pluggable rate limiting with in-memory token bucket

### DIFF
--- a/internal/model/api.go
+++ b/internal/model/api.go
@@ -39,6 +39,7 @@ const (
 	ErrCodeNotFound      = "NOT_FOUND"
 	ErrCodeConflict      = "CONFLICT"
 	ErrCodeInternalError = "INTERNAL_ERROR"
+	ErrCodeRateLimited   = "RATE_LIMITED"
 )
 
 // CreateRunRequest is the request body for POST /v1/runs.

--- a/internal/ratelimit/memory.go
+++ b/internal/ratelimit/memory.go
@@ -1,0 +1,113 @@
+package ratelimit
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// bucket is a single token bucket for one rate-limit key.
+type bucket struct {
+	tokens     float64
+	lastAccess time.Time
+}
+
+// MemoryLimiter implements Limiter using an in-memory token bucket per key.
+//
+// Each key gets an independent bucket with a configurable refill rate
+// (tokens per second) and burst capacity (maximum tokens). A background
+// goroutine evicts stale entries every minute to bound memory.
+type MemoryLimiter struct {
+	rate  float64 // tokens added per second
+	burst float64 // maximum tokens (bucket capacity)
+
+	mu      sync.Mutex
+	buckets map[string]*bucket
+
+	stopOnce sync.Once
+	done     chan struct{}
+}
+
+// NewMemoryLimiter creates a token bucket limiter.
+//   - rate: sustained requests per second per key
+//   - burst: maximum burst size (token bucket capacity)
+//
+// A background goroutine evicts keys not accessed in the last 10 minutes.
+// Call Close to stop it.
+func NewMemoryLimiter(rate float64, burst int) *MemoryLimiter {
+	m := &MemoryLimiter{
+		rate:    rate,
+		burst:   float64(burst),
+		buckets: make(map[string]*bucket),
+		done:    make(chan struct{}),
+	}
+	go m.cleanup()
+	return m
+}
+
+// Allow consumes one token from the bucket for key. Returns true if a token
+// was available (request should proceed), false otherwise (rate limited).
+func (m *MemoryLimiter) Allow(_ context.Context, key string) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	now := time.Now()
+	b, ok := m.buckets[key]
+	if !ok {
+		// First request for this key: start with a full bucket minus one token.
+		m.buckets[key] = &bucket{
+			tokens:     m.burst - 1,
+			lastAccess: now,
+		}
+		return true, nil
+	}
+
+	// Refill tokens based on elapsed time.
+	elapsed := now.Sub(b.lastAccess).Seconds()
+	b.tokens += elapsed * m.rate
+	if b.tokens > m.burst {
+		b.tokens = m.burst
+	}
+	b.lastAccess = now
+
+	if b.tokens < 1 {
+		return false, nil
+	}
+	b.tokens--
+	return true, nil
+}
+
+// Close stops the cleanup goroutine. Safe to call multiple times.
+func (m *MemoryLimiter) Close() error {
+	m.stopOnce.Do(func() { close(m.done) })
+	return nil
+}
+
+const staleThreshold = 10 * time.Minute
+
+// cleanup periodically evicts buckets that haven't been accessed recently.
+func (m *MemoryLimiter) cleanup() {
+	ticker := time.NewTicker(1 * time.Minute)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-m.done:
+			return
+		case <-ticker.C:
+			m.evictStale()
+		}
+	}
+}
+
+func (m *MemoryLimiter) evictStale() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	cutoff := time.Now().Add(-staleThreshold)
+	for key, b := range m.buckets {
+		if b.lastAccess.Before(cutoff) {
+			delete(m.buckets, key)
+		}
+	}
+}

--- a/internal/ratelimit/memory_test.go
+++ b/internal/ratelimit/memory_test.go
@@ -1,0 +1,240 @@
+package ratelimit
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+func closeLimiter(t *testing.T, m *MemoryLimiter) {
+	t.Helper()
+	if err := m.Close(); err != nil {
+		t.Fatalf("Close error: %v", err)
+	}
+}
+
+func TestMemoryLimiterAllowUnderBurst(t *testing.T) {
+	m := NewMemoryLimiter(10, 5) // 10 rps, burst 5
+	defer closeLimiter(t, m)
+
+	ctx := context.Background()
+	for i := 0; i < 5; i++ {
+		ok, err := m.Allow(ctx, "k1")
+		if err != nil {
+			t.Fatalf("Allow returned error on request %d: %v", i, err)
+		}
+		if !ok {
+			t.Fatalf("expected Allow to return true for request %d (within burst)", i)
+		}
+	}
+}
+
+func TestMemoryLimiterDenyAfterBurst(t *testing.T) {
+	m := NewMemoryLimiter(10, 3) // 10 rps, burst 3
+	defer closeLimiter(t, m)
+
+	ctx := context.Background()
+	// Exhaust the burst.
+	for i := 0; i < 3; i++ {
+		ok, err := m.Allow(ctx, "k1")
+		if err != nil {
+			t.Fatalf("Allow error: %v", err)
+		}
+		if !ok {
+			t.Fatalf("expected Allow=true for request %d", i)
+		}
+	}
+
+	// Next request should be denied.
+	ok, err := m.Allow(ctx, "k1")
+	if err != nil {
+		t.Fatalf("Allow error: %v", err)
+	}
+	if ok {
+		t.Fatal("expected Allow=false after burst exhausted")
+	}
+}
+
+func TestMemoryLimiterTokenRefill(t *testing.T) {
+	// Rate of 1000/s means 1 token per millisecond. With burst=2,
+	// after exhausting both tokens, waiting ~2ms should refill at least 1.
+	m := NewMemoryLimiter(1000, 2)
+	defer closeLimiter(t, m)
+
+	ctx := context.Background()
+	// Exhaust.
+	for i := 0; i < 2; i++ {
+		_, _ = m.Allow(ctx, "k1")
+	}
+	ok, _ := m.Allow(ctx, "k1")
+	if ok {
+		t.Fatal("should be denied immediately after exhausting burst")
+	}
+
+	// Wait for refill.
+	time.Sleep(5 * time.Millisecond)
+
+	ok, err := m.Allow(ctx, "k1")
+	if err != nil {
+		t.Fatalf("Allow error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected Allow=true after refill period")
+	}
+}
+
+func TestMemoryLimiterIndependentKeys(t *testing.T) {
+	m := NewMemoryLimiter(10, 1) // burst 1
+	defer closeLimiter(t, m)
+
+	ctx := context.Background()
+	// Exhaust key "a".
+	ok, _ := m.Allow(ctx, "a")
+	if !ok {
+		t.Fatal("first request for 'a' should succeed")
+	}
+	ok, _ = m.Allow(ctx, "a")
+	if ok {
+		t.Fatal("second request for 'a' should be denied")
+	}
+
+	// Key "b" should be unaffected.
+	ok, _ = m.Allow(ctx, "b")
+	if !ok {
+		t.Fatal("first request for 'b' should succeed")
+	}
+}
+
+func TestMemoryLimiterConcurrent(t *testing.T) {
+	m := NewMemoryLimiter(100, 50)
+	defer closeLimiter(t, m)
+
+	ctx := context.Background()
+	var wg sync.WaitGroup
+	allowed := make([]int, 10)
+
+	// 10 goroutines each send 10 requests for the same key.
+	for g := 0; g < 10; g++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			for i := 0; i < 10; i++ {
+				ok, err := m.Allow(ctx, "shared")
+				if err != nil {
+					t.Errorf("goroutine %d: Allow error: %v", idx, err)
+					return
+				}
+				if ok {
+					allowed[idx]++
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	total := 0
+	for _, c := range allowed {
+		total += c
+	}
+	// Burst is 50, so all 100 requests within a single burst should
+	// allow at most 50 and at least 1.
+	if total < 1 || total > 50 {
+		t.Fatalf("expected between 1 and 50 allowed requests, got %d", total)
+	}
+}
+
+func TestMemoryLimiterEvictStale(t *testing.T) {
+	m := NewMemoryLimiter(10, 5)
+	defer closeLimiter(t, m)
+
+	ctx := context.Background()
+	_, _ = m.Allow(ctx, "stale")
+
+	// Manually backdate the bucket.
+	m.mu.Lock()
+	m.buckets["stale"].lastAccess = time.Now().Add(-15 * time.Minute)
+	m.mu.Unlock()
+
+	m.evictStale()
+
+	m.mu.Lock()
+	_, exists := m.buckets["stale"]
+	m.mu.Unlock()
+
+	if exists {
+		t.Fatal("expected stale bucket to be evicted")
+	}
+}
+
+func TestMemoryLimiterEvictKeepsRecent(t *testing.T) {
+	m := NewMemoryLimiter(10, 5)
+	defer closeLimiter(t, m)
+
+	ctx := context.Background()
+	_, _ = m.Allow(ctx, "recent")
+
+	m.evictStale()
+
+	m.mu.Lock()
+	_, exists := m.buckets["recent"]
+	m.mu.Unlock()
+
+	if !exists {
+		t.Fatal("expected recent bucket to survive eviction")
+	}
+}
+
+func TestMemoryLimiterCloseIdempotent(t *testing.T) {
+	m := NewMemoryLimiter(10, 5)
+	// Double close should not panic.
+	if err := m.Close(); err != nil {
+		t.Fatalf("first Close error: %v", err)
+	}
+	if err := m.Close(); err != nil {
+		t.Fatalf("second Close error: %v", err)
+	}
+}
+
+func TestNoopLimiterAlwaysAllows(t *testing.T) {
+	var l NoopLimiter
+	ctx := context.Background()
+	for i := 0; i < 1000; i++ {
+		ok, err := l.Allow(ctx, "anything")
+		if err != nil {
+			t.Fatalf("NoopLimiter.Allow error: %v", err)
+		}
+		if !ok {
+			t.Fatal("NoopLimiter should always return true")
+		}
+	}
+	if err := l.Close(); err != nil {
+		t.Fatalf("NoopLimiter.Close error: %v", err)
+	}
+}
+
+func TestMemoryLimiterTokensCapAtBurst(t *testing.T) {
+	// Even after a long idle period, tokens should not exceed burst.
+	m := NewMemoryLimiter(1000, 3)
+	defer closeLimiter(t, m)
+
+	ctx := context.Background()
+	_, _ = m.Allow(ctx, "k1")
+
+	// Backdate so a large refill would be computed.
+	m.mu.Lock()
+	m.buckets["k1"].lastAccess = time.Now().Add(-1 * time.Hour)
+	m.mu.Unlock()
+
+	// After refill, should be capped at burst (3). Consume 3 -> ok, 4th -> denied.
+	for i := 0; i < 3; i++ {
+		ok, _ := m.Allow(ctx, "k1")
+		if !ok {
+			t.Fatalf("expected Allow=true for request %d after long idle", i)
+		}
+	}
+	ok, _ := m.Allow(ctx, "k1")
+	if ok {
+		t.Fatal("expected Allow=false after burst exhausted, even after long idle")
+	}
+}

--- a/internal/ratelimit/ratelimit.go
+++ b/internal/ratelimit/ratelimit.go
@@ -1,0 +1,30 @@
+// Package ratelimit provides a pluggable rate limiting interface.
+//
+// The OSS distribution ships an in-memory token bucket (MemoryLimiter).
+// Enterprise deployments can substitute a Redis-backed implementation
+// for cross-instance coordination — the Limiter interface is the contract.
+package ratelimit
+
+import "context"
+
+// Limiter decides whether a request identified by key should be allowed.
+// Implementations must be safe for concurrent use.
+type Limiter interface {
+	// Allow returns true if the request should proceed.
+	// The key is opaque — callers construct it (e.g. "org:<uuid>:agent:<id>").
+	// Returning an error signals a limiter malfunction; callers should
+	// treat errors as fail-open (permit the request) rather than blocking traffic.
+	Allow(ctx context.Context, key string) (bool, error)
+
+	// Close releases resources (cleanup goroutines, connections).
+	Close() error
+}
+
+// NoopLimiter permits every request. Used when rate limiting is disabled.
+type NoopLimiter struct{}
+
+// Allow always returns true.
+func (NoopLimiter) Allow(context.Context, string) (bool, error) { return true, nil }
+
+// Close is a no-op.
+func (NoopLimiter) Close() error { return nil }


### PR DESCRIPTION
## Summary

- Adds `internal/ratelimit` package with a pluggable `Limiter` interface, in-memory token bucket (`MemoryLimiter`), and `NoopLimiter`
- Wires `rateLimitMiddleware` into the HTTP middleware chain — per-key (`org:<id>:agent:<id>`) enforcement after auth, fail-open on errors, platform_admin bypass, 429 + `Retry-After: 1` on denial
- Three new config env vars: `AKASHI_RATE_LIMIT_ENABLED` (default: true), `AKASHI_RATE_LIMIT_RPS` (default: 100), `AKASHI_RATE_LIMIT_BURST` (default: 200)
- Enterprise extends by implementing the `Limiter` interface with Redis — no OSS changes needed

This was the sole remaining P0 production gap, flagged across 5 consecutive codebase reviews.

## Files

**New (3):**
| File | Purpose |
|---|---|
| `internal/ratelimit/ratelimit.go` | `Limiter` interface + `NoopLimiter` |
| `internal/ratelimit/memory.go` | In-memory token bucket (per-key, background GC) |
| `internal/ratelimit/memory_test.go` | 10 tests: allow, deny, burst, refill, concurrency, eviction, cap, close |

**Modified (5):**
| File | Change |
|---|---|
| `internal/config/config.go` | `RateLimitEnabled`, `RateLimitRPS`, `RateLimitBurst` + `envFloat64` helper |
| `internal/model/api.go` | `ErrCodeRateLimited` constant |
| `internal/server/middleware.go` | `rateLimitMiddleware` function |
| `internal/server/server.go` | `RateLimiter` field on `ServerConfig`, middleware chain wiring |
| `cmd/akashi/main.go` | Limiter creation + defer Close |

## Test plan

- [x] `go build ./...` — compiles
- [x] `go vet ./...` — no issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test -race -count=1 ./...` — all 12 suites pass, 0 races
- [ ] Manual: set `AKASHI_RATE_LIMIT_RPS=2` and `AKASHI_RATE_LIMIT_BURST=3`, hit any authenticated endpoint 4+ times rapidly, verify 429 on 4th request
- [ ] Manual: verify `AKASHI_RATE_LIMIT_ENABLED=false` disables rate limiting entirely