### PR TITLE
Backend API improvements (#108, #109, #110, #117, #119, #122, #123)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -160,7 +160,32 @@ paths:
       summary: List all agents
       description: |
         List all agents in the caller's organization.
-        Requires `admin` role or higher.
+        Requires `admin` role or higher. Use `?include=stats` to
+        enrich each agent with decision_count and last_decision_at.
+      parameters:
+        - name: include
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [stats]
+          description: |
+            Pass `stats` to include decision_count and last_decision_at
+            on each agent in the response.
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 200
+          description: Maximum number of agents to return (1-1000).
+        - name: offset
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 0
+          description: Number of agents to skip.
       responses:
         "200":
           description: List of agents.
@@ -172,6 +197,57 @@ paths:
           $ref: "#/components/responses/Forbidden"
 
   /v1/agents/{agent_id}:
+    get:
+      operationId: getAgent
+      tags: [Agents]
+      summary: Get an agent by ID
+      description: |
+        Retrieve a single agent by its agent_id.
+        Requires `admin` role or higher.
+      parameters:
+        - $ref: "#/components/parameters/AgentIDPath"
+      responses:
+        "200":
+          description: The agent.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/APIResponse_Agent"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    patch:
+      operationId: updateAgent
+      tags: [Agents]
+      summary: Update an agent
+      description: |
+        Partially update an agent's name and/or metadata. Metadata is
+        merge-patched (new keys are added, existing keys are overwritten).
+        Requires `admin` role or higher.
+      parameters:
+        - $ref: "#/components/parameters/AgentIDPath"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateAgentRequest"
+      responses:
+        "200":
+          description: Agent updated. Returns the updated agent.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/APIResponse_Agent"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
     delete:
       operationId: deleteAgent
       tags: [Agents]
@@ -190,6 +266,32 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/APIResponse_DeleteAgentResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /v1/agents/{agent_id}/stats:
+    get:
+      operationId: getAgentStats
+      tags: [Agents]
+      summary: Get agent statistics
+      description: |
+        Returns aggregate decision statistics for a specific agent:
+        total count, average confidence, quality breakdown, and
+        decision type distribution.
+        Requires `admin` role or higher.
+      parameters:
+        - $ref: "#/components/parameters/AgentIDPath"
+      responses:
+        "200":
+          description: Agent statistics.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/APIResponse_AgentStats"
         "400":
           $ref: "#/components/responses/BadRequest"
         "403":
@@ -568,6 +670,37 @@ paths:
                 $ref: "#/components/schemas/APIResponse_AgentHistoryResponse"
         "400":
           $ref: "#/components/responses/BadRequest"
+
+  /v1/decisions/{id}:
+    get:
+      operationId: getDecision
+      tags: [Decisions]
+      summary: Get a decision by ID
+      description: |
+        Retrieve a single decision by its UUID, including alternatives
+        and evidence. Requires `reader` role or higher. Access is
+        subject to grant-based filtering.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: Decision UUID.
+      responses:
+        "200":
+          description: The decision with alternatives and evidence.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/APIResponse_Decision"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
 
   /v1/decisions/recent:
     get:
@@ -1335,6 +1468,20 @@ components:
           type: object
           additionalProperties: true
 
+    UpdateAgentRequest:
+      type: object
+      description: |
+        Partial update of an agent. At least one field must be provided.
+        Metadata is merge-patched (new keys added, existing keys overwritten).
+      properties:
+        name:
+          type: string
+          description: New display name for the agent.
+        metadata:
+          type: object
+          additionalProperties: true
+          description: Metadata keys to merge into the agent's existing metadata.
+
     UpdateAgentTagsRequest:
       type: object
       required: [tags]
@@ -1346,6 +1493,33 @@ components:
           description: |
             New set of tags for the agent. Replaces existing tags entirely.
             Each tag must match `^[a-z][a-z0-9_-]*$`.
+
+    AgentStats:
+      type: object
+      properties:
+        decision_count:
+          type: integer
+          description: Total number of active decisions by this agent.
+        avg_confidence:
+          type: number
+          format: double
+          description: Average confidence across all decisions.
+        first_decision:
+          type: string
+          format: date-time
+          description: Timestamp of the agent's earliest decision.
+        last_decision:
+          type: string
+          format: date-time
+          description: Timestamp of the agent's most recent decision.
+        low_quality_count:
+          type: integer
+          description: Number of decisions with quality_score below 0.5.
+        decision_types:
+          type: object
+          additionalProperties:
+            type: integer
+          description: Decision count breakdown by decision_type.
 
     DeleteAgentResponse:
       type: object
@@ -2242,6 +2416,29 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Agent"
+        meta:
+          $ref: "#/components/schemas/ResponseMeta"
+
+    APIResponse_AgentStats:
+      type: object
+      required: [data, meta]
+      properties:
+        data:
+          type: object
+          properties:
+            agent_id:
+              type: string
+            stats:
+              $ref: "#/components/schemas/AgentStats"
+        meta:
+          $ref: "#/components/schemas/ResponseMeta"
+
+    APIResponse_Decision:
+      type: object
+      required: [data, meta]
+      properties:
+        data:
+          $ref: "#/components/schemas/Decision"
         meta:
           $ref: "#/components/schemas/ResponseMeta"
 

--- a/internal/model/api.go
+++ b/internal/model/api.go
@@ -127,6 +127,12 @@ type CreateAgentRequest struct {
 	Metadata map[string]any `json:"metadata,omitempty"`
 }
 
+// UpdateAgentRequest is the request body for PATCH /v1/agents/{agent_id}.
+type UpdateAgentRequest struct {
+	Name     *string        `json:"name,omitempty"`
+	Metadata map[string]any `json:"metadata,omitempty"`
+}
+
 // UpdateAgentTagsRequest is the request body for PATCH /v1/agents/{agent_id}/tags.
 type UpdateAgentTagsRequest struct {
 	Tags []string `json:"tags"`

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -94,6 +94,9 @@ func New(cfg ServerConfig) *Server {
 	adminOnly := requireRole(model.RoleAdmin)
 	mux.Handle("POST /v1/agents", adminOnly(http.HandlerFunc(h.HandleCreateAgent)))
 	mux.Handle("GET /v1/agents", adminOnly(http.HandlerFunc(h.HandleListAgents)))
+	mux.Handle("GET /v1/agents/{agent_id}", adminOnly(http.HandlerFunc(h.HandleGetAgent)))
+	mux.Handle("PATCH /v1/agents/{agent_id}", adminOnly(http.HandlerFunc(h.HandleUpdateAgent)))
+	mux.Handle("GET /v1/agents/{agent_id}/stats", adminOnly(http.HandlerFunc(h.HandleAgentStats)))
 	mux.Handle("PATCH /v1/agents/{agent_id}/tags", adminOnly(http.HandlerFunc(h.HandleUpdateAgentTags)))
 	mux.Handle("DELETE /v1/agents/{agent_id}", adminOnly(http.HandlerFunc(h.HandleDeleteAgent)))
 	mux.Handle("GET /v1/export/decisions", adminOnly(http.HandlerFunc(h.HandleExportDecisions)))
@@ -107,6 +110,7 @@ func New(cfg ServerConfig) *Server {
 
 	// Query endpoints (reader+).
 	readRole := requireRole(model.RoleReader)
+	mux.Handle("GET /v1/decisions/{id}", readRole(http.HandlerFunc(h.HandleGetDecision)))
 	mux.Handle("POST /v1/query", readRole(http.HandlerFunc(h.HandleQuery)))
 	mux.Handle("POST /v1/query/temporal", readRole(http.HandlerFunc(h.HandleTemporalQuery)))
 	mux.Handle("GET /v1/runs/{run_id}", readRole(http.HandlerFunc(h.HandleGetRun)))

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -564,7 +564,7 @@ func TestMCPListTools(t *testing.T) {
 
 	toolsResult, err := c.ListTools(ctx, mcplib.ListToolsRequest{})
 	require.NoError(t, err)
-	assert.Len(t, toolsResult.Tools, 6)
+	assert.Len(t, toolsResult.Tools, 7)
 
 	toolNames := make(map[string]bool)
 	for _, tool := range toolsResult.Tools {
@@ -576,6 +576,7 @@ func TestMCPListTools(t *testing.T) {
 	assert.True(t, toolNames["akashi_search"], "expected akashi_search tool")
 	assert.True(t, toolNames["akashi_recent"], "expected akashi_recent tool")
 	assert.True(t, toolNames["akashi_conflicts"], "expected akashi_conflicts tool")
+	assert.True(t, toolNames["akashi_stats"], "expected akashi_stats tool")
 }
 
 func TestMCPListResources(t *testing.T) {


### PR DESCRIPTION
## Summary

- **GET /v1/agents/{agent_id}** (#108): retrieve a single agent by ID (admin-only)
- **PATCH /v1/agents/{agent_id}** (#109): partial update of agent name/metadata with merge-patch semantics and mutation audit
- **GET /v1/agents/{agent_id}/stats** (#110): aggregate decision statistics (count, avg confidence, quality breakdown, type distribution)
- **GET /v1/decisions/{id}** (#117): retrieve a single decision with alternatives and evidence (reader+, access-filtered)
- **?include=stats on GET /v1/agents** (#119): enriches agent list with decision_count and last_decision_at
- **Pagination standardization** (#122): added has_more to HandleAgentHistory
- **akashi_stats MCP tool** (#123): aggregate trace health, agent count, and conflict summary

All new storage queries scoped by org_id. All mutations wrapped in audit entries. OpenAPI spec updated with 4 new endpoints and 3 new schemas. MCP tool count test updated (6 → 7).

Closes #108, #109, #110, #117, #119, #122, #123

## Test plan

- [x] `go mod tidy && git diff --exit-code go.mod go.sum` — no changes
- [x] `go build ./...` — clean build
- [x] `go vet ./...` — no issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `atlas migrate validate --dir file://migrations` — valid
- [x] `go test -race -count=1 ./...` — all pass
- [ ] Manual: GET /v1/agents/{agent_id} returns correct agent
- [ ] Manual: PATCH /v1/agents/{agent_id} with name/metadata updates agent
- [ ] Manual: GET /v1/agents/{agent_id}/stats returns decision breakdown
- [ ] Manual: GET /v1/decisions/{id} returns decision with alts/evidence
- [ ] Manual: GET /v1/agents?include=stats enriches with counts
- [ ] Manual: akashi_stats MCP tool returns health + agent count