### PR TITLE
sdk: add assess() + list_assessments() to all SDKs; normalize decision_type

### DIFF
--- a/sdk/go/akashi/client.go
+++ b/sdk/go/akashi/client.go
@@ -363,6 +363,32 @@ func (c *Client) VerifyDecision(ctx context.Context, decisionID uuid.UUID) (*Ver
 }
 
 // ---------------------------------------------------------------------------
+// Assessments
+// ---------------------------------------------------------------------------
+
+// Assess records an outcome assessment for a prior decision.
+// Assessments are append-only — each call creates a new row. An assessor
+// changing their verdict over time is itself an auditable event; prior
+// assessments are never overwritten.
+func (c *Client) Assess(ctx context.Context, decisionID uuid.UUID, req AssessRequest) (*AssessResponse, error) {
+	var resp AssessResponse
+	if err := c.post(ctx, "/v1/decisions/"+decisionID.String()+"/assess", req, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// ListAssessments returns the full assessment history for a decision, newest first.
+// Multiple rows from the same assessor reflect verdict changes over time.
+func (c *Client) ListAssessments(ctx context.Context, decisionID uuid.UUID) ([]AssessResponse, error) {
+	var items []AssessResponse
+	if _, err := c.doGetList(ctx, "/v1/decisions/"+decisionID.String()+"/assessments", &items); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+// ---------------------------------------------------------------------------
 // Agent tags
 // ---------------------------------------------------------------------------
 
@@ -460,7 +486,7 @@ func buildTraceBody(agentID string, req TraceRequest) traceBody {
 	return traceBody{
 		AgentID: agentID,
 		Decision: traceDecision{
-			DecisionType: req.DecisionType,
+			DecisionType: strings.ToLower(strings.TrimSpace(req.DecisionType)),
 			Outcome:      req.Outcome,
 			Confidence:   req.Confidence,
 			Reasoning:    req.Reasoning,

--- a/sdk/go/akashi/client_test.go
+++ b/sdk/go/akashi/client_test.go
@@ -1803,3 +1803,186 @@ func TestDecisionDeserializesSpec31Fields(t *testing.T) {
 		t.Errorf("expected agent_context.model 'claude-opus-4-6', got %v", d.AgentContext["model"])
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Assessments (spec 29)
+// ---------------------------------------------------------------------------
+
+func TestAssess(t *testing.T) {
+	decisionID := uuid.New()
+	assessmentID := uuid.New()
+	orgID := uuid.New()
+	now := time.Now().UTC().Truncate(time.Second)
+
+	var receivedBody map[string]any
+	srv := mockServer(t, map[string]http.HandlerFunc{
+		"POST /v1/decisions/" + decisionID.String() + "/assess": func(w http.ResponseWriter, r *http.Request) {
+			if err := json.NewDecoder(r.Body).Decode(&receivedBody); err != nil {
+				writeJSON(w, http.StatusBadRequest, map[string]any{
+					"error": map[string]any{"code": "INVALID_INPUT", "message": err.Error()},
+				})
+				return
+			}
+			writeJSON(w, http.StatusCreated, map[string]any{
+				"data": map[string]any{
+					"id":                assessmentID,
+					"decision_id":       decisionID,
+					"org_id":            orgID,
+					"assessor_agent_id": "test-agent",
+					"outcome":           "correct",
+					"notes":             "all tests passed",
+					"created_at":        now,
+				},
+			})
+		},
+	})
+	defer srv.Close()
+
+	client := newTestClient(t, srv.URL)
+	resp, err := client.Assess(context.Background(), decisionID, AssessRequest{
+		Outcome: AssessCorrect,
+		Notes:   "all tests passed",
+	})
+	if err != nil {
+		t.Fatalf("Assess failed: %v", err)
+	}
+	if resp.ID != assessmentID {
+		t.Errorf("expected id %s, got %s", assessmentID, resp.ID)
+	}
+	if resp.DecisionID != decisionID {
+		t.Errorf("expected decision_id %s, got %s", decisionID, resp.DecisionID)
+	}
+	if resp.Outcome != AssessCorrect {
+		t.Errorf("expected outcome %q, got %q", AssessCorrect, resp.Outcome)
+	}
+	if resp.Notes != "all tests passed" {
+		t.Errorf("expected notes %q, got %q", "all tests passed", resp.Notes)
+	}
+	if resp.AssessorAgentID != "test-agent" {
+		t.Errorf("expected assessor_agent_id %q, got %q", "test-agent", resp.AssessorAgentID)
+	}
+
+	// Verify request body.
+	if outcome, ok := receivedBody["outcome"].(string); !ok || outcome != "correct" {
+		t.Errorf("expected request body outcome 'correct', got %v", receivedBody["outcome"])
+	}
+	if notes, ok := receivedBody["notes"].(string); !ok || notes != "all tests passed" {
+		t.Errorf("expected request body notes 'all tests passed', got %v", receivedBody["notes"])
+	}
+}
+
+func TestListAssessments(t *testing.T) {
+	decisionID := uuid.New()
+	orgID := uuid.New()
+	now := time.Now().UTC().Truncate(time.Second)
+
+	srv := mockServer(t, map[string]http.HandlerFunc{
+		"GET /v1/decisions/" + decisionID.String() + "/assessments": func(w http.ResponseWriter, r *http.Request) {
+			writeJSON(w, http.StatusOK, map[string]any{
+				"data": []map[string]any{
+					{
+						"id":                uuid.New(),
+						"decision_id":       decisionID,
+						"org_id":            orgID,
+						"assessor_agent_id": "reviewer",
+						"outcome":           "partially_correct",
+						"notes":             "needs more evidence",
+						"created_at":        now,
+					},
+					{
+						"id":                uuid.New(),
+						"decision_id":       decisionID,
+						"org_id":            orgID,
+						"assessor_agent_id": "reviewer",
+						"outcome":           "correct",
+						"notes":             "updated after review",
+						"created_at":        now.Add(-time.Hour),
+					},
+				},
+				"total":    2,
+				"has_more": false,
+				"limit":    50,
+				"offset":   0,
+			})
+		},
+	})
+	defer srv.Close()
+
+	client := newTestClient(t, srv.URL)
+	items, err := client.ListAssessments(context.Background(), decisionID)
+	if err != nil {
+		t.Fatalf("ListAssessments failed: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("expected 2 assessments, got %d", len(items))
+	}
+	if items[0].Outcome != AssessPartiallyCorrect {
+		t.Errorf("expected first outcome %q, got %q", AssessPartiallyCorrect, items[0].Outcome)
+	}
+	if items[0].AssessorAgentID != "reviewer" {
+		t.Errorf("expected assessor_agent_id 'reviewer', got %q", items[0].AssessorAgentID)
+	}
+	if items[1].Outcome != AssessCorrect {
+		t.Errorf("expected second outcome %q, got %q", AssessCorrect, items[1].Outcome)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// decision_type normalization (issue #254)
+// ---------------------------------------------------------------------------
+
+func TestTraceNormalizesDecisionType(t *testing.T) {
+	var receivedBody map[string]any
+
+	srv := mockServer(t, map[string]http.HandlerFunc{
+		"POST /v1/trace": func(w http.ResponseWriter, r *http.Request) {
+			if err := json.NewDecoder(r.Body).Decode(&receivedBody); err != nil {
+				writeJSON(w, http.StatusBadRequest, map[string]any{
+					"error": map[string]any{"code": "INVALID_INPUT", "message": err.Error()},
+				})
+				return
+			}
+			writeJSON(w, http.StatusOK, map[string]any{
+				"data": map[string]any{
+					"run_id":      uuid.New(),
+					"decision_id": uuid.New(),
+					"event_count": 1,
+				},
+			})
+		},
+	})
+	defer srv.Close()
+
+	client := newTestClient(t, srv.URL)
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"Architecture", "architecture"},
+		{"  SECURITY  ", "security"},
+		{"Code_Review", "code_review"},
+		{"trade_off", "trade_off"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			receivedBody = nil
+			_, err := client.Trace(context.Background(), TraceRequest{
+				DecisionType: tc.input,
+				Outcome:      "chose option A",
+				Confidence:   0.8,
+			})
+			if err != nil {
+				t.Fatalf("Trace failed: %v", err)
+			}
+			decMap, ok := receivedBody["decision"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected decision object in body, got %T", receivedBody["decision"])
+			}
+			if got, _ := decMap["decision_type"].(string); got != tc.want {
+				t.Errorf("decision_type: want %q, got %q", tc.want, got)
+			}
+		})
+	}
+}

--- a/sdk/go/akashi/types.go
+++ b/sdk/go/akashi/types.go
@@ -428,3 +428,33 @@ type ConflictOptions struct {
 	Limit         int
 	Offset        int
 }
+
+// --- Assessment types ---
+
+// AssessOutcome is the verdict an agent records for a prior decision.
+type AssessOutcome string
+
+const (
+	AssessCorrect          AssessOutcome = "correct"
+	AssessIncorrect        AssessOutcome = "incorrect"
+	AssessPartiallyCorrect AssessOutcome = "partially_correct"
+)
+
+// AssessRequest is the input for Client.Assess.
+type AssessRequest struct {
+	// Outcome is required. Must be "correct", "incorrect", or "partially_correct".
+	Outcome AssessOutcome `json:"outcome"`
+	// Notes is optional free-text explanation.
+	Notes string `json:"notes,omitempty"`
+}
+
+// AssessResponse is the output of Client.Assess and an element of Client.ListAssessments.
+type AssessResponse struct {
+	ID              uuid.UUID     `json:"id"`
+	DecisionID      uuid.UUID     `json:"decision_id"`
+	OrgID           uuid.UUID     `json:"org_id"`
+	AssessorAgentID string        `json:"assessor_agent_id"`
+	Outcome         AssessOutcome `json:"outcome"`
+	Notes           string        `json:"notes,omitempty"`
+	CreatedAt       time.Time     `json:"created_at"`
+}

--- a/sdk/python/src/akashi/__init__.py
+++ b/sdk/python/src/akashi/__init__.py
@@ -19,6 +19,9 @@ from akashi.types import (
     AgentEvent,
     AgentRun,
     Alternative,
+    AssessOutcome,
+    AssessRequest,
+    AssessResponse,
     CheckResponse,
     CompleteRunRequest,
     CreateAgentRequest,
@@ -68,6 +71,8 @@ __all__ = [
     "CreateAgentRequest",
     "CreateGrantRequest",
     "TemporalQueryRequest",
+    "AssessOutcome",
+    "AssessRequest",
     # Types — responses
     "TraceResponse",
     "CheckResponse",
@@ -75,6 +80,7 @@ __all__ = [
     "SearchResult",
     "SearchResponse",
     "HealthResponse",
+    "AssessResponse",
     # OTEL helpers
     "trace_id_from_context",
     # Exceptions

--- a/sdk/python/src/akashi/client.py
+++ b/sdk/python/src/akashi/client.py
@@ -24,6 +24,8 @@ from akashi.exceptions import (
 from akashi.types import (
     Agent,
     AgentRun,
+    AssessRequest,
+    AssessResponse,
     CheckResponse,
     CompleteRunRequest,
     CreateAgentRequest,
@@ -69,9 +71,12 @@ def _build_trace_body(agent_id: str, request: TraceRequest) -> dict[str, Any]:
     The server expects ``{agent_id, decision: {decision_type, outcome, ...}}``.
     Rather than popping keys one-by-one and hoping we didn't miss any,
     we build the ``decision`` dict directly from the model's fields.
+
+    decision_type is normalized to lowercase with surrounding whitespace stripped
+    so that callers using "Architecture" vs "architecture" are treated identically.
     """
     decision: dict[str, Any] = {
-        "decision_type": request.decision_type,
+        "decision_type": request.decision_type.strip().lower(),
         "outcome": request.outcome,
         "confidence": request.confidence,
     }
@@ -214,6 +219,14 @@ def _build_conflicts_params(
 def _build_agent_history_params(limit: int) -> dict[str, str]:
     """Build query params for GET /v1/agents/{agent_id}/history."""
     return {"limit": str(limit)}
+
+
+def _build_assess_body(req: AssessRequest) -> dict[str, Any]:
+    """Build the wire-format body for POST /v1/decisions/{id}/assess."""
+    body: dict[str, Any] = {"outcome": req.outcome.value}
+    if req.notes is not None:
+        body["notes"] = req.notes
+    return body
 
 
 # ---------------------------------------------------------------------------
@@ -507,6 +520,23 @@ class AkashiClient:
         )
         return [DecisionConflict.model_validate(c) for c in items]
 
+    # --- Assessments (spec 29) ---
+
+    async def assess(self, decision_id: UUID, req: AssessRequest) -> AssessResponse:
+        """Record an outcome assessment for a prior decision.
+
+        Assessments are append-only — each call creates a new row. An assessor
+        changing their verdict over time is itself an auditable event; prior
+        assessments are never overwritten.
+        """
+        data = await self._post(f"/v1/decisions/{decision_id}/assess", _build_assess_body(req))
+        return AssessResponse.model_validate(data)
+
+    async def list_assessments(self, decision_id: UUID) -> list[AssessResponse]:
+        """Return the full assessment history for a decision, newest first."""
+        items, _ = await self._get_list(f"/v1/decisions/{decision_id}/assessments")
+        return [AssessResponse.model_validate(a) for a in items]
+
     # --- Health (no auth) ---
 
     async def health(self) -> HealthResponse:
@@ -785,6 +815,23 @@ class AkashiSyncClient:
             ),
         )
         return [DecisionConflict.model_validate(c) for c in items]
+
+    # --- Assessments (spec 29) ---
+
+    def assess(self, decision_id: UUID, req: AssessRequest) -> AssessResponse:
+        """Record an outcome assessment for a prior decision.
+
+        Assessments are append-only — each call creates a new row. An assessor
+        changing their verdict over time is itself an auditable event; prior
+        assessments are never overwritten.
+        """
+        data = self._post(f"/v1/decisions/{decision_id}/assess", _build_assess_body(req))
+        return AssessResponse.model_validate(data)
+
+    def list_assessments(self, decision_id: UUID) -> list[AssessResponse]:
+        """Return the full assessment history for a decision, newest first."""
+        items, _ = self._get_list(f"/v1/decisions/{decision_id}/assessments")
+        return [AssessResponse.model_validate(a) for a in items]
 
     # --- Health (no auth) ---
 

--- a/sdk/python/src/akashi/types.py
+++ b/sdk/python/src/akashi/types.py
@@ -312,3 +312,33 @@ class SearchResponse(BaseModel):
 
     results: list[SearchResult]
     total: int
+
+
+# --- Assessment types (spec 29) ---
+
+
+class AssessOutcome(str, Enum):
+    """The verdict an assessor records for a prior decision."""
+
+    correct = "correct"
+    incorrect = "incorrect"
+    partially_correct = "partially_correct"
+
+
+class AssessRequest(BaseModel):
+    """Request body for recording an outcome assessment."""
+
+    outcome: AssessOutcome
+    notes: str | None = None
+
+
+class AssessResponse(BaseModel):
+    """Response from POST /v1/decisions/{id}/assess and a list element from GET /v1/decisions/{id}/assessments."""
+
+    id: UUID
+    decision_id: UUID
+    org_id: UUID
+    assessor_agent_id: str
+    outcome: AssessOutcome
+    notes: str | None = None
+    created_at: datetime

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -23,6 +23,9 @@ from akashi.middleware import AkashiSyncMiddleware
 from akashi.types import (
     Agent,
     AgentRun,
+    AssessOutcome,
+    AssessRequest,
+    AssessResponse,
     CheckResponse,
     CreateAgentRequest,
     CreateGrantRequest,
@@ -1006,3 +1009,229 @@ class TestAsyncClient:
 
         async with _make_async_client() as client:
             await client.delete_grant(grant_id)
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_async_assess(self) -> None:
+        _mock_auth(respx)
+        decision_id = uuid.UUID(DECISION_ID)
+        assessment_id = str(uuid.uuid4())
+        respx.post(f"{BASE_URL}/v1/decisions/{decision_id}/assess").respond(
+            201,
+            json={
+                "data": {
+                    "id": assessment_id,
+                    "decision_id": DECISION_ID,
+                    "org_id": ORG_ID,
+                    "assessor_agent_id": "test-agent",
+                    "outcome": "correct",
+                    "notes": "looks good",
+                    "created_at": NOW,
+                }
+            },
+        )
+
+        async with _make_async_client() as client:
+            resp = await client.assess(
+                decision_id,
+                AssessRequest(outcome=AssessOutcome.correct, notes="looks good"),
+            )
+
+        assert isinstance(resp, AssessResponse)
+        assert resp.outcome == AssessOutcome.correct
+        assert resp.notes == "looks good"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_async_list_assessments(self) -> None:
+        _mock_auth(respx)
+        decision_id = uuid.UUID(DECISION_ID)
+        respx.get(f"{BASE_URL}/v1/decisions/{decision_id}/assessments").respond(
+            200,
+            json={
+                "data": [
+                    {
+                        "id": str(uuid.uuid4()),
+                        "decision_id": DECISION_ID,
+                        "org_id": ORG_ID,
+                        "assessor_agent_id": "reviewer",
+                        "outcome": "partially_correct",
+                        "notes": "needs more context",
+                        "created_at": NOW,
+                    }
+                ],
+                "total": 1,
+                "has_more": False,
+                "limit": 50,
+                "offset": 0,
+            },
+        )
+
+        async with _make_async_client() as client:
+            items = await client.list_assessments(decision_id)
+
+        assert len(items) == 1
+        assert isinstance(items[0], AssessResponse)
+        assert items[0].outcome == AssessOutcome.partially_correct
+
+
+class TestAssess:
+    """Tests for assess() and list_assessments() on the sync client."""
+
+    @respx.mock
+    def test_assess_returns_assess_response(self) -> None:
+        _mock_auth(respx)
+        decision_id = uuid.UUID(DECISION_ID)
+        assessment_id = str(uuid.uuid4())
+        respx.post(f"{BASE_URL}/v1/decisions/{decision_id}/assess").respond(
+            201,
+            json={
+                "data": {
+                    "id": assessment_id,
+                    "decision_id": DECISION_ID,
+                    "org_id": ORG_ID,
+                    "assessor_agent_id": "test-agent",
+                    "outcome": "correct",
+                    "notes": "all tests passed",
+                    "created_at": NOW,
+                }
+            },
+        )
+
+        with _make_client() as client:
+            resp = client.assess(
+                decision_id,
+                AssessRequest(outcome=AssessOutcome.correct, notes="all tests passed"),
+            )
+
+        assert isinstance(resp, AssessResponse)
+        assert resp.outcome == AssessOutcome.correct
+        assert resp.notes == "all tests passed"
+        assert resp.assessor_agent_id == "test-agent"
+
+    @respx.mock
+    def test_assess_without_notes(self) -> None:
+        _mock_auth(respx)
+        decision_id = uuid.UUID(DECISION_ID)
+        captured_body: dict = {}
+
+        def _capture(request: httpx.Request) -> httpx.Response:
+            captured_body.update(json.loads(request.content.decode()))
+            return httpx.Response(
+                201,
+                json={
+                    "data": {
+                        "id": str(uuid.uuid4()),
+                        "decision_id": DECISION_ID,
+                        "org_id": ORG_ID,
+                        "assessor_agent_id": "test-agent",
+                        "outcome": "incorrect",
+                        "created_at": NOW,
+                    }
+                },
+            )
+
+        respx.post(f"{BASE_URL}/v1/decisions/{decision_id}/assess").mock(side_effect=_capture)
+
+        with _make_client() as client:
+            resp = client.assess(decision_id, AssessRequest(outcome=AssessOutcome.incorrect))
+
+        assert resp.outcome == AssessOutcome.incorrect
+        assert captured_body.get("notes") is None
+
+    @respx.mock
+    def test_list_assessments_returns_history(self) -> None:
+        _mock_auth(respx)
+        decision_id = uuid.UUID(DECISION_ID)
+        respx.get(f"{BASE_URL}/v1/decisions/{decision_id}/assessments").respond(
+            200,
+            json={
+                "data": [
+                    {
+                        "id": str(uuid.uuid4()),
+                        "decision_id": DECISION_ID,
+                        "org_id": ORG_ID,
+                        "assessor_agent_id": "reviewer",
+                        "outcome": "partially_correct",
+                        "notes": "needs more evidence",
+                        "created_at": NOW,
+                    },
+                    {
+                        "id": str(uuid.uuid4()),
+                        "decision_id": DECISION_ID,
+                        "org_id": ORG_ID,
+                        "assessor_agent_id": "reviewer",
+                        "outcome": "correct",
+                        "notes": "updated verdict",
+                        "created_at": NOW,
+                    },
+                ],
+                "total": 2,
+                "has_more": False,
+                "limit": 50,
+                "offset": 0,
+            },
+        )
+
+        with _make_client() as client:
+            items = client.list_assessments(decision_id)
+
+        assert len(items) == 2
+        assert items[0].outcome == AssessOutcome.partially_correct
+        assert items[1].outcome == AssessOutcome.correct
+
+    @respx.mock
+    def test_list_assessments_empty(self) -> None:
+        _mock_auth(respx)
+        decision_id = uuid.UUID(DECISION_ID)
+        respx.get(f"{BASE_URL}/v1/decisions/{decision_id}/assessments").respond(
+            200,
+            json={"data": [], "total": 0, "has_more": False, "limit": 50, "offset": 0},
+        )
+
+        with _make_client() as client:
+            items = client.list_assessments(decision_id)
+
+        assert items == []
+
+
+class TestDecisionTypeNormalization:
+    """decision_type should be lowercased and stripped before sending (issue #254)."""
+
+    @respx.mock
+    def test_trace_normalizes_decision_type(self) -> None:
+        _mock_auth(respx)
+        captured_body: dict = {}
+
+        def _capture(request: httpx.Request) -> httpx.Response:
+            captured_body.update(json.loads(request.content.decode()))
+            return httpx.Response(
+                201,
+                json={
+                    "data": {
+                        "run_id": RUN_ID,
+                        "decision_id": DECISION_ID,
+                        "event_count": 1,
+                    }
+                },
+            )
+
+        respx.post(f"{BASE_URL}/v1/trace").mock(side_effect=_capture)
+
+        cases = [
+            ("Architecture", "architecture"),
+            ("  SECURITY  ", "security"),
+            ("Trade_Off", "trade_off"),
+            ("code_review", "code_review"),
+        ]
+
+        with _make_client() as client:
+            for raw, want in cases:
+                captured_body.clear()
+                client.trace(TraceRequest(
+                    decision_type=raw,
+                    outcome="chose option",
+                    confidence=0.8,
+                ))
+                got = captured_body["decision"]["decision_type"]
+                assert got == want, f"expected {want!r} for input {raw!r}, got {got!r}"

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -12,6 +12,8 @@ import {
 import type {
   Agent,
   AgentRun,
+  AssessRequest,
+  AssessResponse,
   CheckResponse,
   CompleteRunRequest,
   CreateAgentRequest,
@@ -57,7 +59,7 @@ function buildTraceBody(
   request: TraceRequest,
 ): Record<string, unknown> {
   const decision: Record<string, unknown> = {
-    decision_type: request.decisionType,
+    decision_type: request.decisionType.trim().toLowerCase(),
     outcome: request.outcome,
     confidence: request.confidence,
   };
@@ -572,6 +574,35 @@ export class AkashiClient {
       params.set("offset", String(options.offset));
     const qs = params.toString();
     return this.get<DecisionConflict[]>(`/v1/conflicts${qs ? `?${qs}` : ""}`);
+  }
+
+  // --- Assessments (spec 29) ---
+
+  /**
+   * Record an outcome assessment for a prior decision.
+   *
+   * Assessments are append-only — each call creates a new row. An assessor
+   * changing their verdict over time is itself an auditable event; prior
+   * assessments are never overwritten.
+   */
+  async assess(
+    decisionId: string,
+    req: AssessRequest,
+  ): Promise<AssessResponse> {
+    const body: Record<string, unknown> = { outcome: req.outcome };
+    if (req.notes !== undefined) body.notes = req.notes;
+    return this.post<AssessResponse>(
+      `/v1/decisions/${encodeURIComponent(decisionId)}/assess`,
+      body,
+    );
+  }
+
+  /** Return the full assessment history for a decision, newest first. */
+  async listAssessments(decisionId: string): Promise<AssessResponse[]> {
+    const envelope = await this.getList<AssessResponse>(
+      `/v1/decisions/${encodeURIComponent(decisionId)}/assessments`,
+    );
+    return envelope.items;
   }
 
   // --- Health (no auth) ---

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -38,4 +38,7 @@ export type {
   CreateGrantRequest,
   Traceable,
   AkashiConfig,
+  AssessOutcome,
+  AssessRequest,
+  AssessResponse,
 } from "./types.js";

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -274,3 +274,26 @@ export interface AkashiConfig {
   /** Override the auto-generated session UUID. If omitted, one is generated. */
   sessionId?: string;
 }
+
+// --- Assessment types (spec 29) ---
+
+export type AssessOutcome = "correct" | "incorrect" | "partially_correct";
+
+/** Request body for recording an outcome assessment. */
+export interface AssessRequest {
+  /** Must be "correct", "incorrect", or "partially_correct". */
+  outcome: AssessOutcome;
+  /** Optional free-text explanation. */
+  notes?: string;
+}
+
+/** Response from POST /v1/decisions/{id}/assess and element of GET /v1/decisions/{id}/assessments. */
+export interface AssessResponse {
+  id: string;
+  decision_id: string;
+  org_id: string;
+  assessor_agent_id: string;
+  outcome: AssessOutcome;
+  notes?: string;
+  created_at: string;
+}

--- a/sdk/typescript/tests/client.test.ts
+++ b/sdk/typescript/tests/client.test.ts
@@ -12,6 +12,7 @@ import {
   ValidationError,
 } from "../src/errors.js";
 import type {
+  AssessResponse,
   CheckResponse,
   Decision,
   TraceRequest,
@@ -1268,6 +1269,179 @@ describe("AkashiClient", () => {
       } catch (e) {
         expect(e).toBeInstanceOf(AuthenticationError);
         expect((e as Error).message).toBe("Authentication failed");
+      }
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Assessments (spec 29)
+  // -----------------------------------------------------------------------
+
+  describe("assess", () => {
+    beforeEach(() => {
+      mockFetch.mockResolvedValueOnce(mockResponse(200, TOKEN_RESPONSE));
+    });
+
+    it("records an assessment and returns AssessResponse", async () => {
+      const resp: AssessResponse = {
+        id: "assess-1",
+        decision_id: "dec-1",
+        org_id: "org-1",
+        assessor_agent_id: "test-agent",
+        outcome: "correct",
+        notes: "all tests passed",
+        created_at: "2024-01-01T00:00:00Z",
+      };
+      mockFetch.mockResolvedValueOnce(mockResponse(201, { data: resp }));
+
+      const result = await client.assess("dec-1", {
+        outcome: "correct",
+        notes: "all tests passed",
+      });
+
+      expect(result).toEqual(resp);
+      const lastCall = mockFetch.mock.calls[mockFetch.mock.calls.length - 1];
+      expect(lastCall[0]).toBe(
+        "http://localhost:8080/v1/decisions/dec-1/assess",
+      );
+      expect(lastCall[1].method).toBe("POST");
+      const body = JSON.parse(lastCall[1].body);
+      expect(body).toEqual({ outcome: "correct", notes: "all tests passed" });
+    });
+
+    it("sends assess without notes", async () => {
+      const resp: AssessResponse = {
+        id: "assess-2",
+        decision_id: "dec-2",
+        org_id: "org-1",
+        assessor_agent_id: "test-agent",
+        outcome: "incorrect",
+        created_at: "2024-01-01T00:00:00Z",
+      };
+      mockFetch.mockResolvedValueOnce(mockResponse(201, { data: resp }));
+
+      await client.assess("dec-2", { outcome: "incorrect" });
+
+      const lastCall = mockFetch.mock.calls[mockFetch.mock.calls.length - 1];
+      const body = JSON.parse(lastCall[1].body);
+      expect(body.notes).toBeUndefined();
+      expect(body.outcome).toBe("incorrect");
+    });
+
+    it("URL-encodes the decision ID", async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockResponse(201, {
+          data: {
+            id: "a",
+            decision_id: "d",
+            org_id: "o",
+            assessor_agent_id: "test-agent",
+            outcome: "correct",
+            created_at: "2024-01-01T00:00:00Z",
+          },
+        }),
+      );
+
+      await client.assess("decision/with spaces", { outcome: "correct" });
+
+      const lastCall = mockFetch.mock.calls[mockFetch.mock.calls.length - 1];
+      expect(lastCall[0]).toBe(
+        "http://localhost:8080/v1/decisions/decision%2Fwith%20spaces/assess",
+      );
+    });
+  });
+
+  describe("listAssessments", () => {
+    beforeEach(() => {
+      mockFetch.mockResolvedValueOnce(mockResponse(200, TOKEN_RESPONSE));
+    });
+
+    it("returns assessment history newest-first", async () => {
+      const assessments: AssessResponse[] = [
+        {
+          id: "assess-1",
+          decision_id: "dec-1",
+          org_id: "org-1",
+          assessor_agent_id: "reviewer",
+          outcome: "partially_correct",
+          notes: "needs more evidence",
+          created_at: "2024-01-02T00:00:00Z",
+        },
+        {
+          id: "assess-0",
+          decision_id: "dec-1",
+          org_id: "org-1",
+          assessor_agent_id: "reviewer",
+          outcome: "correct",
+          notes: "updated verdict",
+          created_at: "2024-01-01T00:00:00Z",
+        },
+      ];
+      mockFetch.mockResolvedValueOnce(
+        mockResponse(200, {
+          data: assessments,
+          total: 2,
+          has_more: false,
+          limit: 50,
+          offset: 0,
+        }),
+      );
+
+      const result = await client.listAssessments("dec-1");
+
+      expect(result).toHaveLength(2);
+      expect(result[0].outcome).toBe("partially_correct");
+      expect(result[1].outcome).toBe("correct");
+      const lastCall = mockFetch.mock.calls[mockFetch.mock.calls.length - 1];
+      expect(lastCall[0]).toBe(
+        "http://localhost:8080/v1/decisions/dec-1/assessments",
+      );
+      expect(lastCall[1].method).toBe("GET");
+    });
+
+    it("returns empty array when no assessments", async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockResponse(200, { data: [], total: 0, has_more: false }),
+      );
+
+      const result = await client.listAssessments("dec-99");
+      expect(result).toEqual([]);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // decision_type normalization (issue #254)
+  // -----------------------------------------------------------------------
+
+  describe("trace decision_type normalization", () => {
+    it("lowercases and trims decision_type before sending", async () => {
+      const cases: Array<[string, string]> = [
+        ["Architecture", "architecture"],
+        ["  SECURITY  ", "security"],
+        ["Trade_Off", "trade_off"],
+        ["code_review", "code_review"],
+      ];
+
+      for (const [raw, want] of cases) {
+        mockFetch.mockReset();
+        mockFetch
+          .mockResolvedValueOnce(mockResponse(200, TOKEN_RESPONSE))
+          .mockResolvedValueOnce(
+            mockResponse(200, {
+              data: { run_id: "r", decision_id: "d", event_count: 1 },
+            }),
+          );
+
+        await client.trace({
+          decisionType: raw,
+          outcome: "chose option",
+          confidence: 0.8,
+        });
+
+        const traceCall =
+          mockFetch.mock.calls[mockFetch.mock.calls.length - 1];
+        const body = JSON.parse(traceCall[1].body);
+        expect(body.decision.decision_type).toBe(want);
       }
     });
   });


### PR DESCRIPTION
## Summary

- **`assess()`** and **`list_assessments()`** added to all three SDKs (Go, Python, TypeScript) — closes #266
- **`decision_type` normalization** (lowercase + trim) applied in every SDK's Trace body builder — closes #254

## Changes

### Go SDK
- `AssessOutcome`, `AssessRequest`, `AssessResponse` types in `types.go`
- `Assess()` and `ListAssessments()` methods in `client.go`
- `decision_type` normalized with `strings.ToLower(strings.TrimSpace(...))`
- 3 new tests

### Python SDK
- `AssessOutcome` (str Enum), `AssessRequest`, `AssessResponse` in `types.py`
- `assess()` and `list_assessments()` on both async (`AkashiClient`) and sync (`AkashiSyncClient`)
- `decision_type` normalized with `.strip().lower()`
- Exported from `__init__.py`
- 7 new tests

### TypeScript SDK
- `AssessOutcome`, `AssessRequest`, `AssessResponse` in `types.ts`
- `assess()` and `listAssessments()` in `client.ts` (with `encodeURIComponent` on decision ID)
- `decision_type` normalized with `.trim().toLowerCase()`
- Exported from `index.ts`
- 5 new tests

## Test plan

- [x] Go SDK: `go test -race ./...` passes
- [x] Python SDK: `pytest` — 45 tests pass
- [x] TypeScript SDK: `vitest run` — 65 tests pass
- [x] Full Go server suite: `go test -race -count=1 ./...` — all packages pass
- [x] `golangci-lint` — 0 issues
- [x] `atlas migrate validate` — clean

Closes #266
Closes #254