### PR TITLE
Fix GDPR deletion to include decision_claims

### DIFF
--- a/migrations/040_decision_claims_fk.sql
+++ b/migrations/040_decision_claims_fk.sql
@@ -1,0 +1,7 @@
+-- 039: Add FK from decision_claims to decisions with cascade delete.
+-- Defense-in-depth: the application explicitly deletes claims in DeleteAgentData
+-- (GDPR erasure), but the FK ensures no orphaned claims survive if a decision is
+-- deleted through any other code path.
+ALTER TABLE decision_claims
+    ADD CONSTRAINT fk_decision_claims_decision
+    FOREIGN KEY (decision_id) REFERENCES decisions(id) ON DELETE CASCADE;

--- a/migrations/atlas.sum
+++ b/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:KeLryKYq3EBQ02BNqVk94Iq1xqMgqi8JPZdnAkAXMvk=
+h1:PHhIkpx9ZVGl21vE1NRE9EsKDFijXzASt5sj1Ee/pzo=
 001_initial.sql h1:uhyGXto+QacAaGYb9ZTGjsBs5chlKi8O0eHz9aCQsrY=
 022_full_text_search.sql h1:9iwtA8MgCzAxDV9YkUBn0CLT9ePSmj3GcPoMGg8TXf0=
 023_fix_outbox_index.sql h1:OtMEFBcMRWej02+ghnBXlPr6BVq+LoA62Id9XUWfDNI=
@@ -18,3 +18,4 @@ h1:KeLryKYq3EBQ02BNqVk94Iq1xqMgqi8JPZdnAkAXMvk=
 037_conflict_scored_at.sql h1:AKuaInJ2GnIxTWa7kK4YnuMXVoKrvf+MNFHvpAykKpM=
 038_conflict_precision.sql h1:Z78MrYF3Ud4Y7Yhrt5VxoJ7ygPqqOJLe67Qc2HGUMq8=
 039_agent_last_seen.sql h1:pVJJsK9ByaYUaf/JJPYEmoHXSgPSxmi4b6jG/xfCYLo=
+040_decision_claims_fk.sql h1:ZIQJlrOCL990XlPoe1APhg8MXJRvE2TVPSGuPSnXO6Q=


### PR DESCRIPTION
## Summary

Fixes #102.

- **`DeleteAgentData`** now archives and deletes `decision_claims` before removing decisions. Claims contain `claim_text` (sentence-level PII from agent reasoning) that must be erased on right-to-erasure requests.
- **`DeleteAgentResult`** reports `claims` count alongside existing table counts.
- **Migration 040** adds `FK (decision_id) REFERENCES decisions(id) ON DELETE CASCADE` as defense-in-depth — no code path can leave orphaned claims.
- Integration test verifies claims are deleted and reported correctly.

## Test plan

- [x] `TestDeleteAgentDataDeletesClaims` — creates agent + decision + 2 claims, runs `DeleteAgentData`, asserts claims=2 in result and 0 rows remain
- [x] `TestDeleteAgentDataClearsExternalSupersedesRefs` — existing test still passes
- [x] `TestDeleteAgentData` (server) — all 4 subtests pass
- [x] Pre-commit: build, vet, lint, atlas validate all clean