### PR TITLE
review hardening: export error signaling, COPY timeout, immutability triggers, FK cascade

### DIFF
--- a/internal/service/trace/buffer.go
+++ b/internal/service/trace/buffer.go
@@ -203,7 +203,9 @@ func (b *Buffer) flushLoop(ctx context.Context) {
 				}
 			} else {
 				// Fallback for direct cancellation without Drain (e.g., tests).
-				fallbackCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				// 30s matches the outbox drain timeout — long enough to flush a
+				// full buffer batch even under transient DB pressure.
+				fallbackCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 				if err := b.flushUntilEmpty(fallbackCtx); err != nil {
 					b.logger.Warn("trace: fallback final flush incomplete", "error", err, "remaining_events", b.Len())
 				}

--- a/migrations/043_review_hardening.sql
+++ b/migrations/043_review_hardening.sql
@@ -1,0 +1,53 @@
+-- 043: Review hardening — immutability triggers and FK cascade fix.
+--
+-- G1: search_outbox_dead_letters is an audit archive but lacked immutability
+--     triggers, allowing accidental UPDATE/DELETE of dead-letter records.
+-- G2: agent_events_archive is an audit archive but lacked immutability
+--     triggers. Note: TimescaleDB retention policies drop entire chunks
+--     (DDL, not row-level DELETE), so these triggers do not interfere with
+--     the retention policy added in migration 041.
+-- G3: resolution_decision_id FK lacked ON DELETE SET NULL. If an agent whose
+--     decision resolved a conflict between two OTHER agents is deleted, the
+--     FK would block the cascade. ON DELETE SET NULL allows the delete to
+--     proceed while preserving the conflict row.
+
+-- G1: search_outbox_dead_letters immutability (append-only).
+CREATE OR REPLACE FUNCTION prevent_outbox_dead_letters_modify()
+RETURNS TRIGGER AS $$ BEGIN
+  RAISE EXCEPTION 'search_outbox_dead_letters is append-only';
+END; $$ LANGUAGE plpgsql;
+
+CREATE TRIGGER outbox_dead_letters_immutable_update
+  BEFORE UPDATE ON search_outbox_dead_letters
+  FOR EACH ROW EXECUTE FUNCTION prevent_outbox_dead_letters_modify();
+
+CREATE TRIGGER outbox_dead_letters_immutable_delete
+  BEFORE DELETE ON search_outbox_dead_letters
+  FOR EACH ROW EXECUTE FUNCTION prevent_outbox_dead_letters_modify();
+
+-- G2: agent_events_archive immutability (append-only).
+-- Row-level triggers are safe alongside TimescaleDB chunk retention because
+-- drop_chunks uses DDL (DROP TABLE on chunk), not row-level DELETE.
+CREATE OR REPLACE FUNCTION prevent_events_archive_modify()
+RETURNS TRIGGER AS $$ BEGIN
+  RAISE EXCEPTION 'agent_events_archive is append-only';
+END; $$ LANGUAGE plpgsql;
+
+CREATE TRIGGER events_archive_immutable_update
+  BEFORE UPDATE ON agent_events_archive
+  FOR EACH ROW EXECUTE FUNCTION prevent_events_archive_modify();
+
+CREATE TRIGGER events_archive_immutable_delete
+  BEFORE DELETE ON agent_events_archive
+  FOR EACH ROW EXECUTE FUNCTION prevent_events_archive_modify();
+
+-- G3: Fix resolution_decision_id FK to use ON DELETE SET NULL.
+-- Migration 038 added the column with a plain REFERENCES (implicit RESTRICT).
+-- This blocks DeleteAgentData when the resolution decision belongs to the
+-- deleted agent but the conflict is between two other agents' decisions.
+ALTER TABLE scored_conflicts
+  DROP CONSTRAINT IF EXISTS scored_conflicts_resolution_decision_id_fkey;
+
+ALTER TABLE scored_conflicts
+  ADD CONSTRAINT scored_conflicts_resolution_decision_id_fkey
+  FOREIGN KEY (resolution_decision_id) REFERENCES decisions(id) ON DELETE SET NULL;

--- a/migrations/atlas.sum
+++ b/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:qW3AgIcMKKOjhexIgqR15CkaGOw4ALZkgDVDXboKhqE=
+h1:Q1Fv2z5ZLotLU32rJIxFIycLVpIG0zdQeDMbfgLDyxI=
 001_initial.sql h1:uhyGXto+QacAaGYb9ZTGjsBs5chlKi8O0eHz9aCQsrY=
 022_full_text_search.sql h1:9iwtA8MgCzAxDV9YkUBn0CLT9ePSmj3GcPoMGg8TXf0=
 023_fix_outbox_index.sql h1:OtMEFBcMRWej02+ghnBXlPr6BVq+LoA62Id9XUWfDNI=
@@ -21,3 +21,4 @@ h1:qW3AgIcMKKOjhexIgqR15CkaGOw4ALZkgDVDXboKhqE=
 040_decision_claims_fk.sql h1:croGT4BMyqS3TLtYWNffX/um6T0ojrAoOjlqWGC9k2w=
 041_archive_hypertable.sql h1:Pnw2tNZqlOa8z4qGbT9ZT0KRxCuvCGt/7AEM54h0cZE=
 042_audit_immutability_and_precision.sql h1:FHDU1AoMRCCAQsMFNL4JObtAx2AaCoJy0gmnDTn6Mdc=
+043_review_hardening.sql h1:IlPsv9TU/TqL5wc7vSBHjS63ffApyQaB0RtoR6Li2yk=


### PR DESCRIPTION
## Summary

Fixes 6 issues from the comprehensive 11-dimension code review (aggregate 83/100):

- **B2**: Export NDJSON now writes an `__error` sentinel on mid-stream DB failures instead of silently truncating
- **B3**: Buffer drain fallback timeout increased from 10s to 30s, aligning with outbox drain timeout
- **B4**: `InsertEvents` COPY now has a 30s context timeout (was unbounded), matching alternatives/evidence paths
- **G1**: Immutability triggers on `search_outbox_dead_letters` (append-only audit archive)
- **G2**: Immutability triggers on `agent_events_archive` (safe alongside TimescaleDB chunk retention)
- **G3**: `resolution_decision_id` FK changed from RESTRICT to ON DELETE SET NULL

**B1 (future AsOf timestamps)** was investigated and determined to be intentional per existing test documentation — zero returns empty results, future returns all current decisions.

## Migration

Migration 043 adds immutability triggers and alters the FK constraint. Non-destructive, no data changes.

## Test plan

- [x] All 16 test packages pass with `-race -count=1`
- [x] `go build ./...`, `go vet ./...`, `golangci-lint run ./...` clean
- [x] `atlas migrate validate` passes
- [ ] CI green