### PR TITLE
chore: remove dead parameters flagged by unparam

### DIFF
--- a/internal/search/qdrant_test.go
+++ b/internal/search/qdrant_test.go
@@ -170,19 +170,19 @@ func TestBuildQdrantFilter(t *testing.T) {
 
 	t.Run("org_id only", func(t *testing.T) {
 		filters := model.QueryFilters{}
-		conditions := buildFilterConditions(uuid.New(), filters)
+		conditions := buildFilterConditions(filters)
 		assert.Len(t, conditions, 1) // org_id only
 	})
 
 	t.Run("with agent_id", func(t *testing.T) {
 		filters := model.QueryFilters{AgentIDs: []string{"planner"}}
-		conditions := buildFilterConditions(uuid.New(), filters)
+		conditions := buildFilterConditions(filters)
 		assert.Len(t, conditions, 2) // org_id + agent_id
 	})
 
 	t.Run("with multiple agent_ids", func(t *testing.T) {
 		filters := model.QueryFilters{AgentIDs: []string{"planner", "coder"}}
-		conditions := buildFilterConditions(uuid.New(), filters)
+		conditions := buildFilterConditions(filters)
 		assert.Len(t, conditions, 2) // org_id + agent_ids (keywords match)
 	})
 
@@ -193,7 +193,7 @@ func TestBuildQdrantFilter(t *testing.T) {
 			DecisionType:  &decType,
 			ConfidenceMin: &confMin,
 		}
-		conditions := buildFilterConditions(uuid.New(), filters)
+		conditions := buildFilterConditions(filters)
 		assert.Len(t, conditions, 3) // org_id + decision_type + confidence
 	})
 
@@ -203,7 +203,7 @@ func TestBuildQdrantFilter(t *testing.T) {
 		filters := model.QueryFilters{
 			TimeRange: &model.TimeRange{From: &from, To: &to},
 		}
-		conditions := buildFilterConditions(uuid.New(), filters)
+		conditions := buildFilterConditions(filters)
 		assert.Len(t, conditions, 3) // org_id + from + to
 	})
 
@@ -218,7 +218,7 @@ func TestBuildQdrantFilter(t *testing.T) {
 			ConfidenceMin: &confMin,
 			TimeRange:     &model.TimeRange{From: &from, To: &to},
 		}
-		conditions := buildFilterConditions(uuid.New(), filters)
+		conditions := buildFilterConditions(filters)
 		assert.Len(t, conditions, 6) // org_id + agent_id + decision_type + confidence + from + to
 	})
 }
@@ -226,7 +226,7 @@ func TestBuildQdrantFilter(t *testing.T) {
 // buildFilterConditions extracts the filter-building logic for testability.
 // This mirrors the condition-building in QdrantIndex.Search, including the
 // SessionID, Tool, Model, and Repo filters added for composite agent identity.
-func buildFilterConditions(orgID uuid.UUID, filters model.QueryFilters) []string {
+func buildFilterConditions(filters model.QueryFilters) []string {
 	var conditions []string
 	conditions = append(conditions, "org_id")
 
@@ -295,7 +295,7 @@ func TestBuildQdrantFilter_SessionAndContext(t *testing.T) {
 		Project:   &project,
 	}
 
-	conditions := buildFilterConditions(uuid.New(), filters)
+	conditions := buildFilterConditions(filters)
 	// Expect 5 conditions: org_id + session_id + tool + model + project.
 	require.Len(t, conditions, 5)
 	assert.Contains(t, conditions, "org_id")

--- a/internal/server/idempotency.go
+++ b/internal/server/idempotency.go
@@ -95,7 +95,6 @@ func (h *Handlers) beginIdempotentWrite(
 }
 
 func (h *Handlers) completeIdempotentWrite(
-	r *http.Request,
 	orgID uuid.UUID,
 	idem *idempotencyHandle,
 	statusCode int,
@@ -150,7 +149,7 @@ func (h *Handlers) completeIdempotentWriteBestEffort(
 	statusCode int,
 	data any,
 ) {
-	if err := h.completeIdempotentWrite(r, orgID, idem, statusCode, data); err != nil {
+	if err := h.completeIdempotentWrite(orgID, idem, statusCode, data); err != nil {
 		h.logger.Error("failed to finalize idempotency record after committed mutation — clearing key to unblock retries",
 			"error", err,
 			"org_id", orgID,


### PR DESCRIPTION
## Summary

- `completeIdempotentWrite` in `idempotency.go`: dropped unused `r *http.Request` parameter — the function intentionally uses `context.Background()` to decouple finalization from request cancellation, so `r` was never read
- `buildFilterConditions` in `qdrant_test.go`: dropped unused `orgID uuid.UUID` parameter — the helper appends the string `"org_id"` unconditionally regardless of the value, which was misleading readers into thinking the UUID was used for filtering logic

Both were caught by `golangci-lint --enable=unparam`.

## What was not changed

- `quality_score` deprecated alias — still in OpenAPI spec; removing it is a breaking API change
- Six test helper `unparam` findings — parameters designed for forward flexibility, not worth churn

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test -race -count=1 ./...` — all 16 packages pass