### PR TITLE
Fix SDK type drift: Grant field names, Agent updated_at

### DIFF
--- a/sdk/python/src/akashi/types.py
+++ b/sdk/python/src/akashi/types.py
@@ -139,6 +139,7 @@ class Agent(BaseModel):
     tags: list[str] = Field(default_factory=list)
     metadata: dict[str, Any] = Field(default_factory=dict)
     created_at: datetime
+    updated_at: datetime
 
 
 class Grant(BaseModel):

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -118,6 +118,7 @@ def _agent_json(agent_id: str = "coder") -> dict:
         "role": "agent",
         "metadata": {},
         "created_at": NOW,
+        "updated_at": NOW,
     }
 
 

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -118,18 +118,20 @@ export interface Agent {
   tags: string[];
   metadata: Record<string, unknown>;
   created_at: string;
+  updated_at: string;
 }
 
 /** An access grant between agents. */
 export interface Grant {
   id: string;
-  grantor_agent_id: string;
-  grantee_agent_id: string;
+  org_id: string;
+  grantor_id: string;
+  grantee_id: string;
   resource_type: string;
   resource_id?: string;
   permission: string;
+  granted_at: string;
   expires_at?: string;
-  created_at: string;
 }
 
 /** Health check payload returned in the standard API envelope. */

--- a/sdk/typescript/tests/client.test.ts
+++ b/sdk/typescript/tests/client.test.ts
@@ -733,8 +733,10 @@ describe("AkashiClient", () => {
         org_id: "org-1",
         name: "New Agent",
         role: "agent",
+        tags: [],
         metadata: { team: "backend" },
         created_at: "2024-01-01T00:00:00Z",
+        updated_at: "2024-01-01T00:00:00Z",
       };
       mockFetch.mockResolvedValueOnce(mockResponse(200, { data: agent }));
 
@@ -767,8 +769,10 @@ describe("AkashiClient", () => {
         org_id: "org-1",
         name: "Minimal",
         role: "reader",
+        tags: [],
         metadata: {},
         created_at: "2024-01-01T00:00:00Z",
+        updated_at: "2024-01-01T00:00:00Z",
       };
       mockFetch.mockResolvedValueOnce(mockResponse(200, { data: agent }));
 
@@ -798,8 +802,10 @@ describe("AkashiClient", () => {
           org_id: "org-1",
           name: "Agent A",
           role: "admin",
+          tags: [],
           metadata: {},
           created_at: "2024-01-01T00:00:00Z",
+          updated_at: "2024-01-01T00:00:00Z",
         },
         {
           id: "uuid-2",
@@ -807,8 +813,10 @@ describe("AkashiClient", () => {
           org_id: "org-1",
           name: "Agent B",
           role: "reader",
+          tags: [],
           metadata: {},
           created_at: "2024-01-02T00:00:00Z",
+          updated_at: "2024-01-02T00:00:00Z",
         },
       ];
       mockFetch.mockResolvedValueOnce(mockResponse(200, { data: agents }));
@@ -970,13 +978,14 @@ describe("AkashiClient", () => {
     it("creates a grant with all fields", async () => {
       const grant: Grant = {
         id: "grant-1",
-        grantor_agent_id: "test-agent",
-        grantee_agent_id: "reader-agent",
+        org_id: "org-1",
+        grantor_id: "test-agent",
+        grantee_id: "reader-agent",
         resource_type: "decision",
         resource_id: "dec-1",
         permission: "read",
+        granted_at: "2024-01-01T00:00:00Z",
         expires_at: "2025-01-01T00:00:00Z",
-        created_at: "2024-01-01T00:00:00Z",
       };
       mockFetch.mockResolvedValueOnce(mockResponse(200, { data: grant }));
 
@@ -1005,11 +1014,12 @@ describe("AkashiClient", () => {
     it("creates a grant without optional fields", async () => {
       const grant: Grant = {
         id: "grant-2",
-        grantor_agent_id: "test-agent",
-        grantee_agent_id: "other",
+        org_id: "org-1",
+        grantor_id: "test-agent",
+        grantee_id: "other",
         resource_type: "run",
         permission: "write",
-        created_at: "2024-01-01T00:00:00Z",
+        granted_at: "2024-01-01T00:00:00Z",
       };
       mockFetch.mockResolvedValueOnce(mockResponse(200, { data: grant }));
 


### PR DESCRIPTION
## Summary
- TypeScript `Grant` interface: `grantor_agent_id`→`grantor_id`, `grantee_agent_id`→`grantee_id`, `created_at`→`granted_at`, added missing `org_id`
- TypeScript `Agent` interface: added `updated_at`
- Python `Agent` class: added `updated_at`
- All SDK tests updated and passing (59 TS, 38 Python, Go SDK)

Fixes P0-R9c and P0-R9d from the 9th code review.

## Test plan
- [x] TypeScript SDK: 59 tests pass (`npx vitest run`)
- [x] Python SDK: 38 tests pass (`pytest tests/ -v`)
- [x] Go SDK: tests pass (`go test -race ./...`)
- [x] Server: `go build`, `go vet`, `golangci-lint` (0 issues), `atlas migrate validate` all green