### PR TITLE
Fix outbox NULL embedding exclusion and shutdown drain durability

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -119,7 +119,7 @@ When enabled, every event is written to the WAL before being buffered in memory.
 | `AKASHI_INTEGRITY_PROOF_INTERVAL` | `5m` | How often Merkle tree proofs are built for new decisions |
 | `AKASHI_ENABLE_DESTRUCTIVE_DELETE` | `false` | Enables irreversible `DELETE /v1/agents/{agent_id}`. Keep `false` in production unless explicitly needed for GDPR workflows |
 | `AKASHI_SHUTDOWN_HTTP_TIMEOUT` | `10s` | HTTP shutdown grace timeout (`0` = wait indefinitely) |
-| `AKASHI_SHUTDOWN_BUFFER_DRAIN_TIMEOUT` | `0` | Reserved. Akashi always waits indefinitely for event buffer drain to avoid data loss. |
+| `AKASHI_SHUTDOWN_BUFFER_DRAIN_TIMEOUT` | `0` | Maximum time to flush in-memory events to Postgres during shutdown. `0` = wait indefinitely (default, durability-first). Non-zero values bound the drain but risk losing unflushed events — process exits non-zero if events remain. |
 | `AKASHI_SHUTDOWN_OUTBOX_DRAIN_TIMEOUT` | `0` | Outbox drain timeout (`0` = wait indefinitely) |
 
 ## Write Idempotency

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -623,7 +623,7 @@ Provider auto-detection order: Ollama (if reachable) > OpenAI (if key set) > noo
 | `AKASHI_CONFLICT_REFRESH_INTERVAL`  | `30s`    | How often the broker polls for new conflicts (SSE). Conflicts are populated on trace. |
 | `AKASHI_INTEGRITY_PROOF_INTERVAL`   | `5m`     | How often Merkle integrity proofs are generated      |
 | `AKASHI_SHUTDOWN_HTTP_TIMEOUT`      | `10s`    | Grace period for HTTP server shutdown (`0` = wait forever) |
-| `AKASHI_SHUTDOWN_BUFFER_DRAIN_TIMEOUT` | `0`   | Reserved. Buffer drain is always indefinite to prevent event loss. |
+| `AKASHI_SHUTDOWN_BUFFER_DRAIN_TIMEOUT` | `0`   | Max time to flush events during shutdown (`0` = wait forever). Non-zero risks data loss — process exits non-zero if events remain. |
 | `AKASHI_SHUTDOWN_OUTBOX_DRAIN_TIMEOUT` | `0`   | Outbox drain timeout (`0` = wait forever)            |
 | `AKASHI_IDEMPOTENCY_CLEANUP_INTERVAL` | `1h` | How often old idempotency keys are cleaned up         |
 | `AKASHI_IDEMPOTENCY_COMPLETED_TTL` | `168h` (7d) | Retention for completed idempotency records      |

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -133,7 +133,7 @@ func TestMain(m *testing.M) {
 
 	testSrv.Close()
 	cancel() // Signal the buffer's flush loop to exit.
-	buf.Drain(context.Background())
+	_ = buf.Drain(context.Background())
 	db.Close(context.Background())
 	_ = testcontainer.Terminate(context.Background())
 	os.Exit(code)


### PR DESCRIPTION
## Summary

Fixes four related issues in the outbox and shutdown drain subsystems:

- **#60** — Decisions without embeddings were silently excluded from the search outbox. `CreateTraceTx` now always queues to `search_outbox`, and `fetchDecisionsForIndex` no longer filters on `d.embedding IS NOT NULL`. `partitionUpsertEntries` defers entries without embeddings until a backfill provides one.

- **#68** — `AKASHI_SHUTDOWN_BUFFER_DRAIN_TIMEOUT` was documented and parsed but overridden to 0 at runtime. Now honored: `0` = wait indefinitely (default, durability-first), positive value = bounded drain with data loss risk.

- **#74** — `Buffer.Drain` now returns an `error` when events remain after the drain context expires. `main.go` treats this as a hard failure and exits non-zero with structured error logging.

- **#67** — Outbox drain now loops until the queue is empty or the deadline expires, instead of processing a single batch.

## Files changed

| File | Change |
|------|--------|
| `internal/storage/trace.go` | Always queue to search_outbox (remove embedding guard) |
| `internal/search/outbox.go` | Remove `AND d.embedding IS NOT NULL`; handle nullable embedding scan; add `drainOutbox` loop; split `processBatch`/`processBatchCount` |
| `internal/service/trace/buffer.go` | `Drain` returns `error`; Error-level log on timeout |
| `cmd/akashi/main.go` | Honor `cfg.ShutdownBufferDrainTimeout`; exit non-zero on drain failure |
| `docs/configuration.md` | Updated SHUTDOWN_BUFFER_DRAIN_TIMEOUT description |
| `docs/runbook.md` | Updated SHUTDOWN_BUFFER_DRAIN_TIMEOUT description |
| `internal/search/outbox_integration_test.go` | Updated tests for new NULL embedding semantics |
| `internal/service/trace/buffer_test.go` | Updated for `Drain` returning error |
| `internal/server/server_test.go` | Handle `Drain` error return |

## Test plan

- [x] `go test -race -count=1 ./...` — all pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] `atlas migrate validate` — clean
- [ ] Manual: verify shutdown with `AKASHI_SHUTDOWN_BUFFER_DRAIN_TIMEOUT=5s` exits non-zero when events are pending
- [ ] Manual: verify outbox drains multiple batches on shutdown

Closes #60, #67, #68, #74.