### PR TITLE
Add composite agent identity and MCP server instructions

### DIFF
--- a/internal/model/api.go
+++ b/internal/model/api.go
@@ -76,6 +76,7 @@ type TraceRequest struct {
 	Decision     TraceDecision  `json:"decision"`
 	PrecedentRef *uuid.UUID     `json:"precedent_ref,omitempty"` // decision that influenced this one
 	Metadata     map[string]any `json:"metadata,omitempty"`
+	Context      map[string]any `json:"context,omitempty"` // Agent context (model, task, repo, branch).
 }
 
 // TraceDecision is the decision portion of a trace convenience request.

--- a/internal/model/decision.go
+++ b/internal/model/decision.go
@@ -40,6 +40,10 @@ type Decision struct {
 
 	CreatedAt time.Time `json:"created_at"`
 
+	// Composite agent identity (Spec 31): multi-dimensional trace attribution.
+	SessionID    *uuid.UUID     `json:"session_id,omitempty"`
+	AgentContext map[string]any `json:"agent_context,omitempty"`
+
 	// Joined data (populated by queries, not stored in decisions table).
 	Alternatives []Alternative `json:"alternatives,omitempty"`
 	Evidence     []Evidence    `json:"evidence,omitempty"`

--- a/internal/model/query.go
+++ b/internal/model/query.go
@@ -14,6 +14,10 @@ type QueryFilters struct {
 	ConfidenceMin *float32   `json:"confidence_min,omitempty"`
 	Outcome       *string    `json:"outcome,omitempty"`
 	TimeRange     *TimeRange `json:"time_range,omitempty"`
+	SessionID     *uuid.UUID `json:"session_id,omitempty"`
+	Tool          *string    `json:"tool,omitempty"`
+	Model         *string    `json:"model,omitempty"`
+	Repo          *string    `json:"repo,omitempty"`
 }
 
 // TimeRange defines a time range for queries.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -119,6 +119,9 @@ func New(cfg ServerConfig) *Server {
 	// Decision revision history (reader+).
 	mux.Handle("GET /v1/decisions/{id}/revisions", readRole(http.HandlerFunc(h.HandleDecisionRevisions)))
 
+	// Session view (reader+).
+	mux.Handle("GET /v1/sessions/{session_id}", readRole(http.HandlerFunc(h.HandleSessionView)))
+
 	// Integrity verification (reader+).
 	mux.Handle("GET /v1/verify/{id}", readRole(http.HandlerFunc(h.HandleVerifyDecision)))
 

--- a/internal/service/decisions/service.go
+++ b/internal/service/decisions/service.go
@@ -68,6 +68,8 @@ type TraceInput struct {
 	Metadata     map[string]any
 	Decision     model.TraceDecision
 	PrecedentRef *uuid.UUID
+	SessionID    *uuid.UUID     // MCP session or X-Akashi-Session header.
+	AgentContext map[string]any // Merged server-extracted + client-supplied context.
 }
 
 // TraceResult is the outcome of recording a decision.
@@ -169,6 +171,8 @@ func (s *Service) Trace(ctx context.Context, orgID uuid.UUID, input TraceInput) 
 			},
 			Alternatives: alts,
 			Evidence:     evs,
+			SessionID:    input.SessionID,
+			AgentContext: input.AgentContext,
 		})
 		return txErr
 	})

--- a/internal/storage/sessions.go
+++ b/internal/storage/sessions.go
@@ -1,0 +1,30 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/ashita-ai/akashi/internal/model"
+)
+
+// GetSessionDecisions returns all active decisions for a given session within an org,
+// ordered chronologically (oldest first) to reconstruct the session timeline.
+func (db *DB) GetSessionDecisions(ctx context.Context, orgID, sessionID uuid.UUID) ([]model.Decision, error) {
+	rows, err := db.pool.Query(ctx,
+		`SELECT id, run_id, agent_id, org_id, decision_type, outcome, confidence, reasoning,
+		 metadata, quality_score, precedent_ref, supersedes_id, content_hash,
+		 valid_from, valid_to, transaction_time, created_at, session_id, agent_context
+		 FROM decisions
+		 WHERE org_id = $1 AND session_id = $2 AND valid_to IS NULL
+		 ORDER BY valid_from ASC`,
+		orgID, sessionID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("storage: get session decisions: %w", err)
+	}
+	defer rows.Close()
+
+	return scanDecisions(rows)
+}

--- a/migrations/024_composite_agent_identity.sql
+++ b/migrations/024_composite_agent_identity.sql
@@ -1,0 +1,25 @@
+-- Migration 024: Composite Agent Identity (Spec 31)
+--
+-- Adds session_id and agent_context to decisions so every trace carries
+-- multi-dimensional identity: who (agent_id), what session (session_id),
+-- with what tool/model/task (agent_context JSONB).
+
+ALTER TABLE decisions ADD COLUMN session_id UUID;
+ALTER TABLE decisions ADD COLUMN agent_context JSONB NOT NULL DEFAULT '{}';
+
+-- Session-scoped queries: "show me all decisions from this session."
+CREATE INDEX idx_decisions_session ON decisions (session_id, valid_from DESC)
+  WHERE session_id IS NOT NULL;
+
+-- Filtered queries on JSONB fields using btree on extracted text values.
+CREATE INDEX idx_decisions_context_tool ON decisions
+  USING btree ((agent_context->>'tool'))
+  WHERE agent_context->>'tool' IS NOT NULL;
+
+CREATE INDEX idx_decisions_context_model ON decisions
+  USING btree ((agent_context->>'model'))
+  WHERE agent_context->>'model' IS NOT NULL;
+
+CREATE INDEX idx_decisions_context_repo ON decisions
+  USING btree ((agent_context->>'repo'))
+  WHERE agent_context->>'repo' IS NOT NULL;

--- a/migrations/atlas.sum
+++ b/migrations/atlas.sum
@@ -1,4 +1,5 @@
-h1:ceEMvO7+NPjuXQvgyOo162e1UvVKsmacES8RdEHeido=
+h1:Zh6GXClDSasQBJ6kzRUcA90nAewune3I04U3QIxuyLA=
 001_initial.sql h1:CHP1Jr6Rx3DJnm5Ms4ZMCbI5f1mR1L/t0AytzkrWrYQ=
 022_full_text_search.sql h1:+tVYf3wB0yIXZlVof84iRrMphSyt2/9NSYPKF/DPVCw=
 023_fix_outbox_index.sql h1:qxDvX19cp/8leTbcj+1hrCv+UHKRnCpno2jfF1eYghw=
+024_composite_agent_identity.sql h1:BY9WpwmJQ5mx3xFbk8XRbfRKKCUD7zyWSkPVgTlOu3M=


### PR DESCRIPTION
## Summary

- Adds `session_id` (UUID) and `agent_context` (JSONB) to the `decisions` table via migration 024, enabling multi-dimensional agent identity beyond just `agent_id`
- MCP and HTTP handlers automatically enrich traces with session info, client tool/version, model, task, and operator from JWT claims — no SDK changes required
- Adds `WithInstructions()` to the MCP server so every connected agent receives the check-before/record-after workflow during initialization, eliminating per-project CLAUDE.md configuration
- New query filters (`session_id`, `tool`, `model`, `repo`) in both Postgres and Qdrant
- New `GET /v1/sessions/{session_id}` endpoint for session timeline with summary stats

Implements spec 31.

## Changes

**Schema** (backward-compatible — nullable session_id, default '{}' agent_context):
- `migrations/024_composite_agent_identity.sql` — 2 new columns + 4 partial indexes

**Model**:
- `internal/model/decision.go` — SessionID, AgentContext fields
- `internal/model/api.go` — Context field on TraceRequest
- `internal/model/query.go` — SessionID, Tool, Model, Repo filters

**Storage** (all 9 SELECT queries, 2 INSERTs, WHERE clause builder):
- `internal/storage/decisions.go` — session_id + agent_context in all queries and filters
- `internal/storage/trace.go` — new params in CreateTraceTx
- `internal/storage/sessions.go` (new) — GetSessionDecisions

**Service + handlers**:
- `internal/service/decisions/service.go` — expanded TraceInput
- `internal/mcp/tools.go` — MCP session/client info extraction, model/task params, new query filters
- `internal/server/handlers_decisions.go` — HTTP enrichment (X-Akashi-Session, User-Agent, body context), HandleSessionView
- `internal/server/server.go` — session view route

**Search** (Qdrant payload + filters):
- `internal/search/qdrant.go` — Point struct, Upsert payload, EnsureCollection indexes, Search filters
- `internal/search/outbox.go` — DecisionForIndex, fetchDecisionsForIndex, processUpserts conversion

**MCP instructions**:
- `internal/mcp/mcp.go` — WithInstructions() sends check-before/record-after workflow to all clients

## Test plan

- [x] `go mod tidy` — no diff
- [x] `go build ./...` — compiles
- [x] `go vet ./...` — clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] `atlas migrate validate` — valid
- [x] `go test -race ./...` — all 18 packages pass
- [ ] Apply migration 024 to staging DB
- [ ] Verify akashi_trace with model/task params stores agent_context
- [ ] Verify akashi_query with tool/model filters returns filtered results
- [ ] Verify MCP client receives instructions during initialize handshake