### PR TITLE
Add managed API key system with per-key decision attribution

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -69,6 +69,10 @@ tags:
     description: Fine-grained access grants between agents
   - name: Export
     description: Bulk data export for auditors
+  - name: Keys
+    description: API key management (admin-only)
+  - name: Usage
+    description: Usage metering (admin-only)
   - name: System
     description: Health, SSE, and infrastructure
 
@@ -1157,6 +1161,162 @@ paths:
         "403":
           $ref: "#/components/responses/Forbidden"
 
+  # ── API Keys ──────────────────────────────────────────────────────
+  /v1/keys:
+    post:
+      operationId: createKey
+      tags: [Keys]
+      summary: Mint a new API key
+      description: |
+        Create a managed API key for an agent. The raw key is returned only
+        once in the response — it cannot be retrieved afterward.
+        Requires `admin` role or higher.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateKeyRequest"
+      responses:
+        "201":
+          description: Key created. `raw_key` is shown only once.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreateKeyResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+    get:
+      operationId: listKeys
+      tags: [Keys]
+      summary: List API keys for the organization
+      description: |
+        Returns all API keys (active and revoked) for the caller's
+        organization. Key hashes are never exposed.
+        Requires `admin` role or higher.
+      parameters:
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 100
+            minimum: 1
+            maximum: 1000
+        - name: offset
+          in: query
+          schema:
+            type: integer
+            default: 0
+            minimum: 0
+      responses:
+        "200":
+          description: List of API keys.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/APIResponse_KeyList"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
+  /v1/keys/{id}:
+    delete:
+      operationId: revokeKey
+      tags: [Keys]
+      summary: Revoke an API key
+      description: |
+        Revokes an API key immediately. The key can no longer be used
+        for authentication. Revocation is permanent.
+        Requires `admin` role or higher.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: The UUID of the key to revoke.
+      responses:
+        "200":
+          description: Key revoked.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: revoked
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /v1/keys/{id}/rotate:
+    post:
+      operationId: rotateKey
+      tags: [Keys]
+      summary: Rotate an API key
+      description: |
+        Atomically revokes the old key and mints a new one for the same
+        agent with the same label. The new raw key is returned only once.
+        Requires `admin` role or higher.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: The UUID of the key to rotate.
+      responses:
+        "200":
+          description: Key rotated. New `raw_key` is shown only once.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RotateKeyResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  # ── Usage ────────────────────────────────────────────────────────
+  /v1/usage:
+    get:
+      operationId: getUsage
+      tags: [Usage]
+      summary: Get usage metering for a billing period
+      description: |
+        Returns decision counts aggregated by API key and agent for the
+        specified billing period. The decisions table is the usage ledger —
+        no separate metering table exists.
+        Requires `admin` role or higher.
+      parameters:
+        - name: period
+          in: query
+          required: true
+          schema:
+            type: string
+            pattern: '^\d{4}-\d{2}$'
+          description: Billing period in YYYY-MM format.
+      responses:
+        "200":
+          description: Usage breakdown for the period.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UsageResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
   # ── System ─────────────────────────────────────────────────────────
   /config:
     get:
@@ -1805,6 +1965,18 @@ components:
         created_at:
           type: string
           format: date-time
+        session_id:
+          type: string
+          format: uuid
+          description: MCP or HTTP session that produced this decision.
+        agent_context:
+          type: object
+          additionalProperties: true
+          description: Composite agent identity context (tool, model, task, etc.).
+        api_key_id:
+          type: string
+          format: uuid
+          description: Managed API key that authenticated this decision.
         alternatives:
           type: array
           items:
@@ -2038,6 +2210,133 @@ components:
           type: string
           default: conflict_resolution
           description: Decision type for the resolution trace (defaults to "conflict_resolution").
+
+    # ── API Key schemas ─────────────────────────────────────────────
+    APIKey:
+      type: object
+      required: [id, prefix, agent_id, org_id, label, created_by, created_at]
+      properties:
+        id:
+          type: string
+          format: uuid
+        prefix:
+          type: string
+          description: First 8 hex chars of the raw key, for identification.
+        agent_id:
+          type: string
+        org_id:
+          type: string
+          format: uuid
+        label:
+          type: string
+          description: Human-readable label for this key.
+        created_by:
+          type: string
+          description: Agent ID of who minted this key.
+        created_at:
+          type: string
+          format: date-time
+        last_used_at:
+          type: string
+          format: date-time
+          nullable: true
+        expires_at:
+          type: string
+          format: date-time
+          nullable: true
+        revoked_at:
+          type: string
+          format: date-time
+          nullable: true
+
+    CreateKeyRequest:
+      type: object
+      required: [agent_id]
+      properties:
+        agent_id:
+          type: string
+          description: The agent this key authenticates as.
+        label:
+          type: string
+          description: Human-readable label (e.g. "Production MCP", "CI Runner").
+        expires_at:
+          type: string
+          format: date-time
+          description: Optional expiration timestamp.
+
+    CreateKeyResponse:
+      type: object
+      required: [id, prefix, agent_id, label, raw_key, created_at]
+      properties:
+        id:
+          type: string
+          format: uuid
+        prefix:
+          type: string
+        agent_id:
+          type: string
+        label:
+          type: string
+        raw_key:
+          type: string
+          description: The full API key. Shown only once — store it securely.
+        created_at:
+          type: string
+          format: date-time
+        expires_at:
+          type: string
+          format: date-time
+          nullable: true
+
+    RotateKeyResponse:
+      type: object
+      required: [new_key, revoked_key_id]
+      properties:
+        new_key:
+          $ref: "#/components/schemas/CreateKeyResponse"
+        revoked_key_id:
+          type: string
+          format: uuid
+
+    UsageResponse:
+      type: object
+      required: [org_id, period, total_decisions, by_key, by_agent]
+      properties:
+        org_id:
+          type: string
+          format: uuid
+        period:
+          type: string
+          description: Billing period (YYYY-MM).
+        total_decisions:
+          type: integer
+          description: Total decisions in the period.
+        by_key:
+          type: array
+          items:
+            type: object
+            properties:
+              key_id:
+                type: string
+                format: uuid
+                nullable: true
+              prefix:
+                type: string
+              label:
+                type: string
+              agent_id:
+                type: string
+              decisions:
+                type: integer
+        by_agent:
+          type: array
+          items:
+            type: object
+            properties:
+              agent_id:
+                type: string
+              decisions:
+                type: integer
 
     # ── Trace schemas ────────────────────────────────────────────────
     TraceRequest:
@@ -2565,6 +2864,26 @@ components:
       properties:
         data:
           $ref: "#/components/schemas/AccessGrant"
+        meta:
+          $ref: "#/components/schemas/ResponseMeta"
+
+    APIResponse_KeyList:
+      type: object
+      required: [data, meta]
+      properties:
+        data:
+          type: object
+          properties:
+            keys:
+              type: array
+              items:
+                $ref: "#/components/schemas/APIKey"
+            total:
+              type: integer
+            limit:
+              type: integer
+            offset:
+              type: integer
         meta:
           $ref: "#/components/schemas/ResponseMeta"
 

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -24,9 +24,10 @@ import (
 // Claims extends jwt.RegisteredClaims with Akashi-specific fields.
 type Claims struct {
 	jwt.RegisteredClaims
-	AgentID string          `json:"agent_id"`
-	OrgID   uuid.UUID       `json:"org_id"`
-	Role    model.AgentRole `json:"role"`
+	AgentID  string          `json:"agent_id"`
+	OrgID    uuid.UUID       `json:"org_id"`
+	Role     model.AgentRole `json:"role"`
+	APIKeyID *uuid.UUID      `json:"api_key_id,omitempty"` // Set when authenticated via a managed API key.
 }
 
 // JWTManager handles JWT creation and validation using Ed25519.

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -538,10 +538,17 @@ func (s *Server) handleTrace(ctx context.Context, request mcplib.CallToolRequest
 		Endpoint:     "akashi_trace",
 	}
 
+	// Extract API key ID from claims for per-key attribution.
+	var apiKeyID *uuid.UUID
+	if claims != nil {
+		apiKeyID = claims.APIKeyID
+	}
+
 	result, err := s.decisionSvc.Trace(ctx, orgID, decisions.TraceInput{
 		AgentID:      agentID,
 		SessionID:    sessionID,
 		AgentContext: agentContext,
+		APIKeyID:     apiKeyID,
 		AuditMeta:    auditMeta,
 		Decision: model.TraceDecision{
 			DecisionType: decisionType,

--- a/internal/model/api_key.go
+++ b/internal/model/api_key.go
@@ -1,0 +1,110 @@
+package model
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// APIKey represents a decoupled API key that authenticates as a specific agent.
+// Multiple keys can exist per agent, enabling rotation and per-environment credentials.
+type APIKey struct {
+	ID         uuid.UUID  `json:"id"`
+	Prefix     string     `json:"prefix"`
+	KeyHash    string     `json:"-"` // Never serialized.
+	AgentID    string     `json:"agent_id"`
+	OrgID      uuid.UUID  `json:"org_id"`
+	Label      string     `json:"label"`
+	CreatedBy  string     `json:"created_by"`
+	CreatedAt  time.Time  `json:"created_at"`
+	LastUsedAt *time.Time `json:"last_used_at,omitempty"`
+	ExpiresAt  *time.Time `json:"expires_at,omitempty"`
+	RevokedAt  *time.Time `json:"revoked_at,omitempty"`
+}
+
+// APIKeyWithRawKey is returned only on creation/rotation — the only time
+// the raw key is available. After this, only the prefix is visible.
+type APIKeyWithRawKey struct {
+	APIKey
+	RawKey string `json:"raw_key"`
+}
+
+// CreateKeyRequest is the request body for POST /v1/keys.
+type CreateKeyRequest struct {
+	AgentID   string  `json:"agent_id"`
+	Label     string  `json:"label"`
+	ExpiresAt *string `json:"expires_at,omitempty"` // RFC3339
+}
+
+// APIKeyResponse is the list response for GET /v1/keys.
+type APIKeyResponse struct {
+	Keys    []APIKey `json:"keys"`
+	Total   int      `json:"total"`
+	Limit   int      `json:"limit"`
+	Offset  int      `json:"offset"`
+	HasMore bool     `json:"has_more"`
+}
+
+// RotateKeyResponse is the response for POST /v1/keys/{id}/rotate.
+type RotateKeyResponse struct {
+	NewKey       APIKeyWithRawKey `json:"new_key"`
+	RevokedKeyID uuid.UUID        `json:"revoked_key_id"`
+}
+
+const (
+	// keyPrefixLen is the number of random bytes used for the key prefix (8 hex chars).
+	keyPrefixLen = 4
+	// keySecretLen is the number of random bytes for the secret portion (32 hex chars).
+	keySecretLen = 16
+	// keyFormatPrefix is the static prefix for all Akashi API keys.
+	keyFormatPrefix = "ak_"
+)
+
+// GenerateRawKey produces a new raw API key in the format: ak_<8-char-prefix>_<32-char-secret>.
+// Returns the full raw key and the prefix separately.
+func GenerateRawKey() (rawKey, prefix string, err error) {
+	prefixBytes := make([]byte, keyPrefixLen)
+	if _, err := rand.Read(prefixBytes); err != nil {
+		return "", "", fmt.Errorf("model: generate key prefix: %w", err)
+	}
+
+	secretBytes := make([]byte, keySecretLen)
+	if _, err := rand.Read(secretBytes); err != nil {
+		return "", "", fmt.Errorf("model: generate key secret: %w", err)
+	}
+
+	prefix = hex.EncodeToString(prefixBytes)
+	secret := hex.EncodeToString(secretBytes)
+	rawKey = keyFormatPrefix + prefix + "_" + secret
+
+	return rawKey, prefix, nil
+}
+
+// ParseRawKey extracts the prefix and full key from a raw key string.
+// Returns an error if the format is invalid.
+func ParseRawKey(rawKey string) (prefix, fullKey string, err error) {
+	if !strings.HasPrefix(rawKey, keyFormatPrefix) {
+		return "", "", fmt.Errorf("model: invalid key format: missing %s prefix", keyFormatPrefix)
+	}
+
+	rest := rawKey[len(keyFormatPrefix):]
+	underIdx := strings.IndexByte(rest, '_')
+	if underIdx < 1 || underIdx == len(rest)-1 {
+		return "", "", fmt.Errorf("model: invalid key format: expected ak_<prefix>_<secret>")
+	}
+
+	prefix = rest[:underIdx]
+	return prefix, rawKey, nil
+}
+
+// ValidateKeyLabel checks that a key label is reasonable.
+func ValidateKeyLabel(label string) error {
+	if len(label) > 255 {
+		return fmt.Errorf("label must be at most 255 characters")
+	}
+	return nil
+}

--- a/internal/model/decision.go
+++ b/internal/model/decision.go
@@ -45,6 +45,9 @@ type Decision struct {
 	SessionID    *uuid.UUID     `json:"session_id,omitempty"`
 	AgentContext map[string]any `json:"agent_context,omitempty"`
 
+	// API key attribution: which managed key authenticated this decision.
+	APIKeyID *uuid.UUID `json:"api_key_id,omitempty"`
+
 	// Joined data (populated by queries, not stored in decisions table).
 	Alternatives []Alternative `json:"alternatives,omitempty"`
 	Evidence     []Evidence    `json:"evidence,omitempty"`

--- a/internal/server/handlers_decisions.go
+++ b/internal/server/handlers_decisions.go
@@ -114,6 +114,7 @@ func (h *Handlers) HandleTrace(w http.ResponseWriter, r *http.Request) {
 		PrecedentRef: req.PrecedentRef,
 		SessionID:    sessionID,
 		AgentContext: agentContext,
+		APIKeyID:     claims.APIKeyID,
 		AuditMeta:    h.buildAuditMeta(r, orgID),
 	})
 	if err != nil {
@@ -611,6 +612,7 @@ func (h *Handlers) HandleResolveConflict(w http.ResponseWriter, r *http.Request)
 			Confidence:   1.0, // Resolution decisions are definitive.
 			Reasoning:    req.Reasoning,
 		},
+		APIKeyID:  claims.APIKeyID,
 		AuditMeta: h.buildAuditMeta(r, orgID),
 	}, storage.ResolveConflictInTraceParams{
 		ConflictID: id,

--- a/internal/server/handlers_keys.go
+++ b/internal/server/handlers_keys.go
@@ -1,0 +1,316 @@
+package server
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/ashita-ai/akashi/internal/auth"
+	"github.com/ashita-ai/akashi/internal/model"
+)
+
+// HandleCreateKey handles POST /v1/keys (admin-only).
+// Mints a new API key for the specified agent and returns the raw key
+// exactly once. After this response, only the prefix is available.
+func (h *Handlers) HandleCreateKey(w http.ResponseWriter, r *http.Request) {
+	claims := ClaimsFromContext(r.Context())
+	orgID := OrgIDFromContext(r.Context())
+
+	var req model.CreateKeyRequest
+	if err := decodeJSON(r, &req, h.maxRequestBodyBytes); err != nil {
+		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "invalid request body")
+		return
+	}
+
+	if req.AgentID == "" {
+		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "agent_id is required")
+		return
+	}
+	if err := model.ValidateAgentID(req.AgentID); err != nil {
+		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, err.Error())
+		return
+	}
+	if err := model.ValidateKeyLabel(req.Label); err != nil {
+		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, err.Error())
+		return
+	}
+
+	// Verify the target agent exists in this org.
+	if _, err := h.db.GetAgentByAgentID(r.Context(), orgID, req.AgentID); err != nil {
+		if isNotFoundError(err) {
+			writeError(w, r, http.StatusNotFound, model.ErrCodeNotFound, "agent not found")
+			return
+		}
+		h.writeInternalError(w, r, "failed to verify agent", err)
+		return
+	}
+
+	var expiresAt *time.Time
+	if req.ExpiresAt != nil {
+		t, err := time.Parse(time.RFC3339, *req.ExpiresAt)
+		if err != nil {
+			writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "invalid expires_at format (expected RFC3339)")
+			return
+		}
+		if t.Before(time.Now()) {
+			writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "expires_at must be in the future")
+			return
+		}
+		expiresAt = &t
+	}
+
+	rawKey, prefix, err := model.GenerateRawKey()
+	if err != nil {
+		h.writeInternalError(w, r, "failed to generate api key", err)
+		return
+	}
+
+	hash, err := auth.HashAPIKey(rawKey)
+	if err != nil {
+		h.writeInternalError(w, r, "failed to hash api key", err)
+		return
+	}
+
+	apiKey := model.APIKey{
+		Prefix:    prefix,
+		KeyHash:   hash,
+		AgentID:   req.AgentID,
+		OrgID:     orgID,
+		Label:     req.Label,
+		CreatedBy: claims.AgentID,
+		ExpiresAt: expiresAt,
+	}
+
+	audit := h.buildAuditEntry(r, orgID, "create_api_key", "api_key", "", nil, nil, nil)
+	created, err := h.db.CreateAPIKeyWithAudit(r.Context(), apiKey, audit)
+	if err != nil {
+		h.writeInternalError(w, r, "failed to create api key", err)
+		return
+	}
+
+	writeJSON(w, r, http.StatusCreated, model.APIKeyWithRawKey{
+		APIKey: created,
+		RawKey: rawKey,
+	})
+}
+
+// HandleListKeys handles GET /v1/keys (admin-only).
+// Returns all keys for the org. Key hashes are never exposed.
+func (h *Handlers) HandleListKeys(w http.ResponseWriter, r *http.Request) {
+	orgID := OrgIDFromContext(r.Context())
+	limit := queryLimit(r, 50)
+	offset := queryOffset(r)
+
+	keys, total, err := h.db.ListAPIKeys(r.Context(), orgID, limit, offset)
+	if err != nil {
+		h.writeInternalError(w, r, "failed to list api keys", err)
+		return
+	}
+	if keys == nil {
+		keys = []model.APIKey{}
+	}
+
+	writeJSON(w, r, http.StatusOK, model.APIKeyResponse{
+		Keys:    keys,
+		Total:   total,
+		Limit:   limit,
+		Offset:  offset,
+		HasMore: offset+len(keys) < total,
+	})
+}
+
+// HandleRevokeKey handles DELETE /v1/keys/{id} (admin-only).
+// Revokes a key by setting revoked_at. The key immediately stops working.
+func (h *Handlers) HandleRevokeKey(w http.ResponseWriter, r *http.Request) {
+	orgID := OrgIDFromContext(r.Context())
+
+	keyIDStr := r.PathValue("id")
+	keyID, err := uuid.Parse(keyIDStr)
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "invalid key id")
+		return
+	}
+
+	audit := h.buildAuditEntry(r, orgID, "revoke_api_key", "api_key", keyIDStr, nil, nil, nil)
+	if err := h.db.RevokeAPIKeyWithAudit(r.Context(), orgID, keyID, audit); err != nil {
+		if isNotFoundError(err) {
+			writeError(w, r, http.StatusNotFound, model.ErrCodeNotFound, "api key not found")
+			return
+		}
+		h.writeInternalError(w, r, "failed to revoke api key", err)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// HandleRotateKey handles POST /v1/keys/{id}/rotate (admin-only).
+// Atomically revokes the old key and creates a new one with the same
+// agent_id and label. Returns the new raw key exactly once.
+func (h *Handlers) HandleRotateKey(w http.ResponseWriter, r *http.Request) {
+	claims := ClaimsFromContext(r.Context())
+	orgID := OrgIDFromContext(r.Context())
+
+	oldKeyIDStr := r.PathValue("id")
+	oldKeyID, err := uuid.Parse(oldKeyIDStr)
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "invalid key id")
+		return
+	}
+
+	// Fetch the old key to inherit agent_id and label.
+	oldKey, err := h.db.GetAPIKeyByID(r.Context(), orgID, oldKeyID)
+	if err != nil {
+		if isNotFoundError(err) {
+			writeError(w, r, http.StatusNotFound, model.ErrCodeNotFound, "api key not found")
+			return
+		}
+		h.writeInternalError(w, r, "failed to get api key", err)
+		return
+	}
+	if oldKey.RevokedAt != nil {
+		writeError(w, r, http.StatusConflict, model.ErrCodeConflict, "key is already revoked")
+		return
+	}
+
+	rawKey, prefix, err := model.GenerateRawKey()
+	if err != nil {
+		h.writeInternalError(w, r, "failed to generate api key", err)
+		return
+	}
+
+	hash, err := auth.HashAPIKey(rawKey)
+	if err != nil {
+		h.writeInternalError(w, r, "failed to hash api key", err)
+		return
+	}
+
+	newKey := model.APIKey{
+		Prefix:    prefix,
+		KeyHash:   hash,
+		AgentID:   oldKey.AgentID,
+		OrgID:     orgID,
+		Label:     oldKey.Label,
+		CreatedBy: claims.AgentID,
+		ExpiresAt: oldKey.ExpiresAt, // Inherit expiration.
+	}
+
+	audit := h.buildAuditEntry(r, orgID, "rotate_api_key", "api_key", oldKeyIDStr, nil, nil, nil)
+	created, err := h.db.RotateAPIKeyWithAudit(r.Context(), orgID, oldKeyID, newKey, audit)
+	if err != nil {
+		if isNotFoundError(err) {
+			writeError(w, r, http.StatusNotFound, model.ErrCodeNotFound, "api key not found or already revoked")
+			return
+		}
+		h.writeInternalError(w, r, "failed to rotate api key", err)
+		return
+	}
+
+	writeJSON(w, r, http.StatusOK, model.RotateKeyResponse{
+		NewKey: model.APIKeyWithRawKey{
+			APIKey: created,
+			RawKey: rawKey,
+		},
+		RevokedKeyID: oldKeyID,
+	})
+}
+
+// HandleGetUsage handles GET /v1/usage (admin-only).
+// Returns decision counts grouped by API key for billing/metering.
+// Accepts ?period=YYYY-MM query parameter (defaults to current month).
+func (h *Handlers) HandleGetUsage(w http.ResponseWriter, r *http.Request) {
+	orgID := OrgIDFromContext(r.Context())
+
+	// Parse period (YYYY-MM format).
+	periodStr := r.URL.Query().Get("period")
+	var from, to time.Time
+	if periodStr == "" {
+		now := time.Now().UTC()
+		from = time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+		to = from.AddDate(0, 1, 0)
+		periodStr = from.Format("2006-01")
+	} else {
+		parsed, err := time.Parse("2006-01", periodStr)
+		if err != nil {
+			writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "invalid period format (expected YYYY-MM)")
+			return
+		}
+		from = parsed
+		to = from.AddDate(0, 1, 0)
+	}
+
+	byKey, total, err := h.db.CountDecisionsByAPIKey(r.Context(), orgID, from, to)
+	if err != nil {
+		h.writeInternalError(w, r, "failed to get usage", err)
+		return
+	}
+
+	// Enrich with key metadata.
+	type keyUsage struct {
+		KeyID   *uuid.UUID `json:"key_id"`
+		Prefix  string     `json:"prefix"`
+		Label   string     `json:"label"`
+		AgentID string     `json:"agent_id"`
+		Count   int        `json:"decisions"`
+	}
+
+	var keyUsages []keyUsage
+
+	// Build a list of key IDs to look up (skip uuid.Nil = legacy).
+	for keyID, count := range byKey {
+		if keyID == uuid.Nil {
+			keyUsages = append(keyUsages, keyUsage{
+				KeyID:   nil,
+				Prefix:  "",
+				Label:   "(legacy)",
+				AgentID: "",
+				Count:   count,
+			})
+			continue
+		}
+
+		// Look up key metadata. Best-effort — if the key was deleted, show ID only.
+		k, err := h.db.GetAPIKeyByID(r.Context(), orgID, keyID)
+		if err != nil {
+			kid := keyID
+			keyUsages = append(keyUsages, keyUsage{
+				KeyID: &kid,
+				Count: count,
+			})
+			continue
+		}
+		kid := keyID
+		keyUsages = append(keyUsages, keyUsage{
+			KeyID:   &kid,
+			Prefix:  k.Prefix,
+			Label:   k.Label,
+			AgentID: k.AgentID,
+			Count:   count,
+		})
+	}
+
+	// Aggregate by agent_id.
+	agentCounts := make(map[string]int)
+	for _, ku := range keyUsages {
+		if ku.AgentID != "" {
+			agentCounts[ku.AgentID] += ku.Count
+		}
+	}
+	type agentUsage struct {
+		AgentID   string `json:"agent_id"`
+		Decisions int    `json:"decisions"`
+	}
+	var byAgent []agentUsage
+	for aid, cnt := range agentCounts {
+		byAgent = append(byAgent, agentUsage{AgentID: aid, Decisions: cnt})
+	}
+
+	writeJSON(w, r, http.StatusOK, map[string]any{
+		"org_id":          orgID,
+		"period":          periodStr,
+		"total_decisions": total,
+		"by_key":          keyUsages,
+		"by_agent":        byAgent,
+	})
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -99,6 +99,15 @@ func New(cfg ServerConfig) *Server {
 	mux.Handle("DELETE /v1/agents/{agent_id}", adminOnly(http.HandlerFunc(h.HandleDeleteAgent)))
 	mux.Handle("GET /v1/export/decisions", adminOnly(http.HandlerFunc(h.HandleExportDecisions)))
 
+	// API key management (admin-only).
+	mux.Handle("POST /v1/keys", adminOnly(http.HandlerFunc(h.HandleCreateKey)))
+	mux.Handle("GET /v1/keys", adminOnly(http.HandlerFunc(h.HandleListKeys)))
+	mux.Handle("DELETE /v1/keys/{id}", adminOnly(http.HandlerFunc(h.HandleRevokeKey)))
+	mux.Handle("POST /v1/keys/{id}/rotate", adminOnly(http.HandlerFunc(h.HandleRotateKey)))
+
+	// Usage metering (admin-only).
+	mux.Handle("GET /v1/usage", adminOnly(http.HandlerFunc(h.HandleGetUsage)))
+
 	// Trace ingestion (agent+).
 	writeRole := requireRole(model.RoleAgent)
 	mux.Handle("POST /v1/runs", writeRole(http.HandlerFunc(h.HandleCreateRun)))

--- a/internal/service/decisions/service.go
+++ b/internal/service/decisions/service.go
@@ -80,6 +80,7 @@ type TraceInput struct {
 	PrecedentRef *uuid.UUID
 	SessionID    *uuid.UUID     // MCP session or X-Akashi-Session header.
 	AgentContext map[string]any // Merged server-extracted + client-supplied context.
+	APIKeyID     *uuid.UUID     // Managed API key that authenticated this request.
 
 	// AuditMeta, when non-nil, causes the trace to include a mutation audit
 	// record inside the same transaction. This closes the gap where mutations
@@ -256,6 +257,7 @@ func (s *Service) prepareTrace(ctx context.Context, orgID uuid.UUID, input Trace
 			OutcomeEmbedding: outcomeEmb,
 			QualityScore:     qualityScore,
 			PrecedentRef:     input.PrecedentRef,
+			APIKeyID:         input.APIKeyID,
 		},
 		Alternatives: alts,
 		Evidence:     evs,

--- a/internal/storage/api_keys.go
+++ b/internal/storage/api_keys.go
@@ -1,0 +1,380 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/ashita-ai/akashi/internal/model"
+)
+
+// CreateAPIKeyWithAudit inserts a new API key and a mutation audit entry
+// atomically within a single transaction.
+func (db *DB) CreateAPIKeyWithAudit(ctx context.Context, key model.APIKey, audit MutationAuditEntry) (model.APIKey, error) {
+	tx, err := db.pool.Begin(ctx)
+	if err != nil {
+		return model.APIKey{}, fmt.Errorf("storage: begin create api key tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if key.ID == uuid.Nil {
+		key.ID = uuid.New()
+	}
+	if key.CreatedAt.IsZero() {
+		key.CreatedAt = time.Now().UTC()
+	}
+
+	_, err = tx.Exec(ctx,
+		`INSERT INTO api_keys (id, prefix, key_hash, agent_id, org_id, label, created_by, created_at, expires_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+		key.ID, key.Prefix, key.KeyHash, key.AgentID, key.OrgID,
+		key.Label, key.CreatedBy, key.CreatedAt, key.ExpiresAt,
+	)
+	if err != nil {
+		return model.APIKey{}, fmt.Errorf("storage: create api key: %w", err)
+	}
+
+	audit.ResourceID = key.ID.String()
+	audit.AfterData = key
+	if err := InsertMutationAuditTx(ctx, tx, audit); err != nil {
+		return model.APIKey{}, fmt.Errorf("storage: audit in create api key tx: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return model.APIKey{}, fmt.Errorf("storage: commit create api key tx: %w", err)
+	}
+	return key, nil
+}
+
+// GetAPIKeyByID retrieves a single API key by its UUID, scoped to an org.
+func (db *DB) GetAPIKeyByID(ctx context.Context, orgID uuid.UUID, keyID uuid.UUID) (model.APIKey, error) {
+	var k model.APIKey
+	err := db.pool.QueryRow(ctx,
+		`SELECT id, prefix, key_hash, agent_id, org_id, label, created_by, created_at, last_used_at, expires_at, revoked_at
+		 FROM api_keys WHERE id = $1 AND org_id = $2`,
+		keyID, orgID,
+	).Scan(
+		&k.ID, &k.Prefix, &k.KeyHash, &k.AgentID, &k.OrgID,
+		&k.Label, &k.CreatedBy, &k.CreatedAt, &k.LastUsedAt, &k.ExpiresAt, &k.RevokedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return model.APIKey{}, fmt.Errorf("storage: api key %s: %w", keyID, ErrNotFound)
+		}
+		return model.APIKey{}, fmt.Errorf("storage: get api key: %w", err)
+	}
+	return k, nil
+}
+
+// GetActiveAPIKeysByAgentIDGlobal returns all active (not revoked, not expired)
+// API keys for an agent_id across all orgs. Used for authentication where org
+// isn't known yet. Similar to GetAgentsByAgentIDGlobal.
+func (db *DB) GetActiveAPIKeysByAgentIDGlobal(ctx context.Context, agentID string) ([]model.APIKey, error) {
+	rows, err := db.pool.Query(ctx,
+		`SELECT id, prefix, key_hash, agent_id, org_id, label, created_by, created_at, last_used_at, expires_at, revoked_at
+		 FROM api_keys
+		 WHERE agent_id = $1
+		   AND revoked_at IS NULL
+		   AND (expires_at IS NULL OR expires_at > now())
+		 ORDER BY created_at ASC`,
+		agentID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("storage: get api keys by agent_id: %w", err)
+	}
+	defer rows.Close()
+
+	var keys []model.APIKey
+	for rows.Next() {
+		var k model.APIKey
+		if err := rows.Scan(
+			&k.ID, &k.Prefix, &k.KeyHash, &k.AgentID, &k.OrgID,
+			&k.Label, &k.CreatedBy, &k.CreatedAt, &k.LastUsedAt, &k.ExpiresAt, &k.RevokedAt,
+		); err != nil {
+			return nil, fmt.Errorf("storage: scan api key: %w", err)
+		}
+		keys = append(keys, k)
+	}
+	return keys, rows.Err()
+}
+
+// ListAPIKeys returns API keys for an org with pagination.
+// Includes revoked/expired keys for admin visibility. Use the revoked_at and
+// expires_at fields to filter in the UI if needed.
+func (db *DB) ListAPIKeys(ctx context.Context, orgID uuid.UUID, limit, offset int) ([]model.APIKey, int, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	if limit > 1000 {
+		limit = 1000
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	var total int
+	if err := db.pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM api_keys WHERE org_id = $1`, orgID,
+	).Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("storage: count api keys: %w", err)
+	}
+
+	rows, err := db.pool.Query(ctx,
+		`SELECT id, prefix, key_hash, agent_id, org_id, label, created_by, created_at, last_used_at, expires_at, revoked_at
+		 FROM api_keys WHERE org_id = $1
+		 ORDER BY created_at DESC
+		 LIMIT $2 OFFSET $3`,
+		orgID, limit, offset,
+	)
+	if err != nil {
+		return nil, 0, fmt.Errorf("storage: list api keys: %w", err)
+	}
+	defer rows.Close()
+
+	var keys []model.APIKey
+	for rows.Next() {
+		var k model.APIKey
+		if err := rows.Scan(
+			&k.ID, &k.Prefix, &k.KeyHash, &k.AgentID, &k.OrgID,
+			&k.Label, &k.CreatedBy, &k.CreatedAt, &k.LastUsedAt, &k.ExpiresAt, &k.RevokedAt,
+		); err != nil {
+			return nil, 0, fmt.Errorf("storage: scan api key: %w", err)
+		}
+		keys = append(keys, k)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("storage: list api keys: %w", err)
+	}
+	return keys, total, nil
+}
+
+// RevokeAPIKeyWithAudit sets revoked_at on an API key and records a mutation
+// audit entry atomically.
+func (db *DB) RevokeAPIKeyWithAudit(ctx context.Context, orgID uuid.UUID, keyID uuid.UUID, audit MutationAuditEntry) error {
+	tx, err := db.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("storage: begin revoke api key tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	// Fetch the key before revoking for audit.
+	var before model.APIKey
+	err = tx.QueryRow(ctx,
+		`SELECT id, prefix, key_hash, agent_id, org_id, label, created_by, created_at, last_used_at, expires_at, revoked_at
+		 FROM api_keys WHERE id = $1 AND org_id = $2`,
+		keyID, orgID,
+	).Scan(
+		&before.ID, &before.Prefix, &before.KeyHash, &before.AgentID, &before.OrgID,
+		&before.Label, &before.CreatedBy, &before.CreatedAt, &before.LastUsedAt, &before.ExpiresAt, &before.RevokedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("storage: api key %s: %w", keyID, ErrNotFound)
+		}
+		return fmt.Errorf("storage: get api key for revocation: %w", err)
+	}
+	if before.RevokedAt != nil {
+		return fmt.Errorf("storage: api key %s already revoked", keyID)
+	}
+
+	tag, err := tx.Exec(ctx,
+		`UPDATE api_keys SET revoked_at = now() WHERE id = $1 AND org_id = $2 AND revoked_at IS NULL`,
+		keyID, orgID,
+	)
+	if err != nil {
+		return fmt.Errorf("storage: revoke api key: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("storage: api key %s: %w", keyID, ErrNotFound)
+	}
+
+	audit.ResourceID = keyID.String()
+	audit.BeforeData = before
+	if err := InsertMutationAuditTx(ctx, tx, audit); err != nil {
+		return fmt.Errorf("storage: audit in revoke api key tx: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("storage: commit revoke api key tx: %w", err)
+	}
+	return nil
+}
+
+// RotateAPIKeyWithAudit revokes the old key and creates a new one atomically.
+// Returns the newly created key.
+func (db *DB) RotateAPIKeyWithAudit(ctx context.Context, orgID uuid.UUID, oldKeyID uuid.UUID, newKey model.APIKey, audit MutationAuditEntry) (model.APIKey, error) {
+	tx, err := db.pool.Begin(ctx)
+	if err != nil {
+		return model.APIKey{}, fmt.Errorf("storage: begin rotate api key tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	// Revoke the old key.
+	tag, err := tx.Exec(ctx,
+		`UPDATE api_keys SET revoked_at = now() WHERE id = $1 AND org_id = $2 AND revoked_at IS NULL`,
+		oldKeyID, orgID,
+	)
+	if err != nil {
+		return model.APIKey{}, fmt.Errorf("storage: revoke old key during rotation: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return model.APIKey{}, fmt.Errorf("storage: old key %s not found or already revoked: %w", oldKeyID, ErrNotFound)
+	}
+
+	// Create the new key.
+	if newKey.ID == uuid.Nil {
+		newKey.ID = uuid.New()
+	}
+	if newKey.CreatedAt.IsZero() {
+		newKey.CreatedAt = time.Now().UTC()
+	}
+
+	_, err = tx.Exec(ctx,
+		`INSERT INTO api_keys (id, prefix, key_hash, agent_id, org_id, label, created_by, created_at, expires_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+		newKey.ID, newKey.Prefix, newKey.KeyHash, newKey.AgentID, newKey.OrgID,
+		newKey.Label, newKey.CreatedBy, newKey.CreatedAt, newKey.ExpiresAt,
+	)
+	if err != nil {
+		return model.APIKey{}, fmt.Errorf("storage: create new key during rotation: %w", err)
+	}
+
+	audit.ResourceID = newKey.ID.String()
+	audit.AfterData = map[string]any{
+		"new_key_id":     newKey.ID,
+		"revoked_key_id": oldKeyID,
+	}
+	if err := InsertMutationAuditTx(ctx, tx, audit); err != nil {
+		return model.APIKey{}, fmt.Errorf("storage: audit in rotate api key tx: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return model.APIKey{}, fmt.Errorf("storage: commit rotate api key tx: %w", err)
+	}
+	return newKey, nil
+}
+
+// TouchAPIKeyLastUsed updates the last_used_at timestamp for an API key.
+// Called from the auth middleware on successful authentication via a managed key.
+// Uses a fire-and-forget pattern — callers should not block on the result.
+func (db *DB) TouchAPIKeyLastUsed(ctx context.Context, keyID uuid.UUID) error {
+	_, err := db.pool.Exec(ctx,
+		`UPDATE api_keys SET last_used_at = now() WHERE id = $1`,
+		keyID,
+	)
+	if err != nil {
+		return fmt.Errorf("storage: touch api key last_used: %w", err)
+	}
+	return nil
+}
+
+// MigrateAgentKeysToAPIKeys copies api_key_hash from agents to api_keys for
+// agents that still have a legacy key. Idempotent: skips agents that already
+// have at least one entry in api_keys. NULLs out agents.api_key_hash after copy.
+// Called once at startup.
+func (db *DB) MigrateAgentKeysToAPIKeys(ctx context.Context) (int, error) {
+	tx, err := db.pool.Begin(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("storage: begin key migration tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	// Find agents with legacy keys that haven't been migrated yet.
+	rows, err := tx.Query(ctx,
+		`SELECT a.id, a.agent_id, a.org_id, a.api_key_hash
+		 FROM agents a
+		 WHERE a.api_key_hash IS NOT NULL
+		   AND NOT EXISTS (
+		       SELECT 1 FROM api_keys k
+		       WHERE k.org_id = a.org_id AND k.agent_id = a.agent_id
+		   )`,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("storage: query agents for key migration: %w", err)
+	}
+	defer rows.Close()
+
+	type legacyKey struct {
+		agentUUID uuid.UUID
+		agentID   string
+		orgID     uuid.UUID
+		keyHash   string
+	}
+	var toMigrate []legacyKey
+
+	for rows.Next() {
+		var lk legacyKey
+		if err := rows.Scan(&lk.agentUUID, &lk.agentID, &lk.orgID, &lk.keyHash); err != nil {
+			return 0, fmt.Errorf("storage: scan legacy key: %w", err)
+		}
+		toMigrate = append(toMigrate, lk)
+	}
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("storage: iterate legacy keys: %w", err)
+	}
+
+	for _, lk := range toMigrate {
+		keyID := uuid.New()
+		now := time.Now().UTC()
+		_, err := tx.Exec(ctx,
+			`INSERT INTO api_keys (id, prefix, key_hash, agent_id, org_id, label, created_by, created_at)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+			keyID, "legacy__", lk.keyHash, lk.agentID, lk.orgID,
+			"Migrated from agent", "system", now,
+		)
+		if err != nil {
+			return 0, fmt.Errorf("storage: insert migrated key for agent %s: %w", lk.agentID, err)
+		}
+
+		// NULL out the legacy hash.
+		_, err = tx.Exec(ctx,
+			`UPDATE agents SET api_key_hash = NULL WHERE id = $1`,
+			lk.agentUUID,
+		)
+		if err != nil {
+			return 0, fmt.Errorf("storage: null legacy hash for agent %s: %w", lk.agentID, err)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return 0, fmt.Errorf("storage: commit key migration tx: %w", err)
+	}
+	return len(toMigrate), nil
+}
+
+// CountDecisionsByAPIKey returns decision counts grouped by api_key_id for
+// usage metering. Keys with NULL api_key_id are grouped under uuid.Nil.
+func (db *DB) CountDecisionsByAPIKey(ctx context.Context, orgID uuid.UUID, from, to time.Time) (map[uuid.UUID]int, int, error) {
+	rows, err := db.pool.Query(ctx,
+		`SELECT api_key_id, count(*)
+		 FROM decisions
+		 WHERE org_id = $1 AND created_at >= $2 AND created_at < $3 AND valid_to IS NULL
+		 GROUP BY api_key_id`,
+		orgID, from, to,
+	)
+	if err != nil {
+		return nil, 0, fmt.Errorf("storage: count decisions by api key: %w", err)
+	}
+	defer rows.Close()
+
+	result := make(map[uuid.UUID]int)
+	total := 0
+	for rows.Next() {
+		var keyID *uuid.UUID
+		var count int
+		if err := rows.Scan(&keyID, &count); err != nil {
+			return nil, 0, fmt.Errorf("storage: scan decision count by key: %w", err)
+		}
+		id := uuid.Nil
+		if keyID != nil {
+			id = *keyID
+		}
+		result[id] = count
+		total += count
+	}
+	return result, total, rows.Err()
+}

--- a/internal/storage/sessions.go
+++ b/internal/storage/sessions.go
@@ -15,7 +15,7 @@ func (db *DB) GetSessionDecisions(ctx context.Context, orgID, sessionID uuid.UUI
 	rows, err := db.pool.Query(ctx,
 		`SELECT id, run_id, agent_id, org_id, decision_type, outcome, confidence, reasoning,
 		 metadata, quality_score, precedent_ref, supersedes_id, content_hash,
-		 valid_from, valid_to, transaction_time, created_at, session_id, agent_context
+		 valid_from, valid_to, transaction_time, created_at, session_id, agent_context, api_key_id
 		 FROM decisions
 		 WHERE org_id = $1 AND session_id = $2 AND valid_to IS NULL
 		 ORDER BY valid_from ASC`,

--- a/internal/storage/trace.go
+++ b/internal/storage/trace.go
@@ -167,13 +167,13 @@ func (db *DB) createTraceInTx(ctx context.Context, tx pgx.Tx, params CreateTrace
 	if _, err := tx.Exec(ctx,
 		`INSERT INTO decisions (id, run_id, agent_id, org_id, decision_type, outcome, confidence,
 		 reasoning, embedding, outcome_embedding, metadata, quality_score, precedent_ref, supersedes_id, content_hash,
-		 valid_from, valid_to, transaction_time, created_at, session_id, agent_context)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)`,
+		 valid_from, valid_to, transaction_time, created_at, session_id, agent_context, api_key_id)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22)`,
 		d.ID, d.RunID, d.AgentID, d.OrgID, d.DecisionType, d.Outcome, d.Confidence,
 		d.Reasoning, d.Embedding, d.OutcomeEmbedding, d.Metadata, d.QualityScore, d.PrecedentRef,
 		d.SupersedesID, d.ContentHash,
 		d.ValidFrom, d.ValidTo, d.TransactionTime, d.CreatedAt,
-		d.SessionID, d.AgentContext,
+		d.SessionID, d.AgentContext, d.APIKeyID,
 	); err != nil {
 		return model.AgentRun{}, model.Decision{}, fmt.Errorf("storage: create decision in trace tx: %w", err)
 	}

--- a/migrations/044_api_keys.sql
+++ b/migrations/044_api_keys.sql
@@ -1,0 +1,33 @@
+-- 044: Decoupled API key management.
+--
+-- Moves API keys from a single hash on the agents table to a dedicated
+-- api_keys table supporting multiple keys per agent, key rotation,
+-- expiration, revocation, and per-key attribution on decisions.
+--
+-- Design: keys inherit the agent's role (no independent role on keys).
+-- The prefix column stores the first 8 characters of the raw key for
+-- identification in logs/UI without exposing the full credential.
+
+CREATE TABLE api_keys (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    prefix        TEXT NOT NULL,
+    key_hash      TEXT NOT NULL,
+    agent_id      TEXT NOT NULL,
+    org_id        UUID NOT NULL REFERENCES organizations(id),
+    label         TEXT NOT NULL DEFAULT '',
+    created_by    TEXT NOT NULL,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    last_used_at  TIMESTAMPTZ,
+    expires_at    TIMESTAMPTZ,
+    revoked_at    TIMESTAMPTZ
+);
+
+-- Active keys lookup by org + agent (most common query path during auth).
+CREATE INDEX idx_api_keys_org_agent ON api_keys(org_id, agent_id) WHERE revoked_at IS NULL;
+
+-- Prefix lookup for key identification in admin UI.
+CREATE INDEX idx_api_keys_prefix ON api_keys(prefix);
+
+-- Add api_key_id FK to decisions for per-key attribution.
+ALTER TABLE decisions ADD COLUMN api_key_id UUID REFERENCES api_keys(id) ON DELETE SET NULL;
+CREATE INDEX idx_decisions_api_key ON decisions(api_key_id) WHERE api_key_id IS NOT NULL;

--- a/migrations/atlas.sum
+++ b/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:6Ga7NAmLJU8RIAnWbpScChYl7Yq29YzOHo9eoaUCIJc=
+h1:VaNZi7nBAgeWFuevlgYJPgkR0MqfgVH2d5Rgg3UZzGo=
 001_initial.sql h1:uhyGXto+QacAaGYb9ZTGjsBs5chlKi8O0eHz9aCQsrY=
 022_full_text_search.sql h1:9iwtA8MgCzAxDV9YkUBn0CLT9ePSmj3GcPoMGg8TXf0=
 023_fix_outbox_index.sql h1:OtMEFBcMRWej02+ghnBXlPr6BVq+LoA62Id9XUWfDNI=
@@ -22,3 +22,4 @@ h1:6Ga7NAmLJU8RIAnWbpScChYl7Yq29YzOHo9eoaUCIJc=
 041_archive_hypertable.sql h1:74bGq9IFahO/2Ok9CFFzfhFoii600SB84D5pg6LkM60=
 042_audit_immutability_and_precision.sql h1:wfF6VR5w/fMzcdUtSKFTBBO1GvwBb1jkpKrXWm6SOmE=
 043_review_hardening.sql h1:XFTUtLleIGMayeep4938tzW3khiunoES2TFJ/xjPNQg=
+044_api_keys.sql h1:5pySkm26ilTxaDygFOYCTEoMSErF8q6LqCg7iPTy9OE=

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -15,8 +15,8 @@ import { Link } from "react-router";
 
 const healthStatusConfig: Record<string, { label: string; color: string }> = {
   healthy: { label: "Healthy", color: "text-emerald-500" },
-  degraded: { label: "Degraded", color: "text-amber-500" },
-  unhealthy: { label: "Unhealthy", color: "text-red-500" },
+  needs_attention: { label: "Needs Attention", color: "text-amber-500" },
+  insufficient_data: { label: "No Data", color: "text-muted-foreground" },
 };
 
 export default function Dashboard() {
@@ -61,7 +61,7 @@ export default function Dashboard() {
             )}
             {traceHealth.data && (
               <p className="text-xs text-muted-foreground">
-                {traceHealth.data.decisions_24h} in last 24h
+                {traceHealth.data.completeness.total_decisions} total traced
               </p>
             )}
           </CardContent>
@@ -80,9 +80,9 @@ export default function Dashboard() {
                 {agents.data?.length ?? 0}
               </div>
             )}
-            {traceHealth.data && traceHealth.data.active_agents > 0 && (
+            {traceHealth.data?.evidence && (
               <p className="text-xs text-muted-foreground">
-                {traceHealth.data.active_agents} active recently
+                {traceHealth.data.evidence.coverage_pct.toFixed(0)}% with evidence
               </p>
             )}
           </CardContent>
@@ -123,7 +123,7 @@ export default function Dashboard() {
                   {healthConfig.label}
                 </div>
                 <p className="text-xs text-muted-foreground">
-                  avg confidence: {((traceHealth.data?.avg_confidence ?? 0) * 100).toFixed(0)}%
+                  avg quality: {((traceHealth.data?.completeness.avg_quality ?? 0) * 100).toFixed(0)}%
                 </p>
               </>
             )}
@@ -141,26 +141,17 @@ export default function Dashboard() {
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="space-y-2">
-              {traceHealth.data.gaps.map((gap) => (
-                <div
-                  key={gap.agent_id}
-                  className="flex items-center justify-between rounded-md border p-3 text-sm"
+            <ul className="space-y-2">
+              {traceHealth.data.gaps.map((gap, i) => (
+                <li
+                  key={i}
+                  className="flex items-center gap-2 rounded-md border p-3 text-sm"
                 >
-                  <div className="flex items-center gap-2">
-                    <Badge variant="outline" className="font-mono text-xs">
-                      {gap.agent_id}
-                    </Badge>
-                    <span className="text-muted-foreground">
-                      last seen {formatRelativeTime(gap.last_seen)}
-                    </span>
-                  </div>
-                  <Badge variant="warning" className="text-xs">
-                    {gap.gap_hours.toFixed(0)}h gap
-                  </Badge>
-                </div>
+                  <AlertTriangle className="h-4 w-4 shrink-0 text-amber-500" />
+                  <span className="text-muted-foreground">{gap}</span>
+                </li>
               ))}
-            </div>
+            </ul>
           </CardContent>
         </Card>
       )}

--- a/ui/src/types/api.ts
+++ b/ui/src/types/api.ts
@@ -245,22 +245,42 @@ export interface AgentStats {
   type_breakdown: Record<string, number>;
 }
 
-// Trace health
+// Trace health — mirrors tracehealth.Metrics from Go
 export interface TraceHealth {
   status: string;
-  total_decisions: number;
-  decisions_24h: number;
-  avg_confidence: number;
-  low_quality_pct: number;
-  conflict_rate: number;
-  active_agents: number;
-  gaps: TraceGap[];
+  completeness: TraceHealthCompleteness;
+  evidence: TraceHealthEvidence;
+  conflicts?: TraceHealthConflicts;
+  gaps: string[];
 }
 
-export interface TraceGap {
-  agent_id: string;
-  last_seen: string;
-  gap_hours: number;
+export interface TraceHealthCompleteness {
+  total_decisions: number;
+  avg_quality: number;
+  below_half: number;
+  below_third: number;
+  with_reasoning: number;
+  reasoning_pct: number;
+  with_alternatives: number;
+  alternatives_pct: number;
+}
+
+export interface TraceHealthEvidence {
+  total_decisions: number;
+  total_records: number;
+  avg_per_decision: number;
+  with_evidence: number;
+  without_evidence: number;
+  coverage_pct: number;
+}
+
+export interface TraceHealthConflicts {
+  total: number;
+  open: number;
+  acknowledged: number;
+  resolved: number;
+  wont_fix: number;
+  resolved_pct: number;
 }
 
 // Session view


### PR DESCRIPTION
## Summary

- **Decoupled API key management**: New `api_keys` table (migration 044) separates credentials from agent identity, enabling key rotation, multi-key per agent, and per-key billing attribution
- **Full key lifecycle**: Mint (`POST /v1/keys`), list (`GET /v1/keys`), revoke (`DELETE /v1/keys/{id}`), and atomic rotate (`POST /v1/keys/{id}/rotate`) — all admin-only
- **Per-key decision attribution**: `api_key_id` FK on decisions table tracks which managed key authenticated each decision; usage metering endpoint (`GET /v1/usage?period=YYYY-MM`) aggregates by key and agent
- **Backward compatible dual auth**: Managed keys checked first, falls back to legacy `agents.api_key_hash`; startup migration copies existing hashes to `api_keys` table

## Key design decisions

- Keys inherit agent role (no independent key-scoped permissions)
- Admin-only key minting (compromised key can't self-mint)
- `api_key_id` nullable on decisions (backward compat with pre-migration decisions)
- Decisions table IS the usage ledger — no separate metering table
- Raw key format: `ak_<8-hex-prefix>_<32-hex-secret>` with Argon2id hashing

## Files changed (19 files, +1365 / -115)

| Area | Files |
|------|-------|
| Migration | `migrations/044_api_keys.sql` |
| Model | `internal/model/api_key.go` (new), `internal/model/decision.go` |
| Storage | `internal/storage/api_keys.go` (new), `decisions.go`, `trace.go`, `sessions.go` |
| Auth | `internal/auth/auth.go` (Claims + APIKeyID) |
| Handlers | `internal/server/handlers_keys.go` (new), `handlers.go`, `handlers_decisions.go` |
| Middleware | `internal/server/middleware.go` (dual lookup, rate limit key) |
| Routes | `internal/server/server.go` |
| Service | `internal/service/decisions/service.go` (TraceInput + APIKeyID) |
| MCP | `internal/mcp/tools.go` (api_key_id propagation) |
| API spec | `api/openapi.yaml` (Keys, Usage tags + schemas) |
| UI | `Dashboard.tsx`, `api.ts` (TraceHealth shape fix) |

## Test plan

- [x] `go mod tidy && git diff --exit-code go.mod go.sum` — no changes
- [x] `go build ./...` — passes
- [x] `go vet ./...` — passes
- [x] `golangci-lint run ./...` — 0 issues
- [x] `atlas migrate validate --dir file://migrations` — passes
- [x] `go test -race -count=1 ./...` — all pass
- [ ] Manual: mint key, authenticate with it, verify `api_key_id` on decisions
- [ ] Manual: rotate key, verify old key rejected, new key works
- [ ] Manual: `GET /v1/usage?period=2026-02` returns per-key breakdown