### PR TITLE
ui: improve search UX, agent dropdown, clickable agents, reasoning column, soften coverage tips

### DIFF
--- a/ui/src/pages/Agents.tsx
+++ b/ui/src/pages/Agents.tsx
@@ -34,6 +34,7 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { formatDate, formatRelativeTime } from "@/lib/utils";
 import { Plus, Trash2 } from "lucide-react";
+import { Link } from "react-router";
 
 const roleColors: Record<AgentRole, "default" | "secondary" | "destructive" | "success" | "warning" | "outline"> = {
   admin: "default",
@@ -228,11 +229,23 @@ export default function Agents() {
           </TableHeader>
           <TableBody>
             {agents.map((agent) => (
-              <TableRow key={agent.id}>
+              <TableRow key={agent.id} className="cursor-pointer">
                 <TableCell className="font-mono text-sm">
-                  {agent.agent_id}
+                  <Link
+                    to={`/decisions?agent=${encodeURIComponent(agent.agent_id)}`}
+                    className="hover:underline"
+                  >
+                    {agent.agent_id}
+                  </Link>
                 </TableCell>
-                <TableCell>{agent.name}</TableCell>
+                <TableCell>
+                  <Link
+                    to={`/decisions?agent=${encodeURIComponent(agent.agent_id)}`}
+                    className="hover:underline"
+                  >
+                    {agent.name}
+                  </Link>
+                </TableCell>
                 <TableCell>
                   <Badge variant={roleColors[agent.role] ?? "secondary"}>
                     {agent.role}

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -5,10 +5,11 @@ import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { formatRelativeTime } from "@/lib/utils";
 import {
-  Activity,
   AlertTriangle,
   FileText,
   HeartPulse,
+  Info,
+  Lightbulb,
   Users,
 } from "lucide-react";
 import { Link } from "react-router";
@@ -131,13 +132,13 @@ export default function Dashboard() {
         </Card>
       </div>
 
-      {/* Trace health gaps */}
+      {/* Coverage tips — informational, not errors */}
       {traceHealth.data?.gaps && traceHealth.data.gaps.length > 0 && (
         <Card>
           <CardHeader>
             <CardTitle className="flex items-center gap-2 text-sm font-medium">
-              <Activity className="h-4 w-4 text-amber-500" />
-              Trace Gaps
+              <Lightbulb className="h-4 w-4 text-muted-foreground" />
+              Coverage Tips
             </CardTitle>
           </CardHeader>
           <CardContent>
@@ -145,9 +146,9 @@ export default function Dashboard() {
               {traceHealth.data.gaps.map((gap, i) => (
                 <li
                   key={i}
-                  className="flex items-center gap-2 rounded-md border p-3 text-sm"
+                  className="flex items-center gap-2 rounded-md bg-muted/50 px-3 py-2 text-sm"
                 >
-                  <AlertTriangle className="h-4 w-4 shrink-0 text-amber-500" />
+                  <Info className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
                   <span className="text-muted-foreground">{gap}</span>
                 </li>
               ))}

--- a/ui/src/pages/SearchPage.tsx
+++ b/ui/src/pages/SearchPage.tsx
@@ -7,17 +7,16 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
-import { formatDate, truncate } from "@/lib/utils";
-import { Search, Sparkles } from "lucide-react";
+import { formatDate } from "@/lib/utils";
+import { Search } from "lucide-react";
 
 export default function SearchPage() {
   const [query, setQuery] = useState("");
   const [submittedQuery, setSubmittedQuery] = useState("");
-  const [semantic, setSemantic] = useState(true);
 
   const { data, isPending, isFetched } = useQuery({
-    queryKey: ["search", submittedQuery, semantic],
-    queryFn: () => searchDecisions(submittedQuery, semantic),
+    queryKey: ["search", submittedQuery],
+    queryFn: () => searchDecisions(submittedQuery, true),
     enabled: submittedQuery.length > 0,
   });
 
@@ -38,22 +37,11 @@ export default function SearchPage() {
           <Input
             value={query}
             onChange={(e) => setQuery(e.target.value)}
-            placeholder="Search decisions\u2026"
+            placeholder="Search decisions"
             className="pl-10"
             autoFocus
           />
         </div>
-        <Button
-          type="button"
-          variant={semantic ? "default" : "outline"}
-          size="sm"
-          onClick={() => setSemantic(!semantic)}
-          className="gap-1.5"
-          title={semantic ? "Semantic search enabled" : "Text search only"}
-        >
-          <Sparkles className="h-4 w-4" />
-          Semantic
-        </Button>
         <Button type="submit" disabled={!query.trim()}>
           Search
         </Button>
@@ -85,33 +73,26 @@ export default function SearchPage() {
             >
               <Card className="transition-colors hover:bg-accent/50">
                 <CardContent className="p-4">
-                  <div className="flex items-start justify-between gap-4">
-                    <div className="space-y-1 min-w-0">
-                      <div className="flex items-center gap-2">
-                        <Badge variant="outline" className="font-mono text-xs">
-                          {result.decision.agent_id}
-                        </Badge>
-                        <Badge variant="secondary">
-                          {result.decision.decision_type}
-                        </Badge>
-                      </div>
-                      <p className="text-sm font-medium">
-                        {truncate(result.decision.outcome, 120)}
-                      </p>
-                      {result.decision.reasoning && (
-                        <p className="text-xs text-muted-foreground">
-                          {truncate(result.decision.reasoning, 200)}
-                        </p>
-                      )}
-                      <p className="text-xs text-muted-foreground">
-                        {formatDate(result.decision.created_at)}
-                      </p>
-                    </div>
-                    {semantic && (
-                      <Badge variant="outline" className="shrink-0 font-mono">
-                        {(result.similarity_score * 100).toFixed(1)}%
+                  <div className="space-y-1.5 min-w-0">
+                    <div className="flex items-center gap-2">
+                      <Badge variant="outline" className="font-mono text-xs">
+                        {result.decision.agent_id}
                       </Badge>
+                      <Badge variant="secondary">
+                        {result.decision.decision_type}
+                      </Badge>
+                    </div>
+                    <p className="text-sm font-medium">
+                      {result.decision.outcome}
+                    </p>
+                    {result.decision.reasoning && (
+                      <p className="text-xs text-muted-foreground line-clamp-2">
+                        {result.decision.reasoning}
+                      </p>
                     )}
+                    <p className="text-xs text-muted-foreground">
+                      {formatDate(result.decision.created_at)}
+                    </p>
                   </div>
                 </CardContent>
               </Card>


### PR DESCRIPTION
## Summary

Five UX improvements based on UI feedback:

- **Search page**: Remove the Semantic toggle — search mechanics are invisible to the user, there's just one Search button. Replace character-truncated outcome/reasoning with full outcome text + `line-clamp-2` CSS on reasoning (no more mid-word ellipsis). Drop the similarity score badge.
- **Decisions filter**: Replace the free-text `agent-id` input with a dropdown populated from `/v1/agents`. Selecting an agent immediately updates the URL filter (no separate Filter click needed). Replace the useless "Alternatives" column (always shows 0) with "Reasoning" — shows a truncated snippet of the decision's reasoning.
- **Agents page**: Agent ID and Name cells are now links to `/decisions?agent=<id>`, so clicking any agent row shows that agent's decisions.
- **Dashboard**: Rename "Trace Gaps" → "Coverage Tips", replace amber `AlertTriangle` icons with neutral `Info` icons and muted background, so the section reads as actionable guidance rather than software errors.

## Test plan

- [ ] Build passes: `cd ui && npm run build` (TypeScript clean, no new warnings)
- [ ] Search: confirm single Search button, no Semantic toggle, results show full outcome without mid-word truncation
- [ ] Decisions: confirm agent dropdown populates with real agents, selecting one filters immediately, Reasoning column shows reasoning snippets
- [ ] Agents: confirm clicking agent name/id navigates to `/decisions?agent=<id>`
- [ ] Dashboard: confirm Coverage Tips section uses info icons and muted styling