### PR TITLE
Add conflict scorer backfill for retroactive scoring

### DIFF
--- a/cmd/akashi/main.go
+++ b/cmd/akashi/main.go
@@ -164,6 +164,14 @@ func run(ctx context.Context, logger *slog.Logger) error {
 	} else if n > 0 {
 		logger.Info("outcome embedding backfill complete", "count", n)
 	}
+	// Backfill conflict scoring for decisions that gained embeddings from the
+	// backfills above. ScoreForDecision only runs on new traces, so previously
+	// unscored decisions need an explicit pass.
+	if n, err := conflictScorer.BackfillScoring(ctx, 500); err != nil {
+		logger.Warn("conflict scoring backfill failed", "error", err)
+	} else if n > 0 {
+		logger.Info("conflict scoring backfill complete", "decisions_scored", n)
+	}
 
 	// Create event buffer.
 	buf := trace.NewBuffer(db, logger, cfg.EventBufferSize, cfg.EventFlushTimeout)


### PR DESCRIPTION
## Summary

- Add `BackfillScoring` to the conflict `Scorer` that iterates all decisions with both embeddings and runs `ScoreForDecision` for each
- Add `FindEmbeddedDecisionIDs` to storage for the lightweight ID+OrgID batch query
- Wire into `main.go` after the embedding backfills at startup
- Safe to call repeatedly — `InsertScoredConflict` uses `ON CONFLICT DO UPDATE`

Previously, the conflict scorer only ran for new decisions at trace time. Decisions that gained embeddings through the startup backfill (e.g., after first enabling an embedding provider) were never cross-scored, leaving `scored_conflicts` empty until fresh traces arrived.

## Test plan

- [x] 3 new scorer tests: `TestBackfillScoring`, `TestBackfillScoring_EmptyDB`, `TestBackfillScoring_ContextCancellation`
- [x] 2 new storage tests: `TestFindEmbeddedDecisionIDs`, `TestFindEmbeddedDecisionIDs_DefaultLimit`
- [x] All 16 test packages pass with `-race`
- [x] `go build`, `go vet`, `golangci-lint`, `atlas validate` all clean
- [x] Verified end-to-end: Docker rebuild → startup backfill scored 30 decisions → 16 conflicts detected → API serves them at GET /v1/conflicts