### PR TITLE
feat(ui): add logo, dark mode, and visual polish

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -5,6 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Akashi — Audit Dashboard</title>
     <meta name="description" content="Decision trace layer for multi-agent AI systems" />
+    <meta name="theme-color" content="#0f1729" media="(prefers-color-scheme: dark)" />
+    <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg' fill='none' stroke='%233b82f6' stroke-linecap='square' stroke-linejoin='miter'%3E%3Cpath d='M7 7H93V48' stroke-width='13'/%3E%3Cpath d='M7 7V93H48' stroke-width='13'/%3E%3Cline x1='87' y1='52' x2='52' y2='87' stroke-width='13'/%3E%3Cline x1='66' y1='52' x2='94' y2='90' stroke-width='13'/%3E%3C/svg%3E" />
   </head>
   <body class="min-h-screen bg-background font-sans antialiased">
     <div id="root"></div>

--- a/ui/src/components/AkashiLogo.tsx
+++ b/ui/src/components/AkashiLogo.tsx
@@ -1,0 +1,42 @@
+import { cn } from "@/lib/utils";
+
+/**
+ * Akashi logo — a square frame with a stylized "K" breaking through
+ * the bottom-right corner. Rendered as inline SVG so it scales cleanly,
+ * works on any background, and inherits color via currentColor.
+ */
+export function AkashiLogo({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 100 100"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="square"
+      strokeLinejoin="miter"
+      className={cn("shrink-0", className)}
+      aria-label="Akashi"
+      role="img"
+    >
+      {/* Square frame — top + right (partial) */}
+      <path d="M7 7 H93 V48" strokeWidth="13" />
+      {/* Square frame — left + bottom (partial) */}
+      <path d="M7 7 V93 H48" strokeWidth="13" />
+      {/* K upper arm: right-end → bottom-end */}
+      <line x1="87" y1="52" x2="52" y2="87" strokeWidth="13" />
+      {/* K lower arm: extends down-right */}
+      <line x1="66" y1="52" x2="94" y2="90" strokeWidth="13" />
+    </svg>
+  );
+}
+
+/**
+ * Full brand mark: logo + "Akashi" wordmark side by side.
+ */
+export function AkashiBrand({ className, logoSize = "h-7 w-7" }: { className?: string; logoSize?: string }) {
+  return (
+    <div className={cn("flex items-center gap-2.5", className)}>
+      <AkashiLogo className={logoSize} />
+      <span className="text-lg font-bold tracking-tight">Akashi</span>
+    </div>
+  );
+}

--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -1,8 +1,10 @@
 import { NavLink, Outlet } from "react-router";
 import { useAuth } from "@/lib/auth";
 import { useSSE, type SSEStatus } from "@/lib/sse";
+import { useTheme } from "@/lib/theme";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { AkashiBrand, AkashiLogo } from "@/components/AkashiLogo";
 import {
   LayoutDashboard,
   FileText,
@@ -13,6 +15,8 @@ import {
   Shield,
   LogOut,
   Menu,
+  Moon,
+  Sun,
   X,
 } from "lucide-react";
 import { useState } from "react";
@@ -20,7 +24,7 @@ import { cn } from "@/lib/utils";
 
 function ConnectionDot({ status }: { status: SSEStatus }) {
   const colors: Record<SSEStatus, string> = {
-    connected: "bg-emerald-500",
+    connected: "bg-emerald-500 shadow-[0_0_6px_1px] shadow-emerald-500/40",
     connecting: "bg-amber-500 animate-pulse",
     disconnected: "bg-red-500",
   };
@@ -50,6 +54,7 @@ const navItems = [
 export default function Layout() {
   const { agentId, token, logout } = useAuth();
   const sseStatus = useSSE(token);
+  const { theme, toggle: toggleTheme } = useTheme();
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
   return (
@@ -57,7 +62,7 @@ export default function Layout() {
       {/* Mobile overlay */}
       {sidebarOpen && (
         <div
-          className="fixed inset-0 z-40 bg-black/50 lg:hidden"
+          className="fixed inset-0 z-40 bg-black/60 backdrop-blur-sm lg:hidden"
           onClick={() => setSidebarOpen(false)}
           aria-hidden="true"
         />
@@ -66,14 +71,15 @@ export default function Layout() {
       {/* Sidebar */}
       <aside
         className={cn(
-          "fixed inset-y-0 left-0 z-50 flex w-64 flex-col border-r bg-card transition-transform lg:static lg:translate-x-0",
+          "fixed inset-y-0 left-0 z-50 flex w-64 flex-col border-r bg-[hsl(var(--sidebar))] transition-transform lg:static lg:translate-x-0",
           sidebarOpen ? "translate-x-0" : "-translate-x-full",
         )}
       >
+        {/* Brand header */}
         <div className="flex h-14 items-center justify-between border-b px-4">
-          <span className="text-lg font-bold tracking-tight">Akashi</span>
+          <AkashiBrand />
           <button
-            className="lg:hidden"
+            className="lg:hidden text-muted-foreground hover:text-foreground transition-colors"
             onClick={() => setSidebarOpen(false)}
             aria-label="Close sidebar"
           >
@@ -81,6 +87,7 @@ export default function Layout() {
           </button>
         </div>
 
+        {/* Navigation */}
         <nav className="flex-1 space-y-1 p-3" aria-label="Main navigation">
           {navItems.map(({ to, label, icon: Icon }) => (
             <NavLink
@@ -90,29 +97,52 @@ export default function Layout() {
               onClick={() => setSidebarOpen(false)}
               className={({ isActive }) =>
                 cn(
-                  "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+                  "group relative flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
                   isActive
                     ? "bg-primary/10 text-primary"
                     : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
                 )
               }
             >
-              <Icon className="h-4 w-4" />
-              {label}
+              {({ isActive }) => (
+                <>
+                  {isActive && (
+                    <span className="absolute left-0 top-1/2 -translate-y-1/2 h-5 w-[3px] rounded-r-full bg-primary" />
+                  )}
+                  <Icon className="h-4 w-4" />
+                  {label}
+                </>
+              )}
             </NavLink>
           ))}
         </nav>
 
+        {/* Footer */}
         <div className="border-t p-4 space-y-3">
-          <ConnectionDot status={sseStatus} />
           <div className="flex items-center justify-between">
-            <div className="flex items-center gap-2">
-              <Badge variant="outline" className="text-xs">
-                {agentId}
-              </Badge>
-            </div>
-            <Button variant="ghost" size="icon" onClick={logout} aria-label="Logout">
-              <LogOut className="h-4 w-4" />
+            <ConnectionDot status={sseStatus} />
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7 text-muted-foreground hover:text-foreground"
+              onClick={toggleTheme}
+              aria-label={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
+            >
+              {theme === "dark" ? <Sun className="h-3.5 w-3.5" /> : <Moon className="h-3.5 w-3.5" />}
+            </Button>
+          </div>
+          <div className="flex items-center justify-between">
+            <Badge variant="outline" className="text-xs font-mono">
+              {agentId}
+            </Badge>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7 text-muted-foreground hover:text-foreground"
+              onClick={logout}
+              aria-label="Logout"
+            >
+              <LogOut className="h-3.5 w-3.5" />
             </Button>
           </div>
         </div>
@@ -124,6 +154,7 @@ export default function Layout() {
           <button onClick={() => setSidebarOpen(true)} aria-label="Open sidebar">
             <Menu className="h-5 w-5" />
           </button>
+          <AkashiLogo className="h-6 w-6" />
           <span className="text-lg font-bold">Akashi</span>
         </header>
         <main className="flex-1 overflow-y-auto p-6">

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -24,28 +24,30 @@
     --input: 220 13% 91%;
     --ring: 220 70% 50%;
     --radius: 0.5rem;
+    --sidebar: 220 16% 97%;
   }
 
   .dark {
-    --background: 224 71% 4%;
+    --background: 222 47% 6%;
     --foreground: 210 20% 98%;
-    --card: 224 71% 4%;
+    --card: 223 40% 8%;
     --card-foreground: 210 20% 98%;
-    --popover: 224 71% 4%;
+    --popover: 223 40% 8%;
     --popover-foreground: 210 20% 98%;
     --primary: 217 91% 60%;
-    --primary-foreground: 224 71% 4%;
-    --secondary: 215 28% 17%;
+    --primary-foreground: 222 47% 6%;
+    --secondary: 215 28% 14%;
     --secondary-foreground: 210 20% 98%;
-    --muted: 215 28% 17%;
-    --muted-foreground: 217 10% 64%;
-    --accent: 215 28% 17%;
+    --muted: 215 25% 13%;
+    --muted-foreground: 217 10% 55%;
+    --accent: 215 28% 14%;
     --accent-foreground: 210 20% 98%;
     --destructive: 0 63% 31%;
     --destructive-foreground: 210 20% 98%;
-    --border: 215 28% 17%;
-    --input: 215 28% 17%;
+    --border: 215 20% 14%;
+    --input: 215 20% 14%;
     --ring: 217 91% 60%;
+    --sidebar: 223 47% 5%;
   }
 }
 
@@ -54,6 +56,29 @@
     @apply border-border;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground antialiased;
+  }
+}
+
+/* Scrollbar styling for dark mode */
+.dark ::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+.dark ::-webkit-scrollbar-track {
+  background: hsl(var(--background));
+}
+.dark ::-webkit-scrollbar-thumb {
+  background: hsl(var(--border));
+  border-radius: 4px;
+}
+.dark ::-webkit-scrollbar-thumb:hover {
+  background: hsl(var(--muted-foreground));
+}
+
+/* Subtle glow on primary interactive elements */
+@layer utilities {
+  .glow-primary {
+    box-shadow: 0 0 20px -4px hsl(var(--primary) / 0.3);
   }
 }

--- a/ui/src/lib/theme.ts
+++ b/ui/src/lib/theme.ts
@@ -1,0 +1,42 @@
+import { useEffect, useState } from "react";
+
+type Theme = "light" | "dark";
+
+const STORAGE_KEY = "akashi-theme";
+
+function getSystemTheme(): Theme {
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+function getStoredTheme(): Theme | null {
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (stored === "light" || stored === "dark") return stored;
+  return null;
+}
+
+function applyTheme(theme: Theme) {
+  document.documentElement.classList.toggle("dark", theme === "dark");
+}
+
+/** Initialize theme on app boot (call once, outside React). */
+export function initTheme() {
+  const theme = getStoredTheme() ?? getSystemTheme();
+  applyTheme(theme);
+}
+
+export function useTheme() {
+  const [theme, setThemeState] = useState<Theme>(
+    () => getStoredTheme() ?? getSystemTheme(),
+  );
+
+  useEffect(() => {
+    applyTheme(theme);
+    localStorage.setItem(STORAGE_KEY, theme);
+  }, [theme]);
+
+  function toggle() {
+    setThemeState((prev) => (prev === "dark" ? "light" : "dark"));
+  }
+
+  return { theme, toggle } as const;
+}

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -5,7 +5,11 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { AuthProvider } from "@/lib/auth";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { router } from "@/router";
+import { initTheme } from "@/lib/theme";
 import "@/index.css";
+
+// Apply saved theme (or system default) before first paint to avoid flash.
+initTheme();
 
 const queryClient = new QueryClient({
   defaultOptions: {

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -14,11 +14,35 @@ import {
 } from "lucide-react";
 import { Link } from "react-router";
 
-const healthStatusConfig: Record<string, { label: string; color: string }> = {
-  healthy: { label: "Healthy", color: "text-emerald-500" },
-  needs_attention: { label: "Needs Attention", color: "text-amber-500" },
-  insufficient_data: { label: "No Data", color: "text-muted-foreground" },
+const healthStatusConfig: Record<string, { label: string; color: string; ring: string }> = {
+  healthy: { label: "Healthy", color: "text-emerald-500", ring: "stroke-emerald-500" },
+  needs_attention: { label: "Needs Attention", color: "text-amber-500", ring: "stroke-amber-500" },
+  insufficient_data: { label: "No Data", color: "text-muted-foreground", ring: "stroke-muted-foreground" },
 };
+
+/** Tiny SVG ring that fills to a given percentage. */
+function ProgressRing({ value, className }: { value: number; className?: string }) {
+  const r = 16;
+  const circumference = 2 * Math.PI * r;
+  const offset = circumference * (1 - Math.min(Math.max(value, 0), 1));
+  return (
+    <svg viewBox="0 0 40 40" className={className} aria-hidden="true">
+      <circle cx="20" cy="20" r={r} fill="none" strokeWidth="4" className="stroke-muted/40" />
+      <circle
+        cx="20"
+        cy="20"
+        r={r}
+        fill="none"
+        strokeWidth="4"
+        strokeLinecap="round"
+        strokeDasharray={circumference}
+        strokeDashoffset={offset}
+        className="transition-[stroke-dashoffset] duration-700 ease-out"
+        transform="rotate(-90 20 20)"
+      />
+    </svg>
+  );
+}
 
 export default function Dashboard() {
   const recent = useQuery({
@@ -35,7 +59,8 @@ export default function Dashboard() {
     staleTime: 30_000,
   });
 
-  const healthConfig = healthStatusConfig[traceHealth.data?.status ?? ""] ?? { label: "Unknown", color: "text-muted-foreground" };
+  const healthConfig = healthStatusConfig[traceHealth.data?.status ?? ""] ?? { label: "Unknown", color: "text-muted-foreground", ring: "stroke-muted-foreground" };
+  const completeness = traceHealth.data?.completeness.avg_completeness ?? 0;
 
   return (
     <div className="space-y-6">
@@ -111,20 +136,26 @@ export default function Dashboard() {
             ) : traceHealth.error ? (
               <p className="text-sm text-muted-foreground">Unavailable</p>
             ) : (
-              <>
-                <div className={`text-2xl font-bold ${healthConfig.color}`}>
-                  {healthConfig.label}
+              <div className="flex items-center gap-3">
+                <ProgressRing
+                  value={completeness}
+                  className={`h-10 w-10 ${healthConfig.ring}`}
+                />
+                <div>
+                  <div className={`text-lg font-bold leading-tight ${healthConfig.color}`}>
+                    {healthConfig.label}
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    {(completeness * 100).toFixed(0)}% complete
+                  </p>
                 </div>
-                <p className="text-xs text-muted-foreground">
-                  avg completeness: {((traceHealth.data?.completeness.avg_completeness ?? 0) * 100).toFixed(0)}%
-                </p>
-              </>
+              </div>
             )}
           </CardContent>
         </Card>
       </div>
 
-      {/* Coverage tips — informational, not errors */}
+      {/* Coverage tips */}
       {traceHealth.data?.gaps && traceHealth.data.gaps.length > 0 && (
         <Card>
           <CardHeader>
@@ -162,9 +193,15 @@ export default function Dashboard() {
               ))}
             </div>
           ) : !recent.data?.decisions?.length ? (
-            <p className="text-sm text-muted-foreground">
-              No decisions recorded yet.
-            </p>
+            <div className="flex flex-col items-center py-12 text-center">
+              <FileText className="h-12 w-12 text-muted-foreground/20 mb-3" />
+              <p className="text-sm text-muted-foreground">
+                No decisions recorded yet.
+              </p>
+              <p className="text-xs text-muted-foreground/60 mt-1">
+                Start tracing with the SDK to see decisions here.
+              </p>
+            </div>
           ) : (
             <div className="space-y-2">
               {recent.data.decisions.map((d) => (
@@ -173,15 +210,15 @@ export default function Dashboard() {
                   to={`/decisions/${d.run_id}`}
                   className="flex items-center justify-between rounded-md border p-3 text-sm transition-colors hover:bg-accent"
                 >
-                  <div className="flex items-center gap-3">
-                    <Badge variant="outline" className="font-mono text-xs">
+                  <div className="flex items-center gap-3 min-w-0">
+                    <Badge variant="outline" className="font-mono text-xs shrink-0">
                       {d.agent_id}
                     </Badge>
                     <span className="truncate max-w-[200px]">
                       {d.outcome}
                     </span>
                   </div>
-                  <div className="flex items-center gap-3 text-muted-foreground">
+                  <div className="flex items-center gap-3 text-muted-foreground shrink-0">
                     <Badge variant="secondary">{d.decision_type}</Badge>
                     <span className="text-xs whitespace-nowrap">
                       {formatRelativeTime(d.created_at)}

--- a/ui/src/pages/Decisions.tsx
+++ b/ui/src/pages/Decisions.tsx
@@ -22,7 +22,7 @@ import {
 } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
 import { formatDate, truncate } from "@/lib/utils";
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import { ChevronLeft, ChevronRight, FileText } from "lucide-react";
 
 const PAGE_SIZE = 25;
 const ALL_AGENTS = "__all__";
@@ -151,9 +151,15 @@ export default function Decisions() {
           ))}
         </div>
       ) : !data?.decisions?.length ? (
-        <p className="text-sm text-muted-foreground py-8 text-center">
-          No decisions found.
-        </p>
+        <div className="flex flex-col items-center py-12 text-center">
+          <FileText className="h-12 w-12 text-muted-foreground/20 mb-3" />
+          <p className="text-sm text-muted-foreground">No decisions found.</p>
+          {(agentFilter || typeFilter) && (
+            <p className="text-xs text-muted-foreground/60 mt-1">
+              Try adjusting your filters.
+            </p>
+          )}
+        </div>
       ) : (
         <>
           <Table>
@@ -195,19 +201,43 @@ export default function Decisions() {
                       {truncate(d.outcome, 60)}
                     </Link>
                   </TableCell>
-                  <TableCell className="text-right font-mono">
-                    {(d.confidence * 100).toFixed(0)}%
+                  <TableCell className="text-right">
+                    <div className="flex items-center justify-end gap-2">
+                      <div className="h-1.5 w-12 rounded-full bg-muted overflow-hidden">
+                        <div
+                          className="h-full rounded-full bg-primary transition-all"
+                          style={{ width: `${(d.confidence * 100).toFixed(0)}%` }}
+                        />
+                      </div>
+                      <span className="font-mono text-xs tabular-nums w-8 text-right">
+                        {(d.confidence * 100).toFixed(0)}%
+                      </span>
+                    </div>
                   </TableCell>
-                  <TableCell className="text-right font-mono">
-                    <span className={
-                      d.completeness_score >= 0.7
-                        ? "text-emerald-600"
-                        : d.completeness_score >= 0.5
-                        ? "text-amber-600"
-                        : "text-red-600"
-                    }>
-                      {(d.completeness_score * 100).toFixed(0)}%
-                    </span>
+                  <TableCell className="text-right">
+                    <div className="flex items-center justify-end gap-2">
+                      <div className="h-1.5 w-12 rounded-full bg-muted overflow-hidden">
+                        <div
+                          className={`h-full rounded-full transition-all ${
+                            d.completeness_score >= 0.7
+                              ? "bg-emerald-500"
+                              : d.completeness_score >= 0.5
+                              ? "bg-amber-500"
+                              : "bg-red-500"
+                          }`}
+                          style={{ width: `${(d.completeness_score * 100).toFixed(0)}%` }}
+                        />
+                      </div>
+                      <span className={`font-mono text-xs tabular-nums w-8 text-right ${
+                        d.completeness_score >= 0.7
+                          ? "text-emerald-600 dark:text-emerald-400"
+                          : d.completeness_score >= 0.5
+                          ? "text-amber-600 dark:text-amber-400"
+                          : "text-red-600 dark:text-red-400"
+                      }`}>
+                        {(d.completeness_score * 100).toFixed(0)}%
+                      </span>
+                    </div>
                   </TableCell>
                   <TableCell className="max-w-[240px] text-xs text-muted-foreground">
                     {d.reasoning ? truncate(d.reasoning, 80) : (

--- a/ui/src/pages/Login.tsx
+++ b/ui/src/pages/Login.tsx
@@ -1,9 +1,12 @@
 import { useState, type FormEvent } from "react";
 import { useAuth } from "@/lib/auth";
+import { useTheme } from "@/lib/theme";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { AkashiLogo } from "@/components/AkashiLogo";
+import { Moon, Sun } from "lucide-react";
 
 export default function Login() {
   const [agentId, setAgentId] = useState("");
@@ -11,6 +14,7 @@ export default function Login() {
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const { login } = useAuth();
+  const { theme, toggle: toggleTheme } = useTheme();
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
@@ -18,9 +22,6 @@ export default function Login() {
     setLoading(true);
     try {
       await login(agentId, apiKey);
-      // persistAuth wrote the token to localStorage before returning.
-      // Use a hard redirect so the app re-initialises from localStorage
-      // cleanly, bypassing React Router v7 data router state tearing.
       window.location.replace("/");
     } catch (err) {
       setError(err instanceof Error ? err.message : "Login failed");
@@ -29,51 +30,81 @@ export default function Login() {
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center px-4">
-      <Card className="w-full max-w-sm">
-        <CardHeader className="text-center">
-          <CardTitle className="text-2xl">Akashi</CardTitle>
-          <CardDescription>
-            Sign in with your agent credentials
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <form onSubmit={handleSubmit} className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="agent-id">Agent ID</Label>
-              <Input
-                id="agent-id"
-                value={agentId}
-                onChange={(e) => setAgentId(e.target.value)}
-                placeholder="admin"
-                required
-                autoFocus
-                autoComplete="username"
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="api-key">API Key</Label>
-              <Input
-                id="api-key"
-                type="password"
-                value={apiKey}
-                onChange={(e) => setApiKey(e.target.value)}
-                placeholder="your-api-key"
-                required
-                autoComplete="current-password"
-              />
-            </div>
-            {error && (
-              <p className="text-sm text-destructive" role="alert">
-                {error}
-              </p>
-            )}
-            <Button type="submit" className="w-full" disabled={loading}>
-              {loading ? "Signing in\u2026" : "Sign in"}
-            </Button>
-          </form>
-        </CardContent>
-      </Card>
+    <div className="relative flex min-h-screen items-center justify-center px-4">
+      {/* Subtle background gradient */}
+      <div className="pointer-events-none absolute inset-0 overflow-hidden">
+        <div className="absolute -top-1/2 left-1/2 -translate-x-1/2 h-[800px] w-[800px] rounded-full bg-primary/5 blur-3xl" />
+      </div>
+
+      {/* Theme toggle */}
+      <Button
+        variant="ghost"
+        size="icon"
+        className="absolute top-4 right-4 text-muted-foreground hover:text-foreground"
+        onClick={toggleTheme}
+        aria-label={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
+      >
+        {theme === "dark" ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+      </Button>
+
+      <div className="relative w-full max-w-sm space-y-8">
+        {/* Logo + tagline */}
+        <div className="flex flex-col items-center gap-4">
+          <AkashiLogo className="h-16 w-16 text-primary" />
+          <div className="text-center space-y-1">
+            <h1 className="text-3xl font-bold tracking-tight">Akashi</h1>
+            <p className="text-sm text-muted-foreground">
+              Decision trace layer for multi-agent AI systems
+            </p>
+          </div>
+        </div>
+
+        {/* Sign-in card */}
+        <Card className="border-border/50 shadow-lg dark:shadow-primary/5">
+          <CardHeader className="text-center pb-4">
+            <CardTitle className="text-lg">Sign in</CardTitle>
+            <CardDescription>
+              Enter your agent credentials
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="agent-id">Agent ID</Label>
+                <Input
+                  id="agent-id"
+                  value={agentId}
+                  onChange={(e) => setAgentId(e.target.value)}
+                  placeholder="admin"
+                  required
+                  autoFocus
+                  autoComplete="username"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="api-key">API Key</Label>
+                <Input
+                  id="api-key"
+                  type="password"
+                  value={apiKey}
+                  onChange={(e) => setApiKey(e.target.value)}
+                  placeholder="your-api-key"
+                  required
+                  autoComplete="current-password"
+                />
+              </div>
+              {error && (
+                <p className="text-sm text-destructive" role="alert">
+                  {error}
+                </p>
+              )}
+              <Button type="submit" className="w-full" disabled={loading}>
+                {loading ? "Signing in\u2026" : "Sign in"}
+              </Button>
+            </form>
+          </CardContent>
+        </Card>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Recreate the Akashi logo as an inline SVG component (`AkashiLogo`, `AkashiBrand`) and place it in the sidebar header, login page, mobile header, and as an SVG browser favicon
- Add dark/light mode with `localStorage` persistence and OS preference detection, toggled via sun/moon button in sidebar footer and login page
- Polish across the board: richer dark palette, active nav accent bar, animated progress ring for trace health, colored confidence/completeness bars in the Decisions table, better empty states, subtle login page glow, custom dark-mode scrollbars

## Test plan

- [ ] Open http://localhost:8080 — login page shows logo, tagline, and radial glow background
- [ ] Sign in — sidebar shows logo + "Akashi" wordmark with blue accent bar on active nav item
- [ ] Toggle dark/light via sun/moon button in sidebar footer — theme persists on reload
- [ ] Dashboard shows animated progress ring on Trace Health card
- [ ] Decisions table shows colored progress bars for confidence and completeness columns
- [ ] Empty states (no decisions, no agents) show icon + hint text
- [ ] Mobile breakpoint: hamburger menu shows logo in top bar, sidebar overlay has backdrop blur
- [ ] Browser tab shows Akashi logo as favicon

🤖 Generated with [Claude Code](https://claude.com/claude-code)