### PR TITLE
Update MCP server instructions with concrete trigger lists

### DIFF
--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -39,6 +39,15 @@ TOOLS:
 - akashi_search: semantic similarity search across decisions
 - akashi_recent: see recent decisions for context
 
+CHECK BEFORE: choosing architecture/technology, starting a review or audit,
+making trade-offs, filing issues/PRs, changing existing behavior.
+
+TRACE AFTER: completing a review, choosing an approach, creating issues/PRs,
+finishing a task that involved choices, making security or access judgments.
+
+SKIP: pure execution (formatting, typo fixes), reading/exploring code,
+asking the user a question (no decision yet).
+
 Be honest about confidence. Reference precedents when they influence you.`
 
 // Server wraps the MCP server with Akashi's service layer.

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -81,7 +81,11 @@ WHAT TO INCLUDE:
 
 EXAMPLE: After choosing a caching strategy, record decision_type="architecture",
 outcome="chose Redis with 5min TTL for session cache", confidence=0.85,
-reasoning="Redis handles our expected QPS, TTL prevents stale reads"`),
+reasoning="Redis handles our expected QPS, TTL prevents stale reads"
+
+TRACE AFTER: completing a review, choosing an approach, creating issues/PRs,
+finishing a task with choices, making security or access judgments.
+SKIP: formatting, typo fixes, running tests, reading code, asking questions.`),
 			mcplib.WithDestructiveHintAnnotation(false),
 			mcplib.WithIdempotentHintAnnotation(false),
 			mcplib.WithOpenWorldHintAnnotation(true),


### PR DESCRIPTION
## Summary
- Replaces vague "non-trivial decision" guidance with explicit CHECK BEFORE / TRACE AFTER / SKIP lists
- Adds trigger lists to `serverInstructions` (MCP initialize handshake) and `akashi_trace` tool description
- Agents now see concrete examples of when to check/trace/skip instead of guessing what "non-trivial" means

## Changes
- `internal/mcp/mcp.go`: Added CHECK BEFORE, TRACE AFTER, SKIP sections to server instructions
- `internal/mcp/tools.go`: Added TRACE AFTER / SKIP guidance to akashi_trace tool description

## Test plan
- [x] All MCP unit tests pass
- [x] golangci-lint clean
- [x] No migration changes

Closes #129