### PR TITLE
Spec 34+35: conflict resolution winner, consensus scoring, and implicit outcome signals

### DIFF
--- a/internal/mcp/compact.go
+++ b/internal/mcp/compact.go
@@ -2,7 +2,10 @@ package mcp
 
 import (
 	"fmt"
+	"math"
 	"strings"
+
+	"github.com/google/uuid"
 
 	"github.com/ashita-ai/akashi/internal/model"
 )
@@ -12,14 +15,17 @@ const maxCompactReasoning = 200
 // compactDecision returns a minimal representation of a decision for MCP responses.
 // Drops internal bookkeeping (content_hash, transaction_time, valid_from/to,
 // quality_score, org_id, run_id, metadata, embedding fields) that agents don't act on.
+// Includes consensus scoring and outcome signals when populated.
 func compactDecision(d model.Decision) map[string]any {
 	m := map[string]any{
-		"id":            d.ID,
-		"agent_id":      d.AgentID,
-		"decision_type": d.DecisionType,
-		"outcome":       d.Outcome,
-		"confidence":    d.Confidence,
-		"created_at":    d.CreatedAt,
+		"id":              d.ID,
+		"agent_id":        d.AgentID,
+		"decision_type":   d.DecisionType,
+		"outcome":         d.Outcome,
+		"confidence":      d.Confidence,
+		"created_at":      d.CreatedAt,
+		"agreement_count": d.AgreementCount,
+		"conflict_count":  d.ConflictCount,
 	}
 	if d.Reasoning != nil && *d.Reasoning != "" {
 		m["reasoning"] = truncate(*d.Reasoning, maxCompactReasoning)
@@ -33,13 +39,52 @@ func compactDecision(d model.Decision) map[string]any {
 	if mdl, ok := d.AgentContext["model"]; ok {
 		m["model"] = mdl
 	}
+
+	// Consensus weight: [0.5, 1.0]; only include when there's meaningful data.
+	total := d.AgreementCount + d.ConflictCount
+	if total > 0 {
+		cw := 0.5 + 0.5*float64(d.AgreementCount)/float64(max(1, total))
+		m["consensus_weight"] = math.Round(cw*1000) / 1000 // 3 decimal places
+	}
+
+	// Outcome-based context note (rule-based, not LLM).
+	if note := generateContextNote(d); note != "" {
+		m["context_note"] = note
+	}
+
 	return m
+}
+
+// generateContextNote produces a human-readable signal note for a decision.
+// Rules are evaluated in priority order; first match wins. Returns "" when no rule fires.
+func generateContextNote(d model.Decision) string {
+	vel := d.SupersessionVelocityHours
+
+	switch {
+	case vel != nil && *vel < 48 && d.PrecedentCitationCount == 0:
+		return fmt.Sprintf("Revised within %.0fh and never cited as precedent — treat with caution.", *vel)
+
+	case vel == nil && d.PrecedentCitationCount >= 2:
+		return fmt.Sprintf("Never superseded. Cited as precedent %d times.", d.PrecedentCitationCount)
+
+	case vel == nil && d.ConflictFate.Won >= 1:
+		return fmt.Sprintf("Never superseded. Won %d conflict resolution(s).", d.ConflictFate.Won)
+
+	case vel != nil && *vel > 720: // > 30 days
+		days := int(math.Round(*vel / 24))
+		return fmt.Sprintf("Stood for %d days before revision.", days)
+
+	case d.ConflictFate.Lost >= 1 && d.ConflictFate.Won == 0:
+		return fmt.Sprintf("Overridden in %d conflict resolution(s).", d.ConflictFate.Lost)
+	}
+	return ""
 }
 
 // compactConflict returns a minimal representation of a conflict for MCP responses.
 // Drops scoring internals (topic_similarity, outcome_divergence, significance,
 // scoring_method, confidence_weight, temporal_decay) and full outcomes/reasoning.
-func compactConflict(c model.DecisionConflict) map[string]any {
+// consensusNote is the optional asymmetry framing string (may be "").
+func compactConflict(c model.DecisionConflict, consensusNote string) map[string]any {
 	m := map[string]any{
 		"id":          c.ID,
 		"agent_a":     c.AgentA,
@@ -59,6 +104,17 @@ func compactConflict(c model.DecisionConflict) map[string]any {
 	// Include brief outcome summaries so agents understand what the conflict is about.
 	m["outcome_a"] = truncate(c.OutcomeA, maxCompactReasoning)
 	m["outcome_b"] = truncate(c.OutcomeB, maxCompactReasoning)
+
+	// Winner: which decision prevailed (nil when not set or conflict is unresolved).
+	if c.WinningDecisionID != nil {
+		m["winning_decision_id"] = c.WinningDecisionID
+	}
+
+	// Consensus asymmetry note, when there's a meaningful corroboration imbalance.
+	if consensusNote != "" {
+		m["consensus_note"] = consensusNote
+	}
+
 	return m
 }
 
@@ -69,8 +125,33 @@ func compactSearchResult(r model.SearchResult) map[string]any {
 	return m
 }
 
+// buildConsensusNote returns a consensus framing note for a conflict when one side
+// has at least 2 more corroborating decisions than the other. Returns "" otherwise.
+func buildConsensusNote(c model.DecisionConflict, agreementCounts map[[16]byte]int) string {
+	aID := [16]byte(c.DecisionAID)
+	bID := [16]byte(c.DecisionBID)
+	countA := agreementCounts[aID]
+	countB := agreementCounts[bID]
+	diff := countA - countB
+	if diff < 0 {
+		diff = -diff
+	}
+	if diff < 2 {
+		return ""
+	}
+	// Determine which side has more corroboration.
+	outcomeA := truncate(c.OutcomeA, 60)
+	outcomeB := truncate(c.OutcomeB, 60)
+	if countA > countB {
+		return fmt.Sprintf("Decision A (%s) has %d corroborating decision(s). Decision B (%s) has %d.",
+			outcomeA, countA, outcomeB, countB)
+	}
+	return fmt.Sprintf("Decision B (%s) has %d corroborating decision(s). Decision A (%s) has %d.",
+		outcomeB, countB, outcomeA, countA)
+}
+
 // generateCheckSummary creates a 1-3 sentence human-readable synthesis of check results.
-// Template-based, no LLM dependency.
+// Template-based, no LLM dependency. Includes consensus framing when material.
 func generateCheckSummary(decisions []model.Decision, conflicts []model.DecisionConflict) string {
 	var parts []string
 
@@ -89,20 +170,38 @@ func generateCheckSummary(decisions []model.Decision, conflicts []model.Decision
 			parts = append(parts, fmt.Sprintf("%d prior decisions across %d types.", len(decisions), len(types)))
 		}
 
-		// Most recent decision.
+		// Most recent decision with outcome signals appended when material.
 		most := decisions[0] // decisions come sorted by valid_from desc
-		parts = append(parts, fmt.Sprintf("Most recent: \"%s\" (%.0f%% confidence).",
-			truncate(most.Outcome, 100), most.Confidence*100))
+		summaryLine := fmt.Sprintf("Most recent: \"%s\" (%.0f%% confidence",
+			truncate(most.Outcome, 100), most.Confidence*100)
+
+		// Append outcome signal context when non-trivial.
+		var signals []string
+		if most.SupersessionVelocityHours == nil {
+			signals = append(signals, "never superseded")
+		}
+		if most.PrecedentCitationCount >= 2 {
+			signals = append(signals, fmt.Sprintf("cited %d times", most.PrecedentCitationCount))
+		}
+		if len(signals) > 0 {
+			summaryLine += ", " + strings.Join(signals, ", ")
+		}
+		summaryLine += ")."
+		parts = append(parts, summaryLine)
 	}
 
-	// Conflict summary.
+	// Conflict summary with winner and consensus framing.
 	if len(conflicts) > 0 {
 		open := 0
 		var maxSeverity string
 		severityRank := map[string]int{"critical": 4, "high": 3, "medium": 2, "low": 1}
 		maxRank := 0
+		resolved := 0
+		resolvedWithWinner := 0
+
 		for _, c := range conflicts {
-			if c.Status == "open" || c.Status == "acknowledged" {
+			switch c.Status {
+			case "open", "acknowledged":
 				open++
 				if c.Severity != nil {
 					if r := severityRank[*c.Severity]; r > maxRank {
@@ -110,18 +209,66 @@ func generateCheckSummary(decisions []model.Decision, conflicts []model.Decision
 						maxSeverity = *c.Severity
 					}
 				}
+			case "resolved", "wont_fix":
+				resolved++
+				if c.WinningDecisionID != nil {
+					resolvedWithWinner++
+				}
 			}
 		}
-		if open > 0 {
-			if maxSeverity != "" {
-				parts = append(parts, fmt.Sprintf("%d open conflict(s), highest severity: %s.", open, maxSeverity))
-			} else {
-				parts = append(parts, fmt.Sprintf("%d open conflict(s).", open))
-			}
+
+		switch {
+		case open > 0:
+			conflictPart := buildOpenConflictSummary(open, maxSeverity, decisions, conflicts)
+			parts = append(parts, conflictPart)
+		case resolvedWithWinner > 0:
+			parts = append(parts, fmt.Sprintf("%d conflict(s) resolved with winner declared.", resolvedWithWinner))
+		case resolved > 0:
+			parts = append(parts, fmt.Sprintf("%d conflict(s) resolved.", resolved))
 		}
 	}
 
 	return strings.Join(parts, " ")
+}
+
+// buildOpenConflictSummary returns a one-sentence summary for open conflict(s),
+// incorporating consensus asymmetry framing when one side has ≥ 2 more corroborating decisions.
+func buildOpenConflictSummary(open int, maxSeverity string, decisions []model.Decision, conflicts []model.DecisionConflict) string {
+	base := fmt.Sprintf("%d open conflict(s).", open)
+	if maxSeverity != "" {
+		base = fmt.Sprintf("%d open conflict(s), highest severity: %s.", open, maxSeverity)
+	}
+
+	// Check for consensus asymmetry.
+	for _, c := range conflicts {
+		if c.Status != "open" && c.Status != "acknowledged" {
+			continue
+		}
+		aCount := decisionAgreementCount(decisions, c.DecisionAID)
+		bCount := decisionAgreementCount(decisions, c.DecisionBID)
+		diff := aCount - bCount
+		if diff < 0 {
+			diff = -diff
+		}
+		if diff >= 2 {
+			if aCount > bCount {
+				return fmt.Sprintf("%d-to-%d in favor of \"%s\".", aCount, bCount, truncate(c.OutcomeA, 60))
+			}
+			return fmt.Sprintf("%d-to-%d in favor of \"%s\".", bCount, aCount, truncate(c.OutcomeB, 60))
+		}
+	}
+	return base
+}
+
+// decisionAgreementCount looks up AgreementCount for a decision ID from a slice.
+// Returns 0 when not found (decision not in the check response, or no embedding).
+func decisionAgreementCount(decisions []model.Decision, id uuid.UUID) int {
+	for _, d := range decisions {
+		if d.ID == id {
+			return d.AgreementCount
+		}
+	}
+	return 0
 }
 
 // actionNeeded returns true if there are open critical/high conflicts.

--- a/internal/mcp/compact_test.go
+++ b/internal/mcp/compact_test.go
@@ -97,7 +97,7 @@ func TestCompactConflict(t *testing.T) {
 		DetectedAt:        time.Now(),
 	}
 
-	m := compactConflict(c)
+	m := compactConflict(c, "")
 
 	// Kept fields.
 	assert.Equal(t, c.ID, m["id"])

--- a/internal/service/tracehealth/service_test.go
+++ b/internal/service/tracehealth/service_test.go
@@ -15,7 +15,7 @@ func TestComputeGaps_AllHealthy(t *testing.T) {
 	es := storage.EvidenceCoverageStats{
 		TotalDecisions: 100, WithEvidence: 80, WithoutEvidenceCount: 20, CoveragePercent: 80,
 	}
-	gaps := computeGaps(qs, es, 5, 0)
+	gaps := computeGaps(qs, es, 5, 0, storage.OutcomeSignalsSummary{})
 
 	// No quality or coverage gaps. No open conflicts. Only "20 decisions lack evidence."
 	assert.LessOrEqual(t, len(gaps), 3)
@@ -33,7 +33,7 @@ func TestComputeGaps_LowQuality(t *testing.T) {
 	es := storage.EvidenceCoverageStats{
 		TotalDecisions: 50, WithEvidence: 30, WithoutEvidenceCount: 20, CoveragePercent: 60,
 	}
-	gaps := computeGaps(qs, es, 0, 0)
+	gaps := computeGaps(qs, es, 0, 0, storage.OutcomeSignalsSummary{})
 
 	assert.GreaterOrEqual(t, len(gaps), 1)
 	assert.Contains(t, gaps[0], "Average decision quality")
@@ -46,7 +46,7 @@ func TestComputeGaps_LowEvidence(t *testing.T) {
 	es := storage.EvidenceCoverageStats{
 		TotalDecisions: 100, WithEvidence: 30, WithoutEvidenceCount: 70, CoveragePercent: 30,
 	}
-	gaps := computeGaps(qs, es, 0, 0)
+	gaps := computeGaps(qs, es, 0, 0, storage.OutcomeSignalsSummary{})
 
 	found := false
 	for _, g := range gaps {
@@ -64,7 +64,7 @@ func TestComputeGaps_UnresolvedConflicts(t *testing.T) {
 	es := storage.EvidenceCoverageStats{
 		TotalDecisions: 100, WithEvidence: 80, WithoutEvidenceCount: 20, CoveragePercent: 80,
 	}
-	gaps := computeGaps(qs, es, 10, 7)
+	gaps := computeGaps(qs, es, 10, 7, storage.OutcomeSignalsSummary{})
 
 	found := false
 	for _, g := range gaps {
@@ -82,7 +82,7 @@ func TestComputeGaps_MaxThree(t *testing.T) {
 	es := storage.EvidenceCoverageStats{
 		TotalDecisions: 100, WithEvidence: 10, WithoutEvidenceCount: 90, CoveragePercent: 10,
 	}
-	gaps := computeGaps(qs, es, 20, 15)
+	gaps := computeGaps(qs, es, 20, 15, storage.OutcomeSignalsSummary{})
 
 	assert.LessOrEqual(t, len(gaps), 3, "should return at most 3 gaps")
 }

--- a/internal/storage/tracehealth.go
+++ b/internal/storage/tracehealth.go
@@ -1,0 +1,80 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+// OutcomeSignalsSummary holds org-level aggregate outcome signal counts
+// for the trace-health endpoint (Spec 35).
+type OutcomeSignalsSummary struct {
+	DecisionsTotal    int `json:"decisions_total"`
+	NeverSuperseded   int `json:"never_superseded"`
+	RevisedWithin48h  int `json:"revised_within_48h"`
+	NeverCited        int `json:"never_cited"`
+	CitedAtLeastOnce  int `json:"cited_at_least_once"`
+	ConflictsWon      int `json:"conflicts_won"`
+	ConflictsLost     int `json:"conflicts_lost"`
+	ConflictsNoWinner int `json:"conflicts_no_winner"`
+}
+
+// GetOutcomeSignalsSummary returns org-level aggregate outcome signal counts
+// for use in GET /v1/trace-health.
+func (db *DB) GetOutcomeSignalsSummary(ctx context.Context, orgID uuid.UUID) (OutcomeSignalsSummary, error) {
+	var s OutcomeSignalsSummary
+
+	// Decision-level counts: total, never_superseded, revised_within_48h, citation coverage.
+	// Uses EXISTS subqueries to avoid joins that would multiply rows.
+	err := db.pool.QueryRow(ctx, `
+		SELECT
+		    COUNT(*)::int,
+		    COUNT(*) FILTER (WHERE NOT EXISTS (
+		        SELECT 1 FROM decisions sup
+		        WHERE sup.supersedes_id = d.id AND sup.org_id = d.org_id
+		    ))::int,
+		    COUNT(*) FILTER (WHERE EXISTS (
+		        SELECT 1 FROM decisions sup
+		        WHERE sup.supersedes_id = d.id
+		          AND sup.org_id = d.org_id
+		          AND EXTRACT(EPOCH FROM (sup.valid_from - d.valid_from)) / 3600 < 48
+		    ))::int,
+		    COUNT(*) FILTER (WHERE NOT EXISTS (
+		        SELECT 1 FROM decisions cit
+		        WHERE cit.precedent_ref = d.id AND cit.org_id = d.org_id AND cit.valid_to IS NULL
+		    ))::int,
+		    COUNT(*) FILTER (WHERE EXISTS (
+		        SELECT 1 FROM decisions cit
+		        WHERE cit.precedent_ref = d.id AND cit.org_id = d.org_id AND cit.valid_to IS NULL
+		    ))::int
+		FROM decisions d
+		WHERE d.org_id = $1 AND d.valid_to IS NULL`, orgID).Scan(
+		&s.DecisionsTotal,
+		&s.NeverSuperseded,
+		&s.RevisedWithin48h,
+		&s.NeverCited,
+		&s.CitedAtLeastOnce,
+	)
+	if err != nil {
+		return s, fmt.Errorf("storage: outcome signals summary: %w", err)
+	}
+
+	// Conflict fate: org-level counts from resolved/wont_fix conflicts.
+	// ConflictsWon = conflicts where a winner was declared (= ConflictsLost, symmetric).
+	// ConflictsNoWinner = conflicts resolved without declaring a winner.
+	err = db.pool.QueryRow(ctx, `
+		SELECT
+		    COUNT(*) FILTER (WHERE winning_decision_id IS NOT NULL)::int,
+		    COUNT(*) FILTER (WHERE winning_decision_id IS NULL AND status = 'resolved')::int
+		FROM scored_conflicts
+		WHERE org_id = $1 AND status IN ('resolved', 'wont_fix')`, orgID).Scan(
+		&s.ConflictsWon, &s.ConflictsNoWinner,
+	)
+	if err != nil {
+		return s, fmt.Errorf("storage: outcome signals conflict counts: %w", err)
+	}
+	s.ConflictsLost = s.ConflictsWon // every decided win has a corresponding loss
+
+	return s, nil
+}

--- a/migrations/046_winning_decision_id.sql
+++ b/migrations/046_winning_decision_id.sql
@@ -1,0 +1,9 @@
+-- 046: Add winning_decision_id to scored_conflicts for structured conflict resolution.
+-- Tracks which decision prevailed when a conflict is resolved. Distinct from
+-- resolution_decision_id (the narrative trace created to document the resolution).
+ALTER TABLE scored_conflicts
+    ADD COLUMN winning_decision_id UUID REFERENCES decisions(id) ON DELETE SET NULL;
+
+CREATE INDEX idx_scored_conflicts_winner
+    ON scored_conflicts(winning_decision_id)
+    WHERE winning_decision_id IS NOT NULL;

--- a/migrations/atlas.sum
+++ b/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:+mJDhsHsdaB/cM7nsv3aS4JaVLSp0jLC4NgYi0SN0cs=
+h1:bTy0XfMhGi/63l9tSGT4j9UCLXK+fWLt/V/n0eg9Mo4=
 001_initial.sql h1:uhyGXto+QacAaGYb9ZTGjsBs5chlKi8O0eHz9aCQsrY=
 022_full_text_search.sql h1:9iwtA8MgCzAxDV9YkUBn0CLT9ePSmj3GcPoMGg8TXf0=
 023_fix_outbox_index.sql h1:OtMEFBcMRWej02+ghnBXlPr6BVq+LoA62Id9XUWfDNI=
@@ -24,3 +24,4 @@ h1:+mJDhsHsdaB/cM7nsv3aS4JaVLSp0jLC4NgYi0SN0cs=
 043_review_hardening.sql h1:XFTUtLleIGMayeep4938tzW3khiunoES2TFJ/xjPNQg=
 044_api_keys.sql h1:5pySkm26ilTxaDygFOYCTEoMSErF8q6LqCg7iPTy9OE=
 045_api_key_fixes.sql h1:FklWkDshO1T5AEKx3Vh9zuzaTBaeWyvM0tXrWCKMkuc=
+046_winning_decision_id.sql h1:4nnwlpzKcBFy78GcEzINYQBg09cuRgxPS6gTXqZW1mA=


### PR DESCRIPTION
## Summary

- **Spec 34 — Conflict resolution winner + consensus scoring**: Adds `winning_decision_id` to `scored_conflicts` (migration 046) so conflict resolution can declare which decision prevailed. Adds per-decision `agreement_count` / `conflict_count` computed at query time via pgvector ANN cluster (cosine ≥ 0.70), exposing `consensus_weight` in compact MCP responses and check summaries.
- **Spec 35 — Implicit outcome signals**: Adds three computed-at-query-time fields to `Decision`: `supersession_velocity_hours` (time to first revision, nil if stable), `precedent_citation_count` (downstream citations), and `conflict_fate` (won/lost/no-winner across resolved conflicts). Extends `TraceHealth` with an `outcome_signals` aggregate section and two new gap detection rules.
- **MCP tool improvements**: `context_note` (rule-based signal synthesis), consensus asymmetry framing in conflict summaries, `precedent_ref_hint` nudge in `akashi_check` responses, and winner attribution in resolved conflict output.

## Implementation notes

- All new DB queries batch with `ANY($1)` or `CROSS JOIN LATERAL` — no N+1 access patterns
- Conflict fate batch uses `UNION ALL` to handle decisions appearing as either `decision_a_id` or `decision_b_id`
- `HandleResolveConflict` validates that `winning_decision_id` (optional) is one of the two conflict parties
- `context_note` is 100% rule-based — no LLM dependency, no latency impact

## Test plan
- [ ] All tests pass: `go test -race -count=1 ./...` (17 packages, 0 failures)
- [ ] No lint issues: `golangci-lint run ./...`
- [ ] Migration validates: `atlas migrate validate --dir file://migrations`
- [ ] Resolve a conflict with `winning_decision_id` set — verify field persists and appears in `akashi_check` output
- [ ] Query a decision with embeddings — verify `agreement_count`, `conflict_count`, `consensus_weight`, and `context_note` appear in compact MCP response
- [ ] Call `akashi_stats` — verify `outcome_signals` section present when decisions exist