### PR TITLE
feat: wire assessment summaries into akashi_check and ReScore

### DIFF
--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -39,9 +39,9 @@ func TestReScore_OutcomeDominatesCompleteness(t *testing.T) {
 
 	scored := ReScore(results, decisions, 10)
 	assert.Len(t, scored, 2)
-	// highCitation: outcomeWeight=0.4*1+0.3*0.5+0.1=0.65; multiplier=0.5+0.195+0=0.695; score=0.9*0.695=0.6255
-	// highCompleteness: outcomeWeight=0.25; multiplier=0.5+0.075+0.1=0.675; score=0.9*0.675=0.6075
-	// highCitation (0.6255) > highCompleteness (0.6075) — citations win.
+	// highCitation: outcomeWeight=0.35*1+0.25*0.5+0.10*1+0.15*0.5=0.650; multiplier=0.5+0.195+0=0.695; score=0.9*0.695=0.6255
+	// highCompleteness: outcomeWeight=0.300; multiplier=0.5+0.09+0.1=0.690; score=0.9*0.690=0.621
+	// highCitation (0.6255) > highCompleteness (0.621) — citations win.
 	assert.Equal(t, highCitation, scored[0].Decision.ID,
 		"decision with 5 citations should outrank one with completeness=0.5 and zero citations")
 }
@@ -100,11 +100,11 @@ func TestReScore_ColdStart(t *testing.T) {
 	scored := ReScore(results, decisions, 10)
 	assert.Len(t, scored, 1)
 
-	// outcome_weight = 0.4*0 + 0.3*0.5 + 0.2*0 + 0.1*1.0 = 0.25
-	// relevance multiplier = 0.5 + 0.3*0.25 + 0.2*0.0 = 0.575
-	// With similarity=1.0 and recency=1.0 (age=0): relevance = 0.575
-	assert.InDelta(t, 0.575, float64(scored[0].SimilarityScore), 0.001,
-		"cold-start decision should have relevance multiplier ~0.575")
+	// outcome_weight = 0.35*0 + 0.25*0.5 + 0.15*0 + 0.10*1.0 + 0.15*0.5 = 0.300
+	// relevance multiplier = 0.5 + 0.3*0.300 + 0.2*0.0 = 0.590
+	// With similarity=1.0 and recency=1.0 (age=0): relevance = 0.590
+	assert.InDelta(t, 0.590, float64(scored[0].SimilarityScore), 0.001,
+		"cold-start decision should have relevance multiplier ~0.590")
 }
 
 // TestReScore_BoundedToOne verifies acceptance criterion 8:


### PR DESCRIPTION
## Summary

- `hydrateAndReScore` now calls `GetAssessmentSummaryBatch` before `ReScore` so assessment data is available during ranking
- `ReScore` gains a 5th outcome signal: `assessment_score` (weight 0.15). Correct=1.0, partially_correct=0.5, incorrect=0.0, no assessments=0.5 neutral. Weights rebalanced: citation 0.35 / conflict_win_rate 0.25 / agreement 0.15 / stability 0.10 / assessment 0.15
- `handleCheck` batch-fetches assessment summaries after consensus scoring, covering both the search and structured-query paths
- `compactDecision` includes `assessment_summary` when present
- `generateContextNote` adds assessment-priority rules: "Assessed correct by N of M agent(s)" appears above indirect signal notes
- `generateCheckSummary` appends "assessed correct N/M" to the summary line

Tests updated to match revised cold-start `outcome_weight` (0.300 vs 0.250) and new expected relevance values.

Closes part of #209 (the feedback loop is now wired end-to-end).

## Test plan

- [ ] All existing tests pass (`go test -race ./...`)
- [ ] `akashi_assess` a decision, then `akashi_check` for the same type — verify `assessment_summary` appears in response and `context_note` reflects the assessment
- [ ] Semantic search for assessed decisions — verify assessed-correct decisions rank above unassessed decisions with similar embeddings

🤖 Generated with [Claude Code](https://claude.com/claude-code)