### PR TITLE
fix(api): flatten list response envelope (#118)

### DIFF
--- a/internal/model/api.go
+++ b/internal/model/api.go
@@ -102,6 +102,18 @@ type APIResponse struct {
 	Meta ResponseMeta `json:"meta"`
 }
 
+// ListResponse is the standard envelope for paginated list endpoints.
+// The array of items is in Data; Total is omitted when access-filtering
+// makes the DB total unreliable (i.e., some rows were hidden by grants).
+type ListResponse struct {
+	Data    any          `json:"data"`
+	Total   *int         `json:"total,omitempty"`
+	HasMore bool         `json:"has_more"`
+	Limit   int          `json:"limit"`
+	Offset  int          `json:"offset"`
+	Meta    ResponseMeta `json:"meta"`
+}
+
 // APIError is the standard error response envelope.
 type APIError struct {
 	Error ErrorDetail  `json:"error"`

--- a/internal/server/handlers_admin.go
+++ b/internal/server/handlers_admin.go
@@ -156,12 +156,8 @@ func (h *Handlers) HandleListAgents(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp := map[string]any{
-		"total":    total,
-		"limit":    limit,
-		"offset":   offset,
-		"has_more": offset+len(agents) < total,
-	}
+	ptotal := total
+	hasMore := offset+len(agents) < total
 
 	if r.URL.Query().Get("include") == "stats" {
 		statsMap, err := h.db.GetAgentListStats(r.Context(), orgID)
@@ -182,12 +178,10 @@ func (h *Handlers) HandleListAgents(w http.ResponseWriter, r *http.Request) {
 				enriched[i].LastDecisionAt = s.LastDecisionAt
 			}
 		}
-		resp["agents"] = enriched
+		writeListJSON(w, r, enriched, &ptotal, hasMore, limit, offset)
 	} else {
-		resp["agents"] = agents
+		writeListJSON(w, r, agents, &ptotal, hasMore, limit, offset)
 	}
-
-	writeJSON(w, r, http.StatusOK, resp)
 }
 
 // HandleCreateGrant handles POST /v1/grants.
@@ -338,13 +332,8 @@ func (h *Handlers) HandleListGrants(w http.ResponseWriter, r *http.Request) {
 		grants = []model.AccessGrant{}
 	}
 
-	writeJSON(w, r, http.StatusOK, map[string]any{
-		"grants":   grants,
-		"total":    total,
-		"limit":    limit,
-		"offset":   offset,
-		"has_more": offset+len(grants) < total,
-	})
+	ptotal := total
+	writeListJSON(w, r, grants, &ptotal, offset+len(grants) < total, limit, offset)
 }
 
 // HandleGetAgent handles GET /v1/agents/{agent_id} (admin-only).

--- a/sdk/go/akashi/client_test.go
+++ b/sdk/go/akashi/client_test.go
@@ -513,22 +513,22 @@ func TestQueryReturnsDecisions(t *testing.T) {
 				})
 				return
 			}
+			total := 1
 			writeJSON(w, http.StatusOK, map[string]any{
-				"data": QueryResponse{
-					Decisions: []Decision{
-						{
-							ID:           decisionID,
-							RunID:        runID,
-							AgentID:      "planner",
-							DecisionType: dt,
-							Outcome:      "microservices",
-							Confidence:   0.85,
-						},
+				"data": []Decision{
+					{
+						ID:           decisionID,
+						RunID:        runID,
+						AgentID:      "planner",
+						DecisionType: dt,
+						Outcome:      "microservices",
+						Confidence:   0.85,
 					},
-					Total:  1,
-					Limit:  50,
-					Offset: 0,
 				},
+				"total":    total,
+				"has_more": false,
+				"limit":    50,
+				"offset":   0,
 			})
 		},
 	})
@@ -574,23 +574,25 @@ func TestSearchReturnsResults(t *testing.T) {
 			if body["query"] != "architecture decisions" {
 				t.Errorf("expected query 'architecture decisions', got %v", body["query"])
 			}
+			total := 1
 			writeJSON(w, http.StatusOK, map[string]any{
-				"data": SearchResponse{
-					Results: []SearchResult{
-						{
-							Decision: Decision{
-								ID:           decisionID,
-								RunID:        runID,
-								AgentID:      "planner",
-								DecisionType: "architecture",
-								Outcome:      "microservices",
-								Confidence:   0.85,
-							},
-							SimilarityScore: 0.92,
+				"data": []SearchResult{
+					{
+						Decision: Decision{
+							ID:           decisionID,
+							RunID:        runID,
+							AgentID:      "planner",
+							DecisionType: "architecture",
+							Outcome:      "microservices",
+							Confidence:   0.85,
 						},
+						SimilarityScore: 0.92,
 					},
-					Total: 1,
 				},
+				"total":    total,
+				"has_more": false,
+				"limit":    100,
+				"offset":   0,
 			})
 		},
 	})
@@ -624,19 +626,22 @@ func TestRecentReturnsDecisions(t *testing.T) {
 			if r.URL.Query().Get("agent_id") != "planner" {
 				t.Errorf("expected agent_id=planner, got %q", r.URL.Query().Get("agent_id"))
 			}
+			total := 1
 			writeJSON(w, http.StatusOK, map[string]any{
-				"data": map[string]any{
-					"decisions": []Decision{
-						{
-							ID:           decisionID,
-							RunID:        runID,
-							AgentID:      "planner",
-							DecisionType: "routing",
-							Outcome:      "route-a",
-							Confidence:   0.88,
-						},
+				"data": []Decision{
+					{
+						ID:           decisionID,
+						RunID:        runID,
+						AgentID:      "planner",
+						DecisionType: "routing",
+						Outcome:      "route-a",
+						Confidence:   0.88,
 					},
 				},
+				"total":    total,
+				"has_more": false,
+				"limit":    5,
+				"offset":   0,
 			})
 		},
 	})
@@ -1099,23 +1104,22 @@ func TestAgentHistory(t *testing.T) {
 			if r.URL.Query().Get("limit") != "10" {
 				t.Errorf("expected limit=10, got %q", r.URL.Query().Get("limit"))
 			}
+			total := 1
 			writeJSON(w, http.StatusOK, map[string]any{
-				"data": map[string]any{
-					"agent_id": "planner",
-					"decisions": []Decision{
-						{
-							ID:           decisionID,
-							RunID:        runID,
-							AgentID:      "planner",
-							DecisionType: "routing",
-							Outcome:      "route-b",
-							Confidence:   0.75,
-						},
+				"data": []Decision{
+					{
+						ID:           decisionID,
+						RunID:        runID,
+						AgentID:      "planner",
+						DecisionType: "routing",
+						Outcome:      "route-b",
+						Confidence:   0.75,
 					},
-					"total":  1,
-					"limit":  10,
-					"offset": 0,
 				},
+				"total":    total,
+				"has_more": false,
+				"limit":    10,
+				"offset":   0,
 			})
 		},
 	})
@@ -1235,31 +1239,31 @@ func TestListConflicts(t *testing.T) {
 			if r.URL.Query().Get("limit") != "10" {
 				t.Errorf("expected limit=10, got %q", r.URL.Query().Get("limit"))
 			}
+			total := 1
 			writeJSON(w, http.StatusOK, map[string]any{
-				"data": map[string]any{
-					"conflicts": []DecisionConflict{
-						{
-							ConflictKind: ConflictKindCrossAgent,
-							DecisionAID:  uuid.New(),
-							DecisionBID:  uuid.New(),
-							AgentA:       "planner",
-							AgentB:       "coder",
-							RunA:         uuid.New(),
-							RunB:         uuid.New(),
-							DecisionType: "architecture",
-							OutcomeA:     "microservices",
-							OutcomeB:     "monolith",
-							ConfidenceA:  0.85,
-							ConfidenceB:  0.90,
-							DecidedAtA:   now,
-							DecidedAtB:   now,
-							DetectedAt:   now,
-						},
+				"data": []DecisionConflict{
+					{
+						ConflictKind: ConflictKindCrossAgent,
+						DecisionAID:  uuid.New(),
+						DecisionBID:  uuid.New(),
+						AgentA:       "planner",
+						AgentB:       "coder",
+						RunA:         uuid.New(),
+						RunB:         uuid.New(),
+						DecisionType: "architecture",
+						OutcomeA:     "microservices",
+						OutcomeB:     "monolith",
+						ConfidenceA:  0.85,
+						ConfidenceB:  0.90,
+						DecidedAtA:   now,
+						DecidedAtB:   now,
+						DetectedAt:   now,
 					},
-					"total":  1,
-					"limit":  10,
-					"offset": 0,
 				},
+				"total":    total,
+				"has_more": false,
+				"limit":    10,
+				"offset":   0,
 			})
 		},
 	})
@@ -1294,13 +1298,13 @@ func TestListConflictsNilOptions(t *testing.T) {
 			if r.URL.RawQuery != "" {
 				t.Errorf("expected no query params, got %q", r.URL.RawQuery)
 			}
+			total := 0
 			writeJSON(w, http.StatusOK, map[string]any{
-				"data": map[string]any{
-					"conflicts": []DecisionConflict{},
-					"total":     0,
-					"limit":     25,
-					"offset":    0,
-				},
+				"data":     []DecisionConflict{},
+				"total":    total,
+				"has_more": false,
+				"limit":    25,
+				"offset":   0,
 			})
 		},
 	})
@@ -1677,33 +1681,32 @@ func TestDecisionDeserializesAllFields(t *testing.T) {
 
 	srv := mockServer(t, map[string]http.HandlerFunc{
 		"POST /v1/query": func(w http.ResponseWriter, r *http.Request) {
+			total := 1
 			writeJSON(w, http.StatusOK, map[string]any{
-				"data": map[string]any{
-					"decisions": []map[string]any{
-						{
-							"id":               decisionID,
-							"run_id":            runID,
-							"agent_id":          "planner",
-							"org_id":            orgID,
-							"decision_type":     "architecture",
-							"outcome":           "microservices",
-							"confidence":        0.85,
-							"metadata":          map[string]any{},
-							"completeness_score": 0.92,
-							"precedent_ref":     precedentRef,
-							"supersedes_id":     supersedesID,
-							"content_hash":      "sha256:abc123def456",
-							"tags":              []string{"backend", "infra"},
-							"valid_from":        now,
-							"transaction_time":  now,
-							"created_at":        now,
-						},
+				"data": []map[string]any{
+					{
+						"id":                decisionID,
+						"run_id":             runID,
+						"agent_id":           "planner",
+						"org_id":             orgID,
+						"decision_type":      "architecture",
+						"outcome":            "microservices",
+						"confidence":         0.85,
+						"metadata":           map[string]any{},
+						"completeness_score": 0.92,
+						"precedent_ref":      precedentRef,
+						"supersedes_id":      supersedesID,
+						"content_hash":       "sha256:abc123def456",
+						"tags":               []string{"backend", "infra"},
+						"valid_from":         now,
+						"transaction_time":   now,
+						"created_at":         now,
 					},
-					"total":  1,
-					"count":  1,
-					"limit":  50,
-					"offset": 0,
 				},
+				"total":    total,
+				"has_more": false,
+				"limit":    50,
+				"offset":   0,
 			})
 		},
 	})
@@ -1716,8 +1719,8 @@ func TestDecisionDeserializesAllFields(t *testing.T) {
 		t.Fatalf("Query failed: %v", err)
 	}
 
-	if resp.Count != 1 {
-		t.Errorf("expected count 1, got %d", resp.Count)
+	if resp.Total != 1 {
+		t.Errorf("expected total 1, got %d", resp.Total)
 	}
 
 	d := resp.Decisions[0]
@@ -1746,35 +1749,34 @@ func TestDecisionDeserializesSpec31Fields(t *testing.T) {
 
 	srv := mockServer(t, map[string]http.HandlerFunc{
 		"POST /v1/query": func(w http.ResponseWriter, r *http.Request) {
+			total := 1
 			writeJSON(w, http.StatusOK, map[string]any{
-				"data": map[string]any{
-					"decisions": []map[string]any{
-						{
-							"id":            uuid.New(),
-							"run_id":        uuid.New(),
-							"agent_id":      "coder",
-							"org_id":        uuid.New(),
-							"decision_type": "architecture",
-							"outcome":       "microservices",
-							"confidence":    0.85,
-							"metadata":      map[string]any{},
-							"session_id":    sessionID,
-							"agent_context": map[string]any{
-								"tool":         "claude-code",
-								"tool_version": "akashi-go/0.2.0",
-								"model":        "claude-opus-4-6",
-								"task":         "code review",
-							},
-							"valid_from":       time.Now(),
-							"transaction_time": time.Now(),
-							"created_at":       time.Now(),
+				"data": []map[string]any{
+					{
+						"id":            uuid.New(),
+						"run_id":        uuid.New(),
+						"agent_id":      "coder",
+						"org_id":        uuid.New(),
+						"decision_type": "architecture",
+						"outcome":       "microservices",
+						"confidence":    0.85,
+						"metadata":      map[string]any{},
+						"session_id":    sessionID,
+						"agent_context": map[string]any{
+							"tool":         "claude-code",
+							"tool_version": "akashi-go/0.2.0",
+							"model":        "claude-opus-4-6",
+							"task":         "code review",
 						},
+						"valid_from":       time.Now(),
+						"transaction_time": time.Now(),
+						"created_at":       time.Now(),
 					},
-					"total":  1,
-					"count":  1,
-					"limit":  50,
-					"offset": 0,
 				},
+				"total":    total,
+				"has_more": false,
+				"limit":    50,
+				"offset":   0,
 			})
 		},
 	})

--- a/sdk/go/akashi/types.go
+++ b/sdk/go/akashi/types.go
@@ -182,7 +182,7 @@ type TraceResponse struct {
 type QueryResponse struct {
 	Decisions []Decision `json:"decisions"`
 	Total     int        `json:"total"`
-	Count     int        `json:"count"`
+	HasMore   bool       `json:"has_more"`
 	Limit     int        `json:"limit"`
 	Offset    int        `json:"offset"`
 }
@@ -385,6 +385,7 @@ type AgentHistoryResponse struct {
 	AgentID   string     `json:"agent_id"`
 	Decisions []Decision `json:"decisions"`
 	Total     int        `json:"total"`
+	HasMore   bool       `json:"has_more"`
 	Limit     int        `json:"limit"`
 	Offset    int        `json:"offset"`
 }
@@ -399,6 +400,7 @@ type DeleteAgentResponse struct {
 type ConflictsResponse struct {
 	Conflicts []DecisionConflict `json:"conflicts"`
 	Total     int                `json:"total"`
+	HasMore   bool               `json:"has_more"`
 	Limit     int                `json:"limit"`
 	Offset    int                `json:"offset"`
 }

--- a/sdk/python/src/akashi/types.py
+++ b/sdk/python/src/akashi/types.py
@@ -293,10 +293,10 @@ class CheckResponse(BaseModel):
 class QueryResponse(BaseModel):
     """Response from a structured query."""
 
-    decisions: list[Decision]
-    total: int
-    count: int = 0
-    limit: int
+    decisions: list[Decision] = Field(default_factory=list)
+    total: int = 0
+    has_more: bool = False
+    limit: int = 0
     offset: int = 0
 
 

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -389,12 +389,11 @@ class TestQuery:
         respx.post(f"{BASE_URL}/v1/query").respond(
             200,
             json={
-                "data": {
-                    "decisions": [_decision_json()],
-                    "total": 1,
-                    "limit": 50,
-                    "offset": 0,
-                }
+                "data": [_decision_json()],
+                "total": 1,
+                "has_more": False,
+                "limit": 50,
+                "offset": 0,
             },
         )
 
@@ -412,12 +411,11 @@ class TestQuery:
         respx.post(f"{BASE_URL}/v1/query").respond(
             200,
             json={
-                "data": {
-                    "decisions": [],
-                    "total": 0,
-                    "limit": 10,
-                    "offset": 0,
-                }
+                "data": [],
+                "total": 0,
+                "has_more": False,
+                "limit": 10,
+                "offset": 0,
             },
         )
 
@@ -439,15 +437,16 @@ class TestSearch:
         respx.post(f"{BASE_URL}/v1/search").respond(
             200,
             json={
-                "data": {
-                    "results": [
-                        {
-                            "decision": _decision_json(),
-                            "similarity_score": 0.92,
-                        }
-                    ],
-                    "total": 1,
-                }
+                "data": [
+                    {
+                        "decision": _decision_json(),
+                        "similarity_score": 0.92,
+                    }
+                ],
+                "total": 1,
+                "has_more": False,
+                "limit": 1,
+                "offset": 0,
             },
         )
 
@@ -466,12 +465,11 @@ class TestRecent:
         respx.get(f"{BASE_URL}/v1/decisions/recent").respond(
             200,
             json={
-                "data": {
-                    "decisions": [_decision_json()],
-                    "total": 1,
-                    "count": 1,
-                    "limit": 10,
-                }
+                "data": [_decision_json()],
+                "total": 1,
+                "has_more": False,
+                "limit": 10,
+                "offset": 0,
             },
         )
 
@@ -644,13 +642,11 @@ class TestAgentHistory:
         respx.get(f"{BASE_URL}/v1/agents/coder/history").respond(
             200,
             json={
-                "data": {
-                    "agent_id": "coder",
-                    "decisions": [_decision_json()],
-                    "total": 1,
-                    "limit": 50,
-                    "offset": 0,
-                }
+                "data": [_decision_json()],
+                "total": 1,
+                "has_more": False,
+                "limit": 50,
+                "offset": 0,
             },
         )
 
@@ -699,12 +695,11 @@ class TestListConflicts:
         respx.get(f"{BASE_URL}/v1/conflicts").respond(
             200,
             json={
-                "data": {
-                    "conflicts": [_conflict_json()],
-                    "total": 1,
-                    "limit": 25,
-                    "offset": 0,
-                }
+                "data": [_conflict_json()],
+                "total": 1,
+                "has_more": False,
+                "limit": 25,
+                "offset": 0,
             },
         )
 
@@ -802,22 +797,21 @@ class TestDecisionSpec31Fields:
         respx.post(f"{BASE_URL}/v1/query").respond(
             200,
             json={
-                "data": {
-                    "decisions": [
-                        {
-                            **_decision_json(),
-                            "session_id": session_id,
-                            "agent_context": {
-                                "tool": "claude-code",
-                                "tool_version": "akashi-python/0.2.0",
-                                "model": "claude-opus-4-6",
-                            },
-                        }
-                    ],
-                    "total": 1,
-                    "limit": 50,
-                    "offset": 0,
-                }
+                "data": [
+                    {
+                        **_decision_json(),
+                        "session_id": session_id,
+                        "agent_context": {
+                            "tool": "claude-code",
+                            "tool_version": "akashi-python/0.2.0",
+                            "model": "claude-opus-4-6",
+                        },
+                    }
+                ],
+                "total": 1,
+                "has_more": False,
+                "limit": 50,
+                "offset": 0,
             },
         )
 

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -241,7 +241,7 @@ export interface CheckResponse {
 export interface QueryResponse {
   decisions: Decision[];
   total: number;
-  count: number;
+  has_more: boolean;
   limit: number;
   offset: number;
 }
@@ -254,6 +254,9 @@ export interface SearchResult {
 export interface SearchResponse {
   results: SearchResult[];
   total: number;
+  has_more: boolean;
+  limit: number;
+  offset: number;
 }
 
 /** Result type that can be converted to a trace request. */

--- a/sdk/typescript/tests/client.test.ts
+++ b/sdk/typescript/tests/client.test.ts
@@ -365,7 +365,7 @@ describe("AkashiClient", () => {
         },
       ];
       mockFetch.mockResolvedValueOnce(
-        mockResponse(200, { data: { decisions, total: 1 } }),
+        mockResponse(200, { data: decisions, total: 1, has_more: false, limit: 20, offset: 10 }),
       );
 
       const result = await client.query(
@@ -385,7 +385,7 @@ describe("AkashiClient", () => {
 
     it("uses defaults for optional parameters", async () => {
       mockFetch.mockResolvedValueOnce(
-        mockResponse(200, { data: { decisions: [], total: 0 } }),
+        mockResponse(200, { data: [], total: 0, has_more: false, limit: 50, offset: 0 }),
       );
 
       await client.query();
@@ -400,9 +400,7 @@ describe("AkashiClient", () => {
 
     it("sends correct wire format for query body", async () => {
       mockFetch.mockResolvedValueOnce(
-        mockResponse(200, {
-          data: { decisions: [], total: 0, limit: 50, offset: 0 },
-        }),
+        mockResponse(200, { data: [], total: 0, has_more: false, limit: 50, offset: 0 }),
       );
 
       await client.query(
@@ -440,7 +438,7 @@ describe("AkashiClient", () => {
         },
       ];
       mockFetch.mockResolvedValueOnce(
-        mockResponse(200, { data: { results } }),
+        mockResponse(200, { data: results, total: 1, has_more: false, limit: 10, offset: 0 }),
       );
 
       const response = await client.search("which model for text tasks", 10, true);
@@ -456,7 +454,7 @@ describe("AkashiClient", () => {
 
     it("sends correct wire format for search body", async () => {
       mockFetch.mockResolvedValueOnce(
-        mockResponse(200, { data: { results: [], total: 0 } }),
+        mockResponse(200, { data: [], total: 0, has_more: false, limit: 5, offset: 0 }),
       );
 
       await client.search("find decisions about storage");
@@ -491,7 +489,7 @@ describe("AkashiClient", () => {
         },
       ];
       mockFetch.mockResolvedValueOnce(
-        mockResponse(200, { data: { decisions } }),
+        mockResponse(200, { data: decisions, total: 1, has_more: false, limit: 5, offset: 0 }),
       );
 
       const result = await client.recent({
@@ -513,7 +511,7 @@ describe("AkashiClient", () => {
 
     it("uses default limit when no options provided", async () => {
       mockFetch.mockResolvedValueOnce(
-        mockResponse(200, { data: { decisions: [] } }),
+        mockResponse(200, { data: [], total: 0, has_more: false, limit: 10, offset: 0 }),
       );
 
       await client.recent();


### PR DESCRIPTION
## Summary

Fixes #118 — API response envelope inconsistency across list endpoints.

- **Before:** items buried under a named key: `{"data": {"decisions": [...], "total": N}}`
- **After:** data IS the items array, pagination at top level: `{"data": [...], "total": N, "has_more": bool, "limit": N, "offset": N}`

Affected endpoints: `/v1/query`, `/v1/decisions/recent`, `/v1/search`, `/v1/agents/{id}/history`, `/v1/conflicts`, `/v1/decisions/{id}/conflicts`, `/v1/agents`, `/v1/grants`

`total` is `*int` (omitempty) when access filtering makes the DB count unreliable — nil signals the caller that an exact count isn't available.

## Changes

- **Server:** `writeListJSON` + `computePagination` helpers replacing `applyPaginationMeta`
- **Go SDK:** `listEnvelope` type + `doGetList`/`doPostList` methods; updated `Query`, `Search`, `Recent`, `AgentHistory`, `ListConflicts`
- **Python SDK:** `_handle_list_body` + `_get_list`/`_post_list` methods; same methods updated
- **TypeScript SDK:** `ListEnvelope` interface + `postList`/`getList` methods; same methods updated
- All SDK tests and server integration tests updated

## Test plan

- [x] `go test -race ./...` — all packages pass
- [x] Python SDK: 38 tests pass
- [x] TypeScript SDK: 59 tests pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] `atlas migrate validate` — clean