### PR TITLE
feat: enforce soft-delete on decisions (block hard DELETE)

### DIFF
--- a/internal/model/event.go
+++ b/internal/model/event.go
@@ -22,6 +22,7 @@ const (
 	EventReasoningStepCompleted EventType = "ReasoningStepCompleted"
 	EventDecisionMade           EventType = "DecisionMade"
 	EventDecisionRevised        EventType = "DecisionRevised"
+	EventDecisionRetracted      EventType = "DecisionRetracted"
 
 	// Tool events.
 	EventToolCallStarted   EventType = "ToolCallStarted"

--- a/internal/server/handlers_decisions.go
+++ b/internal/server/handlers_decisions.go
@@ -1129,3 +1129,57 @@ func (h *Handlers) HandleListAssessments(w http.ResponseWriter, r *http.Request)
 		"count":       len(assessments),
 	})
 }
+
+// HandleRetractDecision handles DELETE /v1/decisions/{id}.
+// Soft-deletes a decision by setting valid_to and recording a DecisionRetracted event.
+func (h *Handlers) HandleRetractDecision(w http.ResponseWriter, r *http.Request) {
+	orgID := OrgIDFromContext(r.Context())
+
+	idStr := r.PathValue("id")
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "invalid decision id")
+		return
+	}
+
+	// Decode optional body with reason.
+	var req struct {
+		Reason string `json:"reason"`
+	}
+	if r.Body != nil && r.ContentLength != 0 {
+		if err := decodeJSON(w, r, &req, h.maxRequestBodyBytes); err != nil {
+			handleDecodeError(w, r, err)
+			return
+		}
+	}
+
+	claims := ClaimsFromContext(r.Context())
+	retractedBy := claims.AgentID
+	if retractedBy == "" {
+		retractedBy = claims.Subject
+	}
+
+	audit := h.buildAuditEntry(r, orgID,
+		"decision_retracted", "decision", id.String(),
+		nil, nil,
+		map[string]any{"retracted_by": retractedBy, "reason": req.Reason},
+	)
+	if err := h.db.RetractDecision(r.Context(), orgID, id, req.Reason, retractedBy, &audit); err != nil {
+		if isNotFoundError(err) {
+			writeError(w, r, http.StatusNotFound, model.ErrCodeNotFound, "decision not found")
+			return
+		}
+		h.writeInternalError(w, r, "failed to retract decision", err)
+		return
+	}
+
+	// Return the retracted decision (with valid_to set).
+	decision, err := h.db.GetDecision(r.Context(), orgID, id, storage.GetDecisionOpts{CurrentOnly: false})
+	if err != nil {
+		// Retraction succeeded but re-fetch failed — return 204 rather than error.
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	writeJSON(w, r, http.StatusOK, decision)
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -117,6 +117,7 @@ func New(cfg ServerConfig) *Server {
 	mux.Handle("GET /v1/agents/{agent_id}/stats", adminOnly(http.HandlerFunc(h.HandleAgentStats)))
 	mux.Handle("PATCH /v1/agents/{agent_id}/tags", adminOnly(http.HandlerFunc(h.HandleUpdateAgentTags)))
 	mux.Handle("DELETE /v1/agents/{agent_id}", adminOnly(http.HandlerFunc(h.HandleDeleteAgent)))
+	mux.Handle("DELETE /v1/decisions/{id}", adminOnly(http.HandlerFunc(h.HandleRetractDecision)))
 	mux.Handle("GET /v1/export/decisions", adminOnly(http.HandlerFunc(h.HandleExportDecisions)))
 
 	// API key management (admin-only).

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -3050,3 +3050,114 @@ func TestHandlePatchConflict_WinningDecisionID(t *testing.T) {
 	// and exists to make conflict-side validation meaningful.
 	_ = decisionBID
 }
+
+// ---- HandleRetractDecision ------------------------------------------------
+
+func TestHandleRetractDecision(t *testing.T) {
+	// Trace a decision to retract.
+	dt := "retract_test_" + uuid.NewString()[:8]
+	traceResp, err := authedRequest("POST", testSrv.URL+"/v1/trace", agentToken,
+		model.TraceRequest{
+			AgentID: "test-agent",
+			Decision: model.TraceDecision{
+				DecisionType: dt,
+				Outcome:      "will be retracted",
+				Confidence:   0.85,
+				Reasoning:    ptrStr("retraction test"),
+			},
+		})
+	require.NoError(t, err)
+	defer func() { _ = traceResp.Body.Close() }()
+	require.Equal(t, http.StatusCreated, traceResp.StatusCode)
+
+	var traceResult struct {
+		Data struct {
+			DecisionID uuid.UUID `json:"decision_id"`
+			RunID      uuid.UUID `json:"run_id"`
+		} `json:"data"`
+	}
+	traceBody, _ := io.ReadAll(traceResp.Body)
+	require.NoError(t, json.Unmarshal(traceBody, &traceResult))
+	decisionID := traceResult.Data.DecisionID
+	runID := traceResult.Data.RunID
+	require.NotEqual(t, uuid.Nil, decisionID)
+	require.NotEqual(t, uuid.Nil, runID)
+
+	t.Run("non-admin gets 403", func(t *testing.T) {
+		resp, err := authedRequest("DELETE", testSrv.URL+"/v1/decisions/"+decisionID.String(), agentToken, nil)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	})
+
+	t.Run("invalid UUID returns 400", func(t *testing.T) {
+		resp, err := authedRequest("DELETE", testSrv.URL+"/v1/decisions/not-a-uuid", adminToken, nil)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	t.Run("nonexistent ID returns 404", func(t *testing.T) {
+		resp, err := authedRequest("DELETE", testSrv.URL+"/v1/decisions/"+uuid.New().String(), adminToken, nil)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	})
+
+	t.Run("successful retraction with reason", func(t *testing.T) {
+		resp, err := authedRequest("DELETE", testSrv.URL+"/v1/decisions/"+decisionID.String(), adminToken,
+			map[string]string{"reason": "inaccurate assessment"})
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var result struct {
+			Data model.Decision `json:"data"`
+		}
+		body, _ := io.ReadAll(resp.Body)
+		require.NoError(t, json.Unmarshal(body, &result))
+		assert.Equal(t, decisionID, result.Data.ID)
+		assert.NotNil(t, result.Data.ValidTo, "valid_to must be set after retraction")
+	})
+
+	t.Run("retracted decision hidden from current-only GET", func(t *testing.T) {
+		resp, err := authedRequest("GET", testSrv.URL+"/v1/decisions/"+decisionID.String(), agentToken, nil)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		// HandleGetDecision does not use CurrentOnly by default, so the decision
+		// is still retrievable. But it should have valid_to set.
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		var result struct {
+			Data model.Decision `json:"data"`
+		}
+		body, _ := io.ReadAll(resp.Body)
+		require.NoError(t, json.Unmarshal(body, &result))
+		assert.NotNil(t, result.Data.ValidTo, "retracted decision must have valid_to set")
+	})
+
+	t.Run("DecisionRetracted event recorded", func(t *testing.T) {
+		// Query events for the run that contained the retracted decision.
+		orgID := uuid.Nil // default org from SeedAdmin
+		events, err := testDB.GetEventsByRun(context.Background(), orgID, runID, 100)
+		require.NoError(t, err)
+
+		var found bool
+		for _, ev := range events {
+			if ev.EventType == model.EventDecisionRetracted {
+				found = true
+				assert.Equal(t, decisionID.String(), ev.Payload["decision_id"])
+				assert.Equal(t, "inaccurate assessment", ev.Payload["reason"])
+				assert.NotEmpty(t, ev.Payload["retracted_by"])
+				break
+			}
+		}
+		assert.True(t, found, "expected a DecisionRetracted event in the run's event log")
+	})
+
+	t.Run("double retract returns 404", func(t *testing.T) {
+		resp, err := authedRequest("DELETE", testSrv.URL+"/v1/decisions/"+decisionID.String(), adminToken, nil)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	})
+}

--- a/internal/storage/decisions.go
+++ b/internal/storage/decisions.go
@@ -225,6 +225,95 @@ func (db *DB) ReviseDecision(ctx context.Context, originalID uuid.UUID, revised 
 	return revised, nil
 }
 
+// RetractDecision soft-deletes a decision by setting valid_to, recording a
+// DecisionRetracted event, queuing a search index deletion, and inserting a
+// mutation audit entry — all atomically in a single transaction.
+func (db *DB) RetractDecision(ctx context.Context, orgID, decisionID uuid.UUID, reason, retractedBy string, audit *MutationAuditEntry) error {
+	tx, err := db.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("storage: begin retract decision tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	now := time.Now().UTC()
+
+	// Fetch the decision's run_id and agent_id for the retraction event.
+	var runID uuid.UUID
+	var agentID string
+	err = tx.QueryRow(ctx,
+		`SELECT run_id, agent_id FROM decisions WHERE id = $1 AND org_id = $2 AND valid_to IS NULL`,
+		decisionID, orgID,
+	).Scan(&runID, &agentID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("storage: decision %s: %w", decisionID, ErrNotFound)
+		}
+		return fmt.Errorf("storage: fetch decision for retraction: %w", err)
+	}
+
+	// Soft-delete: set valid_to on the decision.
+	_, err = tx.Exec(ctx,
+		`UPDATE decisions SET valid_to = $1 WHERE id = $2 AND org_id = $3 AND valid_to IS NULL`,
+		now, decisionID, orgID,
+	)
+	if err != nil {
+		return fmt.Errorf("storage: retract decision: %w", err)
+	}
+
+	// Queue search index deletion.
+	if _, err := tx.Exec(ctx,
+		`INSERT INTO search_outbox (decision_id, org_id, operation)
+		 VALUES ($1, $2, 'delete')
+		 ON CONFLICT (decision_id, operation) DO UPDATE SET created_at = now(), attempts = 0, locked_until = NULL`,
+		decisionID, orgID); err != nil {
+		return fmt.Errorf("storage: queue search outbox delete in retraction: %w", err)
+	}
+
+	// Insert DecisionRetracted event.
+	payload := map[string]any{
+		"decision_id":  decisionID.String(),
+		"retracted_by": retractedBy,
+	}
+	if reason != "" {
+		payload["reason"] = reason
+	}
+	var seqNum int64
+	err = tx.QueryRow(ctx, `SELECT nextval('event_sequence_num_seq')`).Scan(&seqNum)
+	if err != nil {
+		return fmt.Errorf("storage: reserve sequence num for retraction event: %w", err)
+	}
+	_, err = tx.Exec(ctx,
+		`INSERT INTO agent_events (id, run_id, org_id, event_type, sequence_num, occurred_at, agent_id, payload, created_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+		uuid.New(), runID, orgID, string(model.EventDecisionRetracted), seqNum,
+		now, agentID, payload, now,
+	)
+	if err != nil {
+		return fmt.Errorf("storage: insert retraction event: %w", err)
+	}
+
+	// Insert mutation audit entry.
+	if audit != nil {
+		audit.Operation = "decision_retracted"
+		audit.ResourceType = "decision"
+		audit.ResourceID = decisionID.String()
+		audit.BeforeData = map[string]any{"valid_to": nil}
+		audit.AfterData = map[string]any{
+			"valid_to":     now,
+			"retracted_by": retractedBy,
+			"reason":       reason,
+		}
+		if err := InsertMutationAuditTx(ctx, tx, *audit); err != nil {
+			return fmt.Errorf("storage: audit in retraction tx: %w", err)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("storage: commit retraction: %w", err)
+	}
+	return nil
+}
+
 // QueryDecisions executes a structured query with filters, ordering, and pagination.
 // Only returns active decisions (valid_to IS NULL). Use QueryDecisionsTemporal for
 // point-in-time queries that include superseded decisions.


### PR DESCRIPTION
## Summary

- Adds `DELETE /v1/decisions/{id}` endpoint that soft-deletes via `valid_to = now()` instead of issuing `DELETE FROM decisions`
- Records a `DecisionRetracted` event in `agent_events` with decision_id, retracted_by, and optional reason
- Queues search index deletion and writes mutation audit entry, all atomically in a single transaction
- Endpoint is admin-only; accepts optional `{"reason": "..."}` in the request body

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test -race -count=1 ./...` — all pass
- [x] 7 new test cases: 403 for non-admin, 400 for invalid UUID, 404 for nonexistent/already-retracted, 200 with valid_to set, event recorded with reason, double-retract returns 404
- [x] `grep -r 'DELETE FROM decisions' internal/` confirms no new hard deletes introduced

Closes #281