### PR TITLE
feat: GDPR tombstone erasure for decisions

### DIFF
--- a/internal/model/decision.go
+++ b/internal/model/decision.go
@@ -290,3 +290,26 @@ type AssessRequest struct {
 	Outcome AssessmentOutcome `json:"outcome"`
 	Notes   *string           `json:"notes,omitempty"`
 }
+
+// ErasedPlaceholder is the sentinel value used to replace PII fields during
+// GDPR tombstone erasure. The decision row is kept for audit chain integrity
+// but all content that could identify a person is replaced with this value.
+const ErasedPlaceholder = "[erased]"
+
+// DecisionErasure records the provenance of a GDPR erasure. The original
+// content hash is preserved so auditors can verify the chain was intact
+// before erasure occurred.
+type DecisionErasure struct {
+	ID           uuid.UUID `json:"id"`
+	OrgID        uuid.UUID `json:"org_id"`
+	DecisionID   uuid.UUID `json:"decision_id"`
+	ErasedBy     string    `json:"erased_by"`
+	ErasedAt     time.Time `json:"erased_at"`
+	OriginalHash string    `json:"original_hash"`
+	Reason       *string   `json:"reason,omitempty"`
+}
+
+// EraseDecisionRequest is the request body for POST /v1/decisions/{id}/erase.
+type EraseDecisionRequest struct {
+	Reason string `json:"reason"`
+}

--- a/internal/model/event.go
+++ b/internal/model/event.go
@@ -23,6 +23,7 @@ const (
 	EventDecisionMade           EventType = "DecisionMade"
 	EventDecisionRevised        EventType = "DecisionRevised"
 	EventDecisionRetracted      EventType = "DecisionRetracted"
+	EventDecisionErased         EventType = "DecisionErased"
 
 	// Tool events.
 	EventToolCallStarted   EventType = "ToolCallStarted"

--- a/internal/server/handlers_decisions.go
+++ b/internal/server/handlers_decisions.go
@@ -925,6 +925,21 @@ func (h *Handlers) HandleVerifyDecision(w http.ResponseWriter, r *http.Request) 
 
 	resp := map[string]any{"decision_id": id}
 
+	// Check for GDPR erasure first — takes priority over all other statuses.
+	erasure, erasureErr := h.db.GetDecisionErasure(r.Context(), orgID, id)
+	if erasureErr == nil {
+		resp["status"] = "erased"
+		resp["erased_at"] = erasure.ErasedAt.UTC().Format(time.RFC3339Nano)
+		resp["original_hash"] = erasure.OriginalHash
+		resp["message"] = "this decision has been erased under GDPR right-to-erasure; original content is no longer available"
+		// Verify the scrubbed content hash is consistent with the erased fields.
+		valid := integrity.VerifyContentHash(d.ContentHash, d.ID, d.DecisionType, d.Outcome, d.Confidence, d.Reasoning, d.ValidFrom)
+		resp["verified"] = valid
+		resp["content_hash"] = d.ContentHash
+		writeJSON(w, r, http.StatusOK, resp)
+		return
+	}
+
 	switch {
 	case d.ValidTo != nil:
 		// Decision was retracted — still verify hash integrity but report retracted status.
@@ -1256,6 +1271,62 @@ func (h *Handlers) HandleRetractDecision(w http.ResponseWriter, r *http.Request)
 	decision, err := h.db.GetDecision(r.Context(), orgID, id, storage.GetDecisionOpts{CurrentOnly: false})
 	if err != nil {
 		// Retraction succeeded but re-fetch failed — return 204 rather than error.
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	writeJSON(w, r, http.StatusOK, decision)
+}
+
+// HandleEraseDecision handles POST /v1/decisions/{id}/erase.
+// Performs GDPR tombstone erasure: scrubs PII fields in-place while keeping
+// the decision row for audit chain integrity. Requires org_owner role minimum.
+func (h *Handlers) HandleEraseDecision(w http.ResponseWriter, r *http.Request) {
+	orgID := OrgIDFromContext(r.Context())
+
+	idStr := r.PathValue("id")
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "invalid decision id")
+		return
+	}
+
+	var req model.EraseDecisionRequest
+	if r.Body != nil && r.ContentLength != 0 {
+		if err := decodeJSON(w, r, &req, h.maxRequestBodyBytes); err != nil {
+			handleDecodeError(w, r, err)
+			return
+		}
+	}
+
+	claims := ClaimsFromContext(r.Context())
+	erasedBy := claims.AgentID
+	if erasedBy == "" {
+		erasedBy = claims.Subject
+	}
+
+	audit := h.buildAuditEntry(r, orgID,
+		"decision_erased", "decision", id.String(),
+		nil, nil,
+		map[string]any{"erased_by": erasedBy, "reason": req.Reason},
+	)
+	if err := h.db.EraseDecision(r.Context(), orgID, id, req.Reason, erasedBy, &audit); err != nil {
+		if isNotFoundError(err) {
+			writeError(w, r, http.StatusNotFound, model.ErrCodeNotFound, "decision not found")
+			return
+		}
+		if errors.Is(err, storage.ErrAlreadyErased) {
+			writeError(w, r, http.StatusConflict, model.ErrCodeInvalidInput, "decision has already been erased")
+			return
+		}
+		h.writeInternalError(w, r, "failed to erase decision", err)
+		return
+	}
+
+	// Return the erased decision to confirm the operation.
+	decision, err := h.db.GetDecision(r.Context(), orgID, id, storage.GetDecisionOpts{})
+	if err != nil {
+		// Erasure succeeded but re-fetch failed — return 204 rather than error.
 		w.WriteHeader(http.StatusNoContent)
 		return
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -187,6 +187,10 @@ func New(cfg ServerConfig) *Server {
 	mux.Handle("POST /v1/conflicts/{id}/adjudicate", writeRole(http.HandlerFunc(h.HandleAdjudicateConflict)))
 	mux.Handle("PATCH /v1/conflicts/{id}", writeRole(http.HandlerFunc(h.HandlePatchConflict)))
 
+	// GDPR erasure (org_owner+ — stronger than admin because erasure is irreversible).
+	orgOwnerOnly := requireRole(model.RoleOrgOwner)
+	mux.Handle("POST /v1/decisions/{id}/erase", orgOwnerOnly(http.HandlerFunc(h.HandleEraseDecision)))
+
 	// Retention policy and legal holds (admin for writes, reader+ for GET).
 	mux.Handle("GET /v1/retention", readRole(http.HandlerFunc(h.HandleGetRetention)))
 	mux.Handle("PUT /v1/retention", adminOnly(http.HandlerFunc(h.HandleSetRetention)))

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -3468,3 +3468,209 @@ func TestHandleResolveConflictGroup(t *testing.T) {
 		assert.Equal(t, 0, envelope.Data.Resolved, "no open conflicts to resolve on second call")
 	})
 }
+
+// ---- HandleEraseDecision (GDPR tombstone) --------------------------------
+
+func TestHandleEraseDecision(t *testing.T) {
+	// Create an org_owner agent directly in the DB — the admin role cannot
+	// create org_owner via the API because the caller must outrank the target.
+	ownerAgentID := "erasure-owner-" + uuid.NewString()[:8]
+	ownerAPIKey := "erasure-owner-key-" + uuid.NewString()[:8]
+	ownerHash, hashErr := auth.HashAPIKey(ownerAPIKey)
+	require.NoError(t, hashErr)
+	_, createErr := testDB.CreateAgent(context.Background(), model.Agent{
+		AgentID:    ownerAgentID,
+		OrgID:      uuid.Nil,
+		Name:       "Erasure Owner",
+		Role:       model.RoleOrgOwner,
+		APIKeyHash: &ownerHash,
+	})
+	require.NoError(t, createErr)
+	ownerToken := getToken(testSrv.URL, ownerAgentID, ownerAPIKey)
+
+	// Trace a decision to be erased.
+	dt := "erasure_test_" + uuid.NewString()[:8]
+	traceResp, err := authedRequest("POST", testSrv.URL+"/v1/trace", ownerToken,
+		model.TraceRequest{
+			AgentID: ownerAgentID,
+			Decision: model.TraceDecision{
+				DecisionType: dt,
+				Outcome:      "sensitive PII outcome that must be erased",
+				Confidence:   0.85,
+				Reasoning:    ptrStr("contains personal data for erasure test"),
+				Alternatives: []model.TraceAlternative{
+					{Label: "alt with PII", RejectionReason: ptrStr("contained user data")},
+				},
+				Evidence: []model.TraceEvidence{
+					{SourceType: "user_input", Content: "user email: test@example.com"},
+				},
+			},
+		})
+	require.NoError(t, err)
+	defer func() { _ = traceResp.Body.Close() }()
+	require.Equal(t, http.StatusCreated, traceResp.StatusCode)
+
+	var traceResult struct {
+		Data struct {
+			DecisionID uuid.UUID `json:"decision_id"`
+			RunID      uuid.UUID `json:"run_id"`
+		} `json:"data"`
+	}
+	traceBody, _ := io.ReadAll(traceResp.Body)
+	require.NoError(t, json.Unmarshal(traceBody, &traceResult))
+	decisionID := traceResult.Data.DecisionID
+	runID := traceResult.Data.RunID
+	require.NotEqual(t, uuid.Nil, decisionID)
+	require.NotEqual(t, uuid.Nil, runID)
+
+	// Capture the original content hash for later verification.
+	verifyBefore, err := authedRequest("GET", testSrv.URL+"/v1/verify/"+decisionID.String(), ownerToken, nil)
+	require.NoError(t, err)
+	defer func() { _ = verifyBefore.Body.Close() }()
+	var verifyBeforeResult map[string]any
+	vbBody, _ := io.ReadAll(verifyBefore.Body)
+	require.NoError(t, json.Unmarshal(vbBody, &verifyBeforeResult))
+	vbData := verifyBeforeResult["data"].(map[string]any)
+	originalHash := vbData["content_hash"].(string)
+	require.NotEmpty(t, originalHash)
+
+	t.Run("admin role gets 403", func(t *testing.T) {
+		resp, err := authedRequest("POST", testSrv.URL+"/v1/decisions/"+decisionID.String()+"/erase", adminToken,
+			model.EraseDecisionRequest{Reason: "GDPR request"})
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode,
+			"admin role is insufficient for erasure; org_owner minimum required")
+	})
+
+	t.Run("agent role gets 403", func(t *testing.T) {
+		resp, err := authedRequest("POST", testSrv.URL+"/v1/decisions/"+decisionID.String()+"/erase", agentToken, nil)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	})
+
+	t.Run("invalid UUID returns 400", func(t *testing.T) {
+		resp, err := authedRequest("POST", testSrv.URL+"/v1/decisions/not-a-uuid/erase", ownerToken, nil)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	t.Run("nonexistent ID returns 404", func(t *testing.T) {
+		resp, err := authedRequest("POST", testSrv.URL+"/v1/decisions/"+uuid.New().String()+"/erase", ownerToken,
+			model.EraseDecisionRequest{Reason: "GDPR"})
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	})
+
+	t.Run("successful erasure scrubs PII fields", func(t *testing.T) {
+		resp, err := authedRequest("POST", testSrv.URL+"/v1/decisions/"+decisionID.String()+"/erase", ownerToken,
+			model.EraseDecisionRequest{Reason: "GDPR right-to-erasure request #12345"})
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var result struct {
+			Data model.Decision `json:"data"`
+		}
+		body, _ := io.ReadAll(resp.Body)
+		require.NoError(t, json.Unmarshal(body, &result))
+		d := result.Data
+
+		assert.Equal(t, decisionID, d.ID, "decision ID must be preserved")
+		assert.Equal(t, model.ErasedPlaceholder, d.Outcome, "outcome must be scrubbed to [erased]")
+		require.NotNil(t, d.Reasoning, "reasoning pointer must still be set")
+		assert.Equal(t, model.ErasedPlaceholder, *d.Reasoning, "reasoning must be scrubbed to [erased]")
+		assert.Nil(t, d.ValidTo, "erasure must NOT set valid_to (erasure ≠ retraction)")
+		assert.NotEqual(t, originalHash, d.ContentHash, "content hash must be recomputed over scrubbed fields")
+	})
+
+	t.Run("decision still retrievable after erasure", func(t *testing.T) {
+		resp, err := authedRequest("GET", testSrv.URL+"/v1/decisions/"+decisionID.String(), ownerToken, nil)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var result struct {
+			Data model.Decision `json:"data"`
+		}
+		body, _ := io.ReadAll(resp.Body)
+		require.NoError(t, json.Unmarshal(body, &result))
+		assert.Equal(t, model.ErasedPlaceholder, result.Data.Outcome,
+			"erased decision must show scrubbed outcome on retrieval")
+	})
+
+	t.Run("verify returns erased status with original hash", func(t *testing.T) {
+		resp, err := authedRequest("GET", testSrv.URL+"/v1/verify/"+decisionID.String(), ownerToken, nil)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var result map[string]any
+		body, _ := io.ReadAll(resp.Body)
+		require.NoError(t, json.Unmarshal(body, &result))
+
+		data, ok := result["data"].(map[string]any)
+		require.True(t, ok, "expected data wrapper in response")
+		assert.Equal(t, "erased", data["status"], "verify must report erased status")
+		assert.NotEmpty(t, data["erased_at"], "must include erased_at timestamp")
+		assert.Equal(t, originalHash, data["original_hash"],
+			"original content hash must be preserved in erasure record")
+		assert.Equal(t, true, data["verified"],
+			"scrubbed content hash must verify against current fields")
+
+		// Confirm erased_at parses as a valid timestamp.
+		_, parseErr := time.Parse(time.RFC3339Nano, data["erased_at"].(string))
+		assert.NoError(t, parseErr, "erased_at must be a valid RFC3339Nano timestamp")
+	})
+
+	t.Run("DecisionErased event recorded", func(t *testing.T) {
+		orgID := uuid.Nil
+		events, err := testDB.GetEventsByRun(context.Background(), orgID, runID, 100)
+		require.NoError(t, err)
+
+		var found bool
+		for _, ev := range events {
+			if ev.EventType == model.EventDecisionErased {
+				found = true
+				assert.Equal(t, decisionID.String(), ev.Payload["decision_id"])
+				assert.Equal(t, "GDPR right-to-erasure request #12345", ev.Payload["reason"])
+				assert.NotEmpty(t, ev.Payload["erased_by"])
+				break
+			}
+		}
+		assert.True(t, found, "expected a DecisionErased event in the run's event log")
+	})
+
+	t.Run("double erasure returns 409 conflict", func(t *testing.T) {
+		resp, err := authedRequest("POST", testSrv.URL+"/v1/decisions/"+decisionID.String()+"/erase", ownerToken,
+			model.EraseDecisionRequest{Reason: "duplicate request"})
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, http.StatusConflict, resp.StatusCode,
+			"re-erasing an already-erased decision must return 409")
+	})
+
+	t.Run("alternatives and evidence scrubbed", func(t *testing.T) {
+		// Fetch the decision with includes to check alternatives and evidence.
+		orgID := uuid.Nil
+		d, err := testDB.GetDecision(context.Background(), orgID, decisionID,
+			storage.GetDecisionOpts{IncludeAlts: true, IncludeEvidence: true})
+		require.NoError(t, err)
+
+		for _, alt := range d.Alternatives {
+			assert.Equal(t, model.ErasedPlaceholder, alt.Label,
+				"alternative label must be scrubbed")
+			assert.Nil(t, alt.RejectionReason,
+				"alternative rejection_reason must be cleared")
+		}
+		for _, ev := range d.Evidence {
+			assert.Equal(t, model.ErasedPlaceholder, ev.Content,
+				"evidence content must be scrubbed")
+			assert.Nil(t, ev.SourceURI,
+				"evidence source_uri must be cleared")
+		}
+	})
+}

--- a/internal/storage/erasure.go
+++ b/internal/storage/erasure.go
@@ -1,0 +1,196 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/ashita-ai/akashi/internal/integrity"
+	"github.com/ashita-ai/akashi/internal/model"
+)
+
+// EraseDecision performs a GDPR tombstone erasure: scrubs PII fields in-place,
+// recomputes the content hash over the scrubbed content, records the original
+// hash in decision_erasures, queues a search index deletion, inserts a
+// DecisionErased event, and appends a mutation audit entry — all atomically in
+// a single transaction.
+//
+// Erasure is NOT retraction. The row is kept (valid_to is NOT set) so the
+// audit chain remains intact. Only the PII-bearing content fields are replaced
+// with the [erased] sentinel.
+func (db *DB) EraseDecision(ctx context.Context, orgID, decisionID uuid.UUID, reason, erasedBy string, audit *MutationAuditEntry) error {
+	tx, err := db.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("storage: begin erase decision tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	now := time.Now().UTC()
+
+	// Fetch the decision to capture original state. We allow erasure of both
+	// active (valid_to IS NULL) and retracted decisions — PII must be scrubbed
+	// regardless of retraction status.
+	var (
+		runID       uuid.UUID
+		agentID     string
+		outcome     string
+		reasoning   *string
+		contentHash string
+		decType     string
+		confidence  float32
+		validFrom   time.Time
+	)
+	err = tx.QueryRow(ctx,
+		`SELECT run_id, agent_id, outcome, reasoning, content_hash, decision_type, confidence, valid_from
+		 FROM decisions WHERE id = $1 AND org_id = $2`,
+		decisionID, orgID,
+	).Scan(&runID, &agentID, &outcome, &reasoning, &contentHash, &decType, &confidence, &validFrom)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("storage: decision %s: %w", decisionID, ErrNotFound)
+		}
+		return fmt.Errorf("storage: fetch decision for erasure: %w", err)
+	}
+
+	// Guard: don't erase an already-erased decision.
+	if outcome == model.ErasedPlaceholder {
+		return fmt.Errorf("storage: decision %s: %w", decisionID, ErrAlreadyErased)
+	}
+
+	// Preserve original hash. If the decision predates content hashing,
+	// compute one now so the erasure record always has a hash to reference.
+	originalHash := contentHash
+	if originalHash == "" {
+		originalHash = integrity.ComputeContentHash(decisionID, decType, outcome, confidence, reasoning, validFrom)
+	}
+
+	// Scrub PII fields on the decision row.
+	erasedReasoning := model.ErasedPlaceholder
+	newHash := integrity.ComputeContentHash(decisionID, decType, model.ErasedPlaceholder, confidence, &erasedReasoning, validFrom)
+
+	_, err = tx.Exec(ctx,
+		`UPDATE decisions
+		 SET outcome = $1, reasoning = $2, content_hash = $3, embedding = NULL, outcome_embedding = NULL
+		 WHERE id = $4 AND org_id = $5`,
+		model.ErasedPlaceholder, erasedReasoning, newHash, decisionID, orgID,
+	)
+	if err != nil {
+		return fmt.Errorf("storage: scrub decision fields: %w", err)
+	}
+
+	// Scrub alternatives content.
+	_, err = tx.Exec(ctx,
+		`UPDATE alternatives
+		 SET label = $1, rejection_reason = $2
+		 WHERE decision_id = $3
+		   AND decision_id IN (SELECT id FROM decisions WHERE org_id = $4)`,
+		model.ErasedPlaceholder, nil, decisionID, orgID,
+	)
+	if err != nil {
+		return fmt.Errorf("storage: scrub alternatives: %w", err)
+	}
+
+	// Scrub evidence content.
+	_, err = tx.Exec(ctx,
+		`UPDATE evidence
+		 SET content = $1, source_uri = NULL, embedding = NULL
+		 WHERE decision_id = $2 AND org_id = $3`,
+		model.ErasedPlaceholder, decisionID, orgID,
+	)
+	if err != nil {
+		return fmt.Errorf("storage: scrub evidence: %w", err)
+	}
+
+	// Insert decision_erasures record with original hash.
+	_, err = tx.Exec(ctx,
+		`INSERT INTO decision_erasures (org_id, decision_id, erased_by, erased_at, original_hash, reason)
+		 VALUES ($1, $2, $3, $4, $5, $6)`,
+		orgID, decisionID, erasedBy, now, originalHash, reason,
+	)
+	if err != nil {
+		return fmt.Errorf("storage: insert decision erasure: %w", err)
+	}
+
+	// Queue search index deletion so Qdrant removes the vector.
+	if _, err := tx.Exec(ctx,
+		`INSERT INTO search_outbox (decision_id, org_id, operation)
+		 VALUES ($1, $2, 'delete')
+		 ON CONFLICT (decision_id, operation) DO UPDATE SET created_at = now(), attempts = 0, locked_until = NULL`,
+		decisionID, orgID); err != nil {
+		return fmt.Errorf("storage: queue search outbox delete in erasure: %w", err)
+	}
+
+	// Insert DecisionErased event.
+	payload := map[string]any{
+		"decision_id": decisionID.String(),
+		"erased_by":   erasedBy,
+	}
+	if reason != "" {
+		payload["reason"] = reason
+	}
+	var seqNum int64
+	err = tx.QueryRow(ctx, `SELECT nextval('event_sequence_num_seq')`).Scan(&seqNum)
+	if err != nil {
+		return fmt.Errorf("storage: reserve sequence num for erasure event: %w", err)
+	}
+	_, err = tx.Exec(ctx,
+		`INSERT INTO agent_events (id, run_id, org_id, event_type, sequence_num, occurred_at, agent_id, payload, created_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+		uuid.New(), runID, orgID, string(model.EventDecisionErased), seqNum,
+		now, agentID, payload, now,
+	)
+	if err != nil {
+		return fmt.Errorf("storage: insert erasure event: %w", err)
+	}
+
+	// Insert mutation audit entry.
+	if audit != nil {
+		audit.Operation = "decision_erased"
+		audit.ResourceType = "decision"
+		audit.ResourceID = decisionID.String()
+		audit.BeforeData = map[string]any{
+			"outcome":      outcome,
+			"reasoning":    reasoning,
+			"content_hash": contentHash,
+		}
+		audit.AfterData = map[string]any{
+			"outcome":       model.ErasedPlaceholder,
+			"reasoning":     erasedReasoning,
+			"content_hash":  newHash,
+			"original_hash": originalHash,
+			"erased_by":     erasedBy,
+			"reason":        reason,
+		}
+		if err := InsertMutationAuditTx(ctx, tx, *audit); err != nil {
+			return fmt.Errorf("storage: audit in erasure tx: %w", err)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("storage: commit erasure: %w", err)
+	}
+	return nil
+}
+
+// GetDecisionErasure returns the erasure record for a decision, or ErrNotFound
+// if the decision has not been erased.
+func (db *DB) GetDecisionErasure(ctx context.Context, orgID, decisionID uuid.UUID) (model.DecisionErasure, error) {
+	var e model.DecisionErasure
+	err := db.pool.QueryRow(ctx,
+		`SELECT id, org_id, decision_id, erased_by, erased_at, original_hash, reason
+		 FROM decision_erasures
+		 WHERE decision_id = $1 AND org_id = $2`,
+		decisionID, orgID,
+	).Scan(&e.ID, &e.OrgID, &e.DecisionID, &e.ErasedBy, &e.ErasedAt, &e.OriginalHash, &e.Reason)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return model.DecisionErasure{}, ErrNotFound
+		}
+		return model.DecisionErasure{}, fmt.Errorf("storage: get decision erasure: %w", err)
+	}
+	return e, nil
+}

--- a/internal/storage/errors.go
+++ b/internal/storage/errors.go
@@ -4,3 +4,7 @@ import "errors"
 
 // ErrNotFound is returned when a requested entity does not exist.
 var ErrNotFound = errors.New("storage: not found")
+
+// ErrAlreadyErased is returned when attempting to erase a decision that has
+// already been GDPR-erased (outcome == "[erased]").
+var ErrAlreadyErased = errors.New("storage: already erased")

--- a/migrations/055_decision_erasures.sql
+++ b/migrations/055_decision_erasures.sql
@@ -1,0 +1,40 @@
+-- 055: GDPR tombstone erasure support.
+-- Adds decision_erasures table for tracking erasure provenance while
+-- preserving the decision row in-place (tombstone approach). PII fields
+-- are scrubbed to '[erased]' and the original content hash is preserved
+-- in this table so the audit chain remains verifiable.
+
+CREATE TABLE decision_erasures (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    org_id        UUID NOT NULL REFERENCES organizations(id),
+    decision_id   UUID NOT NULL REFERENCES decisions(id),
+    erased_by     TEXT NOT NULL,
+    erased_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    original_hash TEXT NOT NULL,
+    reason        TEXT
+);
+
+CREATE INDEX idx_decision_erasures_org_decision
+    ON decision_erasures (org_id, decision_id);
+
+CREATE INDEX idx_decision_erasures_erased_at
+    ON decision_erasures (org_id, erased_at DESC);
+
+-- Each decision may only be erased once.
+CREATE UNIQUE INDEX idx_decision_erasures_unique_decision
+    ON decision_erasures (decision_id);
+
+-- Append-only: prevent UPDATE and DELETE on erasure records.
+CREATE OR REPLACE FUNCTION prevent_erasure_mutation() RETURNS TRIGGER AS $$
+BEGIN
+    RAISE EXCEPTION 'decision_erasures is append-only: % not allowed', TG_OP;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_decision_erasures_no_update
+    BEFORE UPDATE ON decision_erasures
+    FOR EACH ROW EXECUTE FUNCTION prevent_erasure_mutation();
+
+CREATE TRIGGER trg_decision_erasures_no_delete
+    BEFORE DELETE ON decision_erasures
+    FOR EACH ROW EXECUTE FUNCTION prevent_erasure_mutation();

--- a/migrations/056_erasure_immutability_bypass.sql
+++ b/migrations/056_erasure_immutability_bypass.sql
@@ -1,0 +1,60 @@
+-- 056: Allow GDPR erasure to bypass immutability trigger.
+--
+-- The decisions_immutable_guard trigger (migration 036) correctly prevents
+-- modification of core audit fields. However, GDPR right-to-erasure requires
+-- scrubbing PII fields in-place while keeping the row. This migration
+-- replaces the trigger function to allow updates where the new outcome is
+-- exactly '[erased]' — the GDPR tombstone sentinel. All other immutability
+-- rules remain unchanged.
+
+CREATE OR REPLACE FUNCTION decisions_immutable_guard()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    -- GDPR erasure exemption: when outcome is being set to the erasure
+    -- sentinel '[erased]', allow the update. The application layer
+    -- (EraseDecision) enforces that this only happens through the proper
+    -- erasure workflow with audit trail and role checks.
+    IF NEW.outcome = '[erased]' AND OLD.outcome IS DISTINCT FROM '[erased]' THEN
+        RETURN NEW;
+    END IF;
+
+    -- Standard immutability checks for all non-erasure updates.
+    IF NEW.outcome IS DISTINCT FROM OLD.outcome THEN
+        RAISE EXCEPTION 'decisions row is immutable: cannot modify outcome (decision_id=%)', OLD.id;
+    END IF;
+    IF NEW.reasoning IS DISTINCT FROM OLD.reasoning THEN
+        RAISE EXCEPTION 'decisions row is immutable: cannot modify reasoning (decision_id=%)', OLD.id;
+    END IF;
+    IF NEW.confidence IS DISTINCT FROM OLD.confidence THEN
+        RAISE EXCEPTION 'decisions row is immutable: cannot modify confidence (decision_id=%)', OLD.id;
+    END IF;
+    IF NEW.decision_type IS DISTINCT FROM OLD.decision_type THEN
+        RAISE EXCEPTION 'decisions row is immutable: cannot modify decision_type (decision_id=%)', OLD.id;
+    END IF;
+    IF NEW.agent_id IS DISTINCT FROM OLD.agent_id THEN
+        RAISE EXCEPTION 'decisions row is immutable: cannot modify agent_id (decision_id=%)', OLD.id;
+    END IF;
+    IF NEW.run_id IS DISTINCT FROM OLD.run_id THEN
+        RAISE EXCEPTION 'decisions row is immutable: cannot modify run_id (decision_id=%)', OLD.id;
+    END IF;
+    IF NEW.org_id IS DISTINCT FROM OLD.org_id THEN
+        RAISE EXCEPTION 'decisions row is immutable: cannot modify org_id (decision_id=%)', OLD.id;
+    END IF;
+    IF NEW.content_hash IS DISTINCT FROM OLD.content_hash THEN
+        RAISE EXCEPTION 'decisions row is immutable: cannot modify content_hash (decision_id=%)', OLD.id;
+    END IF;
+    IF NEW.valid_from IS DISTINCT FROM OLD.valid_from THEN
+        RAISE EXCEPTION 'decisions row is immutable: cannot modify valid_from (decision_id=%)', OLD.id;
+    END IF;
+    IF NEW.created_at IS DISTINCT FROM OLD.created_at THEN
+        RAISE EXCEPTION 'decisions row is immutable: cannot modify created_at (decision_id=%)', OLD.id;
+    END IF;
+    IF NEW.transaction_time IS DISTINCT FROM OLD.transaction_time THEN
+        RAISE EXCEPTION 'decisions row is immutable: cannot modify transaction_time (decision_id=%)', OLD.id;
+    END IF;
+
+    RETURN NEW;
+END;
+$$;

--- a/migrations/atlas.sum
+++ b/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:Lpo90eT6Xn4u8j5nK7D2ehcGKTBy/cz8AXfqJtrlWm0=
+h1:+czpZoDmMmvmzCeweWs/Gc9CmItGBJOVMF0O+TFPHUw=
 001_initial.sql h1:uhyGXto+QacAaGYb9ZTGjsBs5chlKi8O0eHz9aCQsrY=
 022_full_text_search.sql h1:9iwtA8MgCzAxDV9YkUBn0CLT9ePSmj3GcPoMGg8TXf0=
 023_fix_outbox_index.sql h1:OtMEFBcMRWej02+ghnBXlPr6BVq+LoA62Id9XUWfDNI=
@@ -33,3 +33,5 @@ h1:Lpo90eT6Xn4u8j5nK7D2ehcGKTBy/cz8AXfqJtrlWm0=
 052_rename_repo_to_project.sql h1:nM5KnntlNvhqBGdflCVA4dXCAd2Q1n5g6dDxW0La9Ws=
 053_data_retention.sql h1:O51+0VKDHGUjbIhoq6ma6kusSxLRfLgVAjkRXdy5DFM=
 054_conflict_groups.sql h1:vMi263BwaLtgwg+uiDZstvCrvQFchVhEgo73EvASfx0=
+055_decision_erasures.sql h1:rwaRSRcXKaIM3p+rywcK6l/nO35ouuR3ZgHOc5zwadA=
+056_erasure_immutability_bypass.sql h1:BLQ7EuPMbLWOQOmEeRJVfaKJUBR2qvnE+AQIk5MTlrk=


### PR DESCRIPTION
## Summary

- Implements GDPR right-to-erasure via in-place PII scrubbing (tombstone approach) — decision rows are kept with content replaced by `[erased]`, preserving the audit chain
- Adds `POST /v1/decisions/{id}/erase` endpoint gated to `org_owner+` role
- `GET /v1/verify/{id}` now returns `"status": "erased"` with `erased_at` and `original_hash` for erased decisions
- Alternatives and evidence content also scrubbed atomically in the same transaction

## Details

**Migrations:**
- `055_decision_erasures.sql` — append-only provenance table with original content hash
- `056_erasure_immutability_bypass.sql` — narrow exemption in immutability trigger for the `[erased]` sentinel

**Key design decisions:**
- Erasure ≠ retraction: `valid_to` is NOT set, so erased decisions remain "active" in the chain
- Immutability bypass uses sentinel check (not trigger disable) for safety
- Double-erase returns 409 Conflict
- `org_owner` minimum role since erasure is irreversible

## Test plan

- [x] Role gate: admin gets 403, agent gets 403, org_owner succeeds
- [x] Invalid/nonexistent ID handling (400, 404)
- [x] PII fields scrubbed: outcome, reasoning → `[erased]`; alternatives labels scrubbed; evidence content scrubbed
- [x] Content hash recomputed over scrubbed fields and verifies correctly
- [x] `valid_to` remains NULL (erasure ≠ retraction)
- [x] Verify endpoint returns `"status": "erased"` with `original_hash` and `erased_at`
- [x] `DecisionErased` event recorded in event log
- [x] Double-erase returns 409
- [x] Full test suite passes with `-race`

Closes #283