### PR TITLE
feat: add batch resolution API for conflict groups

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1120,6 +1120,42 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
+  /v1/conflict-groups/{id}/resolve:
+    patch:
+      operationId: resolveConflictGroup
+      tags: [Query]
+      summary: Batch-resolve all open conflicts in a conflict group
+      description: |
+        Resolves all open or acknowledged conflicts in a conflict group at once.
+        When `winning_agent` is provided with status "resolved", each conflict's
+        `winning_decision_id` is set to the decision from that agent.
+        Requires `agent` role or higher.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: The conflict group ID.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ConflictGroupResolveRequest"
+      responses:
+        "200":
+          description: Batch resolution result.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConflictGroupResolveResult"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
   /v1/check:
     post:
       operationId: checkPrecedent
@@ -2492,6 +2528,38 @@ components:
             Optional. The decision judged to be correct. Must be decision_a_id or
             decision_b_id of the conflict. Only valid when status is "resolved".
             When omitted, the conflict is resolved without declaring a winner.
+
+    ConflictGroupResolveRequest:
+      type: object
+      required: [status]
+      properties:
+        status:
+          type: string
+          enum: [resolved, wont_fix]
+          description: Target status for all open/acknowledged conflicts in the group.
+        resolution_note:
+          type: string
+          description: Explanation applied to every conflict in the group.
+        winning_agent:
+          type: string
+          description: |
+            Optional. Resolve all conflicts in favor of decisions from this agent.
+            Only valid when status is "resolved". Each conflict's winning_decision_id
+            is set to the decision from this agent (decision_a or decision_b).
+
+    ConflictGroupResolveResult:
+      type: object
+      required: [group_id, status, resolved]
+      properties:
+        group_id:
+          type: string
+          format: uuid
+        status:
+          type: string
+          enum: [resolved, wont_fix]
+        resolved:
+          type: integer
+          description: Number of conflicts that were resolved.
 
     AdjudicateConflictRequest:
       type: object

--- a/internal/model/decision.go
+++ b/internal/model/decision.go
@@ -234,6 +234,26 @@ type ConflictStatusUpdate struct {
 	WinningDecisionID *uuid.UUID `json:"winning_decision_id,omitempty"`
 }
 
+// ConflictGroupResolveRequest is the request body for
+// PATCH /v1/conflict-groups/{id}/resolve. It batch-resolves all open or
+// acknowledged conflicts in a conflict group.
+type ConflictGroupResolveRequest struct {
+	Status         string  `json:"status"` // resolved or wont_fix
+	ResolutionNote *string `json:"resolution_note,omitempty"`
+	// WinningAgent optionally declares the agent whose decisions prevail for
+	// every conflict in the group. When set, each conflict's winning_decision_id
+	// is set to the decision from this agent (decision_a or decision_b).
+	WinningAgent *string `json:"winning_agent,omitempty"`
+}
+
+// ConflictGroupResolveResult is the response body for
+// PATCH /v1/conflict-groups/{id}/resolve.
+type ConflictGroupResolveResult struct {
+	GroupID  uuid.UUID `json:"group_id"`
+	Status   string    `json:"status"`
+	Resolved int       `json:"resolved"`
+}
+
 // AssessmentOutcome enumerates valid values for DecisionAssessment.Outcome.
 type AssessmentOutcome string
 

--- a/internal/server/handlers_decisions.go
+++ b/internal/server/handlers_decisions.go
@@ -682,6 +682,72 @@ func (h *Handlers) HandlePatchConflict(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, r, http.StatusOK, conflict)
 }
 
+// validGroupResolveStatuses defines the allowed values for batch conflict group resolution.
+// "acknowledged" is excluded because batch-acknowledging a group is not a resolution action.
+var validGroupResolveStatuses = map[string]bool{
+	"resolved": true,
+	"wont_fix": true,
+}
+
+// HandleResolveConflictGroup handles PATCH /v1/conflict-groups/{id}/resolve.
+// Batch-resolves all open or acknowledged conflicts in a conflict group.
+func (h *Handlers) HandleResolveConflictGroup(w http.ResponseWriter, r *http.Request) {
+	claims := ClaimsFromContext(r.Context())
+	orgID := OrgIDFromContext(r.Context())
+
+	idStr := r.PathValue("id")
+	groupID, err := uuid.Parse(idStr)
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "invalid conflict group id")
+		return
+	}
+
+	var req model.ConflictGroupResolveRequest
+	if err := decodeJSON(w, r, &req, h.maxRequestBodyBytes); err != nil {
+		handleDecodeError(w, r, err)
+		return
+	}
+
+	if !validGroupResolveStatuses[req.Status] {
+		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput,
+			"status must be one of: resolved, wont_fix")
+		return
+	}
+
+	if req.WinningAgent != nil && req.Status != "resolved" {
+		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput,
+			"winning_agent can only be set when status is 'resolved'")
+		return
+	}
+
+	resolvedBy := claims.AgentID
+	if resolvedBy == "" {
+		resolvedBy = claims.Subject
+	}
+
+	audit := h.buildAuditEntry(r, orgID,
+		"conflict_group_resolved", "conflict_group", groupID.String(),
+		nil, nil,
+		map[string]any{"new_status": req.Status, "resolved_by": resolvedBy},
+	)
+
+	affected, err := h.db.ResolveConflictGroup(r.Context(), groupID, orgID, req.Status, resolvedBy, req.ResolutionNote, req.WinningAgent, audit)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			writeError(w, r, http.StatusNotFound, model.ErrCodeNotFound, "conflict group not found")
+			return
+		}
+		h.writeInternalError(w, r, "failed to resolve conflict group", err)
+		return
+	}
+
+	writeJSON(w, r, http.StatusOK, model.ConflictGroupResolveResult{
+		GroupID:  groupID,
+		Status:   req.Status,
+		Resolved: affected,
+	})
+}
+
 // HandleAdjudicateConflict handles POST /v1/conflicts/{id}/adjudicate.
 // Creates an adjudication decision trace and links it to the conflict.
 func (h *Handlers) HandleAdjudicateConflict(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -180,9 +180,10 @@ func New(cfg ServerConfig) *Server {
 	mux.Handle("POST /v1/grants", writeRole(http.HandlerFunc(h.HandleCreateGrant)))
 	mux.Handle("DELETE /v1/grants/{grant_id}", writeRole(http.HandlerFunc(h.HandleDeleteGrant)))
 
-	// Conflicts (reader+ for list, agent+ for adjudicate/patch).
+	// Conflicts (reader+ for list, agent+ for adjudicate/patch/resolve).
 	mux.Handle("GET /v1/conflicts", readRole(http.HandlerFunc(h.HandleListConflicts)))
 	mux.Handle("GET /v1/conflict-groups", readRole(http.HandlerFunc(h.HandleListConflictGroups)))
+	mux.Handle("PATCH /v1/conflict-groups/{id}/resolve", writeRole(http.HandlerFunc(h.HandleResolveConflictGroup)))
 	mux.Handle("POST /v1/conflicts/{id}/adjudicate", writeRole(http.HandlerFunc(h.HandleAdjudicateConflict)))
 	mux.Handle("PATCH /v1/conflicts/{id}", writeRole(http.HandlerFunc(h.HandlePatchConflict)))
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -3161,3 +3161,212 @@ func TestHandleRetractDecision(t *testing.T) {
 		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 	})
 }
+
+// ---- HandleResolveConflictGroup ------------------------------------------
+
+// seedConflictGroup creates two decisions and two open conflicts sharing the
+// same conflict group. Returns the group ID, two conflict IDs, and the two
+// decision IDs (A1, B1 for the first pair; A2, B2 for the second). Agent
+// names are "alpha" (side A) and "beta" (side B).
+func seedConflictGroup(t *testing.T) (groupID uuid.UUID, conflictIDs [2]uuid.UUID, decisionIDs [4]uuid.UUID) {
+	t.Helper()
+	orgID := uuid.Nil
+
+	traceDecision := func(agentID, outcome string, confidence float32) uuid.UUID {
+		resp, tErr := authedRequest("POST", testSrv.URL+"/v1/trace", adminToken, model.TraceRequest{
+			AgentID: agentID,
+			Decision: model.TraceDecision{
+				DecisionType: "architecture",
+				Outcome:      outcome,
+				Confidence:   confidence,
+			},
+		})
+		require.NoError(t, tErr)
+		defer func() { _ = resp.Body.Close() }()
+		require.Contains(t, []int{http.StatusOK, http.StatusCreated, http.StatusAccepted}, resp.StatusCode)
+		var result struct {
+			Data struct {
+				DecisionID uuid.UUID `json:"decision_id"`
+			} `json:"data"`
+		}
+		b, _ := io.ReadAll(resp.Body)
+		require.NoError(t, json.Unmarshal(b, &result))
+		require.NotEqual(t, uuid.Nil, result.Data.DecisionID)
+		return result.Data.DecisionID
+	}
+
+	// Create 4 decisions: two per side
+	decisionIDs[0] = traceDecision("alpha", "use Redis for caching", 0.9)
+	decisionIDs[1] = traceDecision("beta", "use Memcached for caching", 0.8)
+	decisionIDs[2] = traceDecision("alpha", "Redis cluster mode", 0.85)
+	decisionIDs[3] = traceDecision("beta", "Memcached with mcrouter", 0.75)
+
+	require.NoError(t, testBuf.FlushNow(context.Background()))
+
+	// Insert two conflicts — InsertScoredConflict auto-creates and links the group.
+	for i, pair := range [][2]int{{0, 1}, {2, 3}} {
+		c := model.DecisionConflict{
+			OrgID:         orgID,
+			ConflictKind:  model.ConflictKindCrossAgent,
+			DecisionAID:   decisionIDs[pair[0]],
+			DecisionBID:   decisionIDs[pair[1]],
+			AgentA:        "alpha",
+			AgentB:        "beta",
+			DecisionTypeA: "architecture",
+			DecisionTypeB: "architecture",
+			OutcomeA:      "alpha outcome",
+			OutcomeB:      "beta outcome",
+			Status:        "open",
+		}
+		var err error
+		conflictIDs[i], err = testDB.InsertScoredConflict(context.Background(), c)
+		require.NoError(t, err)
+	}
+
+	// Retrieve the group_id that was auto-created.
+	conflict, err := testDB.GetConflict(context.Background(), conflictIDs[0], orgID)
+	require.NoError(t, err)
+	require.NotNil(t, conflict.GroupID, "InsertScoredConflict must set group_id")
+	groupID = *conflict.GroupID
+
+	return groupID, conflictIDs, decisionIDs
+}
+
+func TestHandleResolveConflictGroup(t *testing.T) {
+	t.Run("invalid UUID returns 400", func(t *testing.T) {
+		resp, err := authedRequest("PATCH", testSrv.URL+"/v1/conflict-groups/not-a-uuid/resolve", adminToken,
+			model.ConflictGroupResolveRequest{Status: "resolved"})
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	t.Run("invalid status returns 400", func(t *testing.T) {
+		resp, err := authedRequest("PATCH", testSrv.URL+"/v1/conflict-groups/"+uuid.New().String()+"/resolve", adminToken,
+			model.ConflictGroupResolveRequest{Status: "acknowledged"})
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+		var errResp model.APIError
+		body, _ := io.ReadAll(resp.Body)
+		_ = json.Unmarshal(body, &errResp)
+		assert.Equal(t, model.ErrCodeInvalidInput, errResp.Error.Code)
+	})
+
+	t.Run("winning_agent with wont_fix returns 400", func(t *testing.T) {
+		agent := "alpha"
+		resp, err := authedRequest("PATCH", testSrv.URL+"/v1/conflict-groups/"+uuid.New().String()+"/resolve", adminToken,
+			model.ConflictGroupResolveRequest{Status: "wont_fix", WinningAgent: &agent})
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	t.Run("nonexistent group returns 404", func(t *testing.T) {
+		resp, err := authedRequest("PATCH", testSrv.URL+"/v1/conflict-groups/"+uuid.New().String()+"/resolve", adminToken,
+			model.ConflictGroupResolveRequest{Status: "resolved"})
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	})
+
+	t.Run("resolved without winning_agent resolves all open conflicts", func(t *testing.T) {
+		groupID, _, _ := seedConflictGroup(t)
+		note := "all caching decisions settled"
+
+		resp, err := authedRequest("PATCH", testSrv.URL+"/v1/conflict-groups/"+groupID.String()+"/resolve", adminToken,
+			model.ConflictGroupResolveRequest{Status: "resolved", ResolutionNote: &note})
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var envelope struct {
+			Data model.ConflictGroupResolveResult `json:"data"`
+		}
+		b, _ := io.ReadAll(resp.Body)
+		require.NoError(t, json.Unmarshal(b, &envelope))
+		assert.Equal(t, groupID, envelope.Data.GroupID)
+		assert.Equal(t, "resolved", envelope.Data.Status)
+		assert.Equal(t, 2, envelope.Data.Resolved, "both open conflicts should be resolved")
+	})
+
+	t.Run("resolved with winning_agent sets winning_decision_id", func(t *testing.T) {
+		groupID, conflictIDs, _ := seedConflictGroup(t)
+		agent := "alpha"
+		note := "alpha is authoritative"
+
+		resp, err := authedRequest("PATCH", testSrv.URL+"/v1/conflict-groups/"+groupID.String()+"/resolve", adminToken,
+			model.ConflictGroupResolveRequest{Status: "resolved", WinningAgent: &agent, ResolutionNote: &note})
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var envelope struct {
+			Data model.ConflictGroupResolveResult `json:"data"`
+		}
+		b, _ := io.ReadAll(resp.Body)
+		require.NoError(t, json.Unmarshal(b, &envelope))
+		assert.Equal(t, 2, envelope.Data.Resolved)
+
+		// Verify winning_decision_id was set on each conflict.
+		for _, cid := range conflictIDs {
+			conflict, cErr := testDB.GetConflict(context.Background(), cid, uuid.Nil)
+			require.NoError(t, cErr)
+			require.NotNil(t, conflict)
+			assert.Equal(t, "resolved", conflict.Status)
+			require.NotNil(t, conflict.WinningDecisionID, "winning_decision_id should be set")
+		}
+	})
+
+	t.Run("wont_fix resolves without winner", func(t *testing.T) {
+		groupID, conflictIDs, _ := seedConflictGroup(t)
+
+		resp, err := authedRequest("PATCH", testSrv.URL+"/v1/conflict-groups/"+groupID.String()+"/resolve", adminToken,
+			model.ConflictGroupResolveRequest{Status: "wont_fix"})
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var envelope struct {
+			Data model.ConflictGroupResolveResult `json:"data"`
+		}
+		b, _ := io.ReadAll(resp.Body)
+		require.NoError(t, json.Unmarshal(b, &envelope))
+		assert.Equal(t, "wont_fix", envelope.Data.Status)
+		assert.Equal(t, 2, envelope.Data.Resolved)
+
+		for _, cid := range conflictIDs {
+			conflict, cErr := testDB.GetConflict(context.Background(), cid, uuid.Nil)
+			require.NoError(t, cErr)
+			require.NotNil(t, conflict)
+			assert.Equal(t, "wont_fix", conflict.Status)
+			assert.Nil(t, conflict.WinningDecisionID, "wont_fix should not set winner")
+		}
+	})
+
+	t.Run("idempotent re-resolve returns 0 affected", func(t *testing.T) {
+		groupID, _, _ := seedConflictGroup(t)
+
+		// Resolve first time.
+		resp, err := authedRequest("PATCH", testSrv.URL+"/v1/conflict-groups/"+groupID.String()+"/resolve", adminToken,
+			model.ConflictGroupResolveRequest{Status: "resolved"})
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		// Resolve second time — no open conflicts remain.
+		resp2, err := authedRequest("PATCH", testSrv.URL+"/v1/conflict-groups/"+groupID.String()+"/resolve", adminToken,
+			model.ConflictGroupResolveRequest{Status: "resolved"})
+		require.NoError(t, err)
+		defer func() { _ = resp2.Body.Close() }()
+		require.Equal(t, http.StatusOK, resp2.StatusCode)
+
+		var envelope struct {
+			Data model.ConflictGroupResolveResult `json:"data"`
+		}
+		b, _ := io.ReadAll(resp2.Body)
+		require.NoError(t, json.Unmarshal(b, &envelope))
+		assert.Equal(t, 0, envelope.Data.Resolved, "no open conflicts to resolve on second call")
+	})
+}

--- a/internal/storage/conflicts.go
+++ b/internal/storage/conflicts.go
@@ -792,3 +792,85 @@ func (db *DB) ListConflictGroups(ctx context.Context, orgID uuid.UUID, f Conflic
 
 	return groups, nil
 }
+
+// ResolveConflictGroup batch-resolves all open or acknowledged conflicts in a
+// conflict group. When winningAgent is non-nil, each conflict's winning_decision_id
+// is set to the decision from that agent (decision_a_id when agent_a matches,
+// decision_b_id when agent_b matches). Returns the number of conflicts updated.
+func (db *DB) ResolveConflictGroup(
+	ctx context.Context,
+	groupID, orgID uuid.UUID,
+	status, resolvedBy string,
+	resolutionNote *string,
+	winningAgent *string,
+	audit MutationAuditEntry,
+) (int, error) {
+	tx, err := db.pool.Begin(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("storage: begin resolve group tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	// Verify the group exists and belongs to this org.
+	var exists bool
+	if err := tx.QueryRow(ctx,
+		`SELECT EXISTS(SELECT 1 FROM conflict_groups WHERE id = $1 AND org_id = $2)`,
+		groupID, orgID,
+	).Scan(&exists); err != nil {
+		return 0, fmt.Errorf("storage: check conflict group: %w", err)
+	}
+	if !exists {
+		return 0, fmt.Errorf("storage: conflict group not found")
+	}
+
+	// Build the UPDATE. When winning_agent is set, derive winning_decision_id
+	// per-row from the agent columns. Only "resolved" sets a winner;
+	// "wont_fix" intentionally leaves winning_decision_id NULL.
+	var tag pgconn.CommandTag
+	if winningAgent != nil && status == "resolved" {
+		tag, err = tx.Exec(ctx,
+			`UPDATE scored_conflicts
+			 SET status = $1,
+			     resolved_by = $2,
+			     resolved_at = now(),
+			     resolution_note = $3,
+			     winning_decision_id = CASE
+			         WHEN agent_a = $4 THEN decision_a_id
+			         WHEN agent_b = $4 THEN decision_b_id
+			         ELSE NULL
+			     END
+			 WHERE group_id = $5 AND org_id = $6
+			   AND status IN ('open', 'acknowledged')`,
+			status, resolvedBy, resolutionNote, *winningAgent, groupID, orgID)
+	} else {
+		tag, err = tx.Exec(ctx,
+			`UPDATE scored_conflicts
+			 SET status = $1,
+			     resolved_by = $2,
+			     resolved_at = now(),
+			     resolution_note = $3
+			 WHERE group_id = $4 AND org_id = $5
+			   AND status IN ('open', 'acknowledged')`,
+			status, resolvedBy, resolutionNote, groupID, orgID)
+	}
+	if err != nil {
+		return 0, fmt.Errorf("storage: resolve conflict group: %w", err)
+	}
+
+	affected := int(tag.RowsAffected())
+
+	audit.BeforeData = map[string]any{"group_id": groupID.String(), "open_count": affected}
+	afterData := map[string]any{"status": status, "resolved_by": resolvedBy, "resolved_count": affected}
+	if winningAgent != nil {
+		afterData["winning_agent"] = *winningAgent
+	}
+	audit.AfterData = afterData
+	if err := InsertMutationAuditTx(ctx, tx, audit); err != nil {
+		return 0, fmt.Errorf("storage: audit in resolve group tx: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return 0, fmt.Errorf("storage: commit resolve group tx: %w", err)
+	}
+	return affected, nil
+}


### PR DESCRIPTION
## Summary

- Adds `PATCH /v1/conflict-groups/{id}/resolve` to batch-resolve all open/acknowledged conflicts in a conflict group
- Supports `resolved` and `wont_fix` statuses, with optional `winning_agent` to declare a winner per-conflict
- Single UPDATE statement with mutation audit entry, all in one transaction

Closes #292

## Changes

- **`internal/model/decision.go`** — `ConflictGroupResolveRequest` and `ConflictGroupResolveResult` types
- **`internal/storage/conflicts.go`** — `ResolveConflictGroup()` with org-scoped, transactional batch UPDATE
- **`internal/server/handlers_decisions.go`** — `HandleResolveConflictGroup` handler with input validation
- **`internal/server/server.go`** — Route registration with `writeRole` auth
- **`api/openapi.yaml`** — Endpoint and schema definitions
- **`internal/server/server_test.go`** — 8 test cases (validation, 404, resolve, wont_fix, winning_agent, idempotency)

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `golangci-lint run ./...` — 0 issues
- [x] `atlas migrate validate` passes
- [x] `go test -race -count=1 ./...` — all tests pass
- [x] 8 new integration tests cover: invalid UUID, invalid status, winning_agent+wont_fix rejection, nonexistent group, resolved without winner, resolved with winning_agent, wont_fix, idempotent re-resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)