### PR TITLE
ui: agent dropdowns on all filter pages, quality score column

### DIFF
--- a/ui/src/pages/Decisions.tsx
+++ b/ui/src/pages/Decisions.tsx
@@ -164,6 +164,7 @@ export default function Decisions() {
                 <TableHead>Type</TableHead>
                 <TableHead>Outcome</TableHead>
                 <TableHead className="text-right">Confidence</TableHead>
+                <TableHead className="text-right">Quality</TableHead>
                 <TableHead>Reasoning</TableHead>
               </TableRow>
             </TableHeader>
@@ -196,6 +197,17 @@ export default function Decisions() {
                   </TableCell>
                   <TableCell className="text-right font-mono">
                     {(d.confidence * 100).toFixed(0)}%
+                  </TableCell>
+                  <TableCell className="text-right font-mono">
+                    <span className={
+                      d.quality_score >= 0.7
+                        ? "text-emerald-600"
+                        : d.quality_score >= 0.5
+                        ? "text-amber-600"
+                        : "text-red-600"
+                    }>
+                      {(d.quality_score * 100).toFixed(0)}%
+                    </span>
                   </TableCell>
                   <TableCell className="max-w-[240px] text-xs text-muted-foreground">
                     {d.reasoning ? truncate(d.reasoning, 80) : (

--- a/ui/src/pages/GrantsPage.tsx
+++ b/ui/src/pages/GrantsPage.tsx
@@ -7,6 +7,13 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
   Table,
   TableBody,
   TableCell,
@@ -198,25 +205,44 @@ export default function GrantsPage() {
               </div>
             )}
             <div className="space-y-2">
-              <Label htmlFor="grantee">Grantee Agent ID</Label>
-              <Input
-                id="grantee"
-                placeholder="e.g. reader-bot"
-                value={granteeAgentId}
-                onChange={(e) => setGranteeAgentId(e.target.value)}
-              />
+              <Label htmlFor="grantee">Grantee Agent</Label>
+              <Select
+                value={granteeAgentId || ""}
+                onValueChange={setGranteeAgentId}
+              >
+                <SelectTrigger id="grantee">
+                  <SelectValue placeholder="Select an agent" />
+                </SelectTrigger>
+                <SelectContent>
+                  {agents.map((a) => (
+                    <SelectItem key={a.agent_id} value={a.agent_id}>
+                      {a.agent_id}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
             <div className="space-y-2">
               <Label htmlFor="resource">
-                Resource Agent ID{" "}
+                Resource Agent{" "}
                 <span className="text-muted-foreground">(optional)</span>
               </Label>
-              <Input
-                id="resource"
-                placeholder="All agents (leave blank for wildcard)"
-                value={resourceId}
-                onChange={(e) => setResourceId(e.target.value)}
-              />
+              <Select
+                value={resourceId || "__wildcard__"}
+                onValueChange={(v) => setResourceId(v === "__wildcard__" ? "" : v)}
+              >
+                <SelectTrigger id="resource">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="__wildcard__">All agents (wildcard)</SelectItem>
+                  {agents.map((a) => (
+                    <SelectItem key={a.agent_id} value={a.agent_id}>
+                      {a.agent_id}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
             <div className="space-y-2">
               <Label htmlFor="expires">


### PR DESCRIPTION
## Summary

- **Decisions**: add Quality column showing `quality_score` as a percentage with color coding — green ≥70%, amber ≥50–70%, red <50%
- **Conflicts**: replace agent text input with Select dropdown populated from `listAgents`; both Agent and Status are now direct-update Selects (no Filter button needed); form wrapper removed
- **Export**: replace Agent ID text input with Select dropdown; adds `useQuery` for agents
- **Grants**: replace Grantee Agent and Resource Agent text inputs with Select dropdowns; Resource includes "All agents (wildcard)" as first option

## Test plan

- [ ] Decisions table shows Quality column; colors respond to score bands
- [ ] Conflicts agent dropdown populates from live agents; selecting updates results immediately
- [ ] Export agent dropdown shows all agents; "All agents" passes no filter (exports everything)
- [ ] Grants create dialog: Grantee is a required Select; Resource defaults to wildcard
- [ ] Grants: selecting a specific resource agent scopes the grant correctly
- [ ] `npm run build` passes (TypeScript + Vite)