### PR TITLE
Enable WAL by default for crash durability

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,11 @@ AKASHI_IDEMPOTENCY_CLEANUP_INTERVAL=1h
 AKASHI_IDEMPOTENCY_COMPLETED_TTL=168h
 AKASHI_IDEMPOTENCY_ABANDONED_TTL=24h
 
+# Write-ahead log for crash-durable event buffering.
+# Enabled by default at ./data/wal. Set AKASHI_WAL_DISABLE=true for dev/testing.
+# AKASHI_WAL_DIR=./data/wal
+# AKASHI_WAL_DISABLE=false
+
 # Safety gate: destructive delete endpoint (DELETE /v1/agents/{agent_id})
 # Keep false by default; enable only for controlled GDPR workflows.
 AKASHI_ENABLE_DESTRUCTIVE_DELETE=false

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -122,6 +122,54 @@ func TestLoadSucceedsWithDefaults(t *testing.T) {
 	if cfg.EnableDestructiveDelete {
 		t.Fatal("expected destructive delete to be disabled by default")
 	}
+	// WAL should be enabled by default.
+	if cfg.WALDir != "./data/wal" {
+		t.Fatalf("expected default WALDir %q, got %q", "./data/wal", cfg.WALDir)
+	}
+	if cfg.WALDisable {
+		t.Fatal("expected WALDisable to be false by default")
+	}
+}
+
+func TestLoad_WALDisableOverridesDir(t *testing.T) {
+	t.Setenv("AKASHI_WAL_DISABLE", "true")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("expected Load() to succeed, got: %v", err)
+	}
+	if cfg.WALDir != "" {
+		t.Fatalf("expected WALDir to be empty when AKASHI_WAL_DISABLE=true, got %q", cfg.WALDir)
+	}
+	if !cfg.WALDisable {
+		t.Fatal("expected WALDisable to be true")
+	}
+}
+
+func TestLoad_ExplicitWALDir(t *testing.T) {
+	t.Setenv("AKASHI_WAL_DIR", "/custom/wal/path")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("expected Load() to succeed, got: %v", err)
+	}
+	if cfg.WALDir != "/custom/wal/path" {
+		t.Fatalf("expected WALDir %q, got %q", "/custom/wal/path", cfg.WALDir)
+	}
+}
+
+func TestLoad_WALDisableOverridesExplicitDir(t *testing.T) {
+	// AKASHI_WAL_DISABLE=true should override even an explicit AKASHI_WAL_DIR.
+	t.Setenv("AKASHI_WAL_DIR", "/custom/wal/path")
+	t.Setenv("AKASHI_WAL_DISABLE", "true")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("expected Load() to succeed, got: %v", err)
+	}
+	if cfg.WALDir != "" {
+		t.Fatalf("expected WALDir to be empty when AKASHI_WAL_DISABLE=true, got %q", cfg.WALDir)
+	}
 }
 
 func contains(s, substr string) bool {


### PR DESCRIPTION
## Summary

- **P0 fix**: WAL was opt-in (disabled when `AKASHI_WAL_DIR` was empty). An audit product must not silently lose buffered events on crash.
- Default `AKASHI_WAL_DIR` to `./data/wal` — WAL is now enabled out of the box
- Add `AKASHI_WAL_DISABLE=true` for explicit opt-out (dev/testing only)
- Auto-create WAL directory on startup with `0750` permissions
- Warn at startup when WAL is disabled so operators see the durability risk

## Backward compatibility

- Deployments that already set `AKASHI_WAL_DIR` explicitly: **no change**
- Deployments that relied on WAL being disabled by default: set `AKASHI_WAL_DISABLE=true`

## Test plan

- [x] `TestLoadSucceedsWithDefaults` — verifies WALDir defaults to `./data/wal`
- [x] `TestLoad_WALDisableOverridesDir` — verifies `AKASHI_WAL_DISABLE=true` clears WALDir
- [x] `TestLoad_ExplicitWALDir` — verifies custom WAL path works
- [x] `TestLoad_WALDisableOverridesExplicitDir` — verifies disable wins over explicit dir
- [x] All existing tests pass with `-race`

Fixes #153