### PR TITLE
feat: GDPR tombstone erasure via POST /v1/decisions/{id}/erase

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -955,6 +955,61 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
+  /v1/decisions/{id}/erase:
+    post:
+      operationId: eraseDecision
+      tags: [Decisions, GDPR]
+      summary: GDPR tombstone erasure
+      description: |
+        Scrubs PII fields (outcome, reasoning) from a decision in-place
+        without deleting the row, preserving the audit chain. Also scrubs
+        associated alternatives (label, rejection_reason) and evidence
+        (content, source_uri). Recomputes the content hash over the
+        scrubbed fields and records the original hash in a decision_erasures
+        row for forensic verification.
+
+        This operation is irreversible. Blocked if the decision is covered
+        by an active legal hold.
+
+        Requires `org_owner` role or higher.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: The decision ID to erase.
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reason:
+                  type: string
+                  description: Optional reason for the erasure (e.g., "GDPR data subject request #1234").
+      responses:
+        "200":
+          description: Decision PII successfully erased.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/APIResponse_ErasureResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: Decision is covered by an active legal hold, or has already been erased.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/APIError"
+
   /v1/verify/{id}:
     get:
       operationId: verifyDecision
@@ -3302,20 +3357,68 @@ components:
 
     VerifyResponse:
       type: object
-      required: [decision_id, valid, stored_hash, computed_hash]
+      required: [decision_id, status]
       properties:
         decision_id:
           type: string
           format: uuid
+        status:
+          type: string
+          enum: [verified, tampered, no_hash, erased]
+          description: |
+            Integrity status. "erased" means GDPR tombstone erasure
+            was applied; the hash covers the scrubbed content.
         valid:
           type: boolean
           description: Whether the stored content hash matches the recomputed hash.
-        stored_hash:
+        content_hash:
           type: string
           description: The hash stored in the database.
-        computed_hash:
+        original_hash:
           type: string
-          description: The hash recomputed from current field values.
+          description: Pre-erasure hash (only present when status is "erased").
+        erased_at:
+          type: string
+          format: date-time
+          description: When the erasure occurred (only present when status is "erased").
+        erased_by:
+          type: string
+          description: Agent that performed the erasure (only present when status is "erased").
+        message:
+          type: string
+          description: Explanation (only present when status is "no_hash").
+
+    ErasureResponse:
+      type: object
+      required: [decision_id, erased_at, original_hash, erased_hash, alternatives_erased, evidence_erased]
+      properties:
+        decision_id:
+          type: string
+          format: uuid
+        erased_at:
+          type: string
+          format: date-time
+        original_hash:
+          type: string
+          description: The content hash before erasure.
+        erased_hash:
+          type: string
+          description: The content hash recomputed over scrubbed fields.
+        alternatives_erased:
+          type: integer
+          description: Number of alternatives rows scrubbed.
+        evidence_erased:
+          type: integer
+          description: Number of evidence rows scrubbed.
+
+    APIResponse_ErasureResponse:
+      type: object
+      required: [data, meta]
+      properties:
+        data:
+          $ref: "#/components/schemas/ErasureResponse"
+        meta:
+          $ref: "#/components/schemas/ResponseMeta"
 
     APIResponse_VerifyResponse:
       type: object

--- a/internal/model/decision.go
+++ b/internal/model/decision.go
@@ -290,3 +290,17 @@ type AssessRequest struct {
 	Outcome AssessmentOutcome `json:"outcome"`
 	Notes   *string           `json:"notes,omitempty"`
 }
+
+// DecisionErasure records that a decision's PII was scrubbed per GDPR Art. 17.
+// The original content hash is preserved for forensic verification that the
+// decision existed and was intentionally erased (vs. tampered with).
+type DecisionErasure struct {
+	ID           uuid.UUID `json:"id"`
+	DecisionID   uuid.UUID `json:"decision_id"`
+	OrgID        uuid.UUID `json:"org_id"`
+	ErasedBy     string    `json:"erased_by"`
+	OriginalHash string    `json:"original_hash"`
+	ErasedHash   string    `json:"erased_hash"`
+	Reason       string    `json:"reason"`
+	ErasedAt     time.Time `json:"erased_at"`
+}

--- a/internal/model/event.go
+++ b/internal/model/event.go
@@ -23,6 +23,7 @@ const (
 	EventDecisionMade           EventType = "DecisionMade"
 	EventDecisionRevised        EventType = "DecisionRevised"
 	EventDecisionRetracted      EventType = "DecisionRetracted"
+	EventDecisionErased         EventType = "DecisionErased"
 
 	// Tool events.
 	EventToolCallStarted   EventType = "ToolCallStarted"

--- a/internal/server/handlers_decisions.go
+++ b/internal/server/handlers_decisions.go
@@ -943,14 +943,32 @@ func (h *Handlers) HandleVerifyDecision(w http.ResponseWriter, r *http.Request) 
 		resp["status"] = "no_hash"
 		resp["message"] = "this decision was created before content hashing was enabled"
 	default:
-		valid := integrity.VerifyContentHash(d.ContentHash, d.ID, d.DecisionType, d.Outcome, d.Confidence, d.Reasoning, d.ValidFrom)
-		resp["valid"] = valid
-		if valid {
-			resp["status"] = "verified"
-		} else {
-			resp["status"] = "tampered"
+		// Check for GDPR erasure before standard verification.
+		erasure, erasureErr := h.db.GetDecisionErasure(r.Context(), orgID, id)
+		switch {
+		case erasureErr == nil:
+			// Decision has been erased — verify the erased hash matches.
+			valid := integrity.VerifyContentHash(d.ContentHash, d.ID, d.DecisionType, d.Outcome, d.Confidence, d.Reasoning, d.ValidFrom)
+			resp["status"] = "erased"
+			resp["valid"] = valid
+			resp["content_hash"] = d.ContentHash
+			resp["original_hash"] = erasure.OriginalHash
+			resp["erased_at"] = erasure.ErasedAt
+			resp["erased_by"] = erasure.ErasedBy
+		case !isNotFoundError(erasureErr):
+			h.writeInternalError(w, r, "failed to check erasure status", erasureErr)
+			return
+		default:
+			// No erasure — standard verification.
+			valid := integrity.VerifyContentHash(d.ContentHash, d.ID, d.DecisionType, d.Outcome, d.Confidence, d.Reasoning, d.ValidFrom)
+			resp["valid"] = valid
+			if valid {
+				resp["status"] = "verified"
+			} else {
+				resp["status"] = "tampered"
+			}
+			resp["content_hash"] = d.ContentHash
 		}
-		resp["content_hash"] = d.ContentHash
 	}
 
 	writeJSON(w, r, http.StatusOK, resp)
@@ -1261,4 +1279,75 @@ func (h *Handlers) HandleRetractDecision(w http.ResponseWriter, r *http.Request)
 	}
 
 	writeJSON(w, r, http.StatusOK, decision)
+}
+
+// HandleEraseDecision handles POST /v1/decisions/{id}/erase.
+// GDPR Art. 17 tombstone erasure: scrubs PII fields in-place without deleting
+// the decision row, preserving the audit chain. Requires org_owner role.
+func (h *Handlers) HandleEraseDecision(w http.ResponseWriter, r *http.Request) {
+	orgID := OrgIDFromContext(r.Context())
+
+	idStr := r.PathValue("id")
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "invalid decision id")
+		return
+	}
+
+	// Decode optional body with reason.
+	var req struct {
+		Reason string `json:"reason"`
+	}
+	if r.Body != nil && r.ContentLength != 0 {
+		if err := decodeJSON(w, r, &req, h.maxRequestBodyBytes); err != nil {
+			handleDecodeError(w, r, err)
+			return
+		}
+	}
+
+	// Block erasure if an active legal hold covers this decision.
+	holdActive, err := h.db.ActiveHoldsExistForDecision(r.Context(), orgID, id)
+	if err != nil {
+		h.writeInternalError(w, r, "failed to check legal holds", err)
+		return
+	}
+	if holdActive {
+		writeError(w, r, http.StatusConflict, model.ErrCodeConflict,
+			"decision is covered by an active legal hold and cannot be erased")
+		return
+	}
+
+	claims := ClaimsFromContext(r.Context())
+	erasedBy := claims.AgentID
+	if erasedBy == "" {
+		erasedBy = claims.Subject
+	}
+
+	audit := h.buildAuditEntry(r, orgID,
+		"decision_erased", "decision", id.String(),
+		nil, nil,
+		map[string]any{"erased_by": erasedBy, "reason": req.Reason},
+	)
+	result, err := h.db.EraseDecision(r.Context(), orgID, id, req.Reason, erasedBy, &audit)
+	if err != nil {
+		if isNotFoundError(err) {
+			writeError(w, r, http.StatusNotFound, model.ErrCodeNotFound, "decision not found")
+			return
+		}
+		if errors.Is(err, storage.ErrAlreadyErased) {
+			writeError(w, r, http.StatusConflict, model.ErrCodeConflict, "decision has already been erased")
+			return
+		}
+		h.writeInternalError(w, r, "failed to erase decision", err)
+		return
+	}
+
+	writeJSON(w, r, http.StatusOK, map[string]any{
+		"decision_id":         id,
+		"erased_at":           result.Erasure.ErasedAt,
+		"original_hash":       result.Erasure.OriginalHash,
+		"erased_hash":         result.Erasure.ErasedHash,
+		"alternatives_erased": result.AlternativesErased,
+		"evidence_erased":     result.EvidenceErased,
+	})
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -120,6 +120,10 @@ func New(cfg ServerConfig) *Server {
 	mux.Handle("DELETE /v1/decisions/{id}", adminOnly(http.HandlerFunc(h.HandleRetractDecision)))
 	mux.Handle("GET /v1/export/decisions", adminOnly(http.HandlerFunc(h.HandleExportDecisions)))
 
+	// GDPR erasure (org_owner+ — stronger than admin because erasure is irreversible).
+	orgOwnerOnly := requireRole(model.RoleOrgOwner)
+	mux.Handle("POST /v1/decisions/{id}/erase", orgOwnerOnly(http.HandlerFunc(h.HandleEraseDecision)))
+
 	// API key management (admin-only).
 	mux.Handle("POST /v1/keys", adminOnly(http.HandlerFunc(h.HandleCreateKey)))
 	mux.Handle("GET /v1/keys", adminOnly(http.HandlerFunc(h.HandleListKeys)))

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -41,6 +41,7 @@ var (
 	testcontainer testcontainers.Container
 	adminToken    string
 	agentToken    string
+	orgOwnerToken string
 )
 
 func TestMain(m *testing.M) {
@@ -132,6 +133,29 @@ func TestMain(m *testing.M) {
 	// Create a test agent.
 	createAgent(testSrv.URL, adminToken, "test-agent", "Test Agent", "agent", "test-agent-key")
 	agentToken = getToken(testSrv.URL, "test-agent", "test-agent-key")
+
+	// Create an org_owner agent for GDPR erasure tests.
+	// The seeded admin (rank 3) cannot create org_owner (rank 4) via HTTP because
+	// HandleCreateAgent requires the caller to strictly outrank the requested role.
+	// Insert directly via the storage layer instead.
+	{
+		ownerKeyHash, hashErr := auth.HashAPIKey("test-org-owner-key")
+		if hashErr != nil {
+			fmt.Fprintf(os.Stderr, "failed to hash org owner key: %v\n", hashErr)
+			os.Exit(1)
+		}
+		if _, dbErr := db.CreateAgent(ctx, model.Agent{
+			AgentID:    "test-org-owner",
+			OrgID:      uuid.Nil,
+			Name:       "Test Org Owner",
+			Role:       model.RoleOrgOwner,
+			APIKeyHash: &ownerKeyHash,
+		}); dbErr != nil {
+			fmt.Fprintf(os.Stderr, "failed to create org owner agent: %v\n", dbErr)
+			os.Exit(1)
+		}
+		orgOwnerToken = getToken(testSrv.URL, "test-org-owner", "test-org-owner-key")
+	}
 
 	code := m.Run()
 
@@ -3466,5 +3490,166 @@ func TestHandleResolveConflictGroup(t *testing.T) {
 		b, _ := io.ReadAll(resp2.Body)
 		require.NoError(t, json.Unmarshal(b, &envelope))
 		assert.Equal(t, 0, envelope.Data.Resolved, "no open conflicts to resolve on second call")
+	})
+}
+
+// ---- HandleEraseDecision (GDPR tombstone erasure) -------------------------
+
+func TestHandleEraseDecision(t *testing.T) {
+	// Trace a decision with alternatives and evidence to erase.
+	dt := "erasure_test_" + uuid.NewString()[:8]
+	traceResp, err := authedRequest("POST", testSrv.URL+"/v1/trace", agentToken,
+		model.TraceRequest{
+			AgentID: "test-agent",
+			Decision: model.TraceDecision{
+				DecisionType: dt,
+				Outcome:      "sensitive PII outcome",
+				Confidence:   0.85,
+				Reasoning:    ptrStr("contains PII reasoning"),
+				Alternatives: []model.TraceAlternative{
+					{Label: "alt with PII", RejectionReason: ptrStr("PII rejection reason")},
+				},
+				Evidence: []model.TraceEvidence{
+					{SourceType: "document", Content: "PII evidence content", SourceURI: ptrStr("https://example.com/pii")},
+				},
+			},
+		})
+	require.NoError(t, err)
+	defer func() { _ = traceResp.Body.Close() }()
+	require.Equal(t, http.StatusCreated, traceResp.StatusCode)
+
+	var traceResult struct {
+		Data struct {
+			DecisionID uuid.UUID `json:"decision_id"`
+			RunID      uuid.UUID `json:"run_id"`
+		} `json:"data"`
+	}
+	traceBody, _ := io.ReadAll(traceResp.Body)
+	require.NoError(t, json.Unmarshal(traceBody, &traceResult))
+	decisionID := traceResult.Data.DecisionID
+	runID := traceResult.Data.RunID
+	require.NotEqual(t, uuid.Nil, decisionID)
+
+	t.Run("pre-erasure verify returns verified", func(t *testing.T) {
+		resp, err := authedRequest("GET", testSrv.URL+"/v1/verify/"+decisionID.String(), adminToken, nil)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		var result struct {
+			Data map[string]any `json:"data"`
+		}
+		data, _ := io.ReadAll(resp.Body)
+		require.NoError(t, json.Unmarshal(data, &result))
+		assert.Equal(t, "verified", result.Data["status"])
+	})
+
+	t.Run("agent role gets 403", func(t *testing.T) {
+		resp, err := authedRequest("POST", testSrv.URL+"/v1/decisions/"+decisionID.String()+"/erase", agentToken,
+			map[string]string{"reason": "GDPR request"})
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	})
+
+	t.Run("admin role gets 403", func(t *testing.T) {
+		resp, err := authedRequest("POST", testSrv.URL+"/v1/decisions/"+decisionID.String()+"/erase", adminToken,
+			map[string]string{"reason": "GDPR request"})
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	})
+
+	t.Run("invalid UUID returns 400", func(t *testing.T) {
+		resp, err := authedRequest("POST", testSrv.URL+"/v1/decisions/not-a-uuid/erase", orgOwnerToken, nil)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	t.Run("nonexistent ID returns 404", func(t *testing.T) {
+		resp, err := authedRequest("POST", testSrv.URL+"/v1/decisions/"+uuid.New().String()+"/erase", orgOwnerToken, nil)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	})
+
+	t.Run("successful erasure", func(t *testing.T) {
+		resp, err := authedRequest("POST", testSrv.URL+"/v1/decisions/"+decisionID.String()+"/erase", orgOwnerToken,
+			map[string]string{"reason": "GDPR data subject request #42"})
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var result struct {
+			Data map[string]any `json:"data"`
+		}
+		data, _ := io.ReadAll(resp.Body)
+		require.NoError(t, json.Unmarshal(data, &result))
+		assert.Equal(t, decisionID.String(), result.Data["decision_id"])
+		assert.NotEmpty(t, result.Data["erased_at"])
+		assert.NotEmpty(t, result.Data["original_hash"])
+		assert.NotEmpty(t, result.Data["erased_hash"])
+		assert.NotEqual(t, result.Data["original_hash"], result.Data["erased_hash"])
+	})
+
+	t.Run("decision still retrievable but scrubbed", func(t *testing.T) {
+		resp, err := authedRequest("GET", testSrv.URL+"/v1/decisions/"+decisionID.String(), agentToken, nil)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var result struct {
+			Data model.Decision `json:"data"`
+		}
+		data, _ := io.ReadAll(resp.Body)
+		require.NoError(t, json.Unmarshal(data, &result))
+		assert.Equal(t, "[erased]", result.Data.Outcome)
+		assert.NotNil(t, result.Data.Reasoning)
+		assert.Equal(t, "[erased]", *result.Data.Reasoning)
+		assert.Nil(t, result.Data.ValidTo, "erasure must NOT set valid_to")
+	})
+
+	t.Run("verify returns erased status", func(t *testing.T) {
+		resp, err := authedRequest("GET", testSrv.URL+"/v1/verify/"+decisionID.String(), adminToken, nil)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var result struct {
+			Data map[string]any `json:"data"`
+		}
+		data, _ := io.ReadAll(resp.Body)
+		require.NoError(t, json.Unmarshal(data, &result))
+		assert.Equal(t, "erased", result.Data["status"])
+		assert.Equal(t, true, result.Data["valid"])
+		assert.NotEmpty(t, result.Data["original_hash"])
+		assert.NotEmpty(t, result.Data["erased_at"])
+		assert.NotEmpty(t, result.Data["erased_by"])
+	})
+
+	t.Run("double erasure returns 409", func(t *testing.T) {
+		resp, err := authedRequest("POST", testSrv.URL+"/v1/decisions/"+decisionID.String()+"/erase", orgOwnerToken,
+			map[string]string{"reason": "second attempt"})
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, http.StatusConflict, resp.StatusCode)
+	})
+
+	t.Run("DecisionErased event recorded", func(t *testing.T) {
+		orgID := uuid.Nil // default org from SeedAdmin
+		events, err := testDB.GetEventsByRun(context.Background(), orgID, runID, 100)
+		require.NoError(t, err)
+
+		var found bool
+		for _, ev := range events {
+			if ev.EventType == model.EventDecisionErased {
+				found = true
+				assert.Equal(t, decisionID.String(), ev.Payload["decision_id"])
+				assert.NotEmpty(t, ev.Payload["erased_by"])
+				assert.NotEmpty(t, ev.Payload["original_hash"])
+				break
+			}
+		}
+		assert.True(t, found, "expected a DecisionErased event in the run's event log")
 	})
 }

--- a/internal/storage/decisions.go
+++ b/internal/storage/decisions.go
@@ -314,6 +314,219 @@ func (db *DB) RetractDecision(ctx context.Context, orgID, decisionID uuid.UUID, 
 	return nil
 }
 
+// ErasedSentinel is the placeholder text that replaces PII fields during GDPR erasure.
+const ErasedSentinel = "[erased]"
+
+// DecisionErasureResult contains the erasure record and affected row counts.
+type DecisionErasureResult struct {
+	Erasure            model.DecisionErasure
+	AlternativesErased int64
+	EvidenceErased     int64
+}
+
+// EraseDecision scrubs PII from a decision in-place (GDPR Art. 17 tombstone erasure).
+// Within a single transaction it:
+//  1. Activates the immutability trigger bypass via SET LOCAL
+//  2. Scrubs outcome/reasoning to "[erased]" and recomputes the content hash
+//  3. Scrubs alternatives (label, rejection_reason) and evidence (content, source_uri)
+//  4. Nulls out embeddings (contain semantic PII)
+//  5. Inserts a decision_erasures row with the original hash
+//  6. Records a DecisionErased event and mutation audit entry
+//  7. Queues a search index deletion
+//
+// Does NOT set valid_to — the decision remains "active" but scrubbed.
+func (db *DB) EraseDecision(
+	ctx context.Context,
+	orgID, decisionID uuid.UUID,
+	reason, erasedBy string,
+	audit *MutationAuditEntry,
+) (DecisionErasureResult, error) {
+	tx, err := db.pool.Begin(ctx)
+	if err != nil {
+		return DecisionErasureResult{}, fmt.Errorf("storage: begin erase decision tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	// Activate the erasure bypass for the immutability trigger.
+	// SET LOCAL is scoped to this transaction and auto-resets on commit/rollback.
+	if _, err := tx.Exec(ctx, `SET LOCAL akashi.erasure_in_progress = 'true'`); err != nil {
+		return DecisionErasureResult{}, fmt.Errorf("storage: set erasure session var: %w", err)
+	}
+
+	// Fetch the decision. Must exist and belong to org.
+	var runID uuid.UUID
+	var agentID, oldOutcome, oldContentHash string
+	var oldReasoning *string
+	var decisionType string
+	var confidence float32
+	var validFrom time.Time
+	err = tx.QueryRow(ctx,
+		`SELECT run_id, agent_id, outcome, reasoning, decision_type, confidence,
+		        content_hash, valid_from
+		 FROM decisions WHERE id = $1 AND org_id = $2`,
+		decisionID, orgID,
+	).Scan(&runID, &agentID, &oldOutcome, &oldReasoning, &decisionType,
+		&confidence, &oldContentHash, &validFrom)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return DecisionErasureResult{}, fmt.Errorf("storage: decision %s: %w", decisionID, ErrNotFound)
+		}
+		return DecisionErasureResult{}, fmt.Errorf("storage: fetch decision for erasure: %w", err)
+	}
+
+	// Check idempotency: if already erased, return error.
+	var alreadyErased bool
+	err = tx.QueryRow(ctx,
+		`SELECT EXISTS(SELECT 1 FROM decision_erasures WHERE decision_id = $1)`,
+		decisionID,
+	).Scan(&alreadyErased)
+	if err != nil {
+		return DecisionErasureResult{}, fmt.Errorf("storage: check existing erasure: %w", err)
+	}
+	if alreadyErased {
+		return DecisionErasureResult{}, fmt.Errorf("storage: decision %s: %w", decisionID, ErrAlreadyErased)
+	}
+
+	// Compute new content hash over scrubbed fields.
+	erasedReasoning := ErasedSentinel
+	newHash := integrity.ComputeContentHash(
+		decisionID, decisionType, ErasedSentinel, confidence, &erasedReasoning, validFrom,
+	)
+
+	// Scrub the decision row.
+	_, err = tx.Exec(ctx,
+		`UPDATE decisions
+		 SET outcome = $1, reasoning = $2, content_hash = $3,
+		     embedding = NULL, outcome_embedding = NULL
+		 WHERE id = $4 AND org_id = $5`,
+		ErasedSentinel, ErasedSentinel, newHash, decisionID, orgID,
+	)
+	if err != nil {
+		return DecisionErasureResult{}, fmt.Errorf("storage: scrub decision: %w", err)
+	}
+
+	// Scrub alternatives.
+	altTag, err := tx.Exec(ctx,
+		`UPDATE alternatives
+		 SET label = $1, rejection_reason = $1
+		 WHERE decision_id = $2
+		   AND decision_id IN (SELECT id FROM decisions WHERE org_id = $3)`,
+		ErasedSentinel, decisionID, orgID,
+	)
+	if err != nil {
+		return DecisionErasureResult{}, fmt.Errorf("storage: scrub alternatives: %w", err)
+	}
+
+	// Scrub evidence.
+	evTag, err := tx.Exec(ctx,
+		`UPDATE evidence
+		 SET content = $1, source_uri = NULL, embedding = NULL
+		 WHERE decision_id = $2 AND org_id = $3`,
+		ErasedSentinel, decisionID, orgID,
+	)
+	if err != nil {
+		return DecisionErasureResult{}, fmt.Errorf("storage: scrub evidence: %w", err)
+	}
+
+	// Queue search index deletion.
+	if _, err := tx.Exec(ctx,
+		`INSERT INTO search_outbox (decision_id, org_id, operation)
+		 VALUES ($1, $2, 'delete')
+		 ON CONFLICT (decision_id, operation) DO UPDATE SET created_at = now(), attempts = 0, locked_until = NULL`,
+		decisionID, orgID); err != nil {
+		return DecisionErasureResult{}, fmt.Errorf("storage: queue search outbox delete in erasure: %w", err)
+	}
+
+	// Insert decision_erasures row.
+	var erasure model.DecisionErasure
+	err = tx.QueryRow(ctx,
+		`INSERT INTO decision_erasures (decision_id, org_id, erased_by, original_hash, erased_hash, reason)
+		 VALUES ($1, $2, $3, $4, $5, $6)
+		 RETURNING id, decision_id, org_id, erased_by, original_hash, erased_hash, reason, erased_at`,
+		decisionID, orgID, erasedBy, oldContentHash, newHash, reason,
+	).Scan(&erasure.ID, &erasure.DecisionID, &erasure.OrgID, &erasure.ErasedBy,
+		&erasure.OriginalHash, &erasure.ErasedHash, &erasure.Reason, &erasure.ErasedAt)
+	if err != nil {
+		return DecisionErasureResult{}, fmt.Errorf("storage: insert decision erasure: %w", err)
+	}
+
+	// Insert DecisionErased event.
+	now := time.Now().UTC()
+	payload := map[string]any{
+		"decision_id":   decisionID.String(),
+		"erased_by":     erasedBy,
+		"original_hash": oldContentHash,
+	}
+	if reason != "" {
+		payload["reason"] = reason
+	}
+	var seqNum int64
+	err = tx.QueryRow(ctx, `SELECT nextval('event_sequence_num_seq')`).Scan(&seqNum)
+	if err != nil {
+		return DecisionErasureResult{}, fmt.Errorf("storage: reserve sequence num for erasure event: %w", err)
+	}
+	_, err = tx.Exec(ctx,
+		`INSERT INTO agent_events (id, run_id, org_id, event_type, sequence_num, occurred_at, agent_id, payload, created_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+		uuid.New(), runID, orgID, string(model.EventDecisionErased), seqNum,
+		now, agentID, payload, now,
+	)
+	if err != nil {
+		return DecisionErasureResult{}, fmt.Errorf("storage: insert erasure event: %w", err)
+	}
+
+	// Insert mutation audit entry.
+	if audit != nil {
+		audit.Operation = "decision_erased"
+		audit.ResourceType = "decision"
+		audit.ResourceID = decisionID.String()
+		audit.BeforeData = map[string]any{
+			"outcome":      oldOutcome,
+			"reasoning":    oldReasoning,
+			"content_hash": oldContentHash,
+		}
+		audit.AfterData = map[string]any{
+			"outcome":      ErasedSentinel,
+			"reasoning":    ErasedSentinel,
+			"content_hash": newHash,
+			"erased_by":    erasedBy,
+			"reason":       reason,
+		}
+		if err := InsertMutationAuditTx(ctx, tx, *audit); err != nil {
+			return DecisionErasureResult{}, fmt.Errorf("storage: audit in erasure tx: %w", err)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return DecisionErasureResult{}, fmt.Errorf("storage: commit erasure: %w", err)
+	}
+
+	return DecisionErasureResult{
+		Erasure:            erasure,
+		AlternativesErased: altTag.RowsAffected(),
+		EvidenceErased:     evTag.RowsAffected(),
+	}, nil
+}
+
+// GetDecisionErasure retrieves the erasure record for a decision, if one exists.
+// Returns ErrNotFound if no erasure record exists for this decision.
+func (db *DB) GetDecisionErasure(ctx context.Context, orgID, decisionID uuid.UUID) (model.DecisionErasure, error) {
+	var e model.DecisionErasure
+	err := db.pool.QueryRow(ctx,
+		`SELECT id, decision_id, org_id, erased_by, original_hash, erased_hash, reason, erased_at
+		 FROM decision_erasures WHERE decision_id = $1 AND org_id = $2`,
+		decisionID, orgID,
+	).Scan(&e.ID, &e.DecisionID, &e.OrgID, &e.ErasedBy,
+		&e.OriginalHash, &e.ErasedHash, &e.Reason, &e.ErasedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return model.DecisionErasure{}, fmt.Errorf("storage: erasure for decision %s: %w", decisionID, ErrNotFound)
+		}
+		return model.DecisionErasure{}, fmt.Errorf("storage: get decision erasure: %w", err)
+	}
+	return e, nil
+}
+
 // QueryDecisions executes a structured query with filters, ordering, and pagination.
 // Only returns active decisions (valid_to IS NULL). Use QueryDecisionsTemporal for
 // point-in-time queries that include superseded decisions.

--- a/internal/storage/errors.go
+++ b/internal/storage/errors.go
@@ -4,3 +4,6 @@ import "errors"
 
 // ErrNotFound is returned when a requested entity does not exist.
 var ErrNotFound = errors.New("storage: not found")
+
+// ErrAlreadyErased is returned when attempting to erase an already-erased decision.
+var ErrAlreadyErased = errors.New("storage: already erased")

--- a/internal/storage/retention.go
+++ b/internal/storage/retention.go
@@ -219,6 +219,28 @@ func (db *DB) ActiveHoldsExistForAgent(ctx context.Context, orgID uuid.UUID, age
 	return exists, nil
 }
 
+// ActiveHoldsExistForDecision reports whether any active hold covers the given
+// decision. Used to block GDPR erasure when a legal hold is active.
+func (db *DB) ActiveHoldsExistForDecision(ctx context.Context, orgID, decisionID uuid.UUID) (bool, error) {
+	var exists bool
+	err := db.pool.QueryRow(ctx,
+		`SELECT EXISTS (
+		     SELECT 1 FROM retention_holds rh
+		     JOIN decisions d ON d.org_id = rh.org_id AND d.id = $2
+		     WHERE rh.org_id = $1
+		       AND rh.released_at IS NULL
+		       AND d.created_at BETWEEN rh.hold_from AND rh.hold_to
+		       AND (rh.decision_types IS NULL OR d.decision_type = ANY(rh.decision_types))
+		       AND (rh.agent_ids IS NULL OR d.agent_id = ANY(rh.agent_ids))
+		 )`,
+		orgID, decisionID,
+	).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("storage: check holds for decision: %w", err)
+	}
+	return exists, nil
+}
+
 // StartDeletionLog inserts a deletion_log row and returns its ID.
 // Call CompleteDeletionLog after the run finishes to record counts and completion time.
 func (db *DB) StartDeletionLog(ctx context.Context, orgID uuid.UUID, trigger, initiatedBy string, criteria map[string]any) (uuid.UUID, error) {

--- a/migrations/055_decision_erasures.sql
+++ b/migrations/055_decision_erasures.sql
@@ -1,0 +1,118 @@
+-- 055: GDPR tombstone erasure — decision_erasures table and trigger bypass.
+--
+-- GDPR Article 17 requires scrubbing PII from decision rows without deleting
+-- the row itself (the audit chain must survive). The existing immutability
+-- trigger (migration 036) blocks updates to outcome, reasoning, content_hash.
+-- This migration:
+--
+-- 1. Creates a decision_erasures table that records which decisions were erased,
+--    by whom, and preserves the original content_hash for forensic verification.
+--
+-- 2. Modifies the decisions_immutable_guard() trigger function to check the
+--    session-scoped variable akashi.erasure_in_progress. When set to 'true'
+--    via SET LOCAL (transaction-scoped), the trigger permits updates to
+--    outcome, reasoning, and content_hash — the three fields scrubbed during
+--    erasure. SET LOCAL auto-resets on commit/rollback, so the bypass cannot
+--    leak across transactions.
+--
+-- The erasure transaction must:
+--   SET LOCAL akashi.erasure_in_progress = 'true';
+--   UPDATE decisions SET outcome='[erased]', reasoning='[erased]', content_hash=<recomputed>;
+--   UPDATE alternatives SET label='[erased]', rejection_reason='[erased]';
+--   UPDATE evidence SET content='[erased]', source_uri=NULL;
+--   INSERT INTO decision_erasures (...);
+
+CREATE TABLE decision_erasures (
+    id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    decision_id     UUID        NOT NULL REFERENCES decisions(id),
+    org_id          UUID        NOT NULL REFERENCES organizations(id),
+    erased_by       TEXT        NOT NULL,
+    original_hash   TEXT        NOT NULL,
+    erased_hash     TEXT        NOT NULL,
+    reason          TEXT        NOT NULL DEFAULT '',
+    erased_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE(decision_id)
+);
+
+CREATE INDEX idx_decision_erasures_org ON decision_erasures(org_id, erased_at DESC);
+CREATE INDEX idx_decision_erasures_decision ON decision_erasures(decision_id);
+
+-- Modify the immutability trigger to allow erasure bypass via session variable.
+-- current_setting('akashi.erasure_in_progress', true) returns NULL when the
+-- variable is not set (the second argument = true means "missing_ok"). Only
+-- when explicitly set to 'true' within a transaction are the PII fields unlocked.
+CREATE OR REPLACE FUNCTION decisions_immutable_guard()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    -- GDPR erasure bypass: when the session variable is set within a transaction
+    -- via SET LOCAL, permit updates to the three PII/hash fields only.
+    IF current_setting('akashi.erasure_in_progress', true) = 'true' THEN
+        -- Even during erasure, protect structural fields that are NOT PII.
+        IF NEW.decision_type IS DISTINCT FROM OLD.decision_type THEN
+            RAISE EXCEPTION 'decisions row is immutable: cannot modify decision_type (decision_id=%)', OLD.id;
+        END IF;
+        IF NEW.agent_id IS DISTINCT FROM OLD.agent_id THEN
+            RAISE EXCEPTION 'decisions row is immutable: cannot modify agent_id (decision_id=%)', OLD.id;
+        END IF;
+        IF NEW.run_id IS DISTINCT FROM OLD.run_id THEN
+            RAISE EXCEPTION 'decisions row is immutable: cannot modify run_id (decision_id=%)', OLD.id;
+        END IF;
+        IF NEW.org_id IS DISTINCT FROM OLD.org_id THEN
+            RAISE EXCEPTION 'decisions row is immutable: cannot modify org_id (decision_id=%)', OLD.id;
+        END IF;
+        IF NEW.valid_from IS DISTINCT FROM OLD.valid_from THEN
+            RAISE EXCEPTION 'decisions row is immutable: cannot modify valid_from (decision_id=%)', OLD.id;
+        END IF;
+        IF NEW.created_at IS DISTINCT FROM OLD.created_at THEN
+            RAISE EXCEPTION 'decisions row is immutable: cannot modify created_at (decision_id=%)', OLD.id;
+        END IF;
+        IF NEW.transaction_time IS DISTINCT FROM OLD.transaction_time THEN
+            RAISE EXCEPTION 'decisions row is immutable: cannot modify transaction_time (decision_id=%)', OLD.id;
+        END IF;
+        IF NEW.confidence IS DISTINCT FROM OLD.confidence THEN
+            RAISE EXCEPTION 'decisions row is immutable: cannot modify confidence (decision_id=%)', OLD.id;
+        END IF;
+        -- outcome, reasoning, content_hash are permitted during erasure.
+        RETURN NEW;
+    END IF;
+
+    -- Normal path: full immutability enforcement (unchanged from migration 036).
+    IF NEW.outcome IS DISTINCT FROM OLD.outcome THEN
+        RAISE EXCEPTION 'decisions row is immutable: cannot modify outcome (decision_id=%)', OLD.id;
+    END IF;
+    IF NEW.reasoning IS DISTINCT FROM OLD.reasoning THEN
+        RAISE EXCEPTION 'decisions row is immutable: cannot modify reasoning (decision_id=%)', OLD.id;
+    END IF;
+    IF NEW.confidence IS DISTINCT FROM OLD.confidence THEN
+        RAISE EXCEPTION 'decisions row is immutable: cannot modify confidence (decision_id=%)', OLD.id;
+    END IF;
+    IF NEW.decision_type IS DISTINCT FROM OLD.decision_type THEN
+        RAISE EXCEPTION 'decisions row is immutable: cannot modify decision_type (decision_id=%)', OLD.id;
+    END IF;
+    IF NEW.agent_id IS DISTINCT FROM OLD.agent_id THEN
+        RAISE EXCEPTION 'decisions row is immutable: cannot modify agent_id (decision_id=%)', OLD.id;
+    END IF;
+    IF NEW.run_id IS DISTINCT FROM OLD.run_id THEN
+        RAISE EXCEPTION 'decisions row is immutable: cannot modify run_id (decision_id=%)', OLD.id;
+    END IF;
+    IF NEW.org_id IS DISTINCT FROM OLD.org_id THEN
+        RAISE EXCEPTION 'decisions row is immutable: cannot modify org_id (decision_id=%)', OLD.id;
+    END IF;
+    IF NEW.content_hash IS DISTINCT FROM OLD.content_hash THEN
+        RAISE EXCEPTION 'decisions row is immutable: cannot modify content_hash (decision_id=%)', OLD.id;
+    END IF;
+    IF NEW.valid_from IS DISTINCT FROM OLD.valid_from THEN
+        RAISE EXCEPTION 'decisions row is immutable: cannot modify valid_from (decision_id=%)', OLD.id;
+    END IF;
+    IF NEW.created_at IS DISTINCT FROM OLD.created_at THEN
+        RAISE EXCEPTION 'decisions row is immutable: cannot modify created_at (decision_id=%)', OLD.id;
+    END IF;
+    IF NEW.transaction_time IS DISTINCT FROM OLD.transaction_time THEN
+        RAISE EXCEPTION 'decisions row is immutable: cannot modify transaction_time (decision_id=%)', OLD.id;
+    END IF;
+
+    RETURN NEW;
+END;
+$$;

--- a/migrations/atlas.sum
+++ b/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:Lpo90eT6Xn4u8j5nK7D2ehcGKTBy/cz8AXfqJtrlWm0=
+h1:YLf9+IvX4VlhKFy6iAI6GSI7p3PjXdNYXaZRAqQNo9w=
 001_initial.sql h1:uhyGXto+QacAaGYb9ZTGjsBs5chlKi8O0eHz9aCQsrY=
 022_full_text_search.sql h1:9iwtA8MgCzAxDV9YkUBn0CLT9ePSmj3GcPoMGg8TXf0=
 023_fix_outbox_index.sql h1:OtMEFBcMRWej02+ghnBXlPr6BVq+LoA62Id9XUWfDNI=
@@ -33,3 +33,4 @@ h1:Lpo90eT6Xn4u8j5nK7D2ehcGKTBy/cz8AXfqJtrlWm0=
 052_rename_repo_to_project.sql h1:nM5KnntlNvhqBGdflCVA4dXCAd2Q1n5g6dDxW0La9Ws=
 053_data_retention.sql h1:O51+0VKDHGUjbIhoq6ma6kusSxLRfLgVAjkRXdy5DFM=
 054_conflict_groups.sql h1:vMi263BwaLtgwg+uiDZstvCrvQFchVhEgo73EvASfx0=
+055_decision_erasures.sql h1:Q5WLJVIEB0BQTE4K9JJltpY7IFfntX4PYU6Y+f3gkLs=


### PR DESCRIPTION
## Summary

Closes #283.

- Adds `POST /v1/decisions/{id}/erase` endpoint that scrubs PII fields in-place (outcome, reasoning, alternatives, evidence, embeddings) without deleting the decision row
- Recomputes content hash over scrubbed content; preserves original hash in new `decision_erasures` table for forensic verification
- Uses `SET LOCAL akashi.erasure_in_progress` to bypass the immutability trigger within the erasure transaction only — structural fields remain protected even during erasure
- `GET /v1/verify/{id}` now returns `"status": "erased"` with `erased_at`, `erased_by`, and `original_hash`
- Requires `org_owner` role (stronger than admin, since erasure is irreversible)
- Blocks erasure on decisions covered by active legal holds
- Double-erasure returns 409 Conflict

## Test plan

- [x] `TestHandleEraseDecision` integration tests (9 subtests): RBAC enforcement (agent→403, admin→403), invalid UUID→400, nonexistent→404, successful erasure→200, scrubbed fields verified, verify returns "erased" status with valid hash, double-erasure→409, DecisionErased event recorded
- [x] All existing server tests pass (no regressions)
- [x] golangci-lint clean, atlas migrate validate passes
- [ ] Manual: verify migration applies cleanly against a running instance