### PR TITLE
refactor: rename repo field to project across the entire stack

### DIFF
--- a/akashi.go
+++ b/akashi.go
@@ -704,7 +704,7 @@ func (a *searcherAdapter) Search(ctx context.Context, orgID uuid.UUID, emb []flo
 		SessionID:     filters.SessionID,
 		Tool:          filters.Tool,
 		Model:         filters.Model,
-		Repo:          filters.Repo,
+		Project:       filters.Project,
 	}
 	results, err := a.s.Search(ctx, orgID, emb, pubFilters, limit)
 	if err != nil {

--- a/internal/conflicts/scorer.go
+++ b/internal/conflicts/scorer.go
@@ -186,7 +186,7 @@ func (s *Scorer) scoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 		return
 	}
 
-	qdrantResults, err := s.finder.FindSimilar(ctx, orgID, d.Embedding.Slice(), decisionID, d.Repo, 50)
+	qdrantResults, err := s.finder.FindSimilar(ctx, orgID, d.Embedding.Slice(), decisionID, d.Project, 50)
 	if err != nil {
 		s.logger.Warn("conflict scorer: qdrant find similar failed", "decision_id", decisionID, "error", err)
 		return
@@ -358,8 +358,8 @@ func (s *Scorer) scoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 				CreatedB:        cand.ValidFrom,
 				ReasoningA:      derefString(d.Reasoning),
 				ReasoningB:      derefString(cand.Reasoning),
-				RepoA:           derefString(d.Repo),
-				RepoB:           derefString(cand.Repo),
+				ProjectA:        derefString(d.Project),
+				ProjectB:        derefString(cand.Project),
 				TaskA:           agentContextString(d.AgentContext, "task"),
 				TaskB:           agentContextString(cand.AgentContext, "task"),
 				SessionIDA:      uuidString(d.SessionID),

--- a/internal/conflicts/validator.go
+++ b/internal/conflicts/validator.go
@@ -25,8 +25,8 @@ type ValidateInput struct {
 	// Enrichment fields — may be empty when context is unavailable.
 	ReasoningA      string // decision reasoning
 	ReasoningB      string
-	RepoA           string // from agent_context["repo"]
-	RepoB           string
+	ProjectA        string // from agent_context["project"] (or legacy "repo")
+	ProjectB        string
 	TaskA           string // from agent_context["task"]
 	TaskB           string
 	SessionIDA      string // UUID string
@@ -109,12 +109,12 @@ func formatPrompt(input ValidateInput) string {
 	fmt.Fprintf(&b, "\nContext: These decisions were recorded %s apart by %s.\n", deltaStr, agentContext)
 
 	// --- Project context (#168: cross-project confusion) ---
-	if input.RepoA != "" && input.RepoB != "" {
-		if input.RepoA != input.RepoB {
+	if input.ProjectA != "" && input.ProjectB != "" {
+		if input.ProjectA != input.ProjectB {
 			fmt.Fprintf(&b, "DIFFERENT PROJECTS: Decision A is about %q, Decision B is about %q. Decisions about different codebases are almost always UNRELATED.\n",
-				input.RepoA, input.RepoB)
+				input.ProjectA, input.ProjectB)
 		} else {
-			fmt.Fprintf(&b, "Same project: %s\n", input.RepoA)
+			fmt.Fprintf(&b, "Same project: %s\n", input.ProjectA)
 		}
 	} else if input.AgentA != input.AgentB {
 		// Repository names unavailable — guide the LLM to identify projects from outcome text.

--- a/internal/conflicts/validator_test.go
+++ b/internal/conflicts/validator_test.go
@@ -325,8 +325,8 @@ func TestFormatPrompt_DifferentProjects(t *testing.T) {
 		AgentB:   "coder",
 		CreatedA: now,
 		CreatedB: now.Add(time.Hour),
-		RepoA:    "ashita-ai/akashi",
-		RepoB:    "ashita-ai/engram",
+		ProjectA: "ashita-ai/akashi",
+		ProjectB: "ashita-ai/engram",
 	})
 	assert.Contains(t, prompt, "DIFFERENT PROJECTS")
 	assert.Contains(t, prompt, "ashita-ai/akashi")
@@ -345,8 +345,8 @@ func TestFormatPrompt_SameProject(t *testing.T) {
 		AgentB:   "coder",
 		CreatedA: now,
 		CreatedB: now.Add(time.Hour),
-		RepoA:    "ashita-ai/akashi",
-		RepoB:    "ashita-ai/akashi",
+		ProjectA: "ashita-ai/akashi",
+		ProjectB: "ashita-ai/akashi",
 	})
 	assert.Contains(t, prompt, "Same project: ashita-ai/akashi")
 	assert.NotContains(t, prompt, "DIFFERENT PROJECTS")

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -29,8 +29,8 @@ WORKFLOW — follow this for every non-trivial decision:
    and avoid contradicting prior work.
 
 2. AFTER deciding: call akashi_trace with what you decided (outcome), why (reasoning),
-   your confidence (0.0–1.0), and repo (the project or repo name, e.g. "akashi",
-   "my-service"). This creates a provable record so other agents can learn from it.
+   your confidence (0.0–1.0), and project (the project or app name, e.g. "akashi",
+   "my-langchain-app"). This creates a provable record so other agents can learn from it.
 
 TOOLS:
 - akashi_check: look up precedents before deciding (always call first)

--- a/internal/mcp/prompts.go
+++ b/internal/mcp/prompts.go
@@ -77,7 +77,7 @@ func (s *Server) handleBeforeDecisionPrompt(ctx context.Context, request mcplib.
    - outcome: what you decided (be specific)
    - confidence: your certainty (0.0-1.0)
    - reasoning: why you chose this, referencing precedents if applicable
-   - repo: the project or repo name (e.g. "akashi", "my-service") so this decision
+   - project: the project or application name (e.g. "akashi", "my-langchain-app") so this decision
      appears in project-scoped queries`, decisionType, decisionType, decisionType),
 				},
 			},
@@ -107,7 +107,7 @@ CALL akashi_trace with:
 - confidence: your certainty about this decision (0.0-1.0). Be honest.
 - reasoning: explain your chain of thought. What trade-offs did you accept?
   What constraints or requirements drove the choice? What risks?
-- repo: the project or repo name (e.g. "akashi", "my-service") so this decision
+- project: the project or application name (e.g. "akashi", "my-langchain-app") so this decision
   appears in project-scoped queries.
 - alternatives (optional but recommended): JSON array of options you considered
   and rejected. Each item: {"label":"option description","rejection_reason":"why not chosen"}

--- a/internal/model/decision.go
+++ b/internal/model/decision.go
@@ -54,12 +54,12 @@ type Decision struct {
 	SessionID    *uuid.UUID     `json:"session_id,omitempty"`
 	AgentContext map[string]any `json:"agent_context,omitempty"`
 
-	// First-class attribution columns (migration 048): indexed fast-path for
+	// First-class attribution columns (migration 048/052): indexed fast-path for
 	// the three most-filtered context fields. Auto-computed from agent_context
 	// by generated columns; nil when the context fields were not provided.
-	Tool  *string `json:"tool,omitempty"`
-	Model *string `json:"model,omitempty"`
-	Repo  *string `json:"repo,omitempty"`
+	Tool    *string `json:"tool,omitempty"`
+	Model   *string `json:"model,omitempty"`
+	Project *string `json:"project,omitempty"`
 
 	// API key attribution: which managed key authenticated this decision.
 	APIKeyID *uuid.UUID `json:"api_key_id,omitempty"`

--- a/internal/model/query.go
+++ b/internal/model/query.go
@@ -17,7 +17,7 @@ type QueryFilters struct {
 	SessionID     *uuid.UUID `json:"session_id,omitempty"`
 	Tool          *string    `json:"tool,omitempty"`
 	Model         *string    `json:"model,omitempty"`
-	Repo          *string    `json:"repo,omitempty"`
+	Project       *string    `json:"project,omitempty"`
 }
 
 // TimeRange defines a time range for queries.
@@ -64,7 +64,7 @@ type CheckRequest struct {
 	DecisionType string `json:"decision_type"`
 	Query        string `json:"query,omitempty"`
 	AgentID      string `json:"agent_id,omitempty"`
-	Repo         string `json:"repo,omitempty"`
+	Project      string `json:"project,omitempty"`
 	Limit        int    `json:"limit,omitempty"`
 }
 

--- a/internal/search/qdrant_integration_test.go
+++ b/internal/search/qdrant_integration_test.go
@@ -275,7 +275,7 @@ func TestQdrantUpsert_PointPayloadFields(t *testing.T) {
 		SessionID:         &sessionID,
 		Tool:              "claude-code",
 		Model:             "claude-opus-4-6",
-		Repo:              "ashita-ai/akashi",
+		Project:           "ashita-ai/akashi",
 	}
 
 	// Point with minimal fields (no optional fields).
@@ -353,11 +353,11 @@ func TestQdrantSearch_WithFilters(t *testing.T) {
 		require.Error(t, err)
 	})
 
-	t.Run("tool_model_repo filters", func(t *testing.T) {
+	t.Run("tool_model_project filters", func(t *testing.T) {
 		tool := "claude-code"
 		mdl := "opus"
-		repo := "ashita-ai/akashi"
-		filters := model.QueryFilters{Tool: &tool, Model: &mdl, Repo: &repo}
+		project := "ashita-ai/akashi"
+		filters := model.QueryFilters{Tool: &tool, Model: &mdl, Project: &project}
 		_, err := idx.Search(ctx, uuid.New(), embedding, filters, 10)
 		require.Error(t, err)
 	})

--- a/internal/search/qdrant_test.go
+++ b/internal/search/qdrant_test.go
@@ -257,8 +257,8 @@ func buildFilterConditions(orgID uuid.UUID, filters model.QueryFilters) []string
 	if filters.Model != nil {
 		conditions = append(conditions, "model")
 	}
-	if filters.Repo != nil {
-		conditions = append(conditions, "repo")
+	if filters.Project != nil {
+		conditions = append(conditions, "project")
 	}
 	return conditions
 }
@@ -287,23 +287,23 @@ func TestBuildQdrantFilter_SessionAndContext(t *testing.T) {
 	sessionID := uuid.New()
 	tool := "claude-code"
 	mdl := "claude-opus-4-6"
-	repo := "ashita-ai/akashi"
+	project := "ashita-ai/akashi"
 
 	filters := model.QueryFilters{
 		SessionID: &sessionID,
 		Tool:      &tool,
 		Model:     &mdl,
-		Repo:      &repo,
+		Project:   &project,
 	}
 
 	conditions := buildFilterConditions(uuid.New(), filters)
-	// Expect 5 conditions: org_id + session_id + tool + model + repo.
+	// Expect 5 conditions: org_id + session_id + tool + model + project.
 	require.Len(t, conditions, 5)
 	assert.Contains(t, conditions, "org_id")
 	assert.Contains(t, conditions, "session_id")
 	assert.Contains(t, conditions, "tool")
 	assert.Contains(t, conditions, "model")
-	assert.Contains(t, conditions, "repo")
+	assert.Contains(t, conditions, "project")
 }
 
 func TestOutboxWorkerDrain_WithoutStart(t *testing.T) {

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -39,9 +39,9 @@ type Searcher interface {
 // can type-assert to CandidateFinder when they need internal ANN access.
 type CandidateFinder interface {
 	// FindSimilar returns decision IDs similar to the given embedding within an org.
-	// excludeID is removed from results (the source decision). repo, when non-nil,
-	// restricts results to decisions with the same repo value or no repo.
-	FindSimilar(ctx context.Context, orgID uuid.UUID, embedding []float32, excludeID uuid.UUID, repo *string, limit int) ([]Result, error)
+	// excludeID is removed from results (the source decision). project, when non-nil,
+	// restricts results to decisions with the same project value or no project.
+	FindSimilar(ctx context.Context, orgID uuid.UUID, embedding []float32, excludeID uuid.UUID, project *string, limit int) ([]Result, error)
 }
 
 // ReScore adjusts raw similarity scores with outcome signals, completeness, and recency

--- a/internal/server/handlers_decisions.go
+++ b/internal/server/handlers_decisions.go
@@ -474,7 +474,7 @@ func (h *Handlers) HandleCheck(w http.ResponseWriter, r *http.Request) {
 		DecisionType: req.DecisionType,
 		Query:        req.Query,
 		AgentID:      req.AgentID,
-		Repo:         req.Repo,
+		Project:      req.Project,
 		Limit:        req.Limit,
 	})
 	if err != nil {

--- a/internal/service/decisions/service.go
+++ b/internal/service/decisions/service.go
@@ -328,7 +328,7 @@ type CheckInput struct {
 	DecisionType string
 	Query        string
 	AgentID      string
-	Repo         string
+	Project      string
 	Limit        int
 }
 
@@ -345,8 +345,8 @@ func (s *Service) Check(ctx context.Context, orgID uuid.UUID, input CheckInput) 
 	if input.AgentID != "" {
 		filters.AgentIDs = []string{input.AgentID}
 	}
-	if input.Repo != "" {
-		filters.Repo = &input.Repo
+	if input.Project != "" {
+		filters.Project = &input.Project
 	}
 
 	if input.Query != "" {

--- a/internal/storage/decisions_unit_test.go
+++ b/internal/storage/decisions_unit_test.go
@@ -60,12 +60,12 @@ func TestBuildDecisionWhereClause_ModelFilter(t *testing.T) {
 func TestBuildDecisionWhereClause_RepoFilter(t *testing.T) {
 	orgID := uuid.New()
 	repo := "ashita-ai/akashi"
-	filters := model.QueryFilters{Repo: &repo}
+	filters := model.QueryFilters{Project: &repo}
 
 	where, args := buildDecisionWhereClause(orgID, filters, 1, true)
 
-	// repo is a generated column — filter uses simple equality, not COALESCE.
-	assert.Contains(t, where, "repo = $2")
+	// project is a generated column — filter uses simple equality, not COALESCE.
+	assert.Contains(t, where, "project = $2")
 	assert.NotContains(t, where, "COALESCE")
 	require.Len(t, args, 2)
 	assert.Equal(t, "ashita-ai/akashi", args[1])
@@ -91,13 +91,13 @@ func TestBuildDecisionWhereClause_AllFilters(t *testing.T) {
 		SessionID:     &sessionID,
 		Tool:          &tool,
 		Model:         &mdl,
-		Repo:          &repo,
+		Project:       &repo,
 	}
 
 	where, args := buildDecisionWhereClause(orgID, filters, 1, true)
 
 	// org_id + agent_ids + run_id + decision_type + confidence_min + outcome
-	// + session_id + tool + model + repo = 10 args
+	// + session_id + tool + model + project = 10 args
 	require.Len(t, args, 10)
 
 	// Verify all conditions are present.
@@ -111,7 +111,7 @@ func TestBuildDecisionWhereClause_AllFilters(t *testing.T) {
 	assert.Contains(t, where, "session_id = $7")
 	assert.Contains(t, where, "tool = $8")
 	assert.Contains(t, where, "model = $9")
-	assert.Contains(t, where, "repo = $10")
+	assert.Contains(t, where, "project = $10")
 }
 
 func TestBuildDecisionWhereClause_ArgIndexing(t *testing.T) {

--- a/internal/storage/sessions.go
+++ b/internal/storage/sessions.go
@@ -15,7 +15,7 @@ func (db *DB) GetSessionDecisions(ctx context.Context, orgID, sessionID uuid.UUI
 	rows, err := db.pool.Query(ctx,
 		`SELECT id, run_id, agent_id, org_id, decision_type, outcome, confidence, reasoning,
 		 metadata, completeness_score, precedent_ref, supersedes_id, content_hash,
-		 valid_from, valid_to, transaction_time, created_at, session_id, agent_context, api_key_id, tool, model, repo
+		 valid_from, valid_to, transaction_time, created_at, session_id, agent_context, api_key_id, tool, model, project
 		 FROM decisions
 		 WHERE org_id = $1 AND session_id = $2 AND valid_to IS NULL
 		 ORDER BY valid_from ASC`,

--- a/migrations/052_rename_repo_to_project.sql
+++ b/migrations/052_rename_repo_to_project.sql
@@ -1,0 +1,33 @@
+-- 052: Rename generated column repo → project on decisions.
+--
+-- "repo" was too narrow — the field scopes decisions to a logical project or
+-- application, not necessarily a git repository. LangChain agents, CrewAI crews,
+-- and batch pipelines don't have repos in the traditional sense. "project" is
+-- the correct semantic.
+--
+-- The new generated column prefers agent_context["client"]["project"] and
+-- agent_context["server"]["project"] (new write path), then falls back to the
+-- old "repo" key variants so existing decisions are not lost.
+--
+-- No write-path migration required: the column is computed automatically from
+-- agent_context at INSERT time and backfilled for all existing rows during ALTER.
+
+-- Add the new generated column.
+ALTER TABLE decisions
+  ADD COLUMN IF NOT EXISTS project TEXT GENERATED ALWAYS AS (
+    COALESCE(
+      agent_context->'client'->>'project',
+      agent_context->'server'->>'project',
+      agent_context->>'project',
+      agent_context->'server'->>'repo',
+      agent_context->'client'->>'repo',
+      agent_context->>'repo'
+    )
+  ) STORED;
+
+-- Create the new column index.
+CREATE INDEX IF NOT EXISTS idx_decisions_project ON decisions (project) WHERE project IS NOT NULL;
+
+-- Drop the old column and its index (safe: project column covers all old values).
+DROP INDEX IF EXISTS idx_decisions_repo;
+ALTER TABLE decisions DROP COLUMN IF EXISTS repo;

--- a/migrations/atlas.sum
+++ b/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:ufX1Fx/ItyWi3MB0n0E/YQ3t5I0/FtfDpPW0eeqtanY=
+h1:eiz/MxPuA8PGBxdzCW8Sn80aPutRnzi+GBEBuYX0UeU=
 001_initial.sql h1:uhyGXto+QacAaGYb9ZTGjsBs5chlKi8O0eHz9aCQsrY=
 022_full_text_search.sql h1:9iwtA8MgCzAxDV9YkUBn0CLT9ePSmj3GcPoMGg8TXf0=
 023_fix_outbox_index.sql h1:OtMEFBcMRWej02+ghnBXlPr6BVq+LoA62Id9XUWfDNI=
@@ -30,3 +30,4 @@ h1:ufX1Fx/ItyWi3MB0n0E/YQ3t5I0/FtfDpPW0eeqtanY=
 049_drop_hnsw_indexes.sql h1:X3soDC8e/ThYQrues25Qmme5HacdaZj0/ppvKFsq+mc=
 050_completeness_score.sql h1:1b3WBDX2BO1wLfFvuPaO/myxmVLb8yFmqrc0ZyefzcE=
 051_decision_assessments.sql h1:FmLxZFiedBfMBWdPIZ6gT2ZKLWscQ91XA8aidOZsLJ8=
+052_rename_repo_to_project.sql h1:nM5KnntlNvhqBGdflCVA4dXCAd2Q1n5g6dDxW0La9Ws=

--- a/sdk/go/akashi/types.go
+++ b/sdk/go/akashi/types.go
@@ -147,11 +147,11 @@ type QueryFilters struct {
 	ConfidenceMin *float32 `json:"confidence_min,omitempty"`
 	Outcome       *string  `json:"outcome,omitempty"`
 
-	// Filters for composite agent identity fields (session, tool, model, repo).
+	// Filters for composite agent identity fields (session, tool, model, project).
 	SessionID *string `json:"session_id,omitempty"`
 	Tool      *string `json:"tool,omitempty"`
 	Model     *string `json:"model,omitempty"`
-	Repo      *string `json:"repo,omitempty"`
+	Project   *string `json:"project,omitempty"`
 }
 
 // QueryOptions control ordering and pagination for Client.Query.

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -183,7 +183,7 @@ export interface QueryFilters {
   session_id?: string;
   tool?: string;
   model?: string;
-  repo?: string;
+  project?: string;
 }
 
 /** Request body for creating a run. */

--- a/types.go
+++ b/types.go
@@ -94,7 +94,7 @@ type SearchFilters struct {
 	SessionID     *uuid.UUID
 	Tool          *string
 	Model         *string
-	Repo          *string
+	Project       *string
 }
 
 // SearchResult holds a decision ID and similarity score from a Searcher.

--- a/ui/src/pages/DecisionDetail.tsx
+++ b/ui/src/pages/DecisionDetail.tsx
@@ -182,14 +182,14 @@ function SessionContext({ decision }: { decision: Decision }) {
   const ctx = decision.metadata as Record<string, unknown> | null;
   if (!ctx) return null;
 
-  // Extract agent_context fields (session_id, tool, model, repo)
+  // Extract agent_context fields (session_id, tool, model, project)
   const agentContext = ctx.agent_context as Record<string, unknown> | undefined;
   const sessionId = (ctx.session_id ?? agentContext?.session_id) as string | undefined;
   const tool = agentContext?.tool as string | undefined;
   const model = agentContext?.model as string | undefined;
-  const repo = agentContext?.repo as string | undefined;
+  const project = (ctx.project ?? agentContext?.project ?? agentContext?.repo) as string | undefined;
 
-  if (!sessionId && !tool && !model && !repo) return null;
+  if (!sessionId && !tool && !model && !project) return null;
 
   return (
     <div className="space-y-2">
@@ -214,9 +214,9 @@ function SessionContext({ decision }: { decision: Decision }) {
             {model}
           </Badge>
         )}
-        {repo && (
+        {project && (
           <Badge variant="outline" className="text-xs font-mono">
-            {repo}
+            {project}
           </Badge>
         )}
       </div>


### PR DESCRIPTION
## Summary

- The `repo` field was semantically wrong for non-git contexts (LangChain pipelines, CrewAI crews, batch jobs — these have app/project names, not git repos)
- Renames `repo` → `project` across all 26 files: model, storage, search, conflicts, service, server, MCP tools, SDKs (Go + TypeScript), and UI
- Migration 052 drops the `repo` generated column and adds `project` with a backwards-compatible COALESCE that still reads legacy `repo` keys from `agent_context`, so existing decisions display correctly
- `pointFromDecision` test helper updated to mirror `processUpserts`: reads `d.Project` (from the Postgres generated column) instead of re-parsing `agent_context`
- MCP tool description and server instructions updated with LangChain/CrewAI examples to make the field intent clear

## Test plan

- [x] `go build ./...` — clean
- [x] `go test -race -count=1 ./...` — all packages pass (18 packages, 0 failures)
- [x] `golangci-lint run ./...` — 0 issues
- [x] `atlas migrate validate` — clean
- [x] Backwards-compat: migration 052 COALESCE reads `agent_context->'client'->>'project'`, `agent_context->'server'->>'project'`, `agent_context->>'project'`, then falls back to `server.repo`, `client.repo`, `repo` — existing data is never lost