### PR TITLE
fix(assess): 5 bugs in assessment and conflict clearing

### DIFF
--- a/internal/conflicts/scorer.go
+++ b/internal/conflicts/scorer.go
@@ -551,12 +551,19 @@ func (s *Scorer) Validator() Validator {
 // Returns the number of rows deleted.
 // SECURITY: Intentionally global — one-time startup migration that clears stale
 // conflicts across all orgs when transitioning to LLM validation.
+// Only open/acknowledged conflicts are removed; resolved and wont_fix conflicts
+// represent explicit human decisions and are preserved.
 func (s *Scorer) ClearUnvalidatedConflicts(ctx context.Context) (int, error) {
-	tag, err := s.db.Pool().Exec(ctx, `DELETE FROM scored_conflicts WHERE scoring_method NOT IN ('llm_v2')`)
+	tag, err := s.db.Pool().Exec(ctx,
+		`DELETE FROM scored_conflicts
+		 WHERE scoring_method NOT IN ('llm_v2')
+		   AND status IN ('open', 'acknowledged')`)
 	if err != nil {
 		return 0, fmt.Errorf("conflicts: clear unvalidated: %w", err)
 	}
-	return int(tag.RowsAffected()), nil
+	n := int(tag.RowsAffected())
+	s.logger.Warn("startup: cleared unvalidated conflicts", "deleted", n, "reason", "scoring_method_migration_to_llm_v2")
+	return n, nil
 }
 
 func cosineSimilarity(a, b []float32) float64 {
@@ -576,17 +583,22 @@ func cosineSimilarity(a, b []float32) float64 {
 	return dot / (math.Sqrt(normA) * math.Sqrt(normB))
 }
 
-// ClearAllConflicts deletes all scored_conflicts regardless of scoring method.
-// Used after prompt improvements to force re-evaluation of all decision pairs.
+// ClearAllConflicts deletes open and acknowledged scored_conflicts regardless
+// of scoring method, forcing re-evaluation of all pending decision pairs.
+// Conflicts with status 'resolved' or 'wont_fix' represent explicit human
+// decisions and are preserved — they are never wiped by this operation.
 // Returns the number of rows deleted.
-// SECURITY: Intentionally global — one-time startup operation that clears
-// conflicts across all orgs when the conflict prompt is improved.
+// SECURITY: Intentionally global — one-time startup operation across all orgs.
+// Set AKASHI_FORCE_CONFLICT_RESCORE=true to trigger.
 func (s *Scorer) ClearAllConflicts(ctx context.Context) (int, error) {
-	tag, err := s.db.Pool().Exec(ctx, `DELETE FROM scored_conflicts`)
+	tag, err := s.db.Pool().Exec(ctx,
+		`DELETE FROM scored_conflicts WHERE status IN ('open', 'acknowledged')`)
 	if err != nil {
 		return 0, fmt.Errorf("conflicts: clear all: %w", err)
 	}
-	return int(tag.RowsAffected()), nil
+	n := int(tag.RowsAffected())
+	s.logger.Warn("startup: cleared all open/acknowledged conflicts", "deleted", n, "reason", "AKASHI_FORCE_CONFLICT_RESCORE")
+	return n, nil
 }
 
 func derefString(s *string) string {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -433,7 +433,7 @@ func (s *Server) handleCheck(ctx context.Context, request mcplib.CallToolRequest
 			}
 		}
 		// Assessment summaries: explicit correctness feedback. Non-fatal on error.
-		if assessments, aErr := s.db.GetAssessmentSummaryBatch(ctx, ids); aErr == nil {
+		if assessments, aErr := s.db.GetAssessmentSummaryBatch(ctx, orgID, ids); aErr == nil {
 			for i := range resp.Decisions {
 				if sum, ok := assessments[resp.Decisions[i].ID]; ok {
 					cp := sum

--- a/internal/server/handlers_decisions.go
+++ b/internal/server/handlers_decisions.go
@@ -252,7 +252,7 @@ func (h *Handlers) HandleGetDecision(w http.ResponseWriter, r *http.Request) {
 		d.ConflictFate = signals.ConflictFate
 	}
 
-	summary, err := h.db.GetAssessmentSummary(r.Context(), d.ID)
+	summary, err := h.db.GetAssessmentSummary(r.Context(), orgID, d.ID)
 	if err == nil {
 		d.AssessmentSummary = &summary
 	}
@@ -1018,9 +1018,11 @@ func (h *Handlers) HandleDecisionConflicts(w http.ResponseWriter, r *http.Reques
 }
 
 // HandleAssessDecision handles POST /v1/decisions/{id}/assess (writer+).
-// Creates or updates the caller's outcome assessment for a decision.
-// An assessor may only hold one assessment per decision; re-submitting
-// overwrites the previous outcome and notes.
+// Records an outcome assessment for a decision. Assessments are append-only:
+// each call creates a new row. An assessor changing their verdict over time
+// is itself an auditable event — prior assessments are never overwritten.
+// GetAssessmentSummary uses DISTINCT ON to count only each assessor's latest
+// verdict when computing summary statistics.
 func (h *Handlers) HandleAssessDecision(w http.ResponseWriter, r *http.Request) {
 	claims := ClaimsFromContext(r.Context())
 	orgID := OrgIDFromContext(r.Context())
@@ -1064,6 +1066,9 @@ func (h *Handlers) HandleAssessDecision(w http.ResponseWriter, r *http.Request) 
 		h.writeInternalError(w, r, "failed to save assessment", err)
 		return
 	}
+
+	_ = h.db.Notify(r.Context(), storage.ChannelDecisions,
+		`{"source":"assess","decision_id":"`+decisionID.String()+`","org_id":"`+orgID.String()+`"}`)
 
 	writeJSON(w, r, http.StatusOK, result)
 }
@@ -1111,7 +1116,7 @@ func (h *Handlers) HandleListAssessments(w http.ResponseWriter, r *http.Request)
 		assessments = []model.DecisionAssessment{}
 	}
 
-	summary, err := h.db.GetAssessmentSummary(r.Context(), decisionID)
+	summary, err := h.db.GetAssessmentSummary(r.Context(), orgID, decisionID)
 	if err != nil {
 		h.writeInternalError(w, r, "failed to get assessment summary", err)
 		return

--- a/internal/service/decisions/service.go
+++ b/internal/service/decisions/service.go
@@ -493,7 +493,7 @@ func (s *Service) hydrateAndReScore(ctx context.Context, orgID uuid.UUID, result
 
 	// Enrich with assessment summaries for ReScore (explicit correctness signal).
 	// Non-fatal: a missing batch is just treated as no assessments.
-	assessments, aErr := s.db.GetAssessmentSummaryBatch(ctx, ids)
+	assessments, aErr := s.db.GetAssessmentSummaryBatch(ctx, orgID, ids)
 	if aErr != nil {
 		s.logger.Warn("search: assessment summaries batch", "error", aErr)
 	} else {

--- a/internal/storage/assessments.go
+++ b/internal/storage/assessments.go
@@ -64,9 +64,9 @@ func (db *DB) ListAssessments(ctx context.Context, orgID, decisionID uuid.UUID) 
 	rows, err := db.pool.Query(ctx, `
 		SELECT id, decision_id, org_id, assessor_agent_id, outcome, notes, created_at
 		FROM decision_assessments
-		WHERE decision_id = $1
+		WHERE decision_id = $1 AND org_id = $2
 		ORDER BY created_at DESC`,
-		decisionID,
+		decisionID, orgID,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("storage: list assessments: query: %w", err)
@@ -96,18 +96,18 @@ func (db *DB) ListAssessments(ctx context.Context, orgID, decisionID uuid.UUID) 
 // counts as one "incorrect" in the summary; the history is preserved in
 // ListAssessments but does not skew the current-state count.
 // Returns a zero-value summary (all counts 0) if no assessments exist.
-func (db *DB) GetAssessmentSummary(ctx context.Context, decisionID uuid.UUID) (model.AssessmentSummary, error) {
+func (db *DB) GetAssessmentSummary(ctx context.Context, orgID, decisionID uuid.UUID) (model.AssessmentSummary, error) {
 	rows, err := db.pool.Query(ctx, `
 		SELECT outcome, COUNT(*)
 		FROM (
 			SELECT DISTINCT ON (assessor_agent_id)
 				outcome
 			FROM decision_assessments
-			WHERE decision_id = $1
+			WHERE decision_id = $1 AND org_id = $2
 			ORDER BY assessor_agent_id, created_at DESC
 		) latest
 		GROUP BY outcome`,
-		decisionID,
+		decisionID, orgID,
 	)
 	if err != nil {
 		return model.AssessmentSummary{}, fmt.Errorf("storage: assessment summary: %w", err)
@@ -136,7 +136,7 @@ func (db *DB) GetAssessmentSummary(ctx context.Context, decisionID uuid.UUID) (m
 
 // GetAssessmentSummaryBatch returns latest-per-assessor outcome counts for
 // multiple decisions. Decisions with no assessments are omitted from the map.
-func (db *DB) GetAssessmentSummaryBatch(ctx context.Context, decisionIDs []uuid.UUID) (map[uuid.UUID]model.AssessmentSummary, error) {
+func (db *DB) GetAssessmentSummaryBatch(ctx context.Context, orgID uuid.UUID, decisionIDs []uuid.UUID) (map[uuid.UUID]model.AssessmentSummary, error) {
 	if len(decisionIDs) == 0 {
 		return nil, nil
 	}
@@ -146,11 +146,11 @@ func (db *DB) GetAssessmentSummaryBatch(ctx context.Context, decisionIDs []uuid.
 			SELECT DISTINCT ON (decision_id, assessor_agent_id)
 				decision_id, outcome
 			FROM decision_assessments
-			WHERE decision_id = ANY($1)
+			WHERE decision_id = ANY($1) AND org_id = $2
 			ORDER BY decision_id, assessor_agent_id, created_at DESC
 		) latest
 		GROUP BY decision_id, outcome`,
-		decisionIDs,
+		decisionIDs, orgID,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("storage: assessment summary batch: %w", err)

--- a/internal/storage/delete.go
+++ b/internal/storage/delete.go
@@ -182,6 +182,23 @@ func (db *DB) DeleteAgentData(ctx context.Context, orgID uuid.UUID, agentID stri
 	}
 	result.Claims = tag.RowsAffected()
 
+	// 4c. Archive decision_assessments BEFORE deleting decisions.
+	// decision_assessments.decision_id has ON DELETE CASCADE, so assessments
+	// silently vanish when decisions are deleted. Archive them first so the
+	// assessment history remains recoverable from deletion_audit_log.
+	_, err = tx.Exec(ctx,
+		`INSERT INTO deletion_audit_log (org_id, agent_id, table_name, record_id, record_data)
+		 SELECT $1, $2, 'decision_assessments', da.id::text, to_jsonb(da)
+		 FROM decision_assessments da
+		 WHERE da.decision_id IN (
+		     SELECT id FROM decisions WHERE org_id = $1 AND agent_id = $2
+		 )`,
+		orgID, agentID,
+	)
+	if err != nil {
+		return DeleteAgentResult{}, fmt.Errorf("storage: archive assessments for delete: %w", err)
+	}
+
 	// 5. Delete decisions.
 	_, err = tx.Exec(ctx,
 		`INSERT INTO deletion_audit_log (org_id, agent_id, table_name, record_id, record_data)


### PR DESCRIPTION
## Summary

Fixes five bugs in the assessment subsystem, priority-ordered P0 → P2.

- **#271 (P0 — data loss)** `decision_assessments` not archived before `CASCADE DELETE` in `DeleteAgentData`. On a GDPR erasure, assessment rows silently vanished. Now archived to `deletion_audit_log` before the decision delete fires.
- **#272 (P1 — unaudited global delete)** `ClearAllConflicts` and `ClearUnvalidatedConflicts` ran with no audit trail and wiped human-adjudicated (`resolved`/`wont_fix`) conflicts. Both now scope deletes to `status IN ('open', 'acknowledged')` and emit a structured WARN log on every invocation.
- **#273 (P1 — wrong comment)** `HandleAssessDecision` comment said "overwrites" but storage is append-only. Corrected to match the actual `CreateAssessment` semantics.
- **#274 (P2 — missing org scoping)** `GetAssessmentSummary` and `GetAssessmentSummaryBatch` had no `org_id` parameter. Signatures updated; all four call sites updated (two handlers, MCP tools, service layer).
- **#275 (P2 — missing SSE event)** `HandleAssessDecision` sent no `pg_notify` after recording an assessment. Added notify on `akashi_decisions` channel, matching the pattern used in `HandlePatchConflict`.

## Test plan

- [ ] All tests pass: `go test -race -count=1 ./...`
- [ ] Lint clean: `golangci-lint run ./...`
- [ ] `DeleteAgentData` with an agent that has assessments → `deletion_audit_log` contains `decision_assessments` rows
- [ ] `AKASHI_FORCE_CONFLICT_RESCORE=true` restart → resolved/wont_fix conflicts survive; WARN log emitted
- [ ] `POST /v1/decisions/{id}/assess` → SSE subscribers receive a `akashi_decisions` notification

Closes #271, #272, #273, #274, #275