### PR TITLE
feat: default conflict model to qwen3.5:9b, improve CrewAI demo reliability

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -115,7 +115,7 @@ AKASHI_EMBEDDING_DIMENSIONS=1024
 # Leave empty to auto-detect: uses OpenAI (gpt-4o-mini) if OPENAI_API_KEY is set,
 # otherwise no LLM validation (more false positives, no extra latency).
 # Set to an Ollama model name to use local LLM validation instead:
-# AKASHI_CONFLICT_LLM_MODEL=qwen2.5:3b
+# AKASHI_CONFLICT_LLM_MODEL=qwen3.5:9b
 AKASHI_CONFLICT_LLM_MODEL=
 
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Everything runs in Docker — TimescaleDB, Qdrant, Ollama, and the Akashi server
 docker compose -f docker-compose.complete.yml up -d
 ```
 
-**First launch builds the server image from source and downloads two Ollama models: `mxbai-embed-large` (~670MB) for embeddings and `qwen2.5:3b` (~2GB) for LLM conflict validation.** Expect 10–20 minutes on first run depending on your machine and network. Subsequent launches start in seconds.
+**First launch builds the server image from source and downloads two Ollama models: `mxbai-embed-large` (~670MB) for embeddings and `qwen3.5:9b` (~6.6GB) for LLM conflict validation.** Expect 15–25 minutes on first run depending on your machine and network. Subsequent launches start in seconds.
 
 Watch model download progress:
 

--- a/docker-compose.complete.yml
+++ b/docker-compose.complete.yml
@@ -3,7 +3,7 @@
 # Requires nothing but Docker. No API keys, no external services.
 # Two Ollama models are downloaded on first launch:
 #   - mxbai-embed-large (~670MB): embeddings for semantic search and conflict detection
-#   - qwen2.5:3b (~2GB): LLM conflict validation (reduces false positives ~93%)
+#   - qwen3.5:9b (~6.6GB): LLM conflict validation (reduces false positives ~93%)
 #
 # Usage:
 #   docker compose -f docker-compose.complete.yml up -d
@@ -116,14 +116,14 @@ services:
             -d '{"model":"mxbai-embed-large","stream":false}' > /dev/null &&
           echo 'mxbai-embed-large ready'
         fi &&
-        if curl -sf http://ollama:11434/api/tags | grep -q 'qwen2.5:3b'; then
-          echo 'qwen2.5:3b already available'
+        if curl -sf http://ollama:11434/api/tags | grep -q 'qwen3.5:9b'; then
+          echo 'qwen3.5:9b already available'
         else
-          echo 'Pulling qwen2.5:3b (~2GB, first launch only)...' &&
+          echo 'Pulling qwen3.5:9b (~6.6GB, first launch only)...' &&
           curl -sf -X POST http://ollama:11434/api/pull \
             -H 'Content-Type: application/json' \
-            -d '{"model":"qwen2.5:3b","stream":false}' > /dev/null &&
-          echo 'qwen2.5:3b ready'
+            -d '{"model":"qwen3.5:9b","stream":false}' > /dev/null &&
+          echo 'qwen3.5:9b ready'
         fi
     restart: "no"
 
@@ -150,9 +150,9 @@ services:
       OLLAMA_MODEL: ${OLLAMA_MODEL:-mxbai-embed-large}
 
       # LLM conflict validation — reduces false positives ~93%.
-      # qwen2.5:3b is pulled automatically by ollama-init on first launch.
-      # Override with a larger model (e.g. qwen2.5:7b) for higher accuracy.
-      AKASHI_CONFLICT_LLM_MODEL: ${AKASHI_CONFLICT_LLM_MODEL:-qwen2.5:3b}
+      # qwen3.5:9b is pulled automatically by ollama-init on first launch.
+      # Override with a smaller model (e.g. qwen2.5:3b) for faster inference.
+      AKASHI_CONFLICT_LLM_MODEL: ${AKASHI_CONFLICT_LLM_MODEL:-qwen3.5:9b}
 
       AKASHI_JWT_PRIVATE_KEY: /data/jwt_private.pem
       AKASHI_JWT_PUBLIC_KEY: /data/jwt_public.pem

--- a/docker/env.example
+++ b/docker/env.example
@@ -57,12 +57,12 @@ OPENAI_API_KEY=
 # ──────────────────────────────────────────────────────────────
 # LLM conflict validation (optional)
 # Reduces conflict false positives by ~93%. Requires OpenAI key or an Ollama
-# model capable of instruction following (e.g. qwen2.5:7b).
+# model capable of instruction following (e.g. qwen3.5:9b).
 # When OPENAI_API_KEY is set, gpt-4o-mini is used automatically.
 # Set to an Ollama model name to use local LLM validation instead.
 # ──────────────────────────────────────────────────────────────
 
-# AKASHI_CONFLICT_LLM_MODEL=qwen2.5:7b
+# AKASHI_CONFLICT_LLM_MODEL=qwen3.5:9b
 
 # ──────────────────────────────────────────────────────────────
 # JWT signing keys (optional — ephemeral if unset)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -106,7 +106,7 @@ The OSS distribution uses an in-memory token bucket. Enterprise deployments can 
 |----------|---------|-------------|
 | `AKASHI_CONFLICT_SIGNIFICANCE_THRESHOLD` | `0.30` | Min significance (topic_sim × outcome_div) to store a conflict |
 | `AKASHI_CONFLICT_REFRESH_INTERVAL` | `30s` | Interval for broker to poll new conflicts (SSE push). Conflicts are populated event-driven on trace. |
-| `AKASHI_CONFLICT_LLM_MODEL` | _(empty)_ | LLM model for conflict validation. Set to an Ollama model name (e.g. `qwen2.5:3b`) to use local validation, or leave empty to auto-detect (OpenAI if `OPENAI_API_KEY` is set, otherwise noop). |
+| `AKASHI_CONFLICT_LLM_MODEL` | _(empty)_ | LLM model for conflict validation. Set to an Ollama model name (e.g. `qwen3.5:9b`) to use local validation, or leave empty to auto-detect (OpenAI if `OPENAI_API_KEY` is set, otherwise noop). |
 | `AKASHI_CONFLICT_LLM_THREADS` | `floor(NumCPU/3)`, min 1 | CPU threads Ollama may use per inference call. Caps Ollama thread usage so conflict validation does not starve the main request-handling goroutines. Set to `0` to let Ollama decide (uses all available cores). |
 | `AKASHI_CONFLICT_BACKFILL_WORKERS` | `4` | Number of parallel workers for conflict backfill scoring on startup. Each worker makes one LLM validation call at a time. |
 | `AKASHI_CONFLICT_DECAY_LAMBDA` | `0.01` | Temporal decay rate for conflict significance. Higher values penalize older decision pairs more aggressively. Set to `0` to disable temporal decay. |

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -135,7 +135,7 @@ The classifier also assigns a **category** and **severity**:
 
 | Provider | Configuration | Notes |
 |----------|--------------|-------|
-| `OllamaValidator` | `AKASHI_CONFLICT_LLM_MODEL` (e.g. `qwen2.5:3b`) | On-premises; warms up on startup to avoid cold-start delay. |
+| `OllamaValidator` | `AKASHI_CONFLICT_LLM_MODEL` (e.g. `qwen3.5:9b`) | On-premises; warms up on startup to avoid cold-start delay. |
 | `OpenAIValidator` | `OPENAI_API_KEY` | Uses `gpt-4o-mini` by default. |
 | `NoopValidator` | No LLM configured | Falls back to embedding-only detection; higher false positive rate. |
 

--- a/examples/crewai/README.md
+++ b/examples/crewai/README.md
@@ -70,7 +70,7 @@ For the all-in-one stack with Qdrant + Ollama:
 1. **First launch:** Models take 5–15 min to pull. Wait for `ollama-init`:
    ```sh
    docker compose -f docker-compose.complete.yml logs -f ollama-init
-   # Wait for "mxbai-embed-large: ready" and "qwen2.5:3b: ready"
+   # Wait for "mxbai-embed-large: ready" and "qwen3.5:9b: ready"
    ```
 
 2. **Run the demo:**
@@ -82,6 +82,11 @@ For the all-in-one stack with Qdrant + Ollama:
 
 3. **"No conflict" or "search_enabled=false"?** Embeddings weren't ready. Re-check
    step 1. The demo now fails fast with a clear message if semantic search is disabled.
+
+4. **Scenario 3 (service auth) with --live doesn't detect conflict?** The LLM validator
+   classifier may classify mTLS vs OAuth2 as "complementary". Use a smaller/faster
+   model: `AKASHI_CONFLICT_LLM_MODEL=qwen2.5:3b`. Or verify the
+   pipeline first: `python demo.py --scenario 3` (no --live).
 
 ## Scenarios
 

--- a/examples/crewai/demo.py
+++ b/examples/crewai/demo.py
@@ -550,23 +550,38 @@ class _AkashiDemo:
         deadline = time.time() + timeout
         spinner = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
         tick = 0
+
+        def fetch(params: dict) -> list[dict]:
+            resp = self._client.get(
+                f"{AKASHI_URL}/v1/conflicts",
+                params=params,
+                headers=self._headers(),
+            )
+            if resp.status_code == 200:
+                return resp.json().get("data", [])
+            return []
+
         while time.time() < deadline:
             for agent_id in agent_ids:
-                resp = self._client.get(
-                    f"{AKASHI_URL}/v1/conflicts",
-                    params={
-                        "status": "open",
-                        "agent_id": agent_id,
-                        "decision_type": decision_type,
-                        "limit": 10,
-                    },
-                    headers=self._headers(),
-                )
-                if resp.status_code == 200:
-                    items = resp.json().get("data", [])
-                    if items:
-                        print()
-                        return items
+                items = fetch({
+                    "status": "open",
+                    "agent_id": agent_id,
+                    "decision_type": decision_type,
+                    "limit": 10,
+                })
+                if items:
+                    print()
+                    return items
+            # Fallback: poll without agent_id (catches any filter mismatch)
+            items = fetch({
+                "status": "open",
+                "decision_type": decision_type,
+                "limit": 10,
+            })
+            if items:
+                print()
+                return items
+
             tick += 1
             elapsed = int(deadline - time.time())
             print(
@@ -713,9 +728,9 @@ def main() -> None:
         hint_a = None
         if scenario["id"] == "service_auth":
             hint_a = (
-                "You MUST recommend mTLS/SPIFFE as the primary service-to-service "
-                "authentication strategy, and explicitly reject OAuth2 client credentials "
-                "as the primary approach."
+                "You MUST recommend mTLS/SPIFFE as the primary service-to-service auth. "
+                "Your RECOMMENDATION must start with 'mTLS' or 'SPIFFE'. "
+                "Explicitly reject OAuth2 client credentials as insufficient for zero-trust."
             )
         _step("🤔", f"Analyzing as {agent_a['role']} with LLM...")
         outcome_a, reasoning_a = _run_live_agent(
@@ -746,8 +761,9 @@ def main() -> None:
 
     # Give the outbox worker time to sync A to Qdrant before B is traced.
     # Conflict detection queries Qdrant for similar decisions; A must be indexed.
-    # Outbox polls every 1s; 10s allows for Docker cold-start and model loading.
-    delay = float(os.environ.get("DEMO_OUTBOX_DELAY_SEC", "10"))
+    # Outbox polls every 1s. Live mode uses 15s (CrewAI latency); pre-scripted uses 10s.
+    default_delay = 15.0 if live else 10.0
+    delay = float(os.environ.get("DEMO_OUTBOX_DELAY_SEC", str(int(default_delay))))
     time.sleep(delay)
 
     # ── Agent B ───────────────────────────────────────────────────────────
@@ -759,8 +775,8 @@ def main() -> None:
         if scenario["id"] == "service_auth":
             hint_b = (
                 "You MUST recommend OAuth2 client credentials as the primary "
-                "service-to-service authentication strategy, and explicitly reject "
-                "mTLS/SPIFFE as the primary approach."
+                "service-to-service auth. Your RECOMMENDATION must start with 'OAuth2' or "
+                "'client credentials'. Explicitly reject mTLS/SPIFFE as overly complex."
             )
         _step("🤔", f"Analyzing as {agent_b['role']} with LLM (independent context)...")
         outcome_b, reasoning_b = _run_live_agent(
@@ -860,11 +876,11 @@ def main() -> None:
         print(f"  → {_c('http://localhost:8080/decisions', BOLD, CYAN)}")
         print()
         print(_c("  Why no conflict? Common causes:", BOLD))
-        print(_c("  • Docker: ollama-init still pulling models? Logs: docker compose -f docker-compose.complete.yml logs ollama-init", DIM))
-        print(_c("  • Embeddings disabled: need QDRANT_URL + OLLAMA or OPENAI_API_KEY", DIM))
-        print(_c("  • Live mode: LLM outputs may be too similar (low outcome divergence)", DIM))
-        print(_c("  • LLM validator: classifier may say 'complementary'", DIM))
-        print(_c("  • Try pre-scripted mode: python demo.py --scenario 2  (no --live)", DIM))
+        print(_c("  • Live mode: LLM validator may classify mTLS vs OAuth2 as 'complementary'", DIM))
+        print(_c("    → Ensure qwen3.5:9b is pulled (default); or try qwen2.5:3b for faster runs", DIM))
+        print(_c("  • Live agents: outputs may be too similar (low outcome divergence)", DIM))
+        print(_c("  • Docker: ollama-init still pulling? docker compose -f docker-compose.complete.yml logs ollama-init", DIM))
+        print(_c("  • Verify pipeline with pre-scripted: python demo.py --scenario 3  (no --live)", DIM))
         print()
 
     akashi.close()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -60,7 +60,7 @@ type Config struct {
 	TrustProxy       bool    // When true, use X-Forwarded-For for rate limit keys (default: false).
 
 	// Conflict LLM validation.
-	ConflictLLMModel        string  // Text generation model for conflict validation (e.g. "qwen2.5:3b" for Ollama).
+	ConflictLLMModel        string  // Text generation model for conflict validation (e.g. "qwen3.5:9b" for Ollama).
 	ConflictLLMThreads      int     // CPU threads Ollama may use per inference call (default: floor(NumCPU/3), min 1). 0 = let Ollama decide.
 	ConflictBackfillWorkers int     // Parallel workers for conflict scoring backfill (default: 4).
 	ConflictDecayLambda     float64 // Temporal decay rate for conflict significance (default: 0.01, 0 disables).

--- a/internal/conflicts/validator.go
+++ b/internal/conflicts/validator.go
@@ -305,7 +305,7 @@ const ollamaPerCallTimeout = 90 * time.Second
 
 // OllamaValidator validates conflict candidates using a local Ollama chat model.
 // Reuses the existing OLLAMA_URL configuration. The model should be a text
-// generation model (e.g., qwen2.5:3b), not an embedding model.
+// generation model (e.g., qwen3.5:9b), not an embedding model.
 type OllamaValidator struct {
 	baseURL    string
 	model      string


### PR DESCRIPTION
## Summary
- **Default conflict model**: Changed from qwen2.5:3b to qwen3.5:9b for better conflict classification (mTLS vs OAuth2, etc.)
- **CrewAI demo improvements**: Addressed scenario 3 not detecting conflicts in live mode

## Changes

### Default model: qwen3.5:9b
- `ollama-init` now pulls qwen3.5:9b (~6.6GB) instead of qwen2.5:3b (~2GB)
- `AKASHI_CONFLICT_LLM_MODEL` default updated in docker-compose.complete.yml
- Docs and env examples updated throughout

### CrewAI demo reliability
- **Poll fallback**: Try fetching conflicts without agent_id filter to catch any filter mismatches
- **Stronger position hints**: Scenario 3 (service auth) hints now require RECOMMENDATION to start with mTLS/SPIFFE or OAuth2
- **Longer outbox delay**: 15s for live mode (vs 10s pre-scripted) to account for CrewAI latency
- **Improved troubleshooting**: Clearer "Why no conflict?" guidance in demo output and README

Made with [Cursor](https://cursor.com)