### PR TITLE
fix 9 post-PR#180 correctness issues

### DIFF
--- a/migrations/045_api_key_fixes.sql
+++ b/migrations/045_api_key_fixes.sql
@@ -1,0 +1,47 @@
+-- 045: API key FK constraint and prefix lookup index.
+--
+-- Two changes:
+--
+-- 1. Prefix + agent lookup index for O(1) auth pre-filter before Argon2.
+--    verifyAPIKey currently loads all active keys for an agent and runs a
+--    full Argon2id hash for each. With this index and GetAPIKeyByPrefixAndAgent,
+--    auth for managed-format keys (ak_<prefix>_<secret>) goes from O(N·hash)
+--    to O(1·hash).
+--
+-- 2. FK from api_keys to agents for referential integrity.
+--    api_keys.agent_id was TEXT NOT NULL with no FK. An orphaned key (agent
+--    deleted without cascading) could authenticate successfully with no valid
+--    agent backing it. The FK + ON DELETE CASCADE closes this gap.
+--
+--    Prerequisite: agents(org_id, agent_id) must have a UNIQUE constraint
+--    (not just a unique index) for PostgreSQL to accept a FK reference.
+--    idx_agents_org_agent (from 001) is a unique index; we promote it to a
+--    named unique constraint here using USING INDEX to avoid building a second
+--    index.
+--
+--    Safety pre-check: if any api_keys rows reference an agent_id/org_id pair
+--    that no longer exists in agents, the ALTER TABLE will fail. Run:
+--      SELECT k.agent_id, k.org_id
+--        FROM api_keys k
+--        LEFT JOIN agents a ON a.org_id = k.org_id AND a.agent_id = k.agent_id
+--       WHERE a.id IS NULL;
+--    Must return 0 rows before applying this migration.
+
+-- Prefix + agent lookup index for O(1) auth pre-filter.
+CREATE INDEX idx_api_keys_prefix_agent ON api_keys(prefix, agent_id)
+    WHERE revoked_at IS NULL;
+
+-- Promote the existing unique index to a named constraint so that the FK
+-- below can reference it. USING INDEX adopts the existing index without
+-- building a second one; the index is renamed to match the constraint name.
+ALTER TABLE agents
+    ADD CONSTRAINT uq_agents_org_agent UNIQUE USING INDEX idx_agents_org_agent;
+
+-- FK from api_keys to agents.
+-- Column order must match the unique constraint above: (org_id, agent_id).
+-- ON DELETE CASCADE: deleting an agent cascades to its api_keys.
+-- Decisions retain api_key_id with ON DELETE SET NULL (wired in 044).
+ALTER TABLE api_keys
+    ADD CONSTRAINT fk_api_keys_agent
+    FOREIGN KEY (org_id, agent_id) REFERENCES agents(org_id, agent_id)
+    ON DELETE CASCADE;

--- a/migrations/atlas.sum
+++ b/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:VaNZi7nBAgeWFuevlgYJPgkR0MqfgVH2d5Rgg3UZzGo=
+h1:+mJDhsHsdaB/cM7nsv3aS4JaVLSp0jLC4NgYi0SN0cs=
 001_initial.sql h1:uhyGXto+QacAaGYb9ZTGjsBs5chlKi8O0eHz9aCQsrY=
 022_full_text_search.sql h1:9iwtA8MgCzAxDV9YkUBn0CLT9ePSmj3GcPoMGg8TXf0=
 023_fix_outbox_index.sql h1:OtMEFBcMRWej02+ghnBXlPr6BVq+LoA62Id9XUWfDNI=
@@ -23,3 +23,4 @@ h1:VaNZi7nBAgeWFuevlgYJPgkR0MqfgVH2d5Rgg3UZzGo=
 042_audit_immutability_and_precision.sql h1:wfF6VR5w/fMzcdUtSKFTBBO1GvwBb1jkpKrXWm6SOmE=
 043_review_hardening.sql h1:XFTUtLleIGMayeep4938tzW3khiunoES2TFJ/xjPNQg=
 044_api_keys.sql h1:5pySkm26ilTxaDygFOYCTEoMSErF8q6LqCg7iPTy9OE=
+045_api_key_fixes.sql h1:FklWkDshO1T5AEKx3Vh9zuzaTBaeWyvM0tXrWCKMkuc=


### PR DESCRIPTION
## Summary

Addresses all 9 real issues from the 2026-02-17 review (score 79/100). Issue #1 (mutation_audit_log immutability) was a false positive — triggers already exist from migration 042.

**Fix 1 (P0)**: `HandleCreateAgent` now writes credentials to `api_keys` table via a new atomic `CreateAgentAndKeyTx` storage function. `agents.api_key_hash` is never written for new agents. `api_key` in the request body is now optional (auto-generated if omitted). Response shape updated to include `api_key.id` + `prefix`.

**Fix 2 (P1)**: `verifyAPIKey` O(N·Argon2) → O(1·Argon2). For `ak_`-format keys, new `GetAPIKeyByPrefixAndAgent` uses `idx_api_keys_prefix_agent` (migration 045) to fetch one candidate row before running Argon2. Non-`ak_` keys fall back to full scan for legacy compatibility.

**Fix 3 (P1)**: `MigrateAgentKeysToAPIKeys` now writes `InsertMutationAuditTx` entries for each migrated key, closing the audit gap on startup migration.

**Fix 4 (P1)**: Migration 045 adds `fk_api_keys_agent` FK `(org_id, agent_id) → agents` with `ON DELETE CASCADE`. Also promotes `idx_agents_org_agent` to a named unique constraint (PostgreSQL FK target requirement).

**Fix 5 (P1)**: `HandleListConflicts` pagination total now uses the `preFilterCount` pattern from `HandleQuery` — omits `total` and uses `has_more` when access filtering reduces the result set.

**Fix 6 (P2)**: `HandleDecisionConflicts` replaces hardcoded `limit=100, offset=0` with `queryLimit`/`queryOffset` from query params (default 50, max 200) plus full `CountConflicts` + pagination metadata.

**Fix 7 (P2)**: `HandleGetUsage` replaces N individual `GetAPIKeyByID` calls with a single `GetAPIKeysByIDs` batch query.

**Fix 8 (P2)**: `HandleTemporalQuery` rejects `as_of` values more than 1 minute in the future (400 Bad Request). Updated `TestHandleTemporalQuery_Valid` to use `time.Now()` instead of `time.Now().Add(1h)`.

**Fix 9** (WAL `cleanupSegments` O(N×M)): deferred — format change risk, no correctness impact.

## New storage functions
- `CreateAgentAndKeyTx` — atomic agent + initial key creation in one transaction
- `GetAPIKeyByPrefixAndAgent` — O(1) prefix-indexed key lookup for auth
- `GetAPIKeysByIDs` — batch key metadata fetch for usage reporting

## Test plan
- [x] `go mod tidy && git diff --exit-code go.mod go.sum` — clean
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] `atlas migrate validate --dir file://migrations` — valid
- [x] `go test -race -count=1 ./...` — all 16 packages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)