### PR TITLE
Add UI improvements (#111, #112, #113, #115, #118, #120)

### DIFF
--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -9,6 +9,7 @@ import {
   Users,
   AlertTriangle,
   Search,
+  Download,
   LogOut,
   Menu,
   X,
@@ -41,6 +42,7 @@ const navItems = [
   { to: "/agents", label: "Agents", icon: Users },
   { to: "/conflicts", label: "Conflicts", icon: AlertTriangle },
   { to: "/search", label: "Search", icon: Search },
+  { to: "/export", label: "Export", icon: Download },
 ];
 
 export default function Layout() {

--- a/ui/src/pages/Conflicts.tsx
+++ b/ui/src/pages/Conflicts.tsx
@@ -1,19 +1,85 @@
 import { Link, useSearchParams } from "react-router";
-import { useQuery } from "@tanstack/react-query";
-import { listConflicts } from "@/lib/api";
-import type { DecisionConflict } from "@/types/api";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { listConflicts, patchConflict, ApiError } from "@/lib/api";
+import type { DecisionConflict, ConflictStatus } from "@/types/api";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { formatDate } from "@/lib/utils";
-import { AlertTriangle, ArrowRight, ChevronLeft, ChevronRight, Swords } from "lucide-react";
+import {
+  AlertTriangle,
+  ArrowRight,
+  Check,
+  CheckCircle2,
+  ChevronLeft,
+  ChevronRight,
+  Eye,
+  Swords,
+  XCircle,
+} from "lucide-react";
 import { useState, type FormEvent } from "react";
 
 function truncate(text: string, maxLen: number): string {
   if (text.length <= maxLen) return text;
   return text.slice(0, maxLen).trimEnd() + "\u2026";
+}
+
+const statusConfig: Record<
+  ConflictStatus,
+  { label: string; variant: "default" | "secondary" | "destructive" | "success" | "warning" | "outline" }
+> = {
+  open: { label: "Open", variant: "warning" },
+  acknowledged: { label: "Acknowledged", variant: "secondary" },
+  resolved: { label: "Resolved", variant: "success" },
+  wont_fix: { label: "Won't Fix", variant: "outline" },
+};
+
+const severityConfig: Record<string, { variant: "default" | "secondary" | "destructive" | "success" | "warning" | "outline" }> = {
+  critical: { variant: "destructive" },
+  high: { variant: "warning" },
+  medium: { variant: "secondary" },
+  low: { variant: "outline" },
+};
+
+function StatusBadge({ status }: { status: ConflictStatus }) {
+  const config = statusConfig[status] ?? statusConfig.open;
+  return <Badge variant={config.variant}>{config.label}</Badge>;
+}
+
+function SeverityBadge({ severity }: { severity: string | null }) {
+  if (!severity) return null;
+  const config = severityConfig[severity] ?? { variant: "secondary" as const };
+  return (
+    <Badge variant={config.variant} className="text-xs">
+      {severity}
+    </Badge>
+  );
+}
+
+function CategoryBadge({ category }: { category: string | null }) {
+  if (!category) return null;
+  return (
+    <Badge variant="outline" className="text-xs">
+      {category}
+    </Badge>
+  );
 }
 
 function ConflictSide({
@@ -62,34 +128,74 @@ function ConflictSide({
   );
 }
 
-function ConflictCard({ conflict }: { conflict: DecisionConflict }) {
+function ConflictCard({
+  conflict,
+  onResolve,
+}: {
+  conflict: DecisionConflict;
+  onResolve: (conflict: DecisionConflict) => void;
+}) {
   return (
     <Card>
       <CardHeader className="pb-3">
         <div className="flex items-center justify-between">
-          <CardTitle className="flex items-center gap-2 text-sm">
-            <AlertTriangle className="h-4 w-4 text-amber-500" />
-            <span className="font-mono">{conflict.decision_type}</span>
-          </CardTitle>
+          <div className="flex items-center gap-2">
+            <CardTitle className="flex items-center gap-2 text-sm">
+              <AlertTriangle className="h-4 w-4 text-amber-500" />
+              <span className="font-mono">{conflict.decision_type}</span>
+            </CardTitle>
+            <StatusBadge status={conflict.status} />
+            <SeverityBadge severity={conflict.severity} />
+            <CategoryBadge category={conflict.category} />
+          </div>
           <span className="text-xs text-muted-foreground">
             Detected {formatDate(conflict.detected_at)}
           </span>
         </div>
-        <p className="text-xs text-muted-foreground mt-1">
-          {conflict.conflict_kind === "self_contradiction" ? (
-            <>
-              <span className="font-medium text-foreground">{conflict.agent_a}</span>
-              {" contradicted themselves on the same decision type within 7 days"}
-            </>
-          ) : (
-            <>
-              <span className="font-medium text-foreground">{conflict.agent_a}</span>
-              {" and "}
-              <span className="font-medium text-foreground">{conflict.agent_b}</span>
-              {" reached different conclusions on the same decision type within an hour"}
-            </>
+        <div className="flex items-center justify-between mt-1">
+          <p className="text-xs text-muted-foreground">
+            {conflict.conflict_kind === "self_contradiction" ? (
+              <>
+                <span className="font-medium text-foreground">{conflict.agent_a}</span>
+                {" contradicted themselves on the same decision type within 7 days"}
+              </>
+            ) : (
+              <>
+                <span className="font-medium text-foreground">{conflict.agent_a}</span>
+                {" and "}
+                <span className="font-medium text-foreground">{conflict.agent_b}</span>
+                {" reached different conclusions on the same decision type within an hour"}
+              </>
+            )}
+          </p>
+          {conflict.status === "open" && (
+            <div className="flex gap-1">
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-7 text-xs"
+                onClick={() => onResolve(conflict)}
+              >
+                <Eye className="h-3 w-3 mr-1" />
+                Resolve
+              </Button>
+            </div>
           )}
-        </p>
+        </div>
+        {conflict.explanation && (
+          <p className="text-xs text-muted-foreground mt-2 italic border-l-2 border-muted pl-2">
+            {conflict.explanation}
+          </p>
+        )}
+        {conflict.resolution_note && (
+          <p className="text-xs mt-2 border-l-2 border-emerald-500 pl-2">
+            <span className="text-muted-foreground">Resolution:</span>{" "}
+            {conflict.resolution_note}
+            {conflict.resolved_by && (
+              <span className="text-muted-foreground"> by {conflict.resolved_by}</span>
+            )}
+          </p>
+        )}
       </CardHeader>
       <CardContent>
         <div className="grid gap-3 sm:grid-cols-[1fr,auto,1fr]">
@@ -124,15 +230,21 @@ function ConflictCard({ conflict }: { conflict: DecisionConflict }) {
 const PAGE_SIZE = 25;
 
 export default function Conflicts() {
+  const queryClient = useQueryClient();
   const [searchParams, setSearchParams] = useSearchParams();
 
   const page = Math.max(0, parseInt(searchParams.get("page") ?? "0", 10));
   const agentFilter = searchParams.get("agent") ?? "";
+  const statusFilter = searchParams.get("status") ?? "";
 
   const [agentInput, setAgentInput] = useState(agentFilter);
+  const [resolveTarget, setResolveTarget] = useState<DecisionConflict | null>(null);
+  const [resolveStatus, setResolveStatus] = useState<string>("acknowledged");
+  const [resolveNote, setResolveNote] = useState("");
+  const [resolveError, setResolveError] = useState<string | null>(null);
 
   const { data, isPending } = useQuery({
-    queryKey: ["conflicts", page, agentFilter],
+    queryKey: ["conflicts", page, agentFilter, statusFilter],
     queryFn: () =>
       listConflicts({
         limit: PAGE_SIZE,
@@ -141,20 +253,64 @@ export default function Conflicts() {
       }),
   });
 
+  // Client-side status filter (backend may not support status filter on list)
+  const filteredConflicts = statusFilter
+    ? data?.conflicts?.filter((c) => c.status === statusFilter)
+    : data?.conflicts;
+
   const totalPages = data ? Math.ceil(data.total / PAGE_SIZE) : 0;
+
+  const resolveMutation = useMutation({
+    mutationFn: (params: { id: string; status: string; resolution_note?: string }) =>
+      patchConflict(params.id, { status: params.status, resolution_note: params.resolution_note }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["conflicts"] });
+      setResolveTarget(null);
+      setResolveNote("");
+      setResolveError(null);
+    },
+    onError: (err) => {
+      setResolveError(err instanceof ApiError ? err.message : "Failed to update conflict");
+    },
+  });
 
   function applyFilter(e: FormEvent) {
     e.preventDefault();
     const params: Record<string, string> = {};
     if (agentInput.trim()) params.agent = agentInput.trim();
+    if (statusFilter) params.status = statusFilter;
+    setSearchParams(params);
+  }
+
+  function setStatus(value: string) {
+    const params: Record<string, string> = {};
+    if (agentFilter) params.agent = agentFilter;
+    if (value && value !== "all") params.status = value;
     setSearchParams(params);
   }
 
   function goToPage(p: number) {
     const params: Record<string, string> = {};
     if (agentFilter) params.agent = agentFilter;
+    if (statusFilter) params.status = statusFilter;
     if (p > 0) params.page = String(p);
     setSearchParams(params);
+  }
+
+  function openResolveDialog(conflict: DecisionConflict) {
+    setResolveTarget(conflict);
+    setResolveStatus("acknowledged");
+    setResolveNote("");
+    setResolveError(null);
+  }
+
+  function handleResolve() {
+    if (!resolveTarget) return;
+    resolveMutation.mutate({
+      id: resolveTarget.id,
+      status: resolveStatus,
+      ...(resolveNote.trim() ? { resolution_note: resolveNote.trim() } : {}),
+    });
   }
 
   return (
@@ -166,7 +322,7 @@ export default function Conflicts() {
         )}
       </div>
 
-      {/* Agent filter */}
+      {/* Filters */}
       <form onSubmit={applyFilter} className="flex flex-wrap items-end gap-3">
         <div className="space-y-1">
           <label className="text-xs text-muted-foreground">Agent</label>
@@ -177,10 +333,25 @@ export default function Conflicts() {
             className="w-48"
           />
         </div>
+        <div className="space-y-1">
+          <label className="text-xs text-muted-foreground">Status</label>
+          <Select value={statusFilter || "all"} onValueChange={setStatus}>
+            <SelectTrigger className="w-40">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All statuses</SelectItem>
+              <SelectItem value="open">Open</SelectItem>
+              <SelectItem value="acknowledged">Acknowledged</SelectItem>
+              <SelectItem value="resolved">Resolved</SelectItem>
+              <SelectItem value="wont_fix">Won't Fix</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
         <Button type="submit" size="sm">
           Filter
         </Button>
-        {agentFilter && (
+        {(agentFilter || statusFilter) && (
           <Button
             type="button"
             variant="ghost"
@@ -201,56 +372,128 @@ export default function Conflicts() {
             <Skeleton key={i} className="h-48 w-full" />
           ))}
         </div>
-      ) : !data?.conflicts?.length ? (
+      ) : !filteredConflicts?.length ? (
         <div className="flex flex-col items-center py-12 text-center">
           <AlertTriangle className="h-12 w-12 text-muted-foreground/30 mb-4" />
           <p className="text-sm text-muted-foreground">
-            {agentFilter
-              ? `No conflicts found for agent "${agentFilter}".`
+            {agentFilter || statusFilter
+              ? "No conflicts match the current filters."
               : "No conflicts detected. Agents are in agreement."}
           </p>
         </div>
       ) : (
         <>
           <div className="space-y-4">
-            {data.conflicts.map((conflict) => (
+            {filteredConflicts.map((conflict) => (
               <ConflictCard
-                key={`${conflict.decision_a_id}-${conflict.decision_b_id}`}
+                key={conflict.id ?? `${conflict.decision_a_id}-${conflict.decision_b_id}`}
                 conflict={conflict}
+                onResolve={openResolveDialog}
               />
             ))}
           </div>
 
           {/* Pagination */}
-          <div className="flex items-center justify-between">
-            <p className="text-sm text-muted-foreground">
-              Showing {page * PAGE_SIZE + 1}{"\u2013"}
-              {Math.min((page + 1) * PAGE_SIZE, data.total)} of{" "}
-              {data.total.toLocaleString()}
-            </p>
-            <div className="flex gap-2">
-              <Button
-                variant="outline"
-                size="sm"
-                disabled={page === 0}
-                onClick={() => goToPage(page - 1)}
-              >
-                <ChevronLeft className="h-4 w-4" />
-                Prev
-              </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                disabled={page >= totalPages - 1}
-                onClick={() => goToPage(page + 1)}
-              >
-                Next
-                <ChevronRight className="h-4 w-4" />
-              </Button>
+          {data && data.total > PAGE_SIZE && (
+            <div className="flex items-center justify-between">
+              <p className="text-sm text-muted-foreground">
+                Showing {page * PAGE_SIZE + 1}{"\u2013"}
+                {Math.min((page + 1) * PAGE_SIZE, data.total)} of{" "}
+                {data.total.toLocaleString()}
+              </p>
+              <div className="flex gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={page === 0}
+                  onClick={() => goToPage(page - 1)}
+                >
+                  <ChevronLeft className="h-4 w-4" />
+                  Prev
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={page >= totalPages - 1}
+                  onClick={() => goToPage(page + 1)}
+                >
+                  Next
+                  <ChevronRight className="h-4 w-4" />
+                </Button>
+              </div>
             </div>
-          </div>
+          )}
         </>
       )}
+
+      {/* Resolution dialog */}
+      <Dialog open={resolveTarget !== null} onOpenChange={(open) => !open && setResolveTarget(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Resolve Conflict</DialogTitle>
+            <DialogDescription>
+              Update the status of this conflict between{" "}
+              <strong>{resolveTarget?.agent_a}</strong>
+              {resolveTarget?.agent_a !== resolveTarget?.agent_b && (
+                <> and <strong>{resolveTarget?.agent_b}</strong></>
+              )}
+              {" on "}<strong>{resolveTarget?.decision_type}</strong>.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 py-2">
+            <div className="space-y-2">
+              <label className="text-sm font-medium">Action</label>
+              <div className="flex gap-2">
+                <Button
+                  variant={resolveStatus === "acknowledged" ? "default" : "outline"}
+                  size="sm"
+                  onClick={() => setResolveStatus("acknowledged")}
+                >
+                  <Eye className="h-3.5 w-3.5 mr-1.5" />
+                  Acknowledge
+                </Button>
+                <Button
+                  variant={resolveStatus === "resolved" ? "default" : "outline"}
+                  size="sm"
+                  onClick={() => setResolveStatus("resolved")}
+                >
+                  <CheckCircle2 className="h-3.5 w-3.5 mr-1.5" />
+                  Resolve
+                </Button>
+                <Button
+                  variant={resolveStatus === "wont_fix" ? "default" : "outline"}
+                  size="sm"
+                  onClick={() => setResolveStatus("wont_fix")}
+                >
+                  <XCircle className="h-3.5 w-3.5 mr-1.5" />
+                  Won't Fix
+                </Button>
+              </div>
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm font-medium">Note (optional)</label>
+              <textarea
+                className="w-full rounded-md border bg-background px-3 py-2 text-sm min-h-[80px] resize-none focus:outline-none focus:ring-2 focus:ring-ring"
+                placeholder="Describe why this conflict was resolved this way..."
+                value={resolveNote}
+                onChange={(e) => setResolveNote(e.target.value)}
+              />
+            </div>
+            {resolveError && (
+              <p className="text-sm text-destructive">{resolveError}</p>
+            )}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setResolveTarget(null)}>
+              Cancel
+            </Button>
+            <Button onClick={handleResolve} disabled={resolveMutation.isPending}>
+              <Check className="h-4 w-4 mr-1.5" />
+              {resolveMutation.isPending ? "Saving\u2026" : "Save"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/ui/src/pages/ExportPage.tsx
+++ b/ui/src/pages/ExportPage.tsx
@@ -1,0 +1,113 @@
+import { useState, type FormEvent } from "react";
+import { useAuth } from "@/lib/auth";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Download } from "lucide-react";
+
+export default function ExportPage() {
+  const { token } = useAuth();
+  const [from, setFrom] = useState("");
+  const [to, setTo] = useState("");
+  const [agentId, setAgentId] = useState("");
+  const [decisionType, setDecisionType] = useState("");
+
+  function handleExport(e: FormEvent) {
+    e.preventDefault();
+    const params = new URLSearchParams();
+    if (from) params.set("from", new Date(from).toISOString());
+    if (to) params.set("to", new Date(to).toISOString());
+    if (agentId.trim()) params.set("agent_id", agentId.trim());
+    if (decisionType.trim()) params.set("decision_type", decisionType.trim());
+
+    const qs = params.toString();
+    const url = `/v1/export/decisions${qs ? `?${qs}` : ""}`;
+
+    // Use fetch with auth header to trigger download
+    fetch(url, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then((res) => {
+        if (!res.ok) throw new Error(`Export failed: ${res.status}`);
+        const disposition = res.headers.get("Content-Disposition");
+        const match = disposition?.match(/filename="(.+?)"/);
+        const filename = match?.[1] ?? "akashi-export.ndjson";
+        return res.blob().then((blob) => ({ blob, filename }));
+      })
+      .then(({ blob, filename }) => {
+        const a = document.createElement("a");
+        a.href = URL.createObjectURL(blob);
+        a.download = filename;
+        a.click();
+        URL.revokeObjectURL(a.href);
+      })
+      .catch((err) => {
+        console.error("Export failed:", err);
+      });
+  }
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold tracking-tight">Export</h1>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm font-medium">Export Decisions</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleExport} className="space-y-4">
+            <p className="text-sm text-muted-foreground">
+              Export decisions as NDJSON (newline-delimited JSON). Each line contains a decision
+              with its alternatives and evidence. Requires admin role.
+            </p>
+
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="from">From date</Label>
+                <Input
+                  id="from"
+                  type="datetime-local"
+                  value={from}
+                  onChange={(e) => setFrom(e.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="to">To date</Label>
+                <Input
+                  id="to"
+                  type="datetime-local"
+                  value={to}
+                  onChange={(e) => setTo(e.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="export-agent">Agent ID</Label>
+                <Input
+                  id="export-agent"
+                  placeholder="All agents"
+                  value={agentId}
+                  onChange={(e) => setAgentId(e.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="export-type">Decision type</Label>
+                <Input
+                  id="export-type"
+                  placeholder="All types"
+                  value={decisionType}
+                  onChange={(e) => setDecisionType(e.target.value)}
+                />
+              </div>
+            </div>
+
+            <Button type="submit">
+              <Download className="h-4 w-4 mr-2" />
+              Download NDJSON
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/ui/src/pages/SessionTimeline.tsx
+++ b/ui/src/pages/SessionTimeline.tsx
@@ -1,0 +1,160 @@
+import { useParams, Link } from "react-router";
+import { useQuery } from "@tanstack/react-query";
+import { getSession } from "@/lib/api";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { formatDate, formatRelativeTime } from "@/lib/utils";
+import { ArrowLeft, Clock, FileText } from "lucide-react";
+
+export default function SessionTimeline() {
+  const { sessionId } = useParams<{ sessionId: string }>();
+
+  const { data, isPending, error } = useQuery({
+    queryKey: ["session", sessionId],
+    queryFn: () => getSession(sessionId!),
+    enabled: !!sessionId,
+  });
+
+  if (isPending) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-32 w-full" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div className="space-y-4">
+        <Link to="/" className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground">
+          <ArrowLeft className="h-4 w-4" />
+          Back to dashboard
+        </Link>
+        <p className="text-destructive">
+          {error instanceof Error ? error.message : "Session not found"}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-4">
+        <Link to="/" className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground">
+          <ArrowLeft className="h-4 w-4" />
+          Back
+        </Link>
+        <h1 className="text-2xl font-bold tracking-tight">Session Timeline</h1>
+      </div>
+
+      {/* Session summary */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="font-mono text-sm">
+            {data.session_id}
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <dl className="grid grid-cols-2 gap-4 text-sm sm:grid-cols-4">
+            <div>
+              <dt className="text-muted-foreground">Decisions</dt>
+              <dd className="text-2xl font-bold">{data.decision_count}</dd>
+            </div>
+            {data.summary && (
+              <>
+                <div>
+                  <dt className="text-muted-foreground">Duration</dt>
+                  <dd className="font-medium">
+                    {data.summary.duration_secs < 60
+                      ? `${Math.round(data.summary.duration_secs)}s`
+                      : data.summary.duration_secs < 3600
+                        ? `${Math.round(data.summary.duration_secs / 60)}m`
+                        : `${(data.summary.duration_secs / 3600).toFixed(1)}h`}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-muted-foreground">Avg Confidence</dt>
+                  <dd className="font-medium">
+                    {(data.summary.avg_confidence * 100).toFixed(0)}%
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-muted-foreground">Started</dt>
+                  <dd>{formatRelativeTime(data.summary.started_at)}</dd>
+                </div>
+              </>
+            )}
+          </dl>
+          {data.summary?.decision_types && Object.keys(data.summary.decision_types).length > 0 && (
+            <div className="mt-4 flex flex-wrap gap-2">
+              {Object.entries(data.summary.decision_types).map(([type, count]) => (
+                <Badge key={type} variant="secondary" className="text-xs">
+                  {type}: {count}
+                </Badge>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Decision timeline */}
+      {data.decisions.length === 0 ? (
+        <div className="flex flex-col items-center py-12 text-center">
+          <FileText className="h-12 w-12 text-muted-foreground/30 mb-4" />
+          <p className="text-sm text-muted-foreground">
+            No decisions in this session.
+          </p>
+        </div>
+      ) : (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm font-medium">Decisions</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="relative space-y-4 pl-6 before:absolute before:left-[11px] before:top-2 before:h-[calc(100%-16px)] before:w-px before:bg-border">
+              {data.decisions.map((decision) => (
+                <Link
+                  key={decision.id}
+                  to={`/decisions/${decision.run_id}`}
+                  className="relative block rounded-md border p-4 transition-colors hover:bg-accent"
+                >
+                  <div className="absolute -left-6 top-5 h-2.5 w-2.5 rounded-full border-2 border-background bg-primary" />
+                  <div className="space-y-2">
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-2">
+                        <Badge variant="outline" className="font-mono text-xs">
+                          {decision.agent_id}
+                        </Badge>
+                        <Badge variant="secondary" className="text-xs">
+                          {decision.decision_type}
+                        </Badge>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <Badge variant="secondary" className="text-xs">
+                          {(decision.confidence * 100).toFixed(0)}%
+                        </Badge>
+                        <span className="flex items-center gap-1 text-xs text-muted-foreground">
+                          <Clock className="h-3 w-3" />
+                          {formatDate(decision.created_at)}
+                        </span>
+                      </div>
+                    </div>
+                    <p className="text-sm font-medium">{decision.outcome}</p>
+                    {decision.reasoning && (
+                      <p className="text-xs text-muted-foreground line-clamp-2">
+                        {decision.reasoning}
+                      </p>
+                    )}
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -8,6 +8,8 @@ import DecisionDetail from "@/pages/DecisionDetail";
 import Agents from "@/pages/Agents";
 import Conflicts from "@/pages/Conflicts";
 import SearchPage from "@/pages/SearchPage";
+import ExportPage from "@/pages/ExportPage";
+import SessionTimeline from "@/pages/SessionTimeline";
 import { type ReactNode } from "react";
 
 function AuthGuard({ children }: { children: ReactNode }) {
@@ -48,6 +50,8 @@ export const router = createBrowserRouter([
       { path: "agents", element: <Agents /> },
       { path: "conflicts", element: <Conflicts /> },
       { path: "search", element: <SearchPage /> },
+      { path: "export", element: <ExportPage /> },
+      { path: "sessions/:sessionId", element: <SessionTimeline /> },
     ],
   },
 ]);

--- a/ui/src/types/api.ts
+++ b/ui/src/types/api.ts
@@ -149,6 +149,7 @@ export interface AgentEvent {
 export type ConflictKind = "cross_agent" | "self_contradiction";
 
 export interface DecisionConflict {
+  id: string;
   conflict_kind: ConflictKind;
   decision_a_id: string;
   decision_b_id: string;
@@ -167,6 +168,13 @@ export interface DecisionConflict {
   decided_at_a: string;
   decided_at_b: string;
   detected_at: string;
+  explanation: string | null;
+  category: ConflictCategory | null;
+  severity: ConflictSeverity | null;
+  status: ConflictStatus;
+  resolved_by: string | null;
+  resolved_at: string | null;
+  resolution_note: string | null;
 }
 
 // Search
@@ -219,6 +227,56 @@ export interface AgentsList {
 export interface SearchResponse {
   results: SearchResult[];
   total: number;
+}
+
+// Conflict lifecycle
+export type ConflictStatus = "open" | "acknowledged" | "resolved" | "wont_fix";
+export type ConflictCategory = "factual" | "assessment" | "strategic" | "temporal";
+export type ConflictSeverity = "critical" | "high" | "medium" | "low";
+
+// Agent stats
+export interface AgentStats {
+  agent_id: string;
+  decision_count: number;
+  avg_confidence: number;
+  first_decision_at: string | null;
+  last_decision_at: string | null;
+  low_quality_count: number;
+  type_breakdown: Record<string, number>;
+}
+
+// Trace health
+export interface TraceHealth {
+  status: string;
+  total_decisions: number;
+  decisions_24h: number;
+  avg_confidence: number;
+  low_quality_pct: number;
+  conflict_rate: number;
+  active_agents: number;
+  gaps: TraceGap[];
+}
+
+export interface TraceGap {
+  agent_id: string;
+  last_seen: string;
+  gap_hours: number;
+}
+
+// Session view
+export interface SessionView {
+  session_id: string;
+  decisions: Decision[];
+  decision_count: number;
+  summary: SessionSummary;
+}
+
+export interface SessionSummary {
+  started_at: string;
+  ended_at: string;
+  duration_secs: number;
+  decision_types: Record<string, number>;
+  avg_confidence: number;
 }
 
 // Health


### PR DESCRIPTION
## Summary

- **Agents page (#111)**: Add Decisions count, Created (relative time), and Last Active columns using `?include=stats` endpoint
- **Conflicts page (#112)**: Add status/severity/category badges, status filter dropdown, and resolution workflow dialog (Acknowledge/Resolve/Won't Fix via PATCH /v1/conflicts/{id})
- **Decision detail (#113)**: Add integrity badge (verified/tampered/no-hash), revision history timeline, related conflicts section, and session context (session_id link, tool, model, repo)
- **Export page (#115)**: New page with date range, agent, and decision type filters; triggers authenticated NDJSON download
- **Session timeline (#118)**: New page at /sessions/:sessionId with summary stats and chronological decision timeline
- **Dashboard (#120)**: Add trace health card (healthy/degraded/unhealthy), 24h decision count, active agents, trace gaps section, clickable conflicts card
- **Router/Layout**: Add /export and /sessions/:sessionId routes, Export nav item

## Files changed

| File | Change |
|------|--------|
| `ui/src/types/api.ts` | Add AgentStats, TraceHealth, SessionView types; extend DecisionConflict with lifecycle fields |
| `ui/src/lib/api.ts` | Add 11 new API client methods |
| `ui/src/pages/Agents.tsx` | Add Decisions/Created/Last Active columns |
| `ui/src/pages/Conflicts.tsx` | Status badges, severity/category badges, status filter, resolution dialog |
| `ui/src/pages/DecisionDetail.tsx` | Integrity badge, revision chain, conflicts section, session context |
| `ui/src/pages/Dashboard.tsx` | Trace health card, 24h stats, active agents, trace gaps, clickable conflicts |
| `ui/src/pages/ExportPage.tsx` | **New** - NDJSON export form |
| `ui/src/pages/SessionTimeline.tsx` | **New** - Session decision timeline |
| `ui/src/router.tsx` | Add /export and /sessions/:sessionId routes |
| `ui/src/components/Layout.tsx` | Add Export nav item |

## Notes

- Skipped #116 (response envelopes) per plan - breaking change deferred to API v2
- Skipped #121 (email verification page) - no POST /auth/verify backend endpoint exists
- All new UI calls target endpoints from PR #130 (already merged) + existing endpoints

## Test plan

- [ ] `cd ui && npm ci && npm run build` passes (verified)
- [ ] `go build -tags ui ./...` succeeds (verified)
- [ ] Navigate to each page and verify rendering
- [ ] Test conflict resolution workflow (Acknowledge/Resolve/Won't Fix)
- [ ] Test export with date range and agent filters
- [ ] Visit /sessions/:sessionId with a real session UUID
- [ ] Verify Dashboard shows trace health and gaps