### PR TITLE
fix agent_context namespace regression, refactor query builder

### DIFF
--- a/internal/storage/decisions_unit_test.go
+++ b/internal/storage/decisions_unit_test.go
@@ -1,0 +1,133 @@
+package storage
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ashita-ai/akashi/internal/model"
+)
+
+func TestBuildDecisionWhereClause_CurrentOnly(t *testing.T) {
+	orgID := uuid.New()
+
+	t.Run("currentOnly=true includes valid_to IS NULL", func(t *testing.T) {
+		where, args := buildDecisionWhereClause(orgID, model.QueryFilters{}, 1, true)
+		assert.Contains(t, where, "valid_to IS NULL")
+		require.Len(t, args, 1)
+		assert.Equal(t, orgID, args[0])
+	})
+
+	t.Run("currentOnly=false omits valid_to IS NULL", func(t *testing.T) {
+		where, args := buildDecisionWhereClause(orgID, model.QueryFilters{}, 1, false)
+		assert.NotContains(t, where, "valid_to IS NULL")
+		require.Len(t, args, 1)
+		assert.Equal(t, orgID, args[0])
+	})
+}
+
+func TestBuildDecisionWhereClause_ToolFilterCoalesce(t *testing.T) {
+	orgID := uuid.New()
+	tool := "claude-code"
+	filters := model.QueryFilters{Tool: &tool}
+
+	where, args := buildDecisionWhereClause(orgID, filters, 1, true)
+
+	// The tool filter should use COALESCE to check both namespaced and flat paths.
+	assert.Contains(t, where, "COALESCE(agent_context->'server'->>'tool', agent_context->>'tool')")
+	require.Len(t, args, 2) // org_id + tool
+	assert.Equal(t, "claude-code", args[1])
+}
+
+func TestBuildDecisionWhereClause_ModelFilterCoalesce(t *testing.T) {
+	orgID := uuid.New()
+	model_ := "claude-opus-4-6"
+	filters := model.QueryFilters{Model: &model_}
+
+	where, args := buildDecisionWhereClause(orgID, filters, 1, true)
+
+	assert.Contains(t, where, "COALESCE(agent_context->'client'->>'model', agent_context->>'model')")
+	require.Len(t, args, 2)
+	assert.Equal(t, "claude-opus-4-6", args[1])
+}
+
+func TestBuildDecisionWhereClause_RepoFilterCoalesce(t *testing.T) {
+	orgID := uuid.New()
+	repo := "ashita-ai/akashi"
+	filters := model.QueryFilters{Repo: &repo}
+
+	where, args := buildDecisionWhereClause(orgID, filters, 1, true)
+
+	assert.Contains(t, where, "COALESCE(agent_context->'server'->>'repo', agent_context->>'repo')")
+	require.Len(t, args, 2)
+	assert.Equal(t, "ashita-ai/akashi", args[1])
+}
+
+func TestBuildDecisionWhereClause_AllFilters(t *testing.T) {
+	orgID := uuid.New()
+	runID := uuid.New()
+	decType := "architecture"
+	confMin := float32(0.7)
+	outcome := "chose Redis"
+	sessionID := uuid.New()
+	tool := "claude-code"
+	mdl := "claude-opus-4-6"
+	repo := "ashita-ai/akashi"
+
+	filters := model.QueryFilters{
+		AgentIDs:      []string{"planner", "coder"},
+		RunID:         &runID,
+		DecisionType:  &decType,
+		ConfidenceMin: &confMin,
+		Outcome:       &outcome,
+		SessionID:     &sessionID,
+		Tool:          &tool,
+		Model:         &mdl,
+		Repo:          &repo,
+	}
+
+	where, args := buildDecisionWhereClause(orgID, filters, 1, true)
+
+	// org_id + agent_ids + run_id + decision_type + confidence_min + outcome
+	// + session_id + tool + model + repo = 10 args
+	require.Len(t, args, 10)
+
+	// Verify all conditions are present.
+	assert.Contains(t, where, "org_id = $1")
+	assert.Contains(t, where, "valid_to IS NULL")
+	assert.Contains(t, where, "agent_id = ANY($2)")
+	assert.Contains(t, where, "run_id = $3")
+	assert.Contains(t, where, "decision_type = $4")
+	assert.Contains(t, where, "confidence >= $5")
+	assert.Contains(t, where, "outcome = $6")
+	assert.Contains(t, where, "session_id = $7")
+	assert.Contains(t, where, "COALESCE(agent_context->'server'->>'tool', agent_context->>'tool') = $8")
+	assert.Contains(t, where, "COALESCE(agent_context->'client'->>'model', agent_context->>'model') = $9")
+	assert.Contains(t, where, "COALESCE(agent_context->'server'->>'repo', agent_context->>'repo') = $10")
+}
+
+func TestBuildDecisionWhereClause_ArgIndexing(t *testing.T) {
+	// Verify that startArgIdx=3 shifts all parameter indices correctly.
+	orgID := uuid.New()
+	tool := "cursor"
+	filters := model.QueryFilters{Tool: &tool}
+
+	where, args := buildDecisionWhereClause(orgID, filters, 3, false)
+
+	assert.Contains(t, where, "org_id = $3")
+	assert.Contains(t, where, "COALESCE(agent_context->'server'->>'tool', agent_context->>'tool') = $4")
+	require.Len(t, args, 2)
+}
+
+func TestBuildDecisionWhereClause_OrgIsolationAlwaysFirst(t *testing.T) {
+	orgID := uuid.New()
+
+	where, _ := buildDecisionWhereClause(orgID, model.QueryFilters{}, 1, false)
+
+	// Org_id should be the first condition in the WHERE clause.
+	assert.True(t, strings.HasPrefix(where, " WHERE org_id = $1"),
+		"org_id should be the first condition, got: %s", where)
+}


### PR DESCRIPTION
## Summary

- **Regression fix**: PR #180 changed `agent_context` from flat `{"tool":"..."}` to namespaced `{"server":{"tool":"..."},"client":{"model":"..."}}` but five consumers still read the old flat format, breaking tool/model/repo filters and Qdrant indexing for all post-#180 decisions
- **Query builder refactor**: `buildDecisionWhereClause` now uses COALESCE to check both formats and accepts a `currentOnly` parameter (eliminates 5 duplicated `AND valid_to IS NULL` appends)
- **Outbox fix**: New `agentContextString` helper extracts values from either format; `processUpserts` uses it for Qdrant Point construction

## Test plan

- [x] 7 new unit tests for `buildDecisionWhereClause` (currentOnly, COALESCE filters, arg indexing, org isolation)
- [x] 12 new tests for `agentContextString` (namespaced, flat, precedence, missing, nil, type mismatch)
- [x] Updated `TestPointConversion` to cover flat, namespaced, and nil contexts
- [x] `go test -race` passes
- [x] `golangci-lint` clean
- [ ] Manual: trace a decision via MCP, query with `?tool=claude-code`, verify filter returns the decision