### PR TITLE
Complete trace health metrics and add archive retention policy (#142, #61)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2648,7 +2648,7 @@ components:
 
     CompletenessMetrics:
       type: object
-      required: [total_decisions, avg_quality, below_half, below_third, with_reasoning, reasoning_pct]
+      required: [total_decisions, avg_quality, below_half, below_third, with_reasoning, reasoning_pct, with_alternatives, alternatives_pct]
       properties:
         total_decisions:
           type: integer
@@ -2670,14 +2670,28 @@ components:
           type: number
           format: double
           description: Percentage of decisions with reasoning (0–100).
+        with_alternatives:
+          type: integer
+          description: Count of decisions that have at least one recorded alternative.
+        alternatives_pct:
+          type: number
+          format: double
+          description: Percentage of decisions with alternatives (0–100).
 
     EvidenceMetrics:
       type: object
-      required: [total_decisions, with_evidence, without_evidence, coverage_pct]
+      required: [total_decisions, total_records, avg_per_decision, with_evidence, without_evidence, coverage_pct]
       properties:
         total_decisions:
           type: integer
           description: Total number of active decisions.
+        total_records:
+          type: integer
+          description: Total number of evidence records across all decisions.
+        avg_per_decision:
+          type: number
+          format: double
+          description: Average number of evidence records per decision.
         with_evidence:
           type: integer
           description: Count of decisions that have at least one evidence record.
@@ -2691,7 +2705,7 @@ components:
 
     TraceHealthConflictMetrics:
       type: object
-      required: [total, open, resolved, resolved_pct]
+      required: [total, open, acknowledged, resolved, wont_fix, resolved_pct]
       properties:
         total:
           type: integer
@@ -2699,9 +2713,15 @@ components:
         open:
           type: integer
           description: Number of unresolved conflicts.
+        acknowledged:
+          type: integer
+          description: Number of acknowledged but not yet resolved conflicts.
         resolved:
           type: integer
           description: Number of resolved conflicts.
+        wont_fix:
+          type: integer
+          description: Number of conflicts closed as won't fix.
         resolved_pct:
           type: number
           format: double

--- a/migrations/041_archive_hypertable.sql
+++ b/migrations/041_archive_hypertable.sql
@@ -1,0 +1,23 @@
+-- 041: Convert agent_events_archive to a TimescaleDB hypertable with compression
+-- and retention policies so the archive table doesn't grow without bound.
+--
+-- Compression: chunks older than 30 days (archived data is rarely queried).
+-- Retention: drop chunks older than 365 days. Operators can adjust via:
+--   SELECT remove_retention_policy('agent_events_archive');
+--   SELECT add_retention_policy('agent_events_archive', INTERVAL '730 days');
+
+SELECT create_hypertable('agent_events_archive', 'occurred_at',
+    chunk_time_interval => INTERVAL '7 days',
+    if_not_exists => TRUE,
+    migrate_data => TRUE
+);
+
+ALTER TABLE agent_events_archive SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'org_id',
+    timescaledb.compress_orderby = 'occurred_at DESC, sequence_num'
+);
+
+SELECT add_compression_policy('agent_events_archive', INTERVAL '30 days', if_not_exists => TRUE);
+
+SELECT add_retention_policy('agent_events_archive', INTERVAL '365 days', if_not_exists => TRUE);

--- a/migrations/atlas.sum
+++ b/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:PHhIkpx9ZVGl21vE1NRE9EsKDFijXzASt5sj1Ee/pzo=
+h1:2n1XL1mSGBs/Rqfc8Jpyhi/BS1NHju0QMUmjZ0OswNs=
 001_initial.sql h1:uhyGXto+QacAaGYb9ZTGjsBs5chlKi8O0eHz9aCQsrY=
 022_full_text_search.sql h1:9iwtA8MgCzAxDV9YkUBn0CLT9ePSmj3GcPoMGg8TXf0=
 023_fix_outbox_index.sql h1:OtMEFBcMRWej02+ghnBXlPr6BVq+LoA62Id9XUWfDNI=
@@ -19,3 +19,4 @@ h1:PHhIkpx9ZVGl21vE1NRE9EsKDFijXzASt5sj1Ee/pzo=
 038_conflict_precision.sql h1:Z78MrYF3Ud4Y7Yhrt5VxoJ7ygPqqOJLe67Qc2HGUMq8=
 039_agent_last_seen.sql h1:pVJJsK9ByaYUaf/JJPYEmoHXSgPSxmi4b6jG/xfCYLo=
 040_decision_claims_fk.sql h1:ZIQJlrOCL990XlPoe1APhg8MXJRvE2TVPSGuPSnXO6Q=
+041_archive_hypertable.sql h1:32cIpkv7IGm3mogQjj/6S0ZlT1jlVKucl8zncnlnsCs=


### PR DESCRIPTION
## Summary

- **#142 (Trace health completion)**: Adds the remaining metrics from spec 32 that were missing from the initial implementation:
  - **Alternatives coverage**: `with_alternatives` count and `alternatives_pct` in completeness metrics (via EXISTS subquery on the alternatives table)
  - **Evidence depth**: `total_records` count and `avg_per_decision` in evidence metrics
  - **Conflict status breakdown**: Full status distribution (`open`, `acknowledged`, `resolved`, `wont_fix`) replacing the previous total/open-only counts. New `GetConflictStatusCounts` storage method uses a single query with FILTER aggregates instead of two separate `CountConflicts` calls.
  - OpenAPI spec updated to include all new fields

- **#61 (Archive retention)**: Converts `agent_events_archive` to a TimescaleDB hypertable with lifecycle policies:
  - 7-day chunk interval (matches archival batch patterns)
  - Compression after 30 days (segmented by `org_id`, ordered by `occurred_at DESC, sequence_num`)
  - Retention policy drops chunks older than 365 days
  - Operators can adjust: `SELECT remove_retention_policy('agent_events_archive'); SELECT add_retention_policy('agent_events_archive', INTERVAL '730 days');`

Also noted: **#123 (UI email verification page)** cannot be implemented as described — `POST /auth/verify` does not exist in the codebase. No email verification system is implemented. The issue needs to be re-scoped to include the backend work.

## Files changed

| File | Change |
|------|--------|
| `internal/storage/decisions.go` | Add `WithAlternatives` to `DecisionQualityStats`, EXISTS subquery |
| `internal/storage/evidence.go` | Add `TotalRecords`, `AvgPerDecision` to `EvidenceCoverageStats` |
| `internal/storage/conflicts.go` | New `ConflictStatusCounts` type + `GetConflictStatusCounts` method |
| `internal/service/tracehealth/service.go` | Use new fields, replace two `CountConflicts` calls with one `GetConflictStatusCounts` |
| `api/openapi.yaml` | Add new fields to `CompletenessMetrics`, `EvidenceMetrics`, `TraceHealthConflictMetrics` |
| `migrations/041_archive_hypertable.sql` | Hypertable conversion + compression + retention |

## Test plan

- [x] All 17 test packages pass with `-race`
- [x] `go build`, `go vet`, `golangci-lint`, `atlas migrate validate` all pass
- [ ] Verify `GET /v1/trace-health` returns new fields (alternatives, total_records, conflict breakdown)
- [ ] Verify migration 041 applies cleanly on a fresh database

Closes #142
Closes #61