### PR TITLE
Add concise MCP response format with check summary

### DIFF
--- a/internal/mcp/compact.go
+++ b/internal/mcp/compact.go
@@ -1,0 +1,149 @@
+package mcp
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/ashita-ai/akashi/internal/model"
+)
+
+const maxCompactReasoning = 200
+
+// compactDecision returns a minimal representation of a decision for MCP responses.
+// Drops internal bookkeeping (content_hash, transaction_time, valid_from/to,
+// quality_score, org_id, run_id, metadata, embedding fields) that agents don't act on.
+func compactDecision(d model.Decision) map[string]any {
+	m := map[string]any{
+		"id":            d.ID,
+		"agent_id":      d.AgentID,
+		"decision_type": d.DecisionType,
+		"outcome":       d.Outcome,
+		"confidence":    d.Confidence,
+		"created_at":    d.CreatedAt,
+	}
+	if d.Reasoning != nil && *d.Reasoning != "" {
+		r := *d.Reasoning
+		if len(r) > maxCompactReasoning {
+			r = r[:maxCompactReasoning] + "..."
+		}
+		m["reasoning"] = r
+	}
+	if d.SessionID != nil {
+		m["session_id"] = d.SessionID
+	}
+	if tool, ok := d.AgentContext["tool"]; ok {
+		m["tool"] = tool
+	}
+	if mdl, ok := d.AgentContext["model"]; ok {
+		m["model"] = mdl
+	}
+	return m
+}
+
+// compactConflict returns a minimal representation of a conflict for MCP responses.
+// Drops scoring internals (topic_similarity, outcome_divergence, significance,
+// scoring_method, confidence_weight, temporal_decay) and full outcomes/reasoning.
+func compactConflict(c model.DecisionConflict) map[string]any {
+	m := map[string]any{
+		"id":          c.ID,
+		"agent_a":     c.AgentA,
+		"agent_b":     c.AgentB,
+		"status":      c.Status,
+		"detected_at": c.DetectedAt,
+	}
+	if c.Category != nil {
+		m["category"] = *c.Category
+	}
+	if c.Severity != nil {
+		m["severity"] = *c.Severity
+	}
+	if c.Explanation != nil && *c.Explanation != "" {
+		m["explanation"] = *c.Explanation
+	}
+	// Include brief outcome summaries so agents understand what the conflict is about.
+	m["outcome_a"] = truncate(c.OutcomeA, maxCompactReasoning)
+	m["outcome_b"] = truncate(c.OutcomeB, maxCompactReasoning)
+	return m
+}
+
+// compactSearchResult wraps a search result with its similarity score.
+func compactSearchResult(r model.SearchResult) map[string]any {
+	m := compactDecision(r.Decision)
+	m["similarity_score"] = r.SimilarityScore
+	return m
+}
+
+// generateCheckSummary creates a 1-3 sentence human-readable synthesis of check results.
+// Template-based, no LLM dependency.
+func generateCheckSummary(decisions []model.Decision, conflicts []model.DecisionConflict) string {
+	var parts []string
+
+	// Decision summary.
+	if len(decisions) == 0 {
+		parts = append(parts, "No prior decisions found for this type.")
+	} else {
+		types := map[string]int{}
+		for _, d := range decisions {
+			types[d.DecisionType]++
+		}
+
+		if len(types) == 1 {
+			parts = append(parts, fmt.Sprintf("%d prior decision(s) found.", len(decisions)))
+		} else {
+			parts = append(parts, fmt.Sprintf("%d prior decisions across %d types.", len(decisions), len(types)))
+		}
+
+		// Most recent decision.
+		most := decisions[0] // decisions come sorted by valid_from desc
+		parts = append(parts, fmt.Sprintf("Most recent: \"%s\" (%.0f%% confidence).",
+			truncate(most.Outcome, 100), most.Confidence*100))
+	}
+
+	// Conflict summary.
+	if len(conflicts) > 0 {
+		open := 0
+		var maxSeverity string
+		severityRank := map[string]int{"critical": 4, "high": 3, "medium": 2, "low": 1}
+		maxRank := 0
+		for _, c := range conflicts {
+			if c.Status == "open" || c.Status == "acknowledged" {
+				open++
+				if c.Severity != nil {
+					if r := severityRank[*c.Severity]; r > maxRank {
+						maxRank = r
+						maxSeverity = *c.Severity
+					}
+				}
+			}
+		}
+		if open > 0 {
+			if maxSeverity != "" {
+				parts = append(parts, fmt.Sprintf("%d open conflict(s), highest severity: %s.", open, maxSeverity))
+			} else {
+				parts = append(parts, fmt.Sprintf("%d open conflict(s).", open))
+			}
+		}
+	}
+
+	return strings.Join(parts, " ")
+}
+
+// actionNeeded returns true if there are open critical/high conflicts.
+func actionNeeded(conflicts []model.DecisionConflict) bool {
+	for _, c := range conflicts {
+		if c.Status != "open" && c.Status != "acknowledged" {
+			continue
+		}
+		if c.Severity != nil && (*c.Severity == "critical" || *c.Severity == "high") {
+			return true
+		}
+	}
+	return false
+}
+
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
+}

--- a/internal/mcp/compact_test.go
+++ b/internal/mcp/compact_test.go
@@ -1,0 +1,183 @@
+package mcp
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ashita-ai/akashi/internal/model"
+)
+
+func TestCompactDecision(t *testing.T) {
+	reasoning := "Because Redis handles our expected QPS and TTL prevents stale reads"
+	sessionID := uuid.New()
+	d := model.Decision{
+		ID:           uuid.New(),
+		RunID:        uuid.New(),
+		AgentID:      "planner",
+		OrgID:        uuid.New(),
+		DecisionType: "architecture",
+		Outcome:      "chose Redis with 5min TTL",
+		Confidence:   0.85,
+		Reasoning:    &reasoning,
+		QualityScore: 0.55,
+		ContentHash:  "v2:abc123",
+		ValidFrom:    time.Now(),
+		CreatedAt:    time.Now(),
+		SessionID:    &sessionID,
+		AgentContext: map[string]any{"tool": "claude-code", "model": "claude-opus-4-6", "operator": "System Admin"},
+	}
+
+	m := compactDecision(d)
+
+	// Kept fields.
+	assert.Equal(t, d.ID, m["id"])
+	assert.Equal(t, "planner", m["agent_id"])
+	assert.Equal(t, "architecture", m["decision_type"])
+	assert.Equal(t, "chose Redis with 5min TTL", m["outcome"])
+	assert.Equal(t, float32(0.85), m["confidence"])
+	assert.Equal(t, reasoning, m["reasoning"])
+	assert.Equal(t, &sessionID, m["session_id"])
+	assert.Equal(t, "claude-code", m["tool"])
+	assert.Equal(t, "claude-opus-4-6", m["model"])
+
+	// Dropped fields.
+	_, hasRunID := m["run_id"]
+	_, hasOrgID := m["org_id"]
+	_, hasQuality := m["quality_score"]
+	_, hasContentHash := m["content_hash"]
+	_, hasValidFrom := m["valid_from"]
+	_, hasMetadata := m["metadata"]
+	assert.False(t, hasRunID, "run_id should be dropped")
+	assert.False(t, hasOrgID, "org_id should be dropped")
+	assert.False(t, hasQuality, "quality_score should be dropped")
+	assert.False(t, hasContentHash, "content_hash should be dropped")
+	assert.False(t, hasValidFrom, "valid_from should be dropped")
+	assert.False(t, hasMetadata, "metadata should be dropped")
+}
+
+func TestCompactDecision_TruncatesReasoning(t *testing.T) {
+	long := strings.Repeat("x", 300)
+	d := model.Decision{
+		ID:           uuid.New(),
+		AgentID:      "a",
+		DecisionType: "t",
+		Outcome:      "o",
+		Reasoning:    &long,
+	}
+
+	m := compactDecision(d)
+	r := m["reasoning"].(string)
+	assert.True(t, strings.HasSuffix(r, "..."), "should be truncated")
+	assert.LessOrEqual(t, len(r), maxCompactReasoning+3, "should be at most maxCompactReasoning + ellipsis")
+}
+
+func TestCompactConflict(t *testing.T) {
+	cat := "strategic"
+	sev := "high"
+	expl := "Redis vs in-memory cache disagreement"
+	c := model.DecisionConflict{
+		ID:                uuid.New(),
+		ConflictKind:      model.ConflictKindCrossAgent,
+		AgentA:            "planner",
+		AgentB:            "coder",
+		OutcomeA:          "chose Redis",
+		OutcomeB:          "chose in-memory cache",
+		TopicSimilarity:   ptrFloat64(0.85),
+		OutcomeDivergence: ptrFloat64(0.42),
+		Significance:      ptrFloat64(0.36),
+		ScoringMethod:     "llm",
+		Explanation:       &expl,
+		Category:          &cat,
+		Severity:          &sev,
+		Status:            "open",
+		DetectedAt:        time.Now(),
+	}
+
+	m := compactConflict(c)
+
+	// Kept fields.
+	assert.Equal(t, c.ID, m["id"])
+	assert.Equal(t, "planner", m["agent_a"])
+	assert.Equal(t, "coder", m["agent_b"])
+	assert.Equal(t, "strategic", m["category"])
+	assert.Equal(t, "high", m["severity"])
+	assert.Equal(t, expl, m["explanation"])
+	assert.Equal(t, "open", m["status"])
+	assert.Equal(t, "chose Redis", m["outcome_a"])
+	assert.Equal(t, "chose in-memory cache", m["outcome_b"])
+
+	// Dropped scoring internals.
+	_, hasSim := m["topic_similarity"]
+	_, hasDiv := m["outcome_divergence"]
+	_, hasSig := m["significance"]
+	_, hasMethod := m["scoring_method"]
+	assert.False(t, hasSim, "topic_similarity should be dropped")
+	assert.False(t, hasDiv, "outcome_divergence should be dropped")
+	assert.False(t, hasSig, "significance should be dropped")
+	assert.False(t, hasMethod, "scoring_method should be dropped")
+}
+
+func TestGenerateCheckSummary_NoPrecedents(t *testing.T) {
+	s := generateCheckSummary(nil, nil)
+	assert.Contains(t, s, "No prior decisions found")
+}
+
+func TestGenerateCheckSummary_WithDecisions(t *testing.T) {
+	decs := []model.Decision{
+		{Outcome: "chose Redis", Confidence: 0.85, DecisionType: "architecture"},
+		{Outcome: "chose PostgreSQL", Confidence: 0.9, DecisionType: "architecture"},
+	}
+	s := generateCheckSummary(decs, nil)
+	assert.Contains(t, s, "2 prior decision(s)")
+	assert.Contains(t, s, "chose Redis")
+	assert.Contains(t, s, "85%")
+}
+
+func TestGenerateCheckSummary_WithConflicts(t *testing.T) {
+	sev := "high"
+	decs := []model.Decision{
+		{Outcome: "chose Redis", Confidence: 0.85, DecisionType: "architecture"},
+	}
+	conflicts := []model.DecisionConflict{
+		{Status: "open", Severity: &sev},
+	}
+	s := generateCheckSummary(decs, conflicts)
+	assert.Contains(t, s, "1 open conflict(s)")
+	assert.Contains(t, s, "high")
+}
+
+func TestActionNeeded(t *testing.T) {
+	critical := "critical"
+	high := "high"
+	medium := "medium"
+
+	tests := []struct {
+		name      string
+		conflicts []model.DecisionConflict
+		want      bool
+	}{
+		{"no conflicts", nil, false},
+		{"medium only", []model.DecisionConflict{{Status: "open", Severity: &medium}}, false},
+		{"high open", []model.DecisionConflict{{Status: "open", Severity: &high}}, true},
+		{"critical acknowledged", []model.DecisionConflict{{Status: "acknowledged", Severity: &critical}}, true},
+		{"high resolved", []model.DecisionConflict{{Status: "resolved", Severity: &high}}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, actionNeeded(tt.conflicts))
+		})
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	assert.Equal(t, "hello", truncate("hello", 10))
+	assert.Equal(t, "hel...", truncate("hello world", 3))
+	assert.Equal(t, "", truncate("", 5))
+}
+
+func ptrFloat64(f float64) *float64 { return &f }


### PR DESCRIPTION
## Summary

Fixes #124, fixes #126.

All MCP read tools now default to a compact response format that drops fields agents don't act on. `akashi_check` additionally generates a human-readable summary, `action_needed` flag, and `relevant_count`.

### Concise check response (before: ~300 lines of raw JSON)

```json
{
  "has_precedent": true,
  "summary": "3 prior decision(s) found. Most recent: \"chose Redis with 5min TTL\" (85% confidence). 1 open conflict(s), highest severity: high.",
  "action_needed": true,
  "relevant_count": 3,
  "decisions": [
    {"id": "...", "agent_id": "planner", "decision_type": "architecture", "outcome": "chose Redis with 5min TTL", "confidence": 0.85, "reasoning": "Redis handles our expected QPS...", "created_at": "..."}
  ],
  "conflicts": [
    {"id": "...", "agent_a": "planner", "agent_b": "coder", "category": "strategic", "severity": "high", "explanation": "...", "status": "open", "outcome_a": "...", "outcome_b": "..."}
  ]
}
```

### Compact decision (7 fields vs ~20)

Keeps: `id`, `agent_id`, `decision_type`, `outcome`, `confidence`, `reasoning` (truncated 200 chars), `created_at`, plus `session_id`/`tool`/`model` when present.

Drops: `run_id`, `org_id`, `quality_score`, `content_hash`, `valid_from`, `valid_to`, `transaction_time`, `metadata`, `precedent_ref`, `supersedes_id`.

### Compact conflict (10 fields vs ~25)

Keeps: `id`, `agent_a`, `agent_b`, `category`, `severity`, `status`, `explanation`, `outcome_a`/`outcome_b` (truncated), `detected_at`.

Drops: `decision_a_id`, `decision_b_id`, `org_id`, `run_a`, `run_b`, `confidence_a/b`, `reasoning_a/b`, `topic_similarity`, `outcome_divergence`, `significance`, `scoring_method`, `confidence_weight`, `temporal_decay`.

### Backward compatibility

All tools accept `format="full"` to get the previous complete output.

## Files changed

- `internal/mcp/compact.go` — `compactDecision()`, `compactConflict()`, `generateCheckSummary()`, `actionNeeded()`
- `internal/mcp/compact_test.go` — 8 unit tests covering compact helpers, summary generation, action_needed logic, truncation
- `internal/mcp/tools.go` — Added `format` parameter to 5 tools, wired concise/full branching in all handlers

## Test plan

- [x] 8 unit tests for compact helpers (compact_test.go)
- [x] All 50+ existing MCP unit tests pass
- [x] All MCP integration tests pass (server_test.go: TestMCPCheckTool, TestMCPCheckNoPrecedent, TestMCPRecentTool, etc.)
- [x] Pre-commit: build, vet, lint (0 issues), atlas validate