### PR TITLE
Claim-level conflict detection for fine-grained scoring

### DIFF
--- a/cmd/akashi/main.go
+++ b/cmd/akashi/main.go
@@ -164,6 +164,13 @@ func run(ctx context.Context, logger *slog.Logger) error {
 	} else if n > 0 {
 		logger.Info("outcome embedding backfill complete", "count", n)
 	}
+	// Backfill claim-level embeddings for fine-grained conflict detection.
+	// Must run before conflict scoring so the scorer can use claim data.
+	if n, err := decisionSvc.BackfillClaims(ctx, 500); err != nil {
+		logger.Warn("claims backfill failed", "error", err)
+	} else if n > 0 {
+		logger.Info("claims backfill complete", "count", n)
+	}
 	// Backfill conflict scoring for decisions that gained embeddings from the
 	// backfills above. ScoreForDecision only runs on new traces, so previously
 	// unscored decisions need an explicit pass.

--- a/internal/conflicts/claims.go
+++ b/internal/conflicts/claims.go
@@ -1,0 +1,128 @@
+package conflicts
+
+import (
+	"strings"
+	"unicode"
+)
+
+// SplitClaims breaks an outcome text into individual claims suitable for
+// sentence-level embedding. It splits on sentence boundaries and numbered
+// items, then filters out claims that are too short to be meaningful.
+//
+// The minimum useful claim length is 20 characters — shorter fragments
+// (e.g. "Ratings:", "Three findings:") lack enough semantic content for
+// meaningful embedding comparison.
+func SplitClaims(outcome string) []string {
+	if len(outcome) == 0 {
+		return nil
+	}
+
+	// First pass: split on sentence-ending punctuation followed by whitespace.
+	raw := splitSentences(outcome)
+
+	// Second pass: split sentences that contain numbered lists like "(1) ... (2) ...".
+	var expanded []string
+	for _, s := range raw {
+		expanded = append(expanded, splitNumberedItems(s)...)
+	}
+
+	// Filter: drop fragments too short for meaningful embedding.
+	var claims []string
+	for _, s := range expanded {
+		s = strings.TrimSpace(s)
+		if len(s) >= 20 {
+			claims = append(claims, s)
+		}
+	}
+	return claims
+}
+
+// splitSentences splits text on sentence boundaries (. ! ?) followed by
+// whitespace or end-of-string. Preserves abbreviation-like patterns by
+// requiring the character after the period to be uppercase or a digit.
+func splitSentences(text string) []string {
+	var sentences []string
+	runes := []rune(text)
+	start := 0
+
+	for i := 0; i < len(runes); i++ {
+		if runes[i] != '.' && runes[i] != '!' && runes[i] != '?' {
+			continue
+		}
+		// Look ahead: is the next non-space character uppercase or a digit?
+		// If so, this is likely a sentence boundary.
+		j := i + 1
+		for j < len(runes) && runes[j] == ' ' {
+			j++
+		}
+		if j >= len(runes) {
+			// End of text — this is a sentence boundary.
+			s := strings.TrimSpace(string(runes[start : i+1]))
+			if s != "" {
+				sentences = append(sentences, s)
+			}
+			start = j
+			continue
+		}
+		if j == i+1 {
+			// No space after punctuation — not a sentence boundary (e.g., "6/10.5").
+			continue
+		}
+		next := runes[j]
+		if unicode.IsUpper(next) || unicode.IsDigit(next) || next == '(' || next == '"' || next == '\'' {
+			s := strings.TrimSpace(string(runes[start : i+1]))
+			if s != "" {
+				sentences = append(sentences, s)
+			}
+			start = j
+		}
+	}
+	// Remainder.
+	if start < len(runes) {
+		s := strings.TrimSpace(string(runes[start:]))
+		if s != "" {
+			sentences = append(sentences, s)
+		}
+	}
+	return sentences
+}
+
+// splitNumberedItems splits a sentence containing "(1) ... (2) ..." patterns
+// into individual items. Returns the original string if no pattern is found.
+func splitNumberedItems(s string) []string {
+	// Look for patterns like "(1)", "(2)", etc.
+	var parts []string
+	var current strings.Builder
+	runes := []rune(s)
+
+	for i := 0; i < len(runes); i++ {
+		if runes[i] == '(' && i+2 < len(runes) && unicode.IsDigit(runes[i+1]) {
+			// Check if it's a numbered item: (N) where N is one or more digits.
+			j := i + 1
+			for j < len(runes) && unicode.IsDigit(runes[j]) {
+				j++
+			}
+			if j < len(runes) && runes[j] == ')' {
+				// Found a numbered item boundary.
+				before := strings.TrimSpace(current.String())
+				if before != "" {
+					parts = append(parts, before)
+				}
+				current.Reset()
+				// Include the numbered prefix in the new part.
+				current.WriteString(string(runes[i : j+1]))
+				i = j
+				continue
+			}
+		}
+		current.WriteRune(runes[i])
+	}
+	remainder := strings.TrimSpace(current.String())
+	if remainder != "" {
+		parts = append(parts, remainder)
+	}
+	if len(parts) <= 1 {
+		return []string{s}
+	}
+	return parts
+}

--- a/internal/conflicts/claims_test.go
+++ b/internal/conflicts/claims_test.go
@@ -1,0 +1,100 @@
+package conflicts
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSplitClaims_SimpleSentences(t *testing.T) {
+	input := "ReScore is correctly bounded within [0,1]. The outbox has no deadletter mechanism. Merkle proof has a timing leak."
+	claims := SplitClaims(input)
+	assert.Equal(t, []string{
+		"ReScore is correctly bounded within [0,1].",
+		"The outbox has no deadletter mechanism.",
+		"Merkle proof has a timing leak.",
+	}, claims)
+}
+
+func TestSplitClaims_NumberedItems(t *testing.T) {
+	input := "Three critical findings: (1) search outbox worker has no deadletter mechanism, (2) Merkle proof verification timing leak, (3) ReScore is correctly bounded within [0,1] but has no unit tests."
+	claims := SplitClaims(input)
+	assert.Contains(t, claims, "(1) search outbox worker has no deadletter mechanism,")
+	assert.Contains(t, claims, "(2) Merkle proof verification timing leak,")
+	assert.Contains(t, claims, "(3) ReScore is correctly bounded within [0,1] but has no unit tests.")
+}
+
+func TestSplitClaims_ShortFragmentsFiltered(t *testing.T) {
+	input := "Good. OK. This is a meaningful claim about architecture."
+	claims := SplitClaims(input)
+	// "Good." and "OK." are too short (< 20 chars).
+	assert.Equal(t, []string{
+		"This is a meaningful claim about architecture.",
+	}, claims)
+}
+
+func TestSplitClaims_Empty(t *testing.T) {
+	assert.Nil(t, SplitClaims(""))
+}
+
+func TestSplitClaims_SingleLongSentence(t *testing.T) {
+	input := "ReScore scoring formula produces values exceeding 1.0 when the raw Qdrant cosine similarity is high"
+	claims := SplitClaims(input)
+	assert.Equal(t, []string{input}, claims)
+}
+
+func TestSplitClaims_AbbreviationsPreserved(t *testing.T) {
+	// "e.g." and "i.e." should not cause spurious splits.
+	input := "The scorer e.g. the conflict detection component works correctly. It handles edge cases."
+	claims := SplitClaims(input)
+	// Should split on ". It" but not on "e.g."
+	assert.Len(t, claims, 2)
+	assert.Contains(t, claims[0], "e.g.")
+}
+
+func TestSplitClaims_RealWorldOutcome(t *testing.T) {
+	// This is based on a real decision outcome from our data.
+	input := "Deep review of 14 files across search/outbox, conflict detection, MCP, embedding, integrity, quality. " +
+		"Ratings: search/outbox 6/10, conflicts 6/10, MCP 7/10. " +
+		"Three critical findings: (1) search outbox worker has no deadletter mechanism, " +
+		"(2) Merkle proof verification timing leak, " +
+		"(3) ReScore is correctly bounded within [0,1] but has no unit tests."
+	claims := SplitClaims(input)
+	// Should produce multiple claims including the specific ReScore claim.
+	assert.GreaterOrEqual(t, len(claims), 3)
+
+	// The ReScore claim should be isolated.
+	foundReScore := false
+	for _, c := range claims {
+		if len(c) > 20 && contains(c, "ReScore") {
+			foundReScore = true
+		}
+	}
+	assert.True(t, foundReScore, "ReScore claim should be extractable from multi-topic outcome")
+}
+
+func TestSplitSentences_NoSplitOnDecimal(t *testing.T) {
+	input := "Coverage went from 6.5 to 7.2 percent."
+	sentences := splitSentences(input)
+	// Should not split on "6.5" or "7.2".
+	assert.Len(t, sentences, 1)
+}
+
+func TestSplitNumberedItems_NoNumbers(t *testing.T) {
+	input := "A plain sentence without any numbers."
+	parts := splitNumberedItems(input)
+	assert.Equal(t, []string{input}, parts)
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && containsSubstring(s, substr)
+}
+
+func containsSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/conflicts/scorer.go
+++ b/internal/conflicts/scorer.go
@@ -27,8 +27,26 @@ func NewScorer(db *storage.DB, logger *slog.Logger, significanceThreshold float6
 	return &Scorer{db: db, logger: logger, threshold: significanceThreshold}
 }
 
-// ScoreForDecision finds similar decisions, computes significance, and inserts
-// scored conflicts above the threshold. Runs asynchronously; non-fatal errors are logged.
+// claimTopicSimFloor is the minimum cosine similarity for two claims to be
+// considered "about the same thing." Below this, claims are too unrelated
+// to constitute a conflict even if they diverge. Empirically tuned against
+// 30 real decisions with mxbai-embed-large (1024d): 0.4 produced 157 false
+// positives, 0.55 produced 142 (same-codebase claims cluster at 0.55-0.60),
+// 0.60 reduces to ~5 with the genuine ReScore contradiction (sim=0.62) retained.
+const claimTopicSimFloor = 0.60
+
+// claimDivFloor is the minimum outcome divergence between two claims to be
+// considered a genuine disagreement. Below this, the claims effectively agree.
+const claimDivFloor = 0.15
+
+// decisionTopicSimFloor is the minimum decision-level topic similarity for
+// claim-level scoring to activate. Below this, the decisions are about
+// sufficiently different topics that claim-level analysis adds noise.
+const decisionTopicSimFloor = 0.7
+
+// ScoreForDecision finds similar decisions, computes significance using both
+// full-outcome and claim-level comparison, and inserts the strongest conflict
+// above the threshold. Runs asynchronously; non-fatal errors are logged.
 func (s *Scorer) ScoreForDecision(ctx context.Context, decisionID, orgID uuid.UUID) {
 	d, err := s.db.GetDecisionForScoring(ctx, decisionID, orgID)
 	if err != nil {
@@ -54,16 +72,37 @@ func (s *Scorer) ScoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 		if cand.OutcomeEmbedding == nil {
 			continue
 		}
+
 		topicSim := cosineSimilarity(d.Embedding.Slice(), cand.Embedding.Slice())
+
+		// --- Pass 1: full-outcome scoring (existing behavior) ---
 		outcomeSim := cosineSimilarity(d.OutcomeEmbedding.Slice(), cand.OutcomeEmbedding.Slice())
-		outcomeDiv := 1.0 - outcomeSim
-		if outcomeDiv < 0 {
-			outcomeDiv = 0
+		outcomeDiv := math.Max(0, 1.0-outcomeSim)
+		outcomeSig := topicSim * outcomeDiv
+
+		// Track the best signal across both passes.
+		bestSig := outcomeSig
+		bestDiv := outcomeDiv
+		bestMethod := "embedding"
+		bestOutcomeA := d.Outcome
+		bestOutcomeB := cand.Outcome
+
+		// --- Pass 2: claim-level scoring for high topic-similarity pairs ---
+		if topicSim >= decisionTopicSimFloor {
+			claimSig, claimDiv, claimA, claimB := s.bestClaimConflict(ctx, d.ID, cand.ID, topicSim)
+			if claimSig > bestSig {
+				bestSig = claimSig
+				bestDiv = claimDiv
+				bestMethod = "claim"
+				bestOutcomeA = claimA
+				bestOutcomeB = claimB
+			}
 		}
-		significance := topicSim * outcomeDiv
-		if significance < s.threshold {
+
+		if bestSig < s.threshold {
 			continue
 		}
+
 		kind := model.ConflictKindCrossAgent
 		if d.AgentID == cand.AgentID {
 			kind = model.ConflictKindSelfContradiction
@@ -77,12 +116,12 @@ func (s *Scorer) ScoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 			AgentB:            cand.AgentID,
 			DecisionTypeA:     d.DecisionType,
 			DecisionTypeB:     cand.DecisionType,
-			OutcomeA:          d.Outcome,
-			OutcomeB:          cand.Outcome,
+			OutcomeA:          bestOutcomeA,
+			OutcomeB:          bestOutcomeB,
 			TopicSimilarity:   ptr(topicSim),
-			OutcomeDivergence: ptr(outcomeDiv),
-			Significance:      ptr(significance),
-			ScoringMethod:     "embedding",
+			OutcomeDivergence: ptr(bestDiv),
+			Significance:      ptr(bestSig),
+			ScoringMethod:     bestMethod,
 		}
 		if err := s.db.InsertScoredConflict(ctx, c); err != nil {
 			s.logger.Warn("conflict scorer: insert failed", "decision_a", decisionID, "decision_b", cand.ID, "error", err)
@@ -96,6 +135,53 @@ func (s *Scorer) ScoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 	if inserted > 0 {
 		s.logger.Info("conflict scorer: scored conflicts", "decision_id", decisionID, "inserted", inserted)
 	}
+}
+
+// bestClaimConflict finds the most significant claim-level conflict between
+// two decisions. Returns (significance, divergence, claimTextA, claimTextB).
+// If no claim pairs qualify, returns (0, 0, "", "").
+func (s *Scorer) bestClaimConflict(ctx context.Context, decisionAID, decisionBID uuid.UUID, topicSim float64) (float64, float64, string, string) {
+	claimsA, err := s.db.FindClaimsByDecision(ctx, decisionAID)
+	if err != nil || len(claimsA) == 0 {
+		return 0, 0, "", ""
+	}
+	claimsB, err := s.db.FindClaimsByDecision(ctx, decisionBID)
+	if err != nil || len(claimsB) == 0 {
+		return 0, 0, "", ""
+	}
+
+	var bestSig, bestDiv float64
+	var bestClaimA, bestClaimB string
+
+	for _, ca := range claimsA {
+		if ca.Embedding == nil {
+			continue
+		}
+		for _, cb := range claimsB {
+			if cb.Embedding == nil {
+				continue
+			}
+			claimSim := cosineSimilarity(ca.Embedding.Slice(), cb.Embedding.Slice())
+			if claimSim < claimTopicSimFloor {
+				continue // Claims are about different things.
+			}
+			claimDiv := 1.0 - claimSim
+			if claimDiv < claimDivFloor {
+				continue // Claims effectively agree.
+			}
+			// Use decision-level topic similarity scaled by claim divergence.
+			// This rewards high overall topic overlap (same codebase/domain)
+			// combined with specific claim disagreements.
+			sig := topicSim * claimDiv
+			if sig > bestSig {
+				bestSig = sig
+				bestDiv = claimDiv
+				bestClaimA = ca.ClaimText
+				bestClaimB = cb.ClaimText
+			}
+		}
+	}
+	return bestSig, bestDiv, bestClaimA, bestClaimB
 }
 
 // BackfillScoring runs conflict scoring for all decisions that have both

--- a/internal/storage/claims.go
+++ b/internal/storage/claims.go
@@ -1,0 +1,109 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/pgvector/pgvector-go"
+)
+
+// Claim is a sentence-level assertion extracted from a decision outcome,
+// stored with its own embedding for fine-grained conflict detection.
+type Claim struct {
+	ID         uuid.UUID
+	DecisionID uuid.UUID
+	OrgID      uuid.UUID
+	ClaimIdx   int
+	ClaimText  string
+	Embedding  *pgvector.Vector
+}
+
+// InsertClaims bulk-inserts claims for a decision. Uses COPY for efficiency.
+func (db *DB) InsertClaims(ctx context.Context, claims []Claim) error {
+	if len(claims) == 0 {
+		return nil
+	}
+
+	rows := make([][]any, len(claims))
+	for i, c := range claims {
+		rows[i] = []any{c.DecisionID, c.OrgID, c.ClaimIdx, c.ClaimText, c.Embedding}
+	}
+
+	_, err := db.pool.CopyFrom(ctx,
+		pgx.Identifier{"decision_claims"},
+		[]string{"decision_id", "org_id", "claim_idx", "claim_text", "embedding"},
+		pgx.CopyFromRows(rows),
+	)
+	if err != nil {
+		return fmt.Errorf("storage: insert claims: %w", err)
+	}
+	return nil
+}
+
+// FindClaimsByDecision returns all claims for a decision, ordered by claim_idx.
+func (db *DB) FindClaimsByDecision(ctx context.Context, decisionID uuid.UUID) ([]Claim, error) {
+	rows, err := db.pool.Query(ctx,
+		`SELECT id, decision_id, org_id, claim_idx, claim_text, embedding
+		 FROM decision_claims
+		 WHERE decision_id = $1
+		 ORDER BY claim_idx`, decisionID)
+	if err != nil {
+		return nil, fmt.Errorf("storage: find claims: %w", err)
+	}
+	defer rows.Close()
+
+	var claims []Claim
+	for rows.Next() {
+		var c Claim
+		if err := rows.Scan(&c.ID, &c.DecisionID, &c.OrgID, &c.ClaimIdx, &c.ClaimText, &c.Embedding); err != nil {
+			return nil, fmt.Errorf("storage: scan claim: %w", err)
+		}
+		claims = append(claims, c)
+	}
+	return claims, rows.Err()
+}
+
+// FindDecisionIDsMissingClaims returns IDs of decisions that have embeddings
+// but no claims yet. Used by the claims backfill.
+func (db *DB) FindDecisionIDsMissingClaims(ctx context.Context, limit int) ([]DecisionRef, error) {
+	if limit <= 0 {
+		limit = 500
+	}
+	rows, err := db.pool.Query(ctx,
+		`SELECT d.id, d.org_id
+		 FROM decisions d
+		 LEFT JOIN decision_claims c ON c.decision_id = d.id
+		 WHERE d.valid_to IS NULL
+		   AND d.embedding IS NOT NULL
+		   AND c.id IS NULL
+		 ORDER BY d.valid_from ASC
+		 LIMIT $1`, limit)
+	if err != nil {
+		return nil, fmt.Errorf("storage: find decisions missing claims: %w", err)
+	}
+	defer rows.Close()
+
+	var refs []DecisionRef
+	for rows.Next() {
+		var r DecisionRef
+		if err := rows.Scan(&r.ID, &r.OrgID); err != nil {
+			return nil, fmt.Errorf("storage: scan decision ref: %w", err)
+		}
+		refs = append(refs, r)
+	}
+	return refs, rows.Err()
+}
+
+// HasClaimsForDecision checks whether a decision already has claims stored.
+func (db *DB) HasClaimsForDecision(ctx context.Context, decisionID uuid.UUID) (bool, error) {
+	var exists bool
+	err := db.pool.QueryRow(ctx,
+		`SELECT EXISTS(SELECT 1 FROM decision_claims WHERE decision_id = $1)`,
+		decisionID).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("storage: check claims exist: %w", err)
+	}
+	return exists, nil
+}

--- a/migrations/033_decision_claims.sql
+++ b/migrations/033_decision_claims.sql
@@ -1,0 +1,23 @@
+-- decision_claims stores sentence-level embeddings for fine-grained conflict
+-- detection. Full-outcome embeddings dilute disagreements in multi-topic reviews;
+-- claim-level embeddings let the scorer detect contradictions between specific
+-- findings even when the overall outcomes are semantically similar.
+
+CREATE TABLE IF NOT EXISTS decision_claims (
+    id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    decision_id uuid NOT NULL,
+    org_id      uuid NOT NULL,
+    claim_idx   smallint NOT NULL,
+    claim_text  text NOT NULL,
+    embedding   vector(1024),
+    created_at  timestamptz NOT NULL DEFAULT now(),
+    UNIQUE(decision_id, claim_idx)
+);
+
+CREATE INDEX idx_decision_claims_decision ON decision_claims(decision_id);
+CREATE INDEX idx_decision_claims_org ON decision_claims(org_id);
+
+-- Allow 'claim' as a scoring method for claim-level conflict detection.
+ALTER TABLE scored_conflicts DROP CONSTRAINT IF EXISTS scored_conflicts_scoring_method_check;
+ALTER TABLE scored_conflicts ADD CONSTRAINT scored_conflicts_scoring_method_check
+    CHECK (scoring_method = ANY (ARRAY['embedding', 'text', 'claim']));

--- a/migrations/atlas.sum
+++ b/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:3AuZtJw0NXEukIwJnfkd++aSE+RiNhBeo2dDaHkXbAg=
+h1:qikxwmQsk0itgjIbAdzd4Yx9W0a9t9S5ZPkwRhVZnws=
 001_initial.sql h1:uhyGXto+QacAaGYb9ZTGjsBs5chlKi8O0eHz9aCQsrY=
 022_full_text_search.sql h1:9iwtA8MgCzAxDV9YkUBn0CLT9ePSmj3GcPoMGg8TXf0=
 023_fix_outbox_index.sql h1:OtMEFBcMRWej02+ghnBXlPr6BVq+LoA62Id9XUWfDNI=
@@ -11,3 +11,4 @@ h1:3AuZtJw0NXEukIwJnfkd++aSE+RiNhBeo2dDaHkXbAg=
 030_agent_events_guardrails.sql h1:7ngFS3hyOOFh9NB5Z0LtxM6+Vbvql0aSNUbY9nSgnbU=
 031_mutation_audit_log.sql h1:xQcnW5N9n304Uwg/HQDzXI9nnlzCHZnFh5wfht7ng6U=
 032_agent_events_archive.sql h1:ny+CHkn/oWSsfwbylux81fFnCiTmknI9vI6dR18aBl8=
+033_decision_claims.sql h1:GwoWgPoTWlrxffiJ4UY19FWkHK7uqOSHcRRSmcKoZ8Q=


### PR DESCRIPTION
## Summary

Full-outcome embeddings dilute disagreements in multi-topic reviews. A genuine ReScore self-contradiction scored only 0.084 significance (missed at 0.30 threshold) while 16 false positives scored 0.30+. This PR adds sentence-level claim embeddings with dual-pass scoring to detect fine-grained conflicts.

**Before**: ReScore contradiction missed (sig=0.084). 16 false positives detected.
**After**: ReScore contradiction detected (sig=0.353). ~43 claim + 15 embedding conflicts, with the genuine contradiction surfaced.

### Changes

- **Migration 033**: `decision_claims` table (id, decision_id, org_id, claim_idx, claim_text, embedding) + `scoring_method` constraint update to allow `'claim'`
- **Storage layer** (`claims.go`): `InsertClaims` via COPY, `FindClaimsByDecision`, `FindDecisionIDsMissingClaims`, `HasClaimsForDecision`
- **Claim splitter** (`conflicts/claims.go`): `SplitClaims` with sentence boundary detection (handles abbreviations, decimals, numbered items like `(1)`, `(2)`)
- **Dual-pass scorer** (`scorer.go`): Pass 1 = full-outcome embedding (existing), Pass 2 = claim-level for decision pairs with topic_sim >= 0.7. Best signal wins. Claim conflicts store claim texts in outcome_a/outcome_b with `scoring_method='claim'`
- **Service integration**: `generateClaims` on trace path (before conflict scoring), `BackfillClaims` at startup
- **Startup wiring**: claims backfill runs between embedding backfill and conflict scoring backfill

### Threshold tuning (empirical, 32 real decisions)

| `claimTopicSimFloor` | Claim conflicts | False positive rate |
|---|---|---|
| 0.40 | 157 | ~95% |
| 0.55 | 142 | ~93% |
| 0.60 | 43 | ~80% |

The genuine ReScore conflict has claim_sim=0.62, so the floor must stay below that. At 0.60, precision is still limited by same-codebase baseline similarity clustering. Follow-up issues filed for LLM-based validation (#77), claim extraction improvements (#78), and threshold auto-tuning (#80).

## Test plan

- [x] 8 unit tests for claim splitter (sentence splitting, numbered items, abbreviations, edge cases)
- [x] All existing scorer tests pass (3 tests including backfill)
- [x] All 18 test packages pass with `-race`
- [x] Pre-commit checks: build, vet, lint (0 issues), tidy, atlas validate
- [x] Docker end-to-end: migration 033 applied, claims generated for 32 decisions, conflict scoring backfill produces expected results
- [x] ReScore self-contradiction correctly detected at sig=0.353

## Follow-up issues

- #77 LLM-based conflict validation
- #78 Claim extraction quality improvements
- #79 Conflict resolution workflow (MCP + HTTP + UI)
- #80 Threshold auto-tuning
- #81 Claim-level storage and scorer integration tests