### PR TITLE
fix: cap Ollama inference threads to floor(NumCPU/3) by default

### DIFF
--- a/cmd/akashi/main.go
+++ b/cmd/akashi/main.go
@@ -484,8 +484,8 @@ func newEmbeddingProvider(cfg config.Config, logger *slog.Logger) embedding.Prov
 // (2) else if OPENAI_API_KEY is set, use OpenAI gpt-4o-mini, (3) else NoopValidator.
 func newConflictValidator(cfg config.Config, logger *slog.Logger) conflicts.Validator {
 	if cfg.ConflictLLMModel != "" {
-		logger.Info("conflict validator: ollama", "model", cfg.ConflictLLMModel, "url", cfg.OllamaURL)
-		return conflicts.NewOllamaValidator(cfg.OllamaURL, cfg.ConflictLLMModel)
+		logger.Info("conflict validator: ollama", "model", cfg.ConflictLLMModel, "url", cfg.OllamaURL, "num_threads", cfg.ConflictLLMThreads)
+		return conflicts.NewOllamaValidator(cfg.OllamaURL, cfg.ConflictLLMModel, cfg.ConflictLLMThreads)
 	}
 	if cfg.OpenAIAPIKey != "" {
 		logger.Info("conflict validator: openai (gpt-4o-mini)")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -60,6 +61,7 @@ type Config struct {
 
 	// Conflict LLM validation.
 	ConflictLLMModel        string  // Text generation model for conflict validation (e.g. "qwen2.5:3b" for Ollama).
+	ConflictLLMThreads      int     // CPU threads Ollama may use per inference call (default: floor(NumCPU/3), min 1). 0 = let Ollama decide.
 	ConflictBackfillWorkers int     // Parallel workers for conflict scoring backfill (default: 4).
 	ConflictDecayLambda     float64 // Temporal decay rate for conflict significance (default: 0.01, 0 disables).
 	ForceConflictRescore    bool    // When true (and LLM validator configured), clear all conflicts and re-score at startup.
@@ -125,6 +127,8 @@ func Load() (Config, error) {
 	cfg.EventBufferSize, errs = collectInt(errs, "AKASHI_EVENT_BUFFER_SIZE", 1000)
 	cfg.RateLimitBurst, errs = collectInt(errs, "AKASHI_RATE_LIMIT_BURST", 200)
 	cfg.ConflictBackfillWorkers, errs = collectInt(errs, "AKASHI_CONFLICT_BACKFILL_WORKERS", 4)
+	defaultLLMThreads := max(1, runtime.NumCPU()/3)
+	cfg.ConflictLLMThreads, errs = collectInt(errs, "AKASHI_CONFLICT_LLM_THREADS", defaultLLMThreads)
 	cfg.WALSegmentSize, errs = collectInt(errs, "AKASHI_WAL_SEGMENT_SIZE", 64*1024*1024)
 	cfg.WALSegmentRecords, errs = collectInt(errs, "AKASHI_WAL_SEGMENT_RECORDS", 100_000)
 

--- a/internal/conflicts/validator_test.go
+++ b/internal/conflicts/validator_test.go
@@ -593,7 +593,7 @@ func TestOllamaValidator_Contradiction(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	v := NewOllamaValidator(srv.URL, "test-model")
+	v := NewOllamaValidator(srv.URL, "test-model", 0)
 	result, err := v.Validate(context.Background(), ValidateInput{
 		OutcomeA: "chose Redis for caching",
 		OutcomeB: "chose Memcached for caching",
@@ -625,7 +625,7 @@ func TestOllamaValidator_Complementary(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	v := NewOllamaValidator(srv.URL, "test-model")
+	v := NewOllamaValidator(srv.URL, "test-model", 0)
 	result, err := v.Validate(context.Background(), ValidateInput{
 		OutcomeA: "use PostgreSQL",
 		OutcomeB: "deploy to eu-west-1",
@@ -655,7 +655,7 @@ func TestOllamaValidator_MalformedResponse(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	v := NewOllamaValidator(srv.URL, "test-model")
+	v := NewOllamaValidator(srv.URL, "test-model", 0)
 	_, err := v.Validate(context.Background(), ValidateInput{
 		OutcomeA: "outcome A",
 		OutcomeB: "outcome B",
@@ -676,7 +676,7 @@ func TestOllamaValidator_Timeout(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	v := NewOllamaValidator(srv.URL, "test-model")
+	v := NewOllamaValidator(srv.URL, "test-model", 0)
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	defer cancel()
 
@@ -700,7 +700,7 @@ func TestOllamaValidator_ServerError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	v := NewOllamaValidator(srv.URL, "test-model")
+	v := NewOllamaValidator(srv.URL, "test-model", 0)
 	_, err := v.Validate(context.Background(), ValidateInput{
 		OutcomeA: "outcome A",
 		OutcomeB: "outcome B",


### PR DESCRIPTION
## Summary

- Ollama was using all 14 CPU cores for each qwen2.5:3b inference call, pegging the host during backfill
- Added `AKASHI_CONFLICT_LLM_THREADS` env var (default: `floor(runtime.NumCPU()/3)`, min 1) passed as `options.num_thread` on every Ollama `/api/chat` request
- On a 14-core host: default is 4 threads — leaves ~10 cores for the HTTP server, embedding, and OS
- Set to `0` to restore Ollama's default behavior (all cores)

## Test plan

- [ ] `go test -race ./internal/conflicts/...` — 13 tests pass
- [ ] Start server with Ollama validator; verify `conflict validator: ollama ... num_threads=4` in logs
- [ ] Run backfill; verify CPU usage stays below 50% rather than pinning all cores
- [ ] `AKASHI_CONFLICT_LLM_THREADS=0` skips setting `num_thread` (Ollama picks its own default)