### PR TITLE
Add trace health endpoint for aggregate decision metrics

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -733,6 +733,26 @@ paths:
         "400":
           $ref: "#/components/responses/BadRequest"
 
+  /v1/trace-health:
+    get:
+      operationId: getTraceHealth
+      tags: [Query]
+      summary: Get trace health metrics
+      description: |
+        Returns aggregate health metrics for the organization's decision trace
+        data, including decision quality, evidence coverage, and conflict
+        resolution rates. Identifies gaps and returns an overall status.
+        Requires `admin` role or higher.
+      responses:
+        "200":
+          description: Trace health metrics.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TraceHealthMetrics"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
   # ── Search ─────────────────────────────────────────────────────────
   /v1/search:
     post:
@@ -2191,3 +2211,84 @@ components:
           $ref: "#/components/schemas/VerifyResponse"
         meta:
           $ref: "#/components/schemas/ResponseMeta"
+
+    TraceHealthMetrics:
+      type: object
+      required: [status, completeness, evidence, gaps]
+      properties:
+        status:
+          type: string
+          enum: [healthy, needs_attention, insufficient_data]
+          description: Overall health status of the organization's decision traces.
+        completeness:
+          $ref: "#/components/schemas/CompletenessMetrics"
+        evidence:
+          $ref: "#/components/schemas/EvidenceMetrics"
+        conflicts:
+          $ref: "#/components/schemas/TraceHealthConflictMetrics"
+        gaps:
+          type: array
+          items:
+            type: string
+          description: Up to 3 actionable improvement suggestions, ordered by severity.
+
+    CompletenessMetrics:
+      type: object
+      required: [total_decisions, avg_quality, below_half, below_third, with_reasoning, reasoning_pct]
+      properties:
+        total_decisions:
+          type: integer
+          description: Total number of active decisions.
+        avg_quality:
+          type: number
+          format: double
+          description: Average quality score across all decisions (0.0–1.0).
+        below_half:
+          type: integer
+          description: Count of decisions with quality_score < 0.5.
+        below_third:
+          type: integer
+          description: Count of decisions with quality_score < 0.33.
+        with_reasoning:
+          type: integer
+          description: Count of decisions that include reasoning text.
+        reasoning_pct:
+          type: number
+          format: double
+          description: Percentage of decisions with reasoning (0–100).
+
+    EvidenceMetrics:
+      type: object
+      required: [total_decisions, with_evidence, without_evidence, coverage_pct]
+      properties:
+        total_decisions:
+          type: integer
+          description: Total number of active decisions.
+        with_evidence:
+          type: integer
+          description: Count of decisions that have at least one evidence record.
+        without_evidence:
+          type: integer
+          description: Count of decisions without any evidence records.
+        coverage_pct:
+          type: number
+          format: double
+          description: Percentage of decisions with evidence (0–100).
+
+    TraceHealthConflictMetrics:
+      type: object
+      required: [total, open, resolved, resolved_pct]
+      properties:
+        total:
+          type: integer
+          description: Total number of detected conflicts.
+        open:
+          type: integer
+          description: Number of unresolved conflicts.
+        resolved:
+          type: integer
+          description: Number of resolved conflicts.
+        resolved_pct:
+          type: number
+          format: double
+          description: Percentage of conflicts that have been resolved (0–100).

--- a/internal/server/handlers_decisions.go
+++ b/internal/server/handlers_decisions.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ashita-ai/akashi/internal/integrity"
 	"github.com/ashita-ai/akashi/internal/model"
 	"github.com/ashita-ai/akashi/internal/service/decisions"
+	"github.com/ashita-ai/akashi/internal/service/tracehealth"
 	"github.com/ashita-ai/akashi/internal/storage"
 )
 
@@ -574,6 +575,21 @@ func (h *Handlers) HandleVerifyDecision(w http.ResponseWriter, r *http.Request) 
 	}
 
 	writeJSON(w, r, http.StatusOK, resp)
+}
+
+// HandleTraceHealth handles GET /v1/trace-health.
+// Returns aggregate health metrics for the caller's organization.
+func (h *Handlers) HandleTraceHealth(w http.ResponseWriter, r *http.Request) {
+	orgID := OrgIDFromContext(r.Context())
+
+	svc := tracehealth.New(h.db)
+	metrics, err := svc.Compute(r.Context(), orgID)
+	if err != nil {
+		h.writeInternalError(w, r, "failed to compute trace health", err)
+		return
+	}
+
+	writeJSON(w, r, http.StatusOK, metrics)
 }
 
 // HandleSessionView handles GET /v1/sessions/{session_id}.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -127,6 +127,9 @@ func New(cfg ServerConfig) *Server {
 	// Session view (reader+).
 	mux.Handle("GET /v1/sessions/{session_id}", readRole(http.HandlerFunc(h.HandleSessionView)))
 
+	// Trace health (admin-only).
+	mux.Handle("GET /v1/trace-health", adminOnly(http.HandlerFunc(h.HandleTraceHealth)))
+
 	// Integrity verification (reader+).
 	mux.Handle("GET /v1/verify/{id}", readRole(http.HandlerFunc(h.HandleVerifyDecision)))
 

--- a/internal/service/tracehealth/service.go
+++ b/internal/service/tracehealth/service.go
@@ -1,0 +1,197 @@
+// Package tracehealth computes aggregate health metrics for an organization's
+// decision trace data. It answers the question: "How well is this org using
+// Akashi?" by measuring decision quality, evidence coverage, and conflict
+// resolution rates.
+package tracehealth
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/ashita-ai/akashi/internal/storage"
+)
+
+// Metrics is the top-level trace health response.
+type Metrics struct {
+	Status       string               `json:"status"` // healthy, needs_attention, insufficient_data
+	Completeness *CompletenessMetrics `json:"completeness"`
+	Evidence     *EvidenceMetrics     `json:"evidence"`
+	Conflicts    *ConflictMetrics     `json:"conflicts,omitempty"`
+	Gaps         []string             `json:"gaps"`
+}
+
+// CompletenessMetrics tracks decision quality and reasoning coverage.
+type CompletenessMetrics struct {
+	TotalDecisions int     `json:"total_decisions"`
+	AvgQuality     float64 `json:"avg_quality"`
+	BelowHalf      int     `json:"below_half"`  // quality_score < 0.5
+	BelowThird     int     `json:"below_third"` // quality_score < 0.33
+	WithReasoning  int     `json:"with_reasoning"`
+	ReasoningPct   float64 `json:"reasoning_pct"`
+}
+
+// EvidenceMetrics tracks evidence coverage across decisions.
+type EvidenceMetrics struct {
+	TotalDecisions  int     `json:"total_decisions"`
+	WithEvidence    int     `json:"with_evidence"`
+	WithoutEvidence int     `json:"without_evidence"`
+	CoveragePct     float64 `json:"coverage_pct"`
+}
+
+// ConflictMetrics tracks conflict detection and resolution rates.
+type ConflictMetrics struct {
+	Total       int     `json:"total"`
+	Open        int     `json:"open"`
+	Resolved    int     `json:"resolved"`
+	ResolvedPct float64 `json:"resolved_pct"`
+}
+
+// Service computes trace health metrics.
+type Service struct {
+	db *storage.DB
+}
+
+// New creates a trace health service.
+func New(db *storage.DB) *Service {
+	return &Service{db: db}
+}
+
+// Compute calculates all trace health metrics for an organization.
+func (s *Service) Compute(ctx context.Context, orgID uuid.UUID) (*Metrics, error) {
+	qs, err := s.db.GetDecisionQualityStats(ctx, orgID)
+	if err != nil {
+		return nil, fmt.Errorf("tracehealth: quality stats: %w", err)
+	}
+
+	if qs.Total == 0 {
+		return &Metrics{
+			Status:       "insufficient_data",
+			Completeness: &CompletenessMetrics{},
+			Evidence:     &EvidenceMetrics{},
+			Gaps:         []string{"No decisions recorded yet. Start tracing to see health metrics."},
+		}, nil
+	}
+
+	es, err := s.db.GetEvidenceCoverageStats(ctx, orgID)
+	if err != nil {
+		return nil, fmt.Errorf("tracehealth: evidence stats: %w", err)
+	}
+
+	totalConflicts, err := s.db.CountConflicts(ctx, orgID, storage.ConflictFilters{})
+	if err != nil {
+		return nil, fmt.Errorf("tracehealth: total conflicts: %w", err)
+	}
+
+	openStatus := "open"
+	openConflicts, err := s.db.CountConflicts(ctx, orgID, storage.ConflictFilters{Status: &openStatus})
+	if err != nil {
+		return nil, fmt.Errorf("tracehealth: open conflicts: %w", err)
+	}
+
+	resolvedCount := totalConflicts - openConflicts
+	var resolvedPct float64
+	if totalConflicts > 0 {
+		resolvedPct = float64(resolvedCount) / float64(totalConflicts) * 100
+	}
+
+	var reasoningPct float64
+	if qs.Total > 0 {
+		reasoningPct = float64(qs.WithReasoning) / float64(qs.Total) * 100
+	}
+
+	m := &Metrics{
+		Completeness: &CompletenessMetrics{
+			TotalDecisions: qs.Total,
+			AvgQuality:     qs.AvgQuality,
+			BelowHalf:      qs.BelowHalf,
+			BelowThird:     qs.BelowThird,
+			WithReasoning:  qs.WithReasoning,
+			ReasoningPct:   reasoningPct,
+		},
+		Evidence: &EvidenceMetrics{
+			TotalDecisions:  es.TotalDecisions,
+			WithEvidence:    es.WithEvidence,
+			WithoutEvidence: es.WithoutEvidenceCount,
+			CoveragePct:     es.CoveragePercent,
+		},
+		Gaps: []string{},
+	}
+
+	if totalConflicts > 0 {
+		m.Conflicts = &ConflictMetrics{
+			Total:       totalConflicts,
+			Open:        openConflicts,
+			Resolved:    resolvedCount,
+			ResolvedPct: resolvedPct,
+		}
+	}
+
+	// Gap detection: rule-based, max 3 gaps, ordered by severity.
+	m.Gaps = computeGaps(qs, es, totalConflicts, openConflicts)
+
+	// Overall status.
+	m.Status = computeStatus(qs, es, openConflicts)
+
+	return m, nil
+}
+
+// computeGaps identifies the most important areas for improvement.
+// Returns at most 3 gaps, ordered by severity.
+func computeGaps(qs storage.DecisionQualityStats, es storage.EvidenceCoverageStats, totalConflicts, openConflicts int) []string {
+	var gaps []string
+
+	// Most severe first.
+	if qs.AvgQuality < 0.3 {
+		gaps = append(gaps, fmt.Sprintf(
+			"Average decision quality is %.2f. Most decisions lack substantive reasoning.", qs.AvgQuality))
+	}
+
+	if es.CoveragePercent < 50 {
+		gaps = append(gaps, "Less than half of decisions have supporting evidence.")
+	}
+
+	if openConflicts > 0 && totalConflicts > 0 {
+		gaps = append(gaps, fmt.Sprintf(
+			"%d of %d conflicts are unresolved.", openConflicts, totalConflicts))
+	}
+
+	if len(gaps) < 3 && es.WithoutEvidenceCount > 0 {
+		pct := 0.0
+		if es.TotalDecisions > 0 {
+			pct = float64(es.WithoutEvidenceCount) / float64(es.TotalDecisions) * 100
+		}
+		gaps = append(gaps, fmt.Sprintf(
+			"%d decisions (%.0f%%) lack evidence records.", es.WithoutEvidenceCount, pct))
+	}
+
+	if len(gaps) < 3 && qs.BelowHalf > 0 {
+		gaps = append(gaps, fmt.Sprintf(
+			"%d decisions have quality scores below 0.5.", qs.BelowHalf))
+	}
+
+	if len(gaps) > 3 {
+		gaps = gaps[:3]
+	}
+	return gaps
+}
+
+// computeStatus determines the overall health status.
+func computeStatus(qs storage.DecisionQualityStats, es storage.EvidenceCoverageStats, openConflicts int) string {
+	problems := 0
+	if qs.AvgQuality < 0.3 {
+		problems++
+	}
+	if es.CoveragePercent < 50 {
+		problems++
+	}
+	if openConflicts > 3 {
+		problems++
+	}
+
+	if problems >= 2 {
+		return "needs_attention"
+	}
+	return "healthy"
+}

--- a/internal/service/tracehealth/service_test.go
+++ b/internal/service/tracehealth/service_test.go
@@ -1,0 +1,106 @@
+package tracehealth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ashita-ai/akashi/internal/storage"
+)
+
+func TestComputeGaps_AllHealthy(t *testing.T) {
+	qs := storage.DecisionQualityStats{
+		Total: 100, AvgQuality: 0.8, BelowHalf: 2, BelowThird: 0, WithReasoning: 95,
+	}
+	es := storage.EvidenceCoverageStats{
+		TotalDecisions: 100, WithEvidence: 80, WithoutEvidenceCount: 20, CoveragePercent: 80,
+	}
+	gaps := computeGaps(qs, es, 5, 0)
+
+	// No quality or coverage gaps. No open conflicts. Only "20 decisions lack evidence."
+	assert.LessOrEqual(t, len(gaps), 3)
+	for _, g := range gaps {
+		assert.NotContains(t, g, "Average decision quality")
+		assert.NotContains(t, g, "Less than half")
+		assert.NotContains(t, g, "unresolved")
+	}
+}
+
+func TestComputeGaps_LowQuality(t *testing.T) {
+	qs := storage.DecisionQualityStats{
+		Total: 50, AvgQuality: 0.2, BelowHalf: 30, BelowThird: 20, WithReasoning: 10,
+	}
+	es := storage.EvidenceCoverageStats{
+		TotalDecisions: 50, WithEvidence: 30, WithoutEvidenceCount: 20, CoveragePercent: 60,
+	}
+	gaps := computeGaps(qs, es, 0, 0)
+
+	assert.GreaterOrEqual(t, len(gaps), 1)
+	assert.Contains(t, gaps[0], "Average decision quality")
+}
+
+func TestComputeGaps_LowEvidence(t *testing.T) {
+	qs := storage.DecisionQualityStats{
+		Total: 100, AvgQuality: 0.7, BelowHalf: 5, BelowThird: 0, WithReasoning: 90,
+	}
+	es := storage.EvidenceCoverageStats{
+		TotalDecisions: 100, WithEvidence: 30, WithoutEvidenceCount: 70, CoveragePercent: 30,
+	}
+	gaps := computeGaps(qs, es, 0, 0)
+
+	found := false
+	for _, g := range gaps {
+		if g == "Less than half of decisions have supporting evidence." {
+			found = true
+		}
+	}
+	assert.True(t, found, "expected low evidence gap")
+}
+
+func TestComputeGaps_UnresolvedConflicts(t *testing.T) {
+	qs := storage.DecisionQualityStats{
+		Total: 100, AvgQuality: 0.7, BelowHalf: 5, BelowThird: 0, WithReasoning: 90,
+	}
+	es := storage.EvidenceCoverageStats{
+		TotalDecisions: 100, WithEvidence: 80, WithoutEvidenceCount: 20, CoveragePercent: 80,
+	}
+	gaps := computeGaps(qs, es, 10, 7)
+
+	found := false
+	for _, g := range gaps {
+		if g == "7 of 10 conflicts are unresolved." {
+			found = true
+		}
+	}
+	assert.True(t, found, "expected unresolved conflicts gap")
+}
+
+func TestComputeGaps_MaxThree(t *testing.T) {
+	qs := storage.DecisionQualityStats{
+		Total: 100, AvgQuality: 0.1, BelowHalf: 80, BelowThird: 60, WithReasoning: 10,
+	}
+	es := storage.EvidenceCoverageStats{
+		TotalDecisions: 100, WithEvidence: 10, WithoutEvidenceCount: 90, CoveragePercent: 10,
+	}
+	gaps := computeGaps(qs, es, 20, 15)
+
+	assert.LessOrEqual(t, len(gaps), 3, "should return at most 3 gaps")
+}
+
+func TestComputeStatus_Healthy(t *testing.T) {
+	qs := storage.DecisionQualityStats{Total: 100, AvgQuality: 0.8}
+	es := storage.EvidenceCoverageStats{CoveragePercent: 80}
+	assert.Equal(t, "healthy", computeStatus(qs, es, 0))
+}
+
+func TestComputeStatus_NeedsAttention(t *testing.T) {
+	qs := storage.DecisionQualityStats{Total: 100, AvgQuality: 0.2}
+	es := storage.EvidenceCoverageStats{CoveragePercent: 30}
+	assert.Equal(t, "needs_attention", computeStatus(qs, es, 5))
+}
+
+func TestComputeStatus_OneProblem(t *testing.T) {
+	qs := storage.DecisionQualityStats{Total: 100, AvgQuality: 0.2}
+	es := storage.EvidenceCoverageStats{CoveragePercent: 80}
+	assert.Equal(t, "healthy", computeStatus(qs, es, 0))
+}


### PR DESCRIPTION
## Summary

Closes #94.

- New `GET /v1/trace-health` endpoint (admin-only) returns aggregate health metrics for an organization's decision trace data
- **Decision completeness**: total count, average quality score, below-threshold counts, reasoning coverage
- **Evidence coverage**: decisions with/without evidence, coverage percentage
- **Conflict resolution**: total/open/resolved counts and resolution rate
- **Gap detection**: up to 3 actionable improvement suggestions, ordered by severity
- **Overall status**: `healthy`, `needs_attention`, or `insufficient_data`

## Changes

| File | Change |
|------|--------|
| `internal/service/tracehealth/service.go` | New service: `Compute()`, `computeGaps()`, `computeStatus()` |
| `internal/service/tracehealth/service_test.go` | 8 unit tests covering gap detection and status computation |
| `internal/storage/decisions.go` | `GetDecisionQualityStats()` — aggregate quality query |
| `internal/storage/evidence.go` | `GetEvidenceCoverageStats()` — evidence coverage query |
| `internal/server/handlers_decisions.go` | `HandleTraceHealth` handler |
| `internal/server/server.go` | Route registration (`adminOnly`) |
| `api/openapi.yaml` | Endpoint definition + `TraceHealthMetrics` schema |

## Test plan

- [x] Unit tests for `computeGaps` (all healthy, low quality, low evidence, unresolved conflicts, max 3)
- [x] Unit tests for `computeStatus` (healthy, needs_attention, single problem)
- [x] `go test -race -count=1 ./...` — all 31 packages pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] `atlas migrate validate` — clean