### PR TITLE
Fix akashi_check relevance, add akashi_conflicts tool and per-decision conflicts

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -631,6 +631,56 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
+  /v1/decisions/{id}/conflicts:
+    get:
+      operationId: getDecisionConflicts
+      tags: [Conflicts]
+      summary: Get conflicts involving a decision
+      description: |
+        Returns all detected conflicts where this decision appears as
+        either side (A or B). Useful for understanding whether a specific
+        decision contradicts or supersedes other decisions.
+        Requires `reader` role or higher.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: The decision ID to find conflicts for.
+        - name: status
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [open, acknowledged, resolved, wont_fix]
+          description: Filter by conflict status.
+      responses:
+        "200":
+          description: Conflicts involving this decision.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      decision_id:
+                        type: string
+                        format: uuid
+                      conflicts:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/DecisionConflict"
+                      total:
+                        type: integer
+                  meta:
+                    $ref: "#/components/schemas/ResponseMeta"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+
   /v1/verify/{id}:
     get:
       operationId: verifyDecision

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -124,6 +124,9 @@ func New(cfg ServerConfig) *Server {
 	// Decision revision history (reader+).
 	mux.Handle("GET /v1/decisions/{id}/revisions", readRole(http.HandlerFunc(h.HandleDecisionRevisions)))
 
+	// Decision conflicts (reader+).
+	mux.Handle("GET /v1/decisions/{id}/conflicts", readRole(http.HandlerFunc(h.HandleDecisionConflicts)))
+
 	// Session view (reader+).
 	mux.Handle("GET /v1/sessions/{session_id}", readRole(http.HandlerFunc(h.HandleSessionView)))
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -564,7 +564,7 @@ func TestMCPListTools(t *testing.T) {
 
 	toolsResult, err := c.ListTools(ctx, mcplib.ListToolsRequest{})
 	require.NoError(t, err)
-	assert.Len(t, toolsResult.Tools, 5)
+	assert.Len(t, toolsResult.Tools, 6)
 
 	toolNames := make(map[string]bool)
 	for _, tool := range toolsResult.Tools {
@@ -575,6 +575,7 @@ func TestMCPListTools(t *testing.T) {
 	assert.True(t, toolNames["akashi_query"], "expected akashi_query tool")
 	assert.True(t, toolNames["akashi_search"], "expected akashi_search tool")
 	assert.True(t, toolNames["akashi_recent"], "expected akashi_recent tool")
+	assert.True(t, toolNames["akashi_conflicts"], "expected akashi_conflicts tool")
 }
 
 func TestMCPListResources(t *testing.T) {

--- a/internal/service/decisions/service.go
+++ b/internal/service/decisions/service.go
@@ -291,8 +291,12 @@ func (s *Service) Check(ctx context.Context, orgID uuid.UUID, decisionType, quer
 		if err != nil {
 			return model.CheckResponse{}, fmt.Errorf("check: search: %w", err)
 		}
+		// Filter out low-relevance results so akashi_check doesn't report
+		// has_precedent=true for semantically distant decisions (#101).
 		for _, sr := range results {
-			decisions = append(decisions, sr.Decision)
+			if sr.SimilarityScore >= 0.3 {
+				decisions = append(decisions, sr.Decision)
+			}
 		}
 	} else {
 		// Structured query path.


### PR DESCRIPTION
## Summary

Closes #101, partially addresses #79.

Three improvements to the conflict and check systems:

1. **akashi_check relevance filter** (#101): Semantic search results with similarity < 0.3 are now filtered out before setting `has_precedent`. Previously, distant matches caused `has_precedent=true` for unrelated queries, polluting the check workflow.

2. **akashi_conflicts MCP tool** (#79): New tool for listing and filtering detected conflicts by decision_type, agent_id, status, severity, and category. Defaults to showing only open+acknowledged conflicts (actionable ones).

3. **GET /v1/decisions/{id}/conflicts** (#79): New endpoint that returns all conflicts involving a specific decision (as A or B side), with optional status filter. Adds `DecisionID` filter to `ConflictFilters` for reuse across storage queries.

## Changes

| File | Change |
|------|--------|
| `internal/service/decisions/service.go` | Min similarity filter (0.3) in `Check()` semantic path |
| `internal/storage/conflicts.go` | `DecisionID` field on `ConflictFilters`, clause in `conflictWhere` |
| `internal/mcp/tools.go` | New `akashi_conflicts` tool registration + handler |
| `internal/server/handlers_decisions.go` | `HandleDecisionConflicts` handler |
| `internal/server/server.go` | Route: `GET /v1/decisions/{id}/conflicts` (reader+) |
| `internal/server/server_test.go` | Updated tool count 5 → 6, assert `akashi_conflicts` |
| `api/openapi.yaml` | New endpoint definition |

## Test plan

- [x] `TestMCPListTools` updated for 6 tools (was 5)
- [x] `go test -race -count=1 ./...` — all 31 packages pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] `atlas migrate validate` — clean