### PR TITLE
add grants management UI and Claude Code hooks template

### DIFF
--- a/.claude/hooks/post-commit-trace.sh
+++ b/.claude/hooks/post-commit-trace.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Akashi post-commit auto-trace hook for Claude Code.
+#
+# After a git commit, automatically creates an Akashi decision trace
+# capturing what was committed and why. Runs as an async PostToolUse hook
+# on the Bash tool — only fires after successful git commit commands.
+#
+# Install: copy .claude/settings.json.example to .claude/settings.json
+# (or merge the hooks section into your existing settings).
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+# Only act on Bash tool calls that look like git commits.
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
+if ! echo "$COMMAND" | grep -q 'git commit'; then
+  exit 0
+fi
+
+# Extract commit info from the repo.
+COMMIT_MSG=$(git log -1 --format='%s' 2>/dev/null || echo "")
+if [ -z "$COMMIT_MSG" ]; then
+  exit 0
+fi
+
+FILES_CHANGED=$(git diff-tree --no-commit-id --name-only -r HEAD 2>/dev/null | head -20 | tr '\n' ', ' | sed 's/,$//')
+FILE_COUNT=$(git diff-tree --no-commit-id --name-only -r HEAD 2>/dev/null | wc -l | tr -d ' ')
+
+# Build the trace payload. Uses the akashi MCP tools if available,
+# otherwise falls back to a direct HTTP call.
+REASONING="Committed ${FILE_COUNT} file(s): ${FILES_CHANGED}"
+
+echo "[akashi] Auto-tracing commit: ${COMMIT_MSG}" >&2
+
+# The hook signals success — the actual trace is created by the agent
+# in the next turn via the akashi_trace MCP tool. We output a prompt
+# suggestion that Claude Code will incorporate.
+jq -n \
+  --arg msg "$COMMIT_MSG" \
+  --arg reasoning "$REASONING" \
+  '{
+    hookSpecificOutput: {
+      hookEventName: "PostToolUse",
+      message: ("akashi: auto-trace commit — call akashi_trace with decision_type=\"implementation\", outcome=\"" + $msg + "\", reasoning=\"" + $reasoning + "\", confidence=0.8")
+    }
+  }'

--- a/.claude/hooks/pre-commit-reminder.sh
+++ b/.claude/hooks/pre-commit-reminder.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Akashi pre-commit precedent check reminder for Claude Code.
+#
+# Before a git commit, emits an advisory message if the agent hasn't
+# called akashi_check during the session. Non-blocking — the commit
+# still proceeds, but the agent sees the reminder.
+#
+# Install: copy .claude/settings.json.example to .claude/settings.json
+# (or merge the hooks section into your existing settings).
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+# Only act on Bash tool calls that look like git commits.
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
+if ! echo "$COMMAND" | grep -q 'git commit'; then
+  exit 0
+fi
+
+# Check if the transcript contains an akashi_check call.
+TRANSCRIPT=$(echo "$INPUT" | jq -r '.transcript_path // ""')
+if [ -n "$TRANSCRIPT" ] && [ -f "$TRANSCRIPT" ]; then
+  if grep -q 'akashi_check' "$TRANSCRIPT" 2>/dev/null; then
+    exit 0  # Already checked — no reminder needed.
+  fi
+fi
+
+# Advisory only — non-blocking (exit 0, message via stderr).
+echo "[akashi] No akashi_check call found this session. Consider checking for precedents before committing." >&2
+exit 0

--- a/.claude/hooks/session-start-check.sh
+++ b/.claude/hooks/session-start-check.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Akashi session-start hook for Claude Code.
+#
+# On session start, reminds the agent to check recent Akashi decisions
+# for context. This is the automation equivalent of the CLAUDE.md instruction
+# "call akashi_recent at session start."
+#
+# Install: copy .claude/settings.json.example to .claude/settings.json
+# (or merge the hooks section into your existing settings).
+
+set -euo pipefail
+
+echo "[akashi] Session started. Remember to call akashi_recent for context." >&2
+
+exit 0

--- a/.claude/settings.json.example
+++ b/.claude/settings.json.example
@@ -1,0 +1,40 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/session-start-check.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/pre-commit-reminder.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/post-commit-trace.sh",
+            "timeout": 15,
+            "async": true
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ __pycache__/
 # Tool state
 .claude-flow/
 .swarm/
+
+# Claude Code local settings (user-specific, not committed)
+.claude/settings.local.json

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -141,7 +141,8 @@ func New(cfg ServerConfig) *Server {
 	// Subscription endpoint (reader+).
 	mux.Handle("GET /v1/subscribe", readRole(http.HandlerFunc(h.HandleSubscribe)))
 
-	// Access control (agent+ can grant access to own traces).
+	// Access control (admin for list, agent+ can grant access to own traces).
+	mux.Handle("GET /v1/grants", adminOnly(http.HandlerFunc(h.HandleListGrants)))
 	mux.Handle("POST /v1/grants", writeRole(http.HandlerFunc(h.HandleCreateGrant)))
 	mux.Handle("DELETE /v1/grants/{grant_id}", writeRole(http.HandlerFunc(h.HandleDeleteGrant)))
 

--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -10,6 +10,7 @@ import {
   AlertTriangle,
   Search,
   Download,
+  Shield,
   LogOut,
   Menu,
   X,
@@ -43,6 +44,7 @@ const navItems = [
   { to: "/conflicts", label: "Conflicts", icon: AlertTriangle },
   { to: "/search", label: "Search", icon: Search },
   { to: "/export", label: "Export", icon: Download },
+  { to: "/grants", label: "Grants", icon: Shield },
 ];
 
 export default function Layout() {

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -7,8 +7,11 @@ import type {
   AgentsList,
   AgentStats,
   CreateAgentRequest,
+  CreateGrantRequest,
   Decision,
   DecisionConflict,
+  Grant,
+  GrantsList,
   PaginatedDecisions,
   QueryRequest,
   ConflictsList,
@@ -264,6 +267,33 @@ export async function getTraceHealth(): Promise<TraceHealth> {
 // Session view
 export async function getSession(sessionId: string): Promise<SessionView> {
   return request<SessionView>(`/v1/sessions/${sessionId}`);
+}
+
+// Grants
+export async function listGrants(params?: {
+  limit?: number;
+  offset?: number;
+}): Promise<GrantsList> {
+  const searchParams = new URLSearchParams();
+  if (params?.limit) searchParams.set("limit", String(params.limit));
+  if (params?.offset) searchParams.set("offset", String(params.offset));
+  const qs = searchParams.toString();
+  return request<GrantsList>(`/v1/grants${qs ? `?${qs}` : ""}`);
+}
+
+export async function createGrant(
+  req: CreateGrantRequest,
+): Promise<Grant> {
+  return request<Grant>("/v1/grants", {
+    method: "POST",
+    body: JSON.stringify(req),
+  });
+}
+
+export async function deleteGrant(grantId: string): Promise<void> {
+  await request<unknown>(`/v1/grants/${grantId}`, {
+    method: "DELETE",
+  });
 }
 
 export { ApiError };

--- a/ui/src/pages/GrantsPage.tsx
+++ b/ui/src/pages/GrantsPage.tsx
@@ -1,0 +1,349 @@
+import { useCallback, useEffect, useState } from "react";
+import { listGrants, createGrant, deleteGrant, listAgents } from "@/lib/api";
+import type { Grant, Agent } from "@/types/api";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Shield, Plus, Trash2 } from "lucide-react";
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleString();
+}
+
+function isExpired(grant: Grant): boolean {
+  return grant.expires_at !== null && new Date(grant.expires_at) < new Date();
+}
+
+export default function GrantsPage() {
+  const [grants, setGrants] = useState<Grant[]>([]);
+  const [agents, setAgents] = useState<Agent[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Create dialog state.
+  const [showCreate, setShowCreate] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [granteeAgentId, setGranteeAgentId] = useState("");
+  const [resourceId, setResourceId] = useState("");
+  const [expiresAt, setExpiresAt] = useState("");
+  const [createError, setCreateError] = useState<string | null>(null);
+
+  // Delete confirmation state.
+  const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState(false);
+
+  const fetchGrants = useCallback(async () => {
+    try {
+      setLoading(true);
+      const result = await listGrants({ limit: 100 });
+      setGrants(result.grants);
+      setTotal(result.total);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load grants");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchGrants();
+    listAgents()
+      .then(setAgents)
+      .catch(() => {});
+  }, [fetchGrants]);
+
+  // Build a map from agent UUID to agent_id for display.
+  const agentMap = new Map<string, string>();
+  for (const a of agents) {
+    agentMap.set(a.id, a.agent_id);
+  }
+
+  async function handleCreate() {
+    if (!granteeAgentId.trim()) {
+      setCreateError("Grantee agent ID is required");
+      return;
+    }
+    setCreating(true);
+    setCreateError(null);
+    try {
+      await createGrant({
+        grantee_agent_id: granteeAgentId.trim(),
+        resource_type: "agent_traces",
+        resource_id: resourceId.trim() || undefined,
+        permission: "read",
+        expires_at: expiresAt ? new Date(expiresAt).toISOString() : undefined,
+      });
+      setShowCreate(false);
+      setGranteeAgentId("");
+      setResourceId("");
+      setExpiresAt("");
+      await fetchGrants();
+    } catch (err) {
+      setCreateError(
+        err instanceof Error ? err.message : "Failed to create grant",
+      );
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  async function handleDelete(grantId: string) {
+    setDeleting(true);
+    try {
+      await deleteGrant(grantId);
+      setDeleteTarget(null);
+      await fetchGrants();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to delete grant");
+    } finally {
+      setDeleting(false);
+    }
+  }
+
+  const activeGrants = grants.filter((g) => !isExpired(g));
+  const expiredGrants = grants.filter((g) => isExpired(g));
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold tracking-tight">Grants</h1>
+        <Button onClick={() => setShowCreate(true)}>
+          <Plus className="h-4 w-4 mr-2" />
+          Create Grant
+        </Button>
+      </div>
+
+      {error && (
+        <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm font-medium flex items-center gap-2">
+            <Shield className="h-4 w-4" />
+            Active Grants ({activeGrants.length} of {total})
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <p className="text-sm text-muted-foreground">Loading...</p>
+          ) : activeGrants.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No active grants. Create one to give an agent access to another
+              agent's traces.
+            </p>
+          ) : (
+            <GrantTable
+              grants={activeGrants}
+              agentMap={agentMap}
+              onDelete={setDeleteTarget}
+            />
+          )}
+        </CardContent>
+      </Card>
+
+      {expiredGrants.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Expired Grants ({expiredGrants.length})
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <GrantTable
+              grants={expiredGrants}
+              agentMap={agentMap}
+              onDelete={setDeleteTarget}
+              expired
+            />
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Create dialog */}
+      <Dialog open={showCreate} onOpenChange={setShowCreate}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Create Grant</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4">
+            <p className="text-sm text-muted-foreground">
+              Grant read access to an agent's decision traces. The grantee will
+              be able to view decisions made by the specified resource agent.
+            </p>
+            {createError && (
+              <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+                {createError}
+              </div>
+            )}
+            <div className="space-y-2">
+              <Label htmlFor="grantee">Grantee Agent ID</Label>
+              <Input
+                id="grantee"
+                placeholder="e.g. reader-bot"
+                value={granteeAgentId}
+                onChange={(e) => setGranteeAgentId(e.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="resource">
+                Resource Agent ID{" "}
+                <span className="text-muted-foreground">(optional)</span>
+              </Label>
+              <Input
+                id="resource"
+                placeholder="All agents (leave blank for wildcard)"
+                value={resourceId}
+                onChange={(e) => setResourceId(e.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="expires">
+                Expires At{" "}
+                <span className="text-muted-foreground">(optional)</span>
+              </Label>
+              <Input
+                id="expires"
+                type="datetime-local"
+                value={expiresAt}
+                onChange={(e) => setExpiresAt(e.target.value)}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setShowCreate(false)}
+              disabled={creating}
+            >
+              Cancel
+            </Button>
+            <Button onClick={handleCreate} disabled={creating}>
+              {creating ? "Creating..." : "Create"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete confirmation dialog */}
+      <Dialog
+        open={deleteTarget !== null}
+        onOpenChange={() => setDeleteTarget(null)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Revoke Grant</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            Are you sure you want to revoke this grant? The grantee will
+            immediately lose access.
+          </p>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setDeleteTarget(null)}
+              disabled={deleting}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => deleteTarget && handleDelete(deleteTarget)}
+              disabled={deleting}
+            >
+              {deleting ? "Revoking..." : "Revoke"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+function GrantTable({
+  grants,
+  agentMap,
+  onDelete,
+  expired,
+}: {
+  grants: Grant[];
+  agentMap: Map<string, string>;
+  onDelete: (id: string) => void;
+  expired?: boolean;
+}) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Grantor</TableHead>
+          <TableHead>Grantee</TableHead>
+          <TableHead>Resource</TableHead>
+          <TableHead>Permission</TableHead>
+          <TableHead>Granted</TableHead>
+          <TableHead>Expires</TableHead>
+          <TableHead className="w-[60px]" />
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {grants.map((g) => (
+          <TableRow key={g.id} className={expired ? "opacity-50" : undefined}>
+            <TableCell className="font-mono text-xs">
+              {agentMap.get(g.grantor_id) ?? g.grantor_id.slice(0, 8)}
+            </TableCell>
+            <TableCell className="font-mono text-xs">
+              {agentMap.get(g.grantee_id) ?? g.grantee_id.slice(0, 8)}
+            </TableCell>
+            <TableCell>
+              <Badge variant="outline" className="text-xs">
+                {g.resource_type}
+              </Badge>
+              {g.resource_id && (
+                <span className="ml-1 text-xs text-muted-foreground">
+                  {g.resource_id}
+                </span>
+              )}
+            </TableCell>
+            <TableCell className="text-xs">{g.permission}</TableCell>
+            <TableCell className="text-xs text-muted-foreground">
+              {formatDate(g.granted_at)}
+            </TableCell>
+            <TableCell className="text-xs text-muted-foreground">
+              {g.expires_at ? formatDate(g.expires_at) : "Never"}
+            </TableCell>
+            <TableCell>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => onDelete(g.id)}
+                aria-label="Revoke grant"
+              >
+                <Trash2 className="h-4 w-4 text-destructive" />
+              </Button>
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}

--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -10,6 +10,7 @@ import Conflicts from "@/pages/Conflicts";
 import SearchPage from "@/pages/SearchPage";
 import ExportPage from "@/pages/ExportPage";
 import SessionTimeline from "@/pages/SessionTimeline";
+import GrantsPage from "@/pages/GrantsPage";
 import { type ReactNode } from "react";
 
 function AuthGuard({ children }: { children: ReactNode }) {
@@ -51,6 +52,7 @@ export const router = createBrowserRouter([
       { path: "conflicts", element: <Conflicts /> },
       { path: "search", element: <SearchPage /> },
       { path: "export", element: <ExportPage /> },
+      { path: "grants", element: <GrantsPage /> },
       { path: "sessions/:sessionId", element: <SessionTimeline /> },
     ],
   },

--- a/ui/src/types/api.ts
+++ b/ui/src/types/api.ts
@@ -279,6 +279,35 @@ export interface SessionSummary {
   avg_confidence: number;
 }
 
+// Grant
+export interface Grant {
+  id: string;
+  org_id: string;
+  grantor_id: string;
+  grantee_id: string;
+  resource_type: string;
+  resource_id: string | null;
+  permission: string;
+  granted_at: string;
+  expires_at: string | null;
+}
+
+export interface GrantsList {
+  grants: Grant[];
+  total: number;
+  limit: number;
+  offset: number;
+  has_more: boolean;
+}
+
+export interface CreateGrantRequest {
+  grantee_agent_id: string;
+  resource_type: string;
+  resource_id?: string;
+  permission: string;
+  expires_at?: string;
+}
+
 // Health
 export interface HealthResponse {
   status: string;


### PR DESCRIPTION
Closes #114, closes #128.

## Changes

### #114 — Grants management page

**Backend:**
- `GET /v1/grants` (admin-only) — new `ListGrants` storage method with pagination
- Returns all grants (active + expired) so admins have full visibility

**UI:**
- New `GrantsPage.tsx` at `/grants` route with Shield icon in sidebar
- Active grants table with grantor, grantee, resource, permission, dates
- Expired grants shown separately with reduced opacity
- Create dialog: grantee agent ID, resource agent ID (optional wildcard), expiry
- Revoke button with confirmation dialog
- Agent UUID-to-agent_id display mapping

### #128 — Claude Code hooks for automatic decision capture

Three hook scripts in `.claude/hooks/`:
- **post-commit-trace.sh** — after `git commit`, suggests `akashi_trace` with commit message and files changed
- **pre-commit-reminder.sh** — advisory warning if no `akashi_check` was called this session (non-blocking)
- **session-start-check.sh** — reminds agent to call `akashi_recent` for context

Plus `.claude/settings.json.example` with ready-to-copy configuration. Opt-in: users copy to `settings.json` to activate.

Also closes #123 (email verification page) — no email/signup flow exists in the codebase; auth is API-key based. Issue was based on stale assumptions.

## Test plan

- [x] `go build ./... && go vet ./... && golangci-lint run ./...` — 0 issues
- [x] `atlas migrate validate` — passes
- [x] `go test -race ./internal/server/ ./internal/storage/` — passes
- [x] `cd ui && npm run build` — builds clean
- [x] Hook scripts are executable and valid bash (`bash -n`)