### PR TITLE
fix(docker): local services only start with --profile local

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,22 @@
 # Akashi: Docker Compose for local development.
 #
-# Start:
-#   go run scripts/genkey/main.go   # first time only — generates data/jwt_private.pem + jwt_public.pem
-#   docker compose up -d --build
-#   curl http://localhost:8080/health
-#   # Open http://localhost:8080 for the audit dashboard
+# Two modes:
 #
-# Includes: Postgres (pgvector + TimescaleDB) and Qdrant for local dev.
+#   Full local stack (Postgres + Qdrant run in-container):
+#     docker compose --profile local up -d --build
+#
+#   Cloud services (DATABASE_URL + QDRANT_URL set in .env):
+#     docker compose up -d --build
+#
+# First time only — generate persistent JWT signing keys before first launch:
+#   go run scripts/genkey/main.go   # writes data/jwt_private.pem + data/jwt_public.pem
+#
 # Embeddings: set OPENAI_API_KEY in .env, or point OLLAMA_URL at a local Ollama instance.
 # Without an embedding provider the server starts fine — search falls back to text.
-#
-# Cloud override: set DATABASE_URL, QDRANT_URL, OPENAI_API_KEY etc. in .env and
-# they take precedence over the local service defaults below.
 
 services:
   postgres:
+    profiles: [local]
     image: timescale/timescaledb-ha:pg18
     container_name: akashi-postgres
     restart: unless-stopped
@@ -40,6 +42,7 @@ services:
       retries: 5
 
   qdrant:
+    profiles: [local]
     image: qdrant/qdrant:v1.13.6
     container_name: akashi-qdrant
     restart: unless-stopped
@@ -63,7 +66,7 @@ services:
     ports:
       - "127.0.0.1:8080:8080"
     environment:
-      # Database: defaults to local Postgres; override via DATABASE_URL in .env for cloud.
+      # Database: defaults to local Postgres (local profile); set DATABASE_URL in .env for cloud.
       DATABASE_URL: ${DATABASE_URL:-postgres://akashi:${POSTGRES_PASSWORD:-akashi}@postgres:5432/akashi?sslmode=disable}
       NOTIFY_URL: ${NOTIFY_URL:-postgres://akashi:${POSTGRES_PASSWORD:-akashi}@postgres:5432/akashi?sslmode=disable}
 
@@ -72,7 +75,7 @@ services:
       AKASHI_ADMIN_API_KEY: ${AKASHI_ADMIN_API_KEY:-admin}
       AKASHI_LOG_LEVEL: ${AKASHI_LOG_LEVEL:-info}
 
-      # Qdrant: defaults to local in-stack instance; override via QDRANT_URL in .env for cloud.
+      # Qdrant: defaults to local in-stack instance (local profile); set QDRANT_URL in .env for cloud.
       QDRANT_URL: ${QDRANT_URL:-http://qdrant:6333}
       QDRANT_API_KEY: ${QDRANT_API_KEY:-}
       QDRANT_COLLECTION: ${QDRANT_COLLECTION:-akashi_decisions}
@@ -108,8 +111,10 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+        required: false
       qdrant:
         condition: service_healthy
+        required: false
 
 volumes:
   pgdata:


### PR DESCRIPTION
## Problem

`docker compose up -d` always started local postgres and qdrant even when `DATABASE_URL` and `QDRANT_URL` in `.env` pointed at cloud services. The containers ran but received zero traffic, wasting resources.

## Fix

- Add `profiles: [local]` to the `postgres` and `qdrant` services — they only start when explicitly requested
- Add `required: false` to `depends_on` — akashi starts immediately when cloud services are configured, without waiting for local containers that aren't running

## Usage

```bash
# Cloud services (DATABASE_URL + QDRANT_URL in .env):
docker compose up -d --build

# Full local stack (Postgres + Qdrant in-container):
docker compose --profile local up -d --build
```

## Closes

Stale issues already resolved by prior merges:
- Closes #203 (Qdrant in OSS docker-compose — done in #215)