### PR TITLE
fix(verify): return retracted status instead of 404

### DIFF
--- a/internal/server/handlers_decisions.go
+++ b/internal/server/handlers_decisions.go
@@ -859,11 +859,24 @@ func (h *Handlers) HandleVerifyDecision(w http.ResponseWriter, r *http.Request) 
 
 	resp := map[string]any{"decision_id": id}
 
-	if d.ContentHash == "" {
+	switch {
+	case d.ValidTo != nil:
+		// Decision was retracted — still verify hash integrity but report retracted status.
+		resp["status"] = "retracted"
+		resp["retracted_at"] = d.ValidTo.UTC().Format(time.RFC3339Nano)
+		if d.ContentHash == "" {
+			resp["verified"] = false
+			resp["message"] = "this decision was created before content hashing was enabled"
+		} else {
+			valid := integrity.VerifyContentHash(d.ContentHash, d.ID, d.DecisionType, d.Outcome, d.Confidence, d.Reasoning, d.ValidFrom)
+			resp["verified"] = valid
+			resp["content_hash"] = d.ContentHash
+		}
+	case d.ContentHash == "":
 		// Pre-migration decisions have no hash — don't report them as tampered.
 		resp["status"] = "no_hash"
 		resp["message"] = "this decision was created before content hashing was enabled"
-	} else {
+	default:
 		valid := integrity.VerifyContentHash(d.ContentHash, d.ID, d.DecisionType, d.Outcome, d.Confidence, d.Reasoning, d.ValidFrom)
 		resp["valid"] = valid
 		if valid {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1858,6 +1858,104 @@ func TestHandleVerifyDecision_NotFound(t *testing.T) {
 	assert.Equal(t, model.ErrCodeNotFound, errResp.Error.Code)
 }
 
+func TestHandleVerifyDecision_Active(t *testing.T) {
+	// Trace a decision so it gets a content hash.
+	dt := "verify_active_" + uuid.NewString()[:8]
+	traceResp, err := authedRequest("POST", testSrv.URL+"/v1/trace", agentToken,
+		model.TraceRequest{
+			AgentID: "test-agent",
+			Decision: model.TraceDecision{
+				DecisionType: dt,
+				Outcome:      "active decision for verify test",
+				Confidence:   0.9,
+				Reasoning:    ptrStr("testing verify on active decision"),
+			},
+		})
+	require.NoError(t, err)
+	defer func() { _ = traceResp.Body.Close() }()
+	require.Equal(t, http.StatusCreated, traceResp.StatusCode)
+
+	var traceResult struct {
+		Data struct {
+			DecisionID uuid.UUID `json:"decision_id"`
+		} `json:"data"`
+	}
+	traceBody, _ := io.ReadAll(traceResp.Body)
+	require.NoError(t, json.Unmarshal(traceBody, &traceResult))
+	decisionID := traceResult.Data.DecisionID
+
+	resp, err := authedRequest("GET", testSrv.URL+"/v1/verify/"+decisionID.String(), adminToken, nil)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var result map[string]any
+	body, _ := io.ReadAll(resp.Body)
+	require.NoError(t, json.Unmarshal(body, &result))
+
+	data, ok := result["data"].(map[string]any)
+	require.True(t, ok, "expected data wrapper in response")
+	assert.Equal(t, "verified", data["status"])
+	assert.Equal(t, true, data["valid"])
+	assert.NotEmpty(t, data["content_hash"])
+	assert.Nil(t, data["retracted_at"], "active decision must not have retracted_at")
+}
+
+func TestHandleVerifyDecision_Retracted(t *testing.T) {
+	// Trace a decision, retract it, then verify it.
+	dt := "verify_retracted_" + uuid.NewString()[:8]
+	traceResp, err := authedRequest("POST", testSrv.URL+"/v1/trace", agentToken,
+		model.TraceRequest{
+			AgentID: "test-agent",
+			Decision: model.TraceDecision{
+				DecisionType: dt,
+				Outcome:      "will be retracted then verified",
+				Confidence:   0.75,
+				Reasoning:    ptrStr("testing verify on retracted decision"),
+			},
+		})
+	require.NoError(t, err)
+	defer func() { _ = traceResp.Body.Close() }()
+	require.Equal(t, http.StatusCreated, traceResp.StatusCode)
+
+	var traceResult struct {
+		Data struct {
+			DecisionID uuid.UUID `json:"decision_id"`
+		} `json:"data"`
+	}
+	traceBody, _ := io.ReadAll(traceResp.Body)
+	require.NoError(t, json.Unmarshal(traceBody, &traceResult))
+	decisionID := traceResult.Data.DecisionID
+
+	// Retract the decision.
+	retractResp, err := authedRequest("DELETE", testSrv.URL+"/v1/decisions/"+decisionID.String(), adminToken,
+		map[string]string{"reason": "verify retraction test"})
+	require.NoError(t, err)
+	defer func() { _ = retractResp.Body.Close() }()
+	require.Equal(t, http.StatusOK, retractResp.StatusCode)
+
+	// Verify the retracted decision.
+	resp, err := authedRequest("GET", testSrv.URL+"/v1/verify/"+decisionID.String(), adminToken, nil)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var result map[string]any
+	body, _ := io.ReadAll(resp.Body)
+	require.NoError(t, json.Unmarshal(body, &result))
+
+	data, ok := result["data"].(map[string]any)
+	require.True(t, ok, "expected data wrapper in response")
+	assert.Equal(t, "retracted", data["status"])
+	assert.NotEmpty(t, data["retracted_at"], "retracted decision must have retracted_at")
+	assert.Equal(t, true, data["verified"], "hash should still verify for retracted decision")
+	assert.NotEmpty(t, data["content_hash"])
+
+	// Confirm retracted_at parses as a valid timestamp.
+	_, parseErr := time.Parse(time.RFC3339Nano, data["retracted_at"].(string))
+	assert.NoError(t, parseErr, "retracted_at must be a valid RFC3339Nano timestamp")
+}
+
 func TestHandleSessionView_EmptySession(t *testing.T) {
 	randomID := uuid.New().String()
 	resp, err := authedRequest("GET", testSrv.URL+"/v1/sessions/"+randomID, adminToken, nil)


### PR DESCRIPTION
## Summary

- `GET /v1/verify/{id}` now returns HTTP 200 with `status: "retracted"` and `retracted_at` for soft-deleted decisions, instead of returning the same response as active decisions
- Hash verification still runs on retracted records — the `verified` field indicates whether the content hash is intact
- Non-existent IDs continue to return 404

Closes #282

## Test plan

- [x] `TestHandleVerifyDecision_Retracted`: trace → retract → verify, asserts 200 with `status: "retracted"`, valid `retracted_at` timestamp, `verified: true`, and `content_hash` present
- [x] `TestHandleVerifyDecision_Active`: trace → verify, asserts 200 with `status: "verified"`, `valid: true`
- [x] `TestHandleVerifyDecision_NotFound`: random UUID returns 404 (existing test, unchanged)
- [x] Full test suite passes with `-race`