### PR TITLE
fix(docker): remove hardcoded container_name directives

### DIFF
--- a/docker-compose.complete.yml
+++ b/docker-compose.complete.yml
@@ -41,7 +41,6 @@ services:
 
   postgres:
     image: timescale/timescaledb-ha:pg18
-    container_name: akashi-postgres
     restart: unless-stopped
     environment:
       POSTGRES_USER: akashi
@@ -66,7 +65,6 @@ services:
 
   qdrant:
     image: qdrant/qdrant:v1.13.6
-    container_name: akashi-qdrant
     restart: unless-stopped
     volumes:
       - qdrant_data:/qdrant/storage
@@ -79,7 +77,6 @@ services:
 
   ollama:
     image: ollama/ollama
-    container_name: akashi-ollama
     restart: unless-stopped
     volumes:
       - ollama_data:/root/.ollama
@@ -121,7 +118,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    container_name: akashi-server
     restart: unless-stopped
     ports:
       - "127.0.0.1:${AKASHI_PORT:-8080}:${AKASHI_PORT:-8080}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    container_name: akashi-server
     restart: unless-stopped
     ports:
       - "127.0.0.1:${AKASHI_PORT:-8080}:${AKASHI_PORT:-8080}"


### PR DESCRIPTION
## Summary

- Removes `container_name:` from all services in `docker-compose.complete.yml` (postgres, qdrant, ollama, akashi)
- Removes `container_name:` from the akashi service in `docker-compose.yml`

## Root cause

`container_name` in Docker Compose is **globally scoped** — not scoped to the compose project. When any previous run fails or is interrupted mid-startup, Docker leaves the named containers behind. Every subsequent `docker compose up` then fails immediately with:

```
Error response from daemon: Conflict. The container name '/akashi-postgres' is already in use by container "08ab55f8..."
```

This was the root cause of "server never comes online" on fresh installs: the first run partially started, left containers around, and every retry hit this conflict before any service could start.

## Fix

Remove all `container_name:` directives. Docker Compose generates project-scoped names automatically (e.g. `akashi-postgres-1`), which are namespaced by the compose project name and never conflict between runs.

## Test plan

- [ ] `docker compose -f docker-compose.complete.yml up -d` on a machine that has leftover containers from a previous run — should start cleanly instead of failing
- [ ] `docker compose -f docker-compose.complete.yml ps` — services appear with project-scoped names
- [ ] Health endpoint responds: `curl http://localhost:8080/health`