### PR TITLE
Wire startup key migration, MCP roots, agent_context namespace split

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1971,8 +1971,50 @@ components:
           description: MCP or HTTP session that produced this decision.
         agent_context:
           type: object
+          description: |
+            Composite agent identity context with server/client namespace split.
+            "server" contains values the server extracted or verified (MCP client info,
+            roots, API key prefix). "client" contains self-reported values from tool
+            parameters or request body (model, task, operator). Older decisions may
+            have a flat structure (pre-namespace) — treat as "client" for compatibility.
+          properties:
+            server:
+              type: object
+              description: Server-extracted or verified context.
+              properties:
+                tool:
+                  type: string
+                  description: MCP client name or SDK User-Agent prefix.
+                tool_version:
+                  type: string
+                  description: MCP client version or SDK version.
+                roots:
+                  type: array
+                  items:
+                    type: string
+                  description: MCP roots URIs (file:// paths from client workspace).
+                project:
+                  type: string
+                  description: Inferred project name from the first MCP root URI.
+                api_key_prefix:
+                  type: string
+                  description: First 8 chars of the managed API key used.
+              additionalProperties: true
+            client:
+              type: object
+              description: Self-reported context from the calling agent.
+              properties:
+                model:
+                  type: string
+                  description: LLM model powering the agent.
+                task:
+                  type: string
+                  description: What the agent was working on.
+                operator:
+                  type: string
+                  description: Human-readable agent display name.
+              additionalProperties: true
           additionalProperties: true
-          description: Composite agent identity context (tool, model, task, etc.).
         api_key_id:
           type: string
           format: uuid

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -58,6 +58,7 @@ type Server struct {
 	grantCache   *authz.GrantCache  // optional cache for LoadGrantedSet
 	logger       *slog.Logger
 	checkTracker *checkTracker // tracks check-before-trace workflow compliance
+	rootsCache   *rootsCache   // caches MCP roots per session (one request per session)
 }
 
 // New creates and configures a new MCP server with all resources, tools, and prompts.
@@ -68,6 +69,7 @@ func New(db *storage.DB, decisionSvc *decisions.Service, grantCache *authz.Grant
 		grantCache:   grantCache,
 		logger:       logger,
 		checkTracker: newCheckTracker(time.Hour),
+		rootsCache:   newRootsCache(),
 	}
 
 	s.mcpServer = mcpserver.NewMCPServer(
@@ -76,6 +78,7 @@ func New(db *storage.DB, decisionSvc *decisions.Service, grantCache *authz.Grant
 		mcpserver.WithResourceCapabilities(true, true),
 		mcpserver.WithToolCapabilities(true),
 		mcpserver.WithPromptCapabilities(true),
+		mcpserver.WithRoots(),
 		mcpserver.WithInstructions(serverInstructions),
 	)
 

--- a/internal/mcp/roots.go
+++ b/internal/mcp/roots.go
@@ -1,0 +1,120 @@
+package mcp
+
+import (
+	"context"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+)
+
+// rootsRequestTimeout bounds the synchronous round-trip to the client.
+// If the client doesn't respond in time, we skip roots gracefully.
+const rootsRequestTimeout = 3 * time.Second
+
+// rootsCache caches MCP roots per session ID so we don't re-request
+// on every tool call within the same session. Roots don't change
+// mid-session, so one request per session is sufficient.
+type rootsCache struct {
+	mu    sync.RWMutex
+	cache map[string][]mcplib.Root // sessionID -> roots
+}
+
+func newRootsCache() *rootsCache {
+	return &rootsCache{
+		cache: make(map[string][]mcplib.Root),
+	}
+}
+
+// Get returns cached roots for a session, or nil if not cached.
+func (rc *rootsCache) Get(sessionID string) ([]mcplib.Root, bool) {
+	rc.mu.RLock()
+	defer rc.mu.RUnlock()
+	roots, ok := rc.cache[sessionID]
+	return roots, ok
+}
+
+// Set caches roots for a session.
+func (rc *rootsCache) Set(sessionID string, roots []mcplib.Root) {
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
+	rc.cache[sessionID] = roots
+}
+
+// requestRoots requests roots from the client via the MCP protocol,
+// caching the result per session ID. Returns nil on any error (roots
+// are best-effort context, never blocking).
+func (s *Server) requestRoots(ctx context.Context) []mcplib.Root {
+	session := mcpserver.ClientSessionFromContext(ctx)
+	if session == nil {
+		return nil
+	}
+
+	sessionID := session.SessionID()
+	if sessionID == "" {
+		return nil
+	}
+
+	// Check cache first.
+	if roots, ok := s.rootsCache.Get(sessionID); ok {
+		return roots
+	}
+
+	// Request roots from the client. This is a synchronous round-trip
+	// (server → client → server), so we bound it with a timeout to avoid
+	// blocking the trace if the client is slow or doesn't support roots.
+	reqCtx, cancel := context.WithTimeout(ctx, rootsRequestTimeout)
+	defer cancel()
+	result, err := s.mcpServer.RequestRoots(reqCtx, mcplib.ListRootsRequest{})
+	if err != nil {
+		// Client may not support roots — that's fine.
+		s.logger.Debug("MCP roots request failed (non-fatal)", "error", err, "session_id", sessionID)
+		// Cache empty slice to avoid re-requesting.
+		s.rootsCache.Set(sessionID, []mcplib.Root{})
+		return nil
+	}
+
+	s.rootsCache.Set(sessionID, result.Roots)
+	return result.Roots
+}
+
+// inferProjectFromRoots extracts a likely project name from the first
+// file:// root URI. Returns empty string if no usable root is found.
+//
+// Examples:
+//
+//	file:///Users/evan/Documents/gh/akashi/akashi → "akashi"
+//	file:///home/user/my-project                  → "my-project"
+func inferProjectFromRoots(roots []mcplib.Root) string {
+	for _, root := range roots {
+		if !strings.HasPrefix(root.URI, "file://") {
+			continue
+		}
+		parsed, err := url.Parse(root.URI)
+		if err != nil {
+			continue
+		}
+		path := filepath.Clean(parsed.Path)
+		if path == "" || path == "/" || path == "." {
+			continue
+		}
+		return filepath.Base(path)
+	}
+	return ""
+}
+
+// rootURIs extracts the URI strings from a slice of roots.
+func rootURIs(roots []mcplib.Root) []string {
+	if len(roots) == 0 {
+		return nil
+	}
+	uris := make([]string, len(roots))
+	for i, r := range roots {
+		uris[i] = r.URI
+	}
+	return uris
+}

--- a/internal/mcp/roots_test.go
+++ b/internal/mcp/roots_test.go
@@ -1,0 +1,115 @@
+package mcp
+
+import (
+	"testing"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInferProjectFromRoots(t *testing.T) {
+	tests := []struct {
+		name  string
+		roots []mcplib.Root
+		want  string
+	}{
+		{
+			name:  "empty roots",
+			roots: nil,
+			want:  "",
+		},
+		{
+			name:  "single file URI",
+			roots: []mcplib.Root{{URI: "file:///Users/evan/Documents/gh/akashi/akashi"}},
+			want:  "akashi",
+		},
+		{
+			name:  "multiple roots uses first",
+			roots: []mcplib.Root{{URI: "file:///home/user/project-a"}, {URI: "file:///home/user/project-b"}},
+			want:  "project-a",
+		},
+		{
+			name:  "non-file URI skipped",
+			roots: []mcplib.Root{{URI: "https://example.com/repo"}, {URI: "file:///home/user/my-project"}},
+			want:  "my-project",
+		},
+		{
+			name:  "root path returns empty",
+			roots: []mcplib.Root{{URI: "file:///"}},
+			want:  "",
+		},
+		{
+			name:  "windows-style path",
+			roots: []mcplib.Root{{URI: "file:///C:/Users/dev/my-repo"}},
+			want:  "my-repo",
+		},
+		{
+			name:  "trailing slash stripped",
+			roots: []mcplib.Root{{URI: "file:///home/user/project/"}},
+			want:  "project",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := inferProjectFromRoots(tt.roots)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestRootURIs(t *testing.T) {
+	tests := []struct {
+		name  string
+		roots []mcplib.Root
+		want  []string
+	}{
+		{
+			name:  "nil roots",
+			roots: nil,
+			want:  nil,
+		},
+		{
+			name:  "empty roots",
+			roots: []mcplib.Root{},
+			want:  nil,
+		},
+		{
+			name:  "extracts URIs",
+			roots: []mcplib.Root{{URI: "file:///a"}, {URI: "file:///b"}},
+			want:  []string{"file:///a", "file:///b"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := rootURIs(tt.roots)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestRootsCache(t *testing.T) {
+	cache := newRootsCache()
+
+	// Miss on empty cache.
+	_, ok := cache.Get("session-1")
+	assert.False(t, ok)
+
+	// Set and get.
+	roots := []mcplib.Root{{URI: "file:///test"}}
+	cache.Set("session-1", roots)
+	got, ok := cache.Get("session-1")
+	assert.True(t, ok)
+	assert.Equal(t, roots, got)
+
+	// Different session misses.
+	_, ok = cache.Get("session-2")
+	assert.False(t, ok)
+
+	// Empty slice is cached (distinguishes "checked, no roots" from "not checked").
+	cache.Set("session-2", []mcplib.Root{})
+	got, ok = cache.Get("session-2")
+	assert.True(t, ok)
+	assert.Empty(t, got)
+}

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -262,13 +262,16 @@ func TestHandleTrace_ModelAndTaskContext(t *testing.T) {
 	}
 	require.NoError(t, json.Unmarshal([]byte(parseToolText(t, result)), &resp))
 
-	// Verify agent_context was stored with model and task.
+	// Verify agent_context was stored with model and task under "client" namespace.
 	decID, err := uuid.Parse(resp.DecisionID)
 	require.NoError(t, err)
 	dec, err := testDB.GetDecision(ctx, uuid.Nil, decID, storage.GetDecisionOpts{})
 	require.NoError(t, err)
-	assert.Equal(t, "claude-opus-4-6", dec.AgentContext["model"])
-	assert.Equal(t, "codebase review", dec.AgentContext["task"])
+
+	clientCtx, ok := dec.AgentContext["client"].(map[string]any)
+	require.True(t, ok, "agent_context should have 'client' namespace")
+	assert.Equal(t, "claude-opus-4-6", clientCtx["model"])
+	assert.Equal(t, "codebase review", clientCtx["task"])
 }
 
 func TestHandleTrace_CheckNudge(t *testing.T) {


### PR DESCRIPTION
## Summary

Completes the API key attribution architecture (PR 2 of the [redesign plan](https://github.com/ashita-ai/akashi/pull/179)):

- **Startup migration**: Calls `MigrateAgentKeysToAPIKeys` after `SeedAdmin` to copy legacy `agents.api_key_hash` entries to the `api_keys` table. Idempotent, non-fatal on error.
- **MCP roots integration**: Enables `WithRoots()` on the MCP server. On the first `akashi_trace` per session, requests roots from the client (3s timeout, cached per session). Infers project name from `file://` URIs and stores root paths in `agent_context.server`.
- **agent_context namespace split**: Both MCP and HTTP trace handlers now write `{"server": {...}, "client": {...}}` instead of a flat map. Server namespace holds verified values (tool, tool_version, roots, project, api_key_prefix). Client namespace holds self-reported values (model, task, operator). Backward-compatible with older flat-format decisions.

## Test plan

- [x] All existing tests pass (`go test -race -count=1 ./...`)
- [x] New unit tests for `inferProjectFromRoots`, `rootURIs`, `rootsCache`
- [x] Updated `TestHandleTrace_ModelAndTaskContext` for namespace split
- [x] MCP trace tests work with 3s roots timeout (clients without roots support)
- [x] Pre-commit checks: build, vet, lint (0 issues), atlas validate

🤖 Generated with [Claude Code](https://claude.com/claude-code)