### PR TITLE
fix P2 issues: UTF-8 truncation, dead code, migration comment

### DIFF
--- a/internal/conflicts/validator.go
+++ b/internal/conflicts/validator.go
@@ -188,7 +188,11 @@ func ParseValidatorResponse(response string) (ValidationResult, error) {
 type NoopValidator struct{}
 
 func (NoopValidator) Validate(_ context.Context, _ ValidateInput) (ValidationResult, error) {
-	return ValidationResult{Relationship: "contradiction"}, nil
+	return ValidationResult{
+		Relationship: "contradiction",
+		Category:     "unknown",
+		Severity:     "medium",
+	}, nil
 }
 
 // perCallTimeout is the maximum time for a single LLM validation call.

--- a/internal/conflicts/validator_test.go
+++ b/internal/conflicts/validator_test.go
@@ -230,8 +230,8 @@ func TestNoopValidator(t *testing.T) {
 	assert.Equal(t, "contradiction", result.Relationship, "NoopValidator always returns contradiction")
 	assert.True(t, result.IsConflict())
 	assert.Empty(t, result.Explanation)
-	assert.Empty(t, result.Category)
-	assert.Empty(t, result.Severity)
+	assert.Equal(t, "unknown", result.Category, "NoopValidator defaults to unknown category")
+	assert.Equal(t, "medium", result.Severity, "NoopValidator defaults to medium severity")
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/mcp/compact.go
+++ b/internal/mcp/compact.go
@@ -22,11 +22,7 @@ func compactDecision(d model.Decision) map[string]any {
 		"created_at":    d.CreatedAt,
 	}
 	if d.Reasoning != nil && *d.Reasoning != "" {
-		r := *d.Reasoning
-		if len(r) > maxCompactReasoning {
-			r = r[:maxCompactReasoning] + "..."
-		}
-		m["reasoning"] = r
+		m["reasoning"] = truncate(*d.Reasoning, maxCompactReasoning)
 	}
 	if d.SessionID != nil {
 		m["session_id"] = d.SessionID
@@ -142,8 +138,9 @@ func actionNeeded(conflicts []model.DecisionConflict) bool {
 }
 
 func truncate(s string, maxLen int) string {
-	if len(s) <= maxLen {
+	runes := []rune(s)
+	if len(runes) <= maxLen {
 		return s
 	}
-	return s[:maxLen] + "..."
+	return string(runes[:maxLen]) + "..."
 }

--- a/internal/mcp/compact_test.go
+++ b/internal/mcp/compact_test.go
@@ -178,6 +178,16 @@ func TestTruncate(t *testing.T) {
 	assert.Equal(t, "hello", truncate("hello", 10))
 	assert.Equal(t, "hel...", truncate("hello world", 3))
 	assert.Equal(t, "", truncate("", 5))
+
+	// UTF-8 safety: CJK characters are multi-byte but should truncate at rune boundaries.
+	assert.Equal(t, "日本語...", truncate("日本語テスト", 3))
+	assert.Equal(t, "日本語テスト", truncate("日本語テスト", 10)) // under limit, returned as-is
+
+	// Emoji: each emoji is a single rune (may be multi-byte).
+	assert.Equal(t, "🎉🎊...", truncate("🎉🎊🎈🎁", 2))
+
+	// Mixed ASCII and multi-byte.
+	assert.Equal(t, "ab日...", truncate("ab日本語", 3))
 }
 
 func ptrFloat64(f float64) *float64 { return &f }

--- a/internal/storage/conflicts.go
+++ b/internal/storage/conflicts.go
@@ -319,19 +319,6 @@ func (db *DB) ResolveConflictWithDecisionAndAudit(ctx context.Context, id, orgID
 	return nil
 }
 
-// GetConflictsByDecision returns all conflicts involving a specific decision.
-func (db *DB) GetConflictsByDecision(ctx context.Context, orgID, decisionID uuid.UUID) ([]model.DecisionConflict, error) {
-	rows, err := db.pool.Query(ctx,
-		conflictSelectBase+` WHERE sc.org_id = $1 AND (sc.decision_a_id = $2 OR sc.decision_b_id = $2)
-		 ORDER BY sc.detected_at DESC`, orgID, decisionID)
-	if err != nil {
-		return nil, fmt.Errorf("storage: get conflicts by decision: %w", err)
-	}
-	defer rows.Close()
-
-	return scanConflictRows(rows)
-}
-
 // InsertScoredConflict inserts a semantic conflict into scored_conflicts.
 // Ensures decision_a_id < decision_b_id for consistent ordering.
 func (db *DB) InsertScoredConflict(ctx context.Context, c model.DecisionConflict) error {

--- a/migrations/040_decision_claims_fk.sql
+++ b/migrations/040_decision_claims_fk.sql
@@ -1,4 +1,4 @@
--- 039: Add FK from decision_claims to decisions with cascade delete.
+-- 040: Add FK from decision_claims to decisions with cascade delete.
 -- Defense-in-depth: the application explicitly deletes claims in DeleteAgentData
 -- (GDPR erasure), but the FK ensures no orphaned claims survive if a decision is
 -- deleted through any other code path.

--- a/migrations/atlas.sum
+++ b/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:PjWhy7Ni1qHxxNXtDmYGdlz3fZYje87diSl1adSxD+M=
+h1:qW3AgIcMKKOjhexIgqR15CkaGOw4ALZkgDVDXboKhqE=
 001_initial.sql h1:uhyGXto+QacAaGYb9ZTGjsBs5chlKi8O0eHz9aCQsrY=
 022_full_text_search.sql h1:9iwtA8MgCzAxDV9YkUBn0CLT9ePSmj3GcPoMGg8TXf0=
 023_fix_outbox_index.sql h1:OtMEFBcMRWej02+ghnBXlPr6BVq+LoA62Id9XUWfDNI=
@@ -18,6 +18,6 @@ h1:PjWhy7Ni1qHxxNXtDmYGdlz3fZYje87diSl1adSxD+M=
 037_conflict_scored_at.sql h1:AKuaInJ2GnIxTWa7kK4YnuMXVoKrvf+MNFHvpAykKpM=
 038_conflict_precision.sql h1:Z78MrYF3Ud4Y7Yhrt5VxoJ7ygPqqOJLe67Qc2HGUMq8=
 039_agent_last_seen.sql h1:pVJJsK9ByaYUaf/JJPYEmoHXSgPSxmi4b6jG/xfCYLo=
-040_decision_claims_fk.sql h1:ZIQJlrOCL990XlPoe1APhg8MXJRvE2TVPSGuPSnXO6Q=
-041_archive_hypertable.sql h1:32cIpkv7IGm3mogQjj/6S0ZlT1jlVKucl8zncnlnsCs=
-042_audit_immutability_and_precision.sql h1:74/SEuaNu02LgqrppRFFPaXy4WAJzh6MGd9mXohnras=
+040_decision_claims_fk.sql h1:croGT4BMyqS3TLtYWNffX/um6T0ojrAoOjlqWGC9k2w=
+041_archive_hypertable.sql h1:Pnw2tNZqlOa8z4qGbT9ZT0KRxCuvCGt/7AEM54h0cZE=
+042_audit_immutability_and_precision.sql h1:FHDU1AoMRCCAQsMFNL4JObtAx2AaCoJy0gmnDTn6Mdc=


### PR DESCRIPTION
Closes #160, closes #161, closes #162.

## Changes

**#160 — UTF-8 safe truncation**
- `truncate()` in `mcp/compact.go` now converts to runes before slicing, preventing split multi-byte characters (CJK, emoji)
- `compactDecision` reasoning truncation now uses the same `truncate()` function instead of inline byte slicing
- Tests added for CJK, emoji, and mixed-width text

**#161 — Float precision (already fixed)**
- Migration 042 (PR #164) already widened `topic_similarity`, `outcome_divergence`, and `significance` from REAL to DOUBLE PRECISION
- Closing as resolved

**#162 — Cleanup**
- Migration 040 comment: `-- 039:` → `-- 040:` (with atlas rehash)
- Removed dead `GetConflictsByDecision` from `storage/conflicts.go` (never called; `ListConflicts` with `DecisionID` filter is used instead)
- `NoopValidator` now returns `category="unknown"` and `severity="medium"` instead of empty strings

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` — 0 issues
- [x] `atlas migrate validate` — passes
- [x] `go test -race ./internal/mcp/` — passes with new UTF-8 test cases
- [x] `go test -race ./internal/conflicts/` — passes with updated NoopValidator assertions
- [x] `go test -race -run='^$' ./internal/storage/` — compiles after dead code removal