### PR TITLE
Add idempotency to run complete and MCP trace, fix archive SQL injection (#59, #64, #66)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -419,9 +419,11 @@ paths:
       description: |
         Mark a run as completed or failed. Updates the run status and
         records the completion time.
+        Supports idempotent retries via `Idempotency-Key`.
         Requires `agent` role or higher.
       parameters:
         - $ref: "#/components/parameters/RunIDPath"
+        - $ref: "#/components/parameters/IdempotencyKeyHeader"
       requestBody:
         required: true
         content:

--- a/internal/server/idempotency.go
+++ b/internal/server/idempotency.go
@@ -170,3 +170,7 @@ func (h *Handlers) clearIdempotentWrite(r *http.Request, orgID uuid.UUID, idem *
 func appendEventsEndpoint(runID uuid.UUID) string {
 	return fmt.Sprintf("POST:/v1/runs/%s/events", runID)
 }
+
+func completeRunEndpoint(runID uuid.UUID) string {
+	return fmt.Sprintf("POST:/v1/runs/%s/complete", runID)
+}

--- a/scripts/archive_agent_events.sh
+++ b/scripts/archive_agent_events.sh
@@ -27,6 +27,10 @@ BATCH_DAYS="${BATCH_DAYS:-1}"
 DRY_RUN="${DRY_RUN:-true}"
 ENABLE_PURGE="${ENABLE_PURGE:-false}"
 
+# Validate numeric inputs to prevent SQL injection (issue #59).
+[[ "${RETAIN_DAYS}" =~ ^[0-9]+$ ]] || { echo "error: RETAIN_DAYS must be a positive integer, got '${RETAIN_DAYS}'" >&2; exit 2; }
+[[ "${BATCH_DAYS}" =~ ^[0-9]+$ ]] || { echo "error: BATCH_DAYS must be a positive integer, got '${BATCH_DAYS}'" >&2; exit 2; }
+
 if [[ "${ENABLE_PURGE}" == "true" && "${DRY_RUN}" != "false" ]]; then
   echo "error: ENABLE_PURGE=true requires DRY_RUN=false" >&2
   exit 2


### PR DESCRIPTION
## Summary

- **#66**: `POST /v1/runs/{run_id}/complete` now supports `Idempotency-Key` header with standard replay/mismatch/in-progress behavior, matching the existing pattern in `HandleCreateRun` and `HandleAppendEvents`.
- **#64**: MCP `akashi_trace` gains an optional `idempotency_key` parameter that reuses the same storage primitives (`BeginIdempotency`/`CompleteIdempotency`/`ClearInProgressIdempotency`) for retry-safe decision recording.
- **#59**: `archive_agent_events.sh` validates `RETAIN_DAYS` and `BATCH_DAYS` as positive integers before interpolating them into SQL strings, preventing injection via malicious environment variables.

## Changes

| File | What |
|------|------|
| `internal/server/handlers_runs.go` | Wire `beginIdempotentWrite`/`completeIdempotentWriteBestEffort`/`clearIdempotentWrite` into `HandleCompleteRun` |
| `internal/server/idempotency.go` | Add `completeRunEndpoint()` helper |
| `internal/mcp/tools.go` | Add `idempotency_key` parameter to `akashi_trace`, wire idempotency into `handleTrace`, add `mcpTraceHash()` |
| `api/openapi.yaml` | Document `Idempotency-Key` header on complete endpoint |
| `scripts/archive_agent_events.sh` | Integer validation for `RETAIN_DAYS`/`BATCH_DAYS` |

## Test plan

- [x] All existing tests pass with `-race` (no behavior change for calls without idempotency key)
- [x] `go build ./...`, `go vet ./...`, `golangci-lint run ./...` clean
- [x] `atlas migrate validate` passes (no new migrations)
- [ ] Manual: `POST /v1/runs/{run_id}/complete` with `Idempotency-Key` header replays on retry
- [ ] Manual: MCP `akashi_trace` with `idempotency_key` replays on retry, returns error on payload mismatch
- [ ] Manual: `RETAIN_DAYS="90; DROP TABLE" ./scripts/archive_agent_events.sh` rejects with validation error

Closes #59, #64, #66.