### PR TITLE
fix: block reserved agent_id names at creation time

### DIFF
--- a/internal/model/agent.go
+++ b/internal/model/agent.go
@@ -109,6 +109,31 @@ func ValidateTag(tag string) error {
 	return nil
 }
 
+// reservedAgentIDs is the set of agent_id values that cannot be claimed by
+// user-created agents. These names imply elevated privilege or system identity
+// and would be misleading in the audit trail if assigned to ordinary agents.
+//
+// Note: the seed admin agent (agent_id="admin") is created internally at
+// startup and is intentionally exempt from this check.
+var reservedAgentIDs = map[string]struct{}{
+	"admin":     {},
+	"system":    {},
+	"root":      {},
+	"platform":  {},
+	"superuser": {},
+	"service":   {},
+	"akashi":    {},
+	"internal":  {},
+}
+
+// IsReservedAgentID reports whether id is a reserved name that cannot be
+// claimed by user-created agents. Call this at agent creation time only —
+// not on lookup paths, since the seed "admin" agent already exists.
+func IsReservedAgentID(id string) bool {
+	_, ok := reservedAgentIDs[id]
+	return ok
+}
+
 // ValidateAgentID checks that an agent ID conforms to the allowed format.
 // Agent IDs must be 1-255 ASCII characters: alphanumeric, dots, hyphens,
 // underscores, and @ signs.

--- a/internal/model/agent_test.go
+++ b/internal/model/agent_test.go
@@ -142,6 +142,24 @@ func TestValidateTag(t *testing.T) {
 	})
 }
 
+func TestIsReservedAgentID(t *testing.T) {
+	reserved := []string{
+		"admin", "system", "root", "platform",
+		"superuser", "service", "akashi", "internal",
+	}
+	for _, id := range reserved {
+		assert.True(t, model.IsReservedAgentID(id), "expected %q to be reserved", id)
+	}
+
+	notReserved := []string{
+		"agent", "planner", "coder", "reviewer",
+		"admin-bot", "my-admin", "sys-agent", // prefix/suffix variants are fine
+	}
+	for _, id := range notReserved {
+		assert.False(t, model.IsReservedAgentID(id), "expected %q to not be reserved", id)
+	}
+}
+
 func TestValidateAgentID_Invalid(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/server/handlers_admin.go
+++ b/internal/server/handlers_admin.go
@@ -36,6 +36,11 @@ func (h *Handlers) HandleCreateAgent(w http.ResponseWriter, r *http.Request) {
 		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, err.Error())
 		return
 	}
+	if model.IsReservedAgentID(req.AgentID) {
+		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput,
+			"agent_id \""+req.AgentID+"\" is reserved and cannot be used")
+		return
+	}
 
 	if req.Role == "" {
 		req.Role = model.RoleAgent


### PR DESCRIPTION
## Problem

`ValidateAgentID` validated character set and length but not semantics. An admin could create an agent with `agent_id = "admin"` and `role = "agent"` — the role would be correct, but the `agent_id` would be deceptive in the audit trail. Anyone reading a trace from `agent_id: admin` would reasonably assume it's the system admin.

Not a privilege escalation (role controls access, not agent_id), but a footgun for audit integrity.

## Fix

- Add `IsReservedAgentID(id string) bool` to `internal/model/agent.go` with a blocklist: `admin`, `system`, `root`, `platform`, `superuser`, `service`, `akashi`, `internal`
- Call it in `HandleCreateAgent` only — lookup paths (GET, PATCH, DELETE, trace submission) are unaffected
- The seed admin agent (`agent_id = "admin"`, created internally at startup) is exempt since `SeedAdmin` bypasses the HTTP handler

## What's not changed

- `ValidateAgentID` is unchanged — it validates format, not semantics
- Prefix/suffix variants like `admin-bot` or `my-admin` are fine — the check is exact match only
- No migration needed — pure application logic

## Tests

`TestIsReservedAgentID` covers all blocked names and confirms common variants are not blocked.

Closes #218