### PR TITLE
make HandleResolveConflict atomic and close audit gaps

### DIFF
--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -437,10 +437,18 @@ func (s *Server) handleTrace(ctx context.Context, request mcplib.CallToolRequest
 	// Verify the agent exists within the org, auto-registering if the caller
 	// is admin+ and the agent is new (reduces friction for first-time traces).
 	callerRole := model.AgentRole("")
+	actorID := ""
 	if claims != nil {
 		callerRole = claims.Role
+		actorID = claims.AgentID
 	}
-	if err := s.decisionSvc.ResolveOrCreateAgent(ctx, orgID, agentID, callerRole); err != nil {
+	autoRegAudit := &storage.MutationAuditEntry{
+		OrgID:        orgID,
+		ActorAgentID: actorID,
+		ActorRole:    string(callerRole),
+		Endpoint:     "mcp/akashi_trace",
+	}
+	if err := s.decisionSvc.ResolveOrCreateAgent(ctx, orgID, agentID, callerRole, autoRegAudit); err != nil {
 		return errorResult(err.Error()), nil
 	}
 

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -110,7 +110,7 @@ func mustTrace(t *testing.T, agentID, decisionType, outcome string, confidence f
 	ctx := adminCtx()
 
 	// Ensure agent exists.
-	_ = testSvc.ResolveOrCreateAgent(ctx, uuid.Nil, agentID, model.RoleAdmin)
+	_ = testSvc.ResolveOrCreateAgent(ctx, uuid.Nil, agentID, model.RoleAdmin, nil)
 
 	result, err := testServer.handleTrace(ctx, traceRequest(map[string]any{
 		"agent_id":      agentID,
@@ -136,7 +136,7 @@ func mustTrace(t *testing.T, agentID, decisionType, outcome string, confidence f
 func TestHandleTrace(t *testing.T) {
 	ctx := adminCtx()
 	agentID := "trace-basic-" + uuid.New().String()[:8]
-	_ = testSvc.ResolveOrCreateAgent(ctx, uuid.Nil, agentID, model.RoleAdmin)
+	_ = testSvc.ResolveOrCreateAgent(ctx, uuid.Nil, agentID, model.RoleAdmin, nil)
 
 	result, err := testServer.handleTrace(ctx, traceRequest(map[string]any{
 		"agent_id":      agentID,
@@ -244,7 +244,7 @@ func TestHandleTrace_DefaultsAgentIDFromClaims(t *testing.T) {
 func TestHandleTrace_ModelAndTaskContext(t *testing.T) {
 	ctx := adminCtx()
 	agentID := "trace-ctx-" + uuid.New().String()[:8]
-	_ = testSvc.ResolveOrCreateAgent(ctx, uuid.Nil, agentID, model.RoleAdmin)
+	_ = testSvc.ResolveOrCreateAgent(ctx, uuid.Nil, agentID, model.RoleAdmin, nil)
 
 	result, err := testServer.handleTrace(ctx, traceRequest(map[string]any{
 		"agent_id":      agentID,
@@ -927,7 +927,7 @@ func TestHandleTrace_Concurrent(t *testing.T) {
 	for i := range n {
 		go func(idx int) {
 			agentID := fmt.Sprintf("concurrent-%d-%s", idx, uuid.New().String()[:8])
-			_ = testSvc.ResolveOrCreateAgent(ctx, uuid.Nil, agentID, model.RoleAdmin)
+			_ = testSvc.ResolveOrCreateAgent(ctx, uuid.Nil, agentID, model.RoleAdmin, nil)
 
 			result, err := testServer.handleTrace(ctx, traceRequest(map[string]any{
 				"agent_id":      agentID,

--- a/internal/service/decisions/service_test.go
+++ b/internal/service/decisions/service_test.go
@@ -203,7 +203,7 @@ func TestResolveOrCreateAgent_Existing(t *testing.T) {
 	agentID := "existing-" + uuid.New().String()[:8]
 	createAgent(t, agentID)
 
-	err := testSvc.ResolveOrCreateAgent(ctx, uuid.Nil, agentID, model.RoleAdmin)
+	err := testSvc.ResolveOrCreateAgent(ctx, uuid.Nil, agentID, model.RoleAdmin, nil)
 	assert.NoError(t, err, "existing agent should resolve without error")
 }
 
@@ -211,7 +211,7 @@ func TestResolveOrCreateAgent_AutoRegisterAsAdmin(t *testing.T) {
 	ctx := context.Background()
 	agentID := "auto-reg-" + uuid.New().String()[:8]
 
-	err := testSvc.ResolveOrCreateAgent(ctx, uuid.Nil, agentID, model.RoleAdmin)
+	err := testSvc.ResolveOrCreateAgent(ctx, uuid.Nil, agentID, model.RoleAdmin, nil)
 	require.NoError(t, err, "admin should auto-register new agents")
 
 	// Verify it was actually created.
@@ -223,7 +223,7 @@ func TestResolveOrCreateAgent_DeniedAsNonAdmin(t *testing.T) {
 	ctx := context.Background()
 	agentID := "no-auto-" + uuid.New().String()[:8]
 
-	err := testSvc.ResolveOrCreateAgent(ctx, uuid.Nil, agentID, model.RoleAgent)
+	err := testSvc.ResolveOrCreateAgent(ctx, uuid.Nil, agentID, model.RoleAgent, nil)
 	assert.ErrorIs(t, err, decisions.ErrAgentNotFound, "non-admin should not auto-register")
 }
 

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -299,7 +299,7 @@ func TestReviseDecision(t *testing.T) {
 		DecisionType: "loan_approval",
 		Outcome:      "deny",
 		Confidence:   0.95,
-	})
+	}, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "deny", revised.Outcome)
 
@@ -982,7 +982,7 @@ func TestGetDecisionRevisions_Chain(t *testing.T) {
 		Outcome:      "version_b",
 		Confidence:   0.7,
 		Metadata:     map[string]any{},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	c, err := testDB.ReviseDecision(ctx, b.ID, model.Decision{
@@ -992,7 +992,7 @@ func TestGetDecisionRevisions_Chain(t *testing.T) {
 		Outcome:      "version_c",
 		Confidence:   0.9,
 		Metadata:     map[string]any{},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	// Query the full chain starting from C.
@@ -1037,13 +1037,13 @@ func TestGetRevisionChainIDs_TransitiveChain(t *testing.T) {
 	b, err := testDB.ReviseDecision(ctx, a.ID, model.Decision{
 		RunID: run.ID, AgentID: agentID, DecisionType: "chain_test",
 		Outcome: "version_b", Confidence: 0.7, Metadata: map[string]any{},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	c, err := testDB.ReviseDecision(ctx, b.ID, model.Decision{
 		RunID: run.ID, AgentID: agentID, DecisionType: "chain_test",
 		Outcome: "version_c", Confidence: 0.9, Metadata: map[string]any{},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	// From A: should return B and C (forward chain).


### PR DESCRIPTION
## Summary

Fixes #158 and #159.

- **#158 (atomicity)**: Resolution decision creation + conflict status update now happen in a single transaction. Previously two separate transactions — a crash between them would leave an orphaned resolution decision and an unresolved conflict. Extracted `createTraceInTx` from `CreateTraceTx` and added `CreateTraceAndResolveConflictTx`. Refactored `service.Trace` into `prepareTrace` + `postTraceAsync` so the new `ResolveConflictWithTrace` reuses all preparation and post-commit logic without duplication.

- **#159 (audit gaps)**: `ReviseDecision` now accepts an optional `*MutationAuditEntry` inserted atomically in the same transaction as the revision. `ResolveOrCreateAgent` now accepts an optional audit entry and uses `CreateAgentWithAudit` for auto-registered agents, making auto-registration visible in the audit trail. Both HTTP and MCP callers pass audit context.

## Changes

| File | What |
|------|------|
| `internal/storage/trace.go` | Extract `createTraceInTx`, add `CreateTraceAndResolveConflictTx` + `ResolveConflictInTraceParams` |
| `internal/storage/decisions.go` | Add optional `*MutationAuditEntry` to `ReviseDecision` |
| `internal/service/decisions/service.go` | Extract `prepareTrace`/`postTraceAsync`, add `ResolveConflictWithTrace`, add audit param to `ResolveOrCreateAgent` |
| `internal/server/handlers_decisions.go` | Use `ResolveConflictWithTrace` in `HandleResolveConflict`, pass audit to `ResolveOrCreateAgent` |
| `internal/mcp/tools.go` | Pass audit entry to `ResolveOrCreateAgent` |
| `*_test.go` | Update call sites with `nil` audit |

## Test plan

- [x] `go test -race -count=1 ./...` — all 22 packages pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] `atlas migrate validate` — pass