### PR TITLE
Fix four ADR compliance gaps (ADR-007, ADR-015, ADR-016, ADR-019)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2019,6 +2019,25 @@ components:
           type: string
           format: uuid
           description: Managed API key that authenticated this decision.
+        agreement_count:
+          type: integer
+          description: |
+            Number of decisions in this decision's embedding-similarity cluster whose
+            outcomes agree (outcome cosine similarity ≥ 0.75). Computed at query time.
+        conflict_count:
+          type: integer
+          description: |
+            Number of open or acknowledged conflicts involving this decision.
+            Computed at query time.
+        consensus_weight:
+          type: number
+          format: float
+          minimum: 0.5
+          maximum: 1
+          description: |
+            0.5 + 0.5 × (agreement_count / max(1, agreement_count + conflict_count)).
+            Range [0.5, 1.0]. Only present when at least one agreement or conflict exists.
+            Not stored — computed at response time.
         alternatives:
           type: array
           items:
@@ -2227,6 +2246,13 @@ components:
           type: number
           format: float
           description: exp(-lambda × days_between) scaling factor applied to significance.
+        winning_decision_id:
+          type: string
+          format: uuid
+          description: |
+            ID of the decision judged to be correct when this conflict was adjudicated.
+            Must be either decision_a_id or decision_b_id. Optional — resolution is
+            valid without declaring a winner.
 
     ConflictStatusUpdate:
       type: object
@@ -2252,6 +2278,13 @@ components:
           type: string
           default: conflict_resolution
           description: Decision type for the adjudication trace (defaults to "conflict_resolution").
+        winning_decision_id:
+          type: string
+          format: uuid
+          description: |
+            Optional. The decision judged to be correct. Must be decision_a_id or
+            decision_b_id of the conflict being adjudicated. When omitted, the conflict
+            is resolved without declaring a winner.
 
     # ── API Key schemas ─────────────────────────────────────────────
     APIKey:

--- a/internal/conflicts/scorer.go
+++ b/internal/conflicts/scorer.go
@@ -323,7 +323,7 @@ func (s *Scorer) scoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 			continue
 		}
 		inserted++
-		if err := s.db.Notify(ctx, storage.ChannelConflicts, `{"source":"scorer"}`); err != nil {
+		if err := s.db.Notify(ctx, storage.ChannelConflicts, `{"source":"scorer","org_id":"`+orgID.String()+`"}`); err != nil {
 			s.logger.Debug("conflict scorer: notify failed", "error", err)
 		}
 	}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -114,8 +114,7 @@ SKIP: formatting, typo fixes, running tests, reading code, asking questions.`),
 				mcplib.Required(),
 			),
 			mcplib.WithNumber("confidence",
-				mcplib.Description("How certain you are about this decision (0.0 = guessing, 1.0 = certain)"),
-				mcplib.Required(),
+				mcplib.Description("How certain you are about this decision (0.0 = guessing, 1.0 = certain). Defaults to 0.7 if omitted."),
 				mcplib.Min(0),
 				mcplib.Max(1),
 			),
@@ -463,7 +462,7 @@ func (s *Server) handleTrace(ctx context.Context, request mcplib.CallToolRequest
 	agentID := request.GetString("agent_id", "")
 	decisionType := request.GetString("decision_type", "")
 	outcome := request.GetString("outcome", "")
-	confidence := float32(request.GetFloat("confidence", 0))
+	confidence := float32(request.GetFloat("confidence", 0.7))
 	reasoning := request.GetString("reasoning", "")
 
 	// Default agent_id to the caller's authenticated identity.

--- a/internal/server/handlers_decisions.go
+++ b/internal/server/handlers_decisions.go
@@ -545,9 +545,11 @@ func (h *Handlers) HandleListConflicts(w http.ResponseWriter, r *http.Request) {
 		filters.Category = &cat
 	}
 	// Default to open conflicts unless explicitly overridden.
-	if st := r.URL.Query().Get("status"); st != "" {
-		filters.Status = &st
+	st := r.URL.Query().Get("status")
+	if st == "" {
+		st = "open"
 	}
+	filters.Status = &st
 	limit := queryLimit(r, 25)
 	offset := queryOffset(r)
 


### PR DESCRIPTION
## Summary

Four small fixes identified by the comprehensive ADR compliance audit (2026-02-19).

- **ADR-007**: Conflict SSE notifications were silently dropped for all tenants — `scorer.go` sent `pg_notify` without `org_id`, which the SSE broker uses for routing. Added `org_id` to the payload.
- **ADR-015**: `GET /v1/conflicts` returned all statuses by default instead of `status=open` as the ADR specifies. Fixed the handler to default to `open` when no `?status` param is provided (consistent with `akashi_check` MCP tool behaviour).
- **ADR-016**: `akashi_trace` had `confidence` marked `Required()`, forcing agents to provide 3 fields instead of the 2 the ADR mandates. Removed `Required()` and changed the default from `0` to `0.7`.
- **ADR-019**: `openapi.yaml` was missing `agreement_count`, `conflict_count`, `consensus_weight` from the `Decision` schema, and `winning_decision_id` from `DecisionConflict` and `AdjudicateConflictRequest`. All fields were already present in live API responses — only the spec was incomplete.

## Test plan

- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] `golangci-lint run ./...` passes (0 issues)
- [ ] `atlas migrate validate` passes (no schema changes)
- [ ] Verify `GET /v1/conflicts` (no params) returns only open conflicts
- [ ] Verify `akashi_trace` via MCP succeeds with only `decision_type` + `outcome`
- [ ] Verify SSE conflict notifications are delivered after a new conflict is scored