### PR TITLE
fix: decodeJSON nil ResponseWriter, eliminate HandleTrace double agent fetch

### DIFF
--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -448,7 +448,7 @@ func (s *Server) handleTrace(ctx context.Context, request mcplib.CallToolRequest
 		ActorRole:    string(callerRole),
 		Endpoint:     "mcp/akashi_trace",
 	}
-	if err := s.decisionSvc.ResolveOrCreateAgent(ctx, orgID, agentID, callerRole, autoRegAudit); err != nil {
+	if _, err := s.decisionSvc.ResolveOrCreateAgent(ctx, orgID, agentID, callerRole, autoRegAudit); err != nil {
 		return errorResult(err.Error()), nil
 	}
 

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -110,7 +110,7 @@ func mustTrace(t *testing.T, agentID, decisionType, outcome string, confidence f
 	ctx := adminCtx()
 
 	// Ensure agent exists.
-	_ = testSvc.ResolveOrCreateAgent(ctx, uuid.Nil, agentID, model.RoleAdmin, nil)
+	_, _ = testSvc.ResolveOrCreateAgent(ctx, uuid.Nil, agentID, model.RoleAdmin, nil)
 
 	result, err := testServer.handleTrace(ctx, traceRequest(map[string]any{
 		"agent_id":      agentID,
@@ -136,7 +136,7 @@ func mustTrace(t *testing.T, agentID, decisionType, outcome string, confidence f
 func TestHandleTrace(t *testing.T) {
 	ctx := adminCtx()
 	agentID := "trace-basic-" + uuid.New().String()[:8]
-	_ = testSvc.ResolveOrCreateAgent(ctx, uuid.Nil, agentID, model.RoleAdmin, nil)
+	_, _ = testSvc.ResolveOrCreateAgent(ctx, uuid.Nil, agentID, model.RoleAdmin, nil)
 
 	result, err := testServer.handleTrace(ctx, traceRequest(map[string]any{
 		"agent_id":      agentID,
@@ -244,7 +244,7 @@ func TestHandleTrace_DefaultsAgentIDFromClaims(t *testing.T) {
 func TestHandleTrace_ModelAndTaskContext(t *testing.T) {
 	ctx := adminCtx()
 	agentID := "trace-ctx-" + uuid.New().String()[:8]
-	_ = testSvc.ResolveOrCreateAgent(ctx, uuid.Nil, agentID, model.RoleAdmin, nil)
+	_, _ = testSvc.ResolveOrCreateAgent(ctx, uuid.Nil, agentID, model.RoleAdmin, nil)
 
 	result, err := testServer.handleTrace(ctx, traceRequest(map[string]any{
 		"agent_id":      agentID,
@@ -930,7 +930,7 @@ func TestHandleTrace_Concurrent(t *testing.T) {
 	for i := range n {
 		go func(idx int) {
 			agentID := fmt.Sprintf("concurrent-%d-%s", idx, uuid.New().String()[:8])
-			_ = testSvc.ResolveOrCreateAgent(ctx, uuid.Nil, agentID, model.RoleAdmin, nil)
+			_, _ = testSvc.ResolveOrCreateAgent(ctx, uuid.Nil, agentID, model.RoleAdmin, nil)
 
 			result, err := testServer.handleTrace(ctx, traceRequest(map[string]any{
 				"agent_id":      agentID,

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -76,8 +76,8 @@ func NewHandlers(d HandlersDeps) *Handlers {
 // Checks managed api_keys table first, falls back to agents.api_key_hash.
 func (h *Handlers) HandleAuthToken(w http.ResponseWriter, r *http.Request) {
 	var req model.AuthTokenRequest
-	if err := decodeJSON(r, &req, h.maxRequestBodyBytes); err != nil {
-		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "invalid request body")
+	if err := decodeJSON(w, r, &req, h.maxRequestBodyBytes); err != nil {
+		handleDecodeError(w, r, err)
 		return
 	}
 

--- a/internal/server/handlers_admin.go
+++ b/internal/server/handlers_admin.go
@@ -23,8 +23,8 @@ func (h *Handlers) HandleCreateAgent(w http.ResponseWriter, r *http.Request) {
 	orgID := OrgIDFromContext(r.Context())
 
 	var req model.CreateAgentRequest
-	if err := decodeJSON(r, &req, h.maxRequestBodyBytes); err != nil {
-		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "invalid request body")
+	if err := decodeJSON(w, r, &req, h.maxRequestBodyBytes); err != nil {
+		handleDecodeError(w, r, err)
 		return
 	}
 
@@ -191,8 +191,8 @@ func (h *Handlers) HandleCreateGrant(w http.ResponseWriter, r *http.Request) {
 	orgID := OrgIDFromContext(r.Context())
 
 	var req model.CreateGrantRequest
-	if err := decodeJSON(r, &req, h.maxRequestBodyBytes); err != nil {
-		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "invalid request body")
+	if err := decodeJSON(w, r, &req, h.maxRequestBodyBytes); err != nil {
+		handleDecodeError(w, r, err)
 		return
 	}
 
@@ -375,8 +375,8 @@ func (h *Handlers) HandleUpdateAgent(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req model.UpdateAgentRequest
-	if err := decodeJSON(r, &req, h.maxRequestBodyBytes); err != nil {
-		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "invalid request body")
+	if err := decodeJSON(w, r, &req, h.maxRequestBodyBytes); err != nil {
+		handleDecodeError(w, r, err)
 		return
 	}
 
@@ -497,8 +497,8 @@ func (h *Handlers) HandleUpdateAgentTags(w http.ResponseWriter, r *http.Request)
 	}
 
 	var req model.UpdateAgentTagsRequest
-	if err := decodeJSON(r, &req, h.maxRequestBodyBytes); err != nil {
-		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "invalid request body")
+	if err := decodeJSON(w, r, &req, h.maxRequestBodyBytes); err != nil {
+		handleDecodeError(w, r, err)
 		return
 	}
 

--- a/internal/server/handlers_keys.go
+++ b/internal/server/handlers_keys.go
@@ -18,8 +18,8 @@ func (h *Handlers) HandleCreateKey(w http.ResponseWriter, r *http.Request) {
 	orgID := OrgIDFromContext(r.Context())
 
 	var req model.CreateKeyRequest
-	if err := decodeJSON(r, &req, h.maxRequestBodyBytes); err != nil {
-		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "invalid request body")
+	if err := decodeJSON(w, r, &req, h.maxRequestBodyBytes); err != nil {
+		handleDecodeError(w, r, err)
 		return
 	}
 

--- a/internal/server/handlers_runs.go
+++ b/internal/server/handlers_runs.go
@@ -18,8 +18,8 @@ func (h *Handlers) HandleCreateRun(w http.ResponseWriter, r *http.Request) {
 	orgID := OrgIDFromContext(r.Context())
 
 	var req model.CreateRunRequest
-	if err := decodeJSON(r, &req, h.maxRequestBodyBytes); err != nil {
-		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "invalid request body")
+	if err := decodeJSON(w, r, &req, h.maxRequestBodyBytes); err != nil {
+		handleDecodeError(w, r, err)
 		return
 	}
 
@@ -83,8 +83,8 @@ func (h *Handlers) HandleAppendEvents(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req model.AppendEventsRequest
-	if err := decodeJSON(r, &req, h.maxRequestBodyBytes); err != nil {
-		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "invalid request body")
+	if err := decodeJSON(w, r, &req, h.maxRequestBodyBytes); err != nil {
+		handleDecodeError(w, r, err)
 		return
 	}
 
@@ -185,8 +185,8 @@ func (h *Handlers) HandleCompleteRun(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req model.CompleteRunRequest
-	if err := decodeJSON(r, &req, h.maxRequestBodyBytes); err != nil {
-		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "invalid request body")
+	if err := decodeJSON(w, r, &req, h.maxRequestBodyBytes); err != nil {
+		handleDecodeError(w, r, err)
 		return
 	}
 


### PR DESCRIPTION
## Summary

Three bugs identified in the 2026-02-17 code review, now fixed:

- **`decodeJSON` nil ResponseWriter** (P0): `http.MaxBytesReader` was called with `nil` instead of `w`. This prevents the server from marking the connection non-reusable after a 413, causing connection pool corruption. Fixed: pass `w`, return `413` via new `errBodyTooLarge` sentinel + `handleDecodeError` helper. All 16 call sites updated.
- **`HandleTrace` double agent fetch** (P1): `ResolveOrCreateAgent` was called to get the agent, then `GetAgentByAgentID` was called again immediately to populate operator context — two DB roundtrips for every trace. Fixed: `ResolveOrCreateAgent` now returns `(model.Agent, error)`, caller reuses the agent directly.
- **`CountDecisionsByAPIKey` undocumented semantics** (P2): `valid_to IS NULL` filter counted only active decisions, not all trace events. Intentional billing design but completely undocumented. Fixed: added explicit comment explaining the semantics.

## Test plan

- [ ] `go test -race ./internal/service/decisions/... ./internal/server/... ./internal/mcp/...` — passes
- [ ] `go vet ./...` — clean
- [ ] `golangci-lint run ./...` — clean
- [ ] Send request with body > limit, verify 413 response (not 400)
- [ ] Trace a decision, verify no double DB fetch in logs