### PR TITLE
feat(hooks): block Edit/Write/MultiEdit until akashi_check is on record

### DIFF
--- a/scripts/hooks/akashi-check-marker.sh
+++ b/scripts/hooks/akashi-check-marker.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Claude Code PostToolUse hook.
+# Fires after akashi_check or akashi_trace MCP tool calls.
+# Writes a marker file so akashi-precheck-gate.sh knows a check is on record
+# and allows subsequent Edit/Write/MultiEdit calls to proceed.
+#
+# Installed by: make install-hooks
+# Registered in: ~/.claude/settings.json
+
+touch "/tmp/akashi-checked-$(whoami)"

--- a/scripts/hooks/akashi-precheck-gate.sh
+++ b/scripts/hooks/akashi-precheck-gate.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Claude Code PreToolUse hook.
+# Fires before Edit, Write, or MultiEdit. Blocks the call if akashi_check
+# has not been called recently, forcing Claude to establish decision context
+# before touching any files.
+#
+# Installed by: make install-hooks
+# Registered in: ~/.claude/settings.json
+
+MARKER="/tmp/akashi-checked-$(whoami)"
+MAX_AGE=7200  # 2 hours
+
+if [ -f "$MARKER" ]; then
+    # macOS uses stat -f %m; Linux uses stat -c %Y
+    mtime=$(stat -f %m "$MARKER" 2>/dev/null || stat -c %Y "$MARKER" 2>/dev/null || echo 0)
+    age=$(( $(date +%s) - mtime ))
+    if [ "$age" -lt "$MAX_AGE" ]; then
+        exit 0  # recent check on record — allow
+    fi
+fi
+
+echo "AKASHI GATE: You have not called akashi_check in this session. Call it now before editing any files. Check for prior decisions and precedents, then proceed."
+exit 2

--- a/scripts/install-claude-hooks.sh
+++ b/scripts/install-claude-hooks.sh
@@ -10,22 +10,25 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-HOOK_SRC="$SCRIPT_DIR/hooks/akashi-trace-reminder.sh"
-HOOK_DST="$HOME/.claude/hooks/akashi-trace-reminder.sh"
+HOOKS_SRC="$SCRIPT_DIR/hooks"
+HOOKS_DST="$HOME/.claude/hooks"
 SETTINGS="$HOME/.claude/settings.json"
 
-# -- 1. Install hook script ---------------------------------------------------
-mkdir -p "$HOME/.claude/hooks"
-cp "$HOOK_SRC" "$HOOK_DST"
-chmod +x "$HOOK_DST"
-echo "  hook script -> $HOOK_DST"
+mkdir -p "$HOOKS_DST"
+
+# -- 1. Install hook scripts --------------------------------------------------
+for script in akashi-trace-reminder.sh akashi-precheck-gate.sh akashi-check-marker.sh; do
+    cp "$HOOKS_SRC/$script" "$HOOKS_DST/$script"
+    chmod +x "$HOOKS_DST/$script"
+    echo "  hook script -> $HOOKS_DST/$script"
+done
 
 # -- 2. Register in ~/.claude/settings.json (idempotent) ---------------------
 python3 - <<EOF
 import json, os, sys
 
 settings_path = "$SETTINGS"
-hook_cmd = "$HOOK_DST"
+hooks_dst = "$HOOKS_DST"
 
 try:
     with open(settings_path) as f:
@@ -34,25 +37,47 @@ except FileNotFoundError:
     settings = {}
 
 hooks = settings.setdefault("hooks", {})
+
+def already_registered(hook_list, matcher, cmd):
+    for entry in hook_list:
+        if entry.get("matcher") == matcher:
+            for h in entry.get("hooks", []):
+                if h.get("command") == cmd:
+                    return True
+    return False
+
+def add_hook(hook_list, matcher, cmd):
+    if not already_registered(hook_list, matcher, cmd):
+        hook_list.append({"matcher": matcher, "hooks": [{"type": "command", "command": cmd}]})
+        return True
+    return False
+
+registered = []
+
+# PostToolUse: trace reminder after git commit
 post = hooks.setdefault("PostToolUse", [])
+if add_hook(post, "Bash", f"{hooks_dst}/akashi-trace-reminder.sh"):
+    registered.append("PostToolUse[Bash] -> akashi-trace-reminder.sh")
 
-# Already registered?
-for entry in post:
-    for h in entry.get("hooks", []):
-        if h.get("command") == hook_cmd:
-            print(f"  settings.json -> already registered, skipping")
-            sys.exit(0)
+# PostToolUse: write marker after akashi_check or akashi_trace
+for mcp_tool in ("mcp__akashi__akashi_check", "mcp__akashi__akashi_trace"):
+    if add_hook(post, mcp_tool, f"{hooks_dst}/akashi-check-marker.sh"):
+        registered.append(f"PostToolUse[{mcp_tool}] -> akashi-check-marker.sh")
 
-post.append({
-    "matcher": "Bash",
-    "hooks": [{"type": "command", "command": hook_cmd}]
-})
+# PreToolUse: gate on Edit/Write/MultiEdit until akashi_check is on record
+pre = hooks.setdefault("PreToolUse", [])
+for tool in ("Edit", "Write", "MultiEdit"):
+    if add_hook(pre, tool, f"{hooks_dst}/akashi-precheck-gate.sh"):
+        registered.append(f"PreToolUse[{tool}] -> akashi-precheck-gate.sh")
 
-with open(settings_path, "w") as f:
-    json.dump(settings, f, indent=2)
-    f.write("\n")
-
-print(f"  settings.json -> registered PostToolUse hook")
+if registered:
+    with open(settings_path, "w") as f:
+        json.dump(settings, f, indent=2)
+        f.write("\n")
+    for r in registered:
+        print(f"  settings.json -> registered {r}")
+else:
+    print("  settings.json -> all hooks already registered, skipping")
 EOF
 
 echo "Done. Hooks active for the next Claude Code session."


### PR DESCRIPTION
## Summary

Soft reminders don't work. This adds a hard enforcement mechanism via two new hooks registered in `~/.claude/settings.json`:

- **`akashi-precheck-gate.sh`** (PreToolUse on Edit/Write/MultiEdit): exits with code 2, blocking the tool call, if `akashi_check` has not been called in the last 2 hours. This makes it impossible to edit files without first establishing decision context.
- **`akashi-check-marker.sh`** (PostToolUse on `mcp__akashi__akashi_check` and `mcp__akashi__akashi_trace`): writes `/tmp/akashi-checked-<user>` after a successful akashi MCP call, which satisfies the gate for the next 2 hours.

Updated `install-claude-hooks.sh` to install all three scripts and register all hooks. The idempotency check is now scoped per matcher so the same command can register under multiple matchers without being incorrectly deduplicated.

## How it works

1. Start of any session: first Edit/Write/MultiEdit is blocked with: `AKASHI GATE: Call akashi_check before editing files.`
2. Call `akashi_check` → marker file written → gate satisfied
3. All subsequent edits proceed silently for 2 hours
4. After 2 hours of no akashi activity: gate fires again

## Test plan

- [x] `make install-hooks` installs all three scripts and registers all six hook entries
- [x] Re-running `make install-hooks` is idempotent (no duplicates)
- [x] Attempting an Edit without calling akashi_check is blocked
- [x] Calling `akashi_check` then Edit proceeds without interruption

🤖 Generated with [Claude Code](https://claude.com/claude-code)