### PR TITLE
feat(ui): add glow effects, gradients, and animations

### DIFF
--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -24,7 +24,7 @@ import { cn } from "@/lib/utils";
 
 function ConnectionDot({ status }: { status: SSEStatus }) {
   const colors: Record<SSEStatus, string> = {
-    connected: "bg-emerald-500 shadow-[0_0_6px_1px] shadow-emerald-500/40",
+    connected: "bg-emerald-500 shadow-[0_0_8px_2px] shadow-emerald-500/50 animate-pulse-glow text-emerald-500",
     connecting: "bg-amber-500 animate-pulse",
     disconnected: "bg-red-500",
   };
@@ -97,19 +97,19 @@ export default function Layout() {
               onClick={() => setSidebarOpen(false)}
               className={({ isActive }) =>
                 cn(
-                  "group relative flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+                  "group relative flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-all duration-200",
                   isActive
-                    ? "bg-primary/10 text-primary"
-                    : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
+                    ? "bg-primary/10 text-primary shadow-[inset_0_0_20px_-8px_hsl(var(--glow-blue)/0.15)]"
+                    : "text-muted-foreground hover:bg-accent hover:text-accent-foreground hover:translate-x-0.5",
                 )
               }
             >
               {({ isActive }) => (
                 <>
                   {isActive && (
-                    <span className="absolute left-0 top-1/2 -translate-y-1/2 h-5 w-[3px] rounded-r-full bg-primary" />
+                    <span className="absolute left-0 inset-y-1 w-[3px] rounded-r-full bg-gradient-to-b from-primary via-primary/80 to-purple-500/60" />
                   )}
-                  <Icon className="h-4 w-4" />
+                  <Icon className={cn("h-4 w-4 transition-all duration-200", isActive && "drop-shadow-[0_0_4px_hsl(var(--glow-blue)/0.5)]")} />
                   {label}
                 </>
               )}
@@ -118,7 +118,7 @@ export default function Layout() {
         </nav>
 
         {/* Footer */}
-        <div className="border-t p-4 space-y-3">
+        <div className="border-t border-t-border/50 p-4 space-y-3">
           <div className="flex items-center justify-between">
             <ConnectionDot status={sseStatus} />
             <Button
@@ -149,7 +149,7 @@ export default function Layout() {
       </aside>
 
       {/* Main content */}
-      <div className="flex flex-1 flex-col overflow-hidden">
+      <div className="flex flex-1 flex-col overflow-hidden bg-atmosphere">
         <header className="flex h-14 items-center gap-4 border-b px-4 lg:hidden">
           <button onClick={() => setSidebarOpen(true)} aria-label="Open sidebar">
             <Menu className="h-5 w-5" />

--- a/ui/src/components/ui/badge.tsx
+++ b/ui/src/components/ui/badge.tsx
@@ -3,21 +3,33 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const badgeVariants = cva(
-  "inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  "inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
   {
     variants: {
       variant: {
         default:
-          "border-transparent bg-primary text-primary-foreground shadow",
+          "border-transparent bg-primary text-primary-foreground shadow dark:shadow-[0_0_12px_-3px_hsl(var(--glow-blue)/0.4)]",
         secondary:
           "border-transparent bg-secondary text-secondary-foreground",
         destructive:
-          "border-transparent bg-destructive text-destructive-foreground shadow",
+          "border-transparent bg-destructive text-destructive-foreground shadow dark:shadow-[0_0_12px_-3px_hsl(var(--glow-red)/0.3)]",
         outline: "text-foreground",
         success:
-          "border-transparent bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-400",
+          "border-transparent bg-emerald-100 text-emerald-800 dark:bg-emerald-500/10 dark:text-emerald-400 dark:border-emerald-500/20 dark:shadow-[0_0_10px_-3px_hsl(var(--glow-emerald)/0.3)]",
         warning:
-          "border-transparent bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400",
+          "border-transparent bg-amber-100 text-amber-800 dark:bg-amber-500/10 dark:text-amber-400 dark:border-amber-500/20 dark:shadow-[0_0_10px_-3px_hsl(var(--glow-amber)/0.3)]",
+        architecture:
+          "border-transparent bg-purple-100 text-purple-800 dark:bg-purple-500/10 dark:text-purple-400 dark:border-purple-500/20 dark:shadow-[0_0_10px_-3px_hsl(var(--glow-purple)/0.3)]",
+        security:
+          "border-transparent bg-red-100 text-red-800 dark:bg-red-500/10 dark:text-red-400 dark:border-red-500/20 dark:shadow-[0_0_10px_-3px_hsl(var(--glow-red)/0.25)]",
+        code_review:
+          "border-transparent bg-cyan-100 text-cyan-800 dark:bg-cyan-500/10 dark:text-cyan-400 dark:border-cyan-500/20 dark:shadow-[0_0_10px_-3px_hsl(var(--glow-cyan)/0.3)]",
+        trade_off:
+          "border-transparent bg-amber-100 text-amber-800 dark:bg-amber-500/10 dark:text-amber-400 dark:border-amber-500/20",
+        planning:
+          "border-transparent bg-blue-100 text-blue-800 dark:bg-blue-500/10 dark:text-blue-400 dark:border-blue-500/20",
+        investigation:
+          "border-transparent bg-emerald-100 text-emerald-800 dark:bg-emerald-500/10 dark:text-emerald-400 dark:border-emerald-500/20",
       },
     },
     defaultVariants: {
@@ -36,4 +48,25 @@ function Badge({ className, variant, ...props }: BadgeProps) {
   );
 }
 
-export { Badge, badgeVariants };
+/** Maps a decision_type string to the best badge variant. */
+function decisionTypeBadgeVariant(
+  decisionType: string,
+): NonNullable<VariantProps<typeof badgeVariants>["variant"]> {
+  const map: Record<string, NonNullable<VariantProps<typeof badgeVariants>["variant"]>> = {
+    architecture: "architecture",
+    security: "security",
+    code_review: "code_review",
+    trade_off: "trade_off",
+    planning: "planning",
+    investigation: "investigation",
+    assessment: "trade_off",
+    model_selection: "architecture",
+    data_source: "planning",
+    deployment: "security",
+    error_handling: "warning",
+    feature_scope: "code_review",
+  };
+  return map[decisionType] ?? "secondary";
+}
+
+export { Badge, badgeVariants, decisionTypeBadgeVariant };

--- a/ui/src/components/ui/button.tsx
+++ b/ui/src/components/ui/button.tsx
@@ -4,14 +4,14 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all duration-200 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {
         default:
-          "bg-primary text-primary-foreground shadow hover:bg-primary/90",
+          "bg-primary text-primary-foreground shadow hover:bg-primary/90 hover:shadow-glow-sm active:scale-[0.98]",
         destructive:
-          "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
+          "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90 hover:shadow-[0_0_12px_-3px_hsl(var(--glow-red)/0.3)] active:scale-[0.98]",
         outline:
           "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
         secondary:

--- a/ui/src/components/ui/card.tsx
+++ b/ui/src/components/ui/card.tsx
@@ -6,7 +6,7 @@ const Card = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
     <div
       ref={ref}
       className={cn(
-        "rounded-lg border bg-card text-card-foreground shadow-sm",
+        "rounded-lg border bg-card text-card-foreground shadow-sm transition-all duration-250 hover:shadow-card-hover dark:border-border/60",
         className,
       )}
       {...props}

--- a/ui/src/components/ui/skeleton.tsx
+++ b/ui/src/components/ui/skeleton.tsx
@@ -4,7 +4,7 @@ import { cn } from "@/lib/utils";
 function Skeleton({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
   return (
     <div
-      className={cn("animate-pulse rounded-md bg-primary/10", className)}
+      className={cn("rounded-md bg-primary/10 shimmer", className)}
       {...props}
     />
   );

--- a/ui/src/components/ui/table.tsx
+++ b/ui/src/components/ui/table.tsx
@@ -18,7 +18,7 @@ const TableHeader = forwardRef<
   HTMLTableSectionElement,
   HTMLAttributes<HTMLTableSectionElement>
 >(({ className, ...props }, ref) => (
-  <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
+  <thead ref={ref} className={cn("[&_tr]:border-b [&_tr]:border-border/70 dark:[&_tr]:border-b-[hsl(var(--glow-blue)/0.15)]", className)} {...props} />
 ));
 TableHeader.displayName = "TableHeader";
 
@@ -41,7 +41,7 @@ const TableRow = forwardRef<
   <tr
     ref={ref}
     className={cn(
-      "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+      "border-b transition-all duration-200 hover:bg-muted/50 data-[state=selected]:bg-muted even:bg-muted/20",
       className,
     )}
     {...props}
@@ -56,7 +56,7 @@ const TableHead = forwardRef<
   <th
     ref={ref}
     className={cn(
-      "h-10 px-2 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+      "h-10 px-2 text-left align-middle font-medium text-muted-foreground/80 text-xs uppercase tracking-wider [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
       className,
     )}
     {...props}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -25,6 +25,19 @@
     --ring: 220 70% 50%;
     --radius: 0.5rem;
     --sidebar: 220 16% 97%;
+
+    /* Glow palette — light mode */
+    --glow-blue: 220 70% 50%;
+    --glow-purple: 265 60% 50%;
+    --glow-cyan: 183 60% 40%;
+    --glow-emerald: 160 60% 35%;
+    --glow-amber: 38 70% 45%;
+    --glow-red: 0 65% 50%;
+    --gradient-from: 220 70% 50%;
+    --gradient-via: 230 65% 50%;
+    --gradient-to: 265 60% 50%;
+    --card-glow: 220 70% 50%;
+    --card-highlight: 220 14% 92%;
   }
 
   .dark {
@@ -48,6 +61,19 @@
     --input: 215 20% 14%;
     --ring: 217 91% 60%;
     --sidebar: 223 47% 5%;
+
+    /* Glow palette — dark mode */
+    --glow-blue: 217 91% 60%;
+    --glow-purple: 265 89% 62%;
+    --glow-cyan: 183 90% 55%;
+    --glow-emerald: 160 84% 39%;
+    --glow-amber: 38 92% 50%;
+    --glow-red: 0 72% 51%;
+    --gradient-from: 217 91% 60%;
+    --gradient-via: 230 85% 55%;
+    --gradient-to: 265 89% 62%;
+    --card-glow: 217 91% 60%;
+    --card-highlight: 215 25% 16%;
   }
 }
 
@@ -76,9 +102,161 @@
   background: hsl(var(--muted-foreground));
 }
 
-/* Subtle glow on primary interactive elements */
-@layer utilities {
-  .glow-primary {
-    box-shadow: 0 0 20px -4px hsl(var(--primary) / 0.3);
+@layer components {
+  /* Staggered list entrance */
+  .animate-list-item {
+    animation: fade-in-up 0.3s ease-out both;
   }
+  .animate-list-item:nth-child(1) { animation-delay: 0ms; }
+  .animate-list-item:nth-child(2) { animation-delay: 40ms; }
+  .animate-list-item:nth-child(3) { animation-delay: 80ms; }
+  .animate-list-item:nth-child(4) { animation-delay: 120ms; }
+  .animate-list-item:nth-child(5) { animation-delay: 160ms; }
+  .animate-list-item:nth-child(6) { animation-delay: 200ms; }
+  .animate-list-item:nth-child(7) { animation-delay: 240ms; }
+  .animate-list-item:nth-child(8) { animation-delay: 280ms; }
+  .animate-list-item:nth-child(9) { animation-delay: 320ms; }
+  .animate-list-item:nth-child(10) { animation-delay: 360ms; }
+  .animate-list-item:nth-child(n+11) { animation-delay: 400ms; }
+
+  /* Page entrance */
+  .animate-page {
+    animation: fade-in-up 0.35s ease-out;
+  }
+
+  /* Progress bar fill animation */
+  .progress-fill-animated {
+    transform-origin: left;
+    animation: progress-fill 0.8s ease-out both;
+  }
+}
+
+@layer utilities {
+  /* Glow utilities */
+  .glow-primary {
+    box-shadow: 0 0 20px -4px hsl(var(--glow-blue) / 0.3);
+  }
+  .glow-purple {
+    box-shadow: 0 0 20px -4px hsl(var(--glow-purple) / 0.3);
+  }
+  .glow-cyan {
+    box-shadow: 0 0 20px -4px hsl(var(--glow-cyan) / 0.3);
+  }
+  .glow-emerald {
+    box-shadow: 0 0 20px -4px hsl(var(--glow-emerald) / 0.3);
+  }
+  .glow-amber {
+    box-shadow: 0 0 20px -4px hsl(var(--glow-amber) / 0.3);
+  }
+  .glow-red {
+    box-shadow: 0 0 20px -4px hsl(var(--glow-red) / 0.3);
+  }
+
+  /* Gradient border — use on elements with rounded corners */
+  .gradient-border {
+    position: relative;
+  }
+  .gradient-border::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    padding: 1px;
+    background: linear-gradient(
+      135deg,
+      hsl(var(--gradient-from) / 0.5),
+      hsl(var(--gradient-via) / 0.2),
+      hsl(var(--gradient-to) / 0.5)
+    );
+    -webkit-mask:
+      linear-gradient(#fff 0 0) content-box,
+      linear-gradient(#fff 0 0);
+    -webkit-mask-composite: xor;
+    mask-composite: exclude;
+    pointer-events: none;
+  }
+
+  /* Shimmer loading effect */
+  .shimmer {
+    background: linear-gradient(
+      110deg,
+      transparent 33%,
+      hsl(var(--glow-blue) / 0.08) 50%,
+      transparent 67%
+    );
+    background-size: 200% 100%;
+    animation: shimmer 2s ease-in-out infinite;
+  }
+
+  /* Atmospheric background overlay */
+  .bg-atmosphere {
+    background:
+      radial-gradient(
+        ellipse 80% 60% at 50% -10%,
+        hsl(var(--glow-blue) / 0.04) 0%,
+        transparent 70%
+      ),
+      radial-gradient(
+        ellipse 50% 40% at 100% 100%,
+        hsl(var(--glow-purple) / 0.03) 0%,
+        transparent 70%
+      );
+  }
+
+  /* Decision type left-border accents */
+  .type-border-architecture { border-left: 3px solid hsl(var(--glow-purple) / 0.7); }
+  .type-border-security     { border-left: 3px solid hsl(var(--glow-red) / 0.7); }
+  .type-border-code_review  { border-left: 3px solid hsl(var(--glow-cyan) / 0.7); }
+  .type-border-trade_off    { border-left: 3px solid hsl(var(--glow-amber) / 0.7); }
+  .type-border-planning     { border-left: 3px solid hsl(var(--glow-blue) / 0.7); }
+  .type-border-investigation { border-left: 3px solid hsl(var(--glow-emerald) / 0.7); }
+  .type-border-assessment   { border-left: 3px solid hsl(var(--glow-amber) / 0.5); }
+  .type-border-default      { border-left: 3px solid hsl(var(--border)); }
+}
+
+/* Keyframes */
+@keyframes shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+@keyframes fade-in-up {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes slide-in-left {
+  from {
+    opacity: 0;
+    transform: translateX(-8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes pulse-glow {
+  0%, 100% {
+    box-shadow: 0 0 4px 0px currentColor;
+  }
+  50% {
+    box-shadow: 0 0 12px 2px currentColor;
+  }
+}
+
+@keyframes progress-fill {
+  from { transform: scaleX(0); }
+  to { transform: scaleX(1); }
 }

--- a/ui/src/pages/Agents.tsx
+++ b/ui/src/pages/Agents.tsx
@@ -117,7 +117,7 @@ export default function Agents() {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 animate-page">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold tracking-tight">Agents</h1>
         <Dialog open={createOpen} onOpenChange={setCreateOpen}>

--- a/ui/src/pages/Conflicts.tsx
+++ b/ui/src/pages/Conflicts.tsx
@@ -3,7 +3,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { listConflictGroups, patchConflict, listAgents, ApiError } from "@/lib/api";
 import type { ConflictGroup, DecisionConflict } from "@/types/api";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
+import { Badge, decisionTypeBadgeVariant } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
@@ -237,7 +237,7 @@ function ConflictGroupCard({
                   self
                 </Badge>
               )}
-              <Badge variant="outline" className="font-mono text-xs">
+              <Badge variant={decisionTypeBadgeVariant(group.decision_type)} className="font-mono text-xs">
                 {group.decision_type}
               </Badge>
             </div>
@@ -476,7 +476,7 @@ export default function Conflicts() {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 animate-page">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold tracking-tight">Conflicts</h1>
         {data?.total != null && data.total > 0 && (
@@ -547,11 +547,12 @@ export default function Conflicts() {
         <>
           <div className="space-y-3">
             {groups.map((group) => (
-              <ConflictGroupCard
-                key={group.id}
-                group={group}
-                onAdjudicate={openAdjudicateDialog}
-              />
+              <div key={group.id} className="animate-list-item">
+                <ConflictGroupCard
+                  group={group}
+                  onAdjudicate={openAdjudicateDialog}
+                />
+              </div>
             ))}
           </div>
 

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { getRecentDecisions, listAgents, getTraceHealth } from "@/lib/api";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
+import { Badge, decisionTypeBadgeVariant } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { formatRelativeTime } from "@/lib/utils";
 import {
@@ -27,6 +27,15 @@ function ProgressRing({ value, className }: { value: number; className?: string 
   const offset = circumference * (1 - Math.min(Math.max(value, 0), 1));
   return (
     <svg viewBox="0 0 40 40" className={className} aria-hidden="true">
+      <defs>
+        <filter id="ring-glow">
+          <feGaussianBlur stdDeviation="1.5" result="blur" />
+          <feMerge>
+            <feMergeNode in="blur" />
+            <feMergeNode in="SourceGraphic" />
+          </feMerge>
+        </filter>
+      </defs>
       <circle cx="20" cy="20" r={r} fill="none" strokeWidth="4" className="stroke-muted/40" />
       <circle
         cx="20"
@@ -39,6 +48,7 @@ function ProgressRing({ value, className }: { value: number; className?: string 
         strokeDashoffset={offset}
         className="transition-[stroke-dashoffset] duration-700 ease-out"
         transform="rotate(-90 20 20)"
+        filter="url(#ring-glow)"
       />
     </svg>
   );
@@ -63,15 +73,15 @@ export default function Dashboard() {
   const completeness = traceHealth.data?.completeness.avg_completeness ?? 0;
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 animate-page">
       <h1 className="text-2xl font-bold tracking-tight">Dashboard</h1>
 
       {/* Metric cards */}
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        <Card>
+        <Card className="gradient-border">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Decisions</CardTitle>
-            <FileText className="h-4 w-4 text-muted-foreground" />
+            <FileText className="h-4 w-4 text-primary/60" />
           </CardHeader>
           <CardContent>
             {recent.isPending ? (
@@ -89,10 +99,10 @@ export default function Dashboard() {
           </CardContent>
         </Card>
 
-        <Card>
+        <Card className="gradient-border">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Active Agents</CardTitle>
-            <Users className="h-4 w-4 text-muted-foreground" />
+            <Users className="h-4 w-4 text-primary/60" />
           </CardHeader>
           <CardContent>
             {agents.isPending ? (
@@ -107,10 +117,10 @@ export default function Dashboard() {
         </Card>
 
         <Link to="/conflicts">
-          <Card className="transition-colors hover:border-primary/50">
+          <Card className="gradient-border">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-sm font-medium">Open Conflicts</CardTitle>
-              <AlertTriangle className="h-4 w-4 text-muted-foreground" />
+              <AlertTriangle className="h-4 w-4 text-amber-500/70" />
             </CardHeader>
             <CardContent>
               {traceHealth.isPending ? (
@@ -125,10 +135,10 @@ export default function Dashboard() {
           </Card>
         </Link>
 
-        <Card>
+        <Card className="gradient-border">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Trace Health</CardTitle>
-            <HeartPulse className="h-4 w-4 text-muted-foreground" />
+            <HeartPulse className="h-4 w-4 text-emerald-500/70" />
           </CardHeader>
           <CardContent>
             {traceHealth.isPending ? (
@@ -208,7 +218,7 @@ export default function Dashboard() {
                 <Link
                   key={d.id}
                   to={`/decisions/${d.run_id}`}
-                  className="flex items-center justify-between rounded-md border p-3 text-sm transition-colors hover:bg-accent"
+                  className="animate-list-item flex items-center justify-between rounded-md border p-3 text-sm transition-all duration-200 hover:bg-accent hover:shadow-glow-sm hover:border-primary/30"
                 >
                   <div className="flex items-center gap-3 min-w-0">
                     <Badge variant="outline" className="font-mono text-xs shrink-0">
@@ -219,7 +229,7 @@ export default function Dashboard() {
                     </span>
                   </div>
                   <div className="flex items-center gap-3 text-muted-foreground shrink-0">
-                    <Badge variant="secondary">{d.decision_type}</Badge>
+                    <Badge variant={decisionTypeBadgeVariant(d.decision_type)}>{d.decision_type}</Badge>
                     <span className="text-xs whitespace-nowrap">
                       {formatRelativeTime(d.created_at)}
                     </span>

--- a/ui/src/pages/DecisionDetail.tsx
+++ b/ui/src/pages/DecisionDetail.tsx
@@ -3,7 +3,8 @@ import { useQuery } from "@tanstack/react-query";
 import { getRun, getDecisionRevisions, getDecisionConflicts, verifyDecisionIntegrity } from "@/lib/api";
 import type { Decision, DecisionConflict } from "@/types/api";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
+import { Badge, decisionTypeBadgeVariant } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   Table,
@@ -26,6 +27,17 @@ import {
   ShieldX,
   XCircle,
 } from "lucide-react";
+
+const evidenceSourceColors: Record<string, string> = {
+  tool_output: "border-l-cyan-500/60",
+  api_response: "border-l-blue-500/60",
+  document: "border-l-purple-500/60",
+  agent_output: "border-l-emerald-500/60",
+  user_input: "border-l-amber-500/60",
+  search_result: "border-l-blue-400/60",
+  memory: "border-l-pink-500/60",
+  database_query: "border-l-cyan-600/60",
+};
 
 const statusIcon = {
   running: <Clock className="h-4 w-4 text-amber-500" />,
@@ -86,7 +98,7 @@ function RevisionChain({ decisionId }: { decisionId: string }) {
         </CardTitle>
       </CardHeader>
       <CardContent>
-        <div className="relative space-y-3 pl-6 before:absolute before:left-[11px] before:top-2 before:h-[calc(100%-16px)] before:w-px before:bg-border">
+        <div className="relative space-y-3 pl-6 before:absolute before:left-[11px] before:top-2 before:h-[calc(100%-16px)] before:w-px before:bg-gradient-to-b before:from-primary/60 before:to-border">
           {data.revisions.map((rev: Decision, idx: number) => (
             <div key={rev.id} className="relative">
               <div className="absolute -left-6 top-1 h-2.5 w-2.5 rounded-full border-2 border-background bg-primary" />
@@ -277,7 +289,7 @@ export default function DecisionDetail() {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 animate-page">
       <div className="flex items-center gap-4">
         <Link to="/decisions" className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground">
           <ArrowLeft className="h-4 w-4" />
@@ -340,7 +352,7 @@ export default function DecisionDetail() {
             <CardTitle className="text-sm font-medium">Event Timeline</CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="relative space-y-4 pl-6 before:absolute before:left-[11px] before:top-2 before:h-[calc(100%-16px)] before:w-px before:bg-border">
+            <div className="relative space-y-4 pl-6 before:absolute before:left-[11px] before:top-2 before:h-[calc(100%-16px)] before:w-px before:bg-gradient-to-b before:from-primary/60 before:to-border">
               {run.events.map((event) => (
                 <div key={event.id} className="relative">
                   <div className="absolute -left-6 top-1 h-2.5 w-2.5 rounded-full border-2 border-background bg-primary" />
@@ -382,7 +394,7 @@ export default function DecisionDetail() {
                   </CardTitle>
                   <div className="flex items-center gap-2">
                     <IntegrityBadge decisionId={decision.id} />
-                    <Badge variant="secondary">
+                    <Badge variant={decisionTypeBadgeVariant(decision.decision_type)}>
                       {(decision.confidence * 100).toFixed(0)}% confidence
                     </Badge>
                   </div>
@@ -463,7 +475,7 @@ export default function DecisionDetail() {
                       {decision.evidence.map((ev) => (
                         <div
                           key={ev.id}
-                          className="rounded-md border p-3 text-sm"
+                          className={cn("rounded-md border border-l-[3px] p-3 text-sm", evidenceSourceColors[ev.source_type] ?? "border-l-border")}
                         >
                           <div className="flex items-center gap-2 mb-1">
                             <Badge variant="outline" className="text-xs">

--- a/ui/src/pages/Decisions.tsx
+++ b/ui/src/pages/Decisions.tsx
@@ -10,7 +10,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { Badge } from "@/components/ui/badge";
+import { Badge, decisionTypeBadgeVariant } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -23,6 +23,19 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { formatDate, truncate } from "@/lib/utils";
 import { ChevronLeft, ChevronRight, FileText } from "lucide-react";
+
+function typeRowClass(decisionType: string): string {
+  const map: Record<string, string> = {
+    architecture: "type-border-architecture",
+    security: "type-border-security",
+    code_review: "type-border-code_review",
+    trade_off: "type-border-trade_off",
+    planning: "type-border-planning",
+    investigation: "type-border-investigation",
+    assessment: "type-border-assessment",
+  };
+  return map[decisionType] ?? "";
+}
 
 const PAGE_SIZE = 25;
 const ALL_AGENTS = "__all__";
@@ -92,7 +105,7 @@ export default function Decisions() {
   const totalPages = data ? Math.ceil(data.total / PAGE_SIZE) : 0;
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 animate-page">
       <h1 className="text-2xl font-bold tracking-tight">Decisions</h1>
 
       {/* Filters */}
@@ -176,7 +189,7 @@ export default function Decisions() {
             </TableHeader>
             <TableBody>
               {data.decisions.map((d) => (
-                <TableRow key={d.id}>
+                <TableRow key={d.id} className={typeRowClass(d.decision_type)}>
                   <TableCell className="whitespace-nowrap text-xs text-muted-foreground">
                     <Link
                       to={`/decisions/${d.run_id}`}
@@ -191,7 +204,7 @@ export default function Decisions() {
                     </Badge>
                   </TableCell>
                   <TableCell>
-                    <Badge variant="secondary">{d.decision_type}</Badge>
+                    <Badge variant={decisionTypeBadgeVariant(d.decision_type)}>{d.decision_type}</Badge>
                   </TableCell>
                   <TableCell className="max-w-[200px]">
                     <Link
@@ -205,7 +218,7 @@ export default function Decisions() {
                     <div className="flex items-center justify-end gap-2">
                       <div className="h-1.5 w-12 rounded-full bg-muted overflow-hidden">
                         <div
-                          className="h-full rounded-full bg-primary transition-all"
+                          className="h-full rounded-full bg-gradient-to-r from-primary to-blue-400 progress-fill-animated shadow-[0_0_6px_-1px_hsl(var(--glow-blue)/0.4)]"
                           style={{ width: `${(d.confidence * 100).toFixed(0)}%` }}
                         />
                       </div>
@@ -218,12 +231,12 @@ export default function Decisions() {
                     <div className="flex items-center justify-end gap-2">
                       <div className="h-1.5 w-12 rounded-full bg-muted overflow-hidden">
                         <div
-                          className={`h-full rounded-full transition-all ${
+                          className={`h-full rounded-full progress-fill-animated ${
                             d.completeness_score >= 0.7
-                              ? "bg-emerald-500"
+                              ? "bg-gradient-to-r from-emerald-600 to-emerald-400 shadow-[0_0_6px_-1px_hsl(var(--glow-emerald)/0.4)]"
                               : d.completeness_score >= 0.5
-                              ? "bg-amber-500"
-                              : "bg-red-500"
+                              ? "bg-gradient-to-r from-amber-600 to-amber-400 shadow-[0_0_6px_-1px_hsl(var(--glow-amber)/0.4)]"
+                              : "bg-gradient-to-r from-red-600 to-red-400 shadow-[0_0_6px_-1px_hsl(var(--glow-red)/0.4)]"
                           }`}
                           style={{ width: `${(d.completeness_score * 100).toFixed(0)}%` }}
                         />

--- a/ui/src/pages/ExportPage.tsx
+++ b/ui/src/pages/ExportPage.tsx
@@ -65,7 +65,7 @@ export default function ExportPage() {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 animate-page">
       <h1 className="text-2xl font-bold tracking-tight">Export</h1>
 
       <Card>

--- a/ui/src/pages/GrantsPage.tsx
+++ b/ui/src/pages/GrantsPage.tsx
@@ -130,7 +130,7 @@ export default function GrantsPage() {
   const expiredGrants = grants.filter((g) => isExpired(g));
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 animate-page">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold tracking-tight">Grants</h1>
         <Button onClick={() => setShowCreate(true)}>

--- a/ui/src/pages/Login.tsx
+++ b/ui/src/pages/Login.tsx
@@ -34,6 +34,7 @@ export default function Login() {
       {/* Subtle background gradient */}
       <div className="pointer-events-none absolute inset-0 overflow-hidden">
         <div className="absolute -top-1/2 left-1/2 -translate-x-1/2 h-[800px] w-[800px] rounded-full bg-primary/5 blur-3xl" />
+        <div className="absolute -bottom-1/3 right-0 h-[600px] w-[600px] rounded-full bg-purple-500/[0.03] blur-3xl" />
       </div>
 
       {/* Theme toggle */}
@@ -50,7 +51,7 @@ export default function Login() {
       <div className="relative w-full max-w-sm space-y-8">
         {/* Logo + tagline */}
         <div className="flex flex-col items-center gap-4">
-          <AkashiLogo className="h-16 w-16 text-primary" />
+          <AkashiLogo className="h-16 w-16 text-primary drop-shadow-[0_0_12px_hsl(var(--glow-blue)/0.4)]" />
           <div className="text-center space-y-1">
             <h1 className="text-3xl font-bold tracking-tight">Akashi</h1>
             <p className="text-sm text-muted-foreground">
@@ -60,7 +61,7 @@ export default function Login() {
         </div>
 
         {/* Sign-in card */}
-        <Card className="border-border/50 shadow-lg dark:shadow-primary/5">
+        <Card className="gradient-border border-border/50 shadow-card-elevated">
           <CardHeader className="text-center pb-4">
             <CardTitle className="text-lg">Sign in</CardTitle>
             <CardDescription>

--- a/ui/src/pages/SearchPage.tsx
+++ b/ui/src/pages/SearchPage.tsx
@@ -4,7 +4,7 @@ import { Link } from "react-router";
 import { searchDecisions } from "@/lib/api";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
+import { Badge, decisionTypeBadgeVariant } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { formatDate } from "@/lib/utils";
@@ -28,7 +28,7 @@ export default function SearchPage() {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 animate-page">
       <h1 className="text-2xl font-bold tracking-tight">Search</h1>
 
       <form onSubmit={handleSubmit} className="flex gap-3">
@@ -38,7 +38,7 @@ export default function SearchPage() {
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             placeholder="Search decisions"
-            className="pl-10"
+            className="pl-10 dark:focus-visible:shadow-glow-sm"
             autoFocus
           />
         </div>
@@ -76,15 +76,16 @@ export default function SearchPage() {
             <Link
               key={result.decision.id}
               to={`/decisions/${result.decision.run_id}`}
+              className="animate-list-item block"
             >
-              <Card className="transition-colors hover:bg-accent/50">
+              <Card className="transition-all duration-200 hover:bg-accent/50 hover:shadow-glow-sm">
                 <CardContent className="p-4">
                   <div className="space-y-1.5 min-w-0">
                     <div className="flex items-center gap-2">
                       <Badge variant="outline" className="font-mono text-xs">
                         {result.decision.agent_id}
                       </Badge>
-                      <Badge variant="secondary">
+                      <Badge variant={decisionTypeBadgeVariant(result.decision.decision_type)}>
                         {result.decision.decision_type}
                       </Badge>
                     </div>

--- a/ui/src/pages/SessionTimeline.tsx
+++ b/ui/src/pages/SessionTimeline.tsx
@@ -2,7 +2,7 @@ import { useParams, Link } from "react-router";
 import { useQuery } from "@tanstack/react-query";
 import { getSession } from "@/lib/api";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
+import { Badge, decisionTypeBadgeVariant } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { formatDate, formatRelativeTime } from "@/lib/utils";
 import { ArrowLeft, Clock, FileText } from "lucide-react";
@@ -41,7 +41,7 @@ export default function SessionTimeline() {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 animate-page">
       <div className="flex items-center gap-4">
         <Link to="/" className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground">
           <ArrowLeft className="h-4 w-4" />
@@ -91,7 +91,7 @@ export default function SessionTimeline() {
           {data.summary?.decision_types && Object.keys(data.summary.decision_types).length > 0 && (
             <div className="mt-4 flex flex-wrap gap-2">
               {Object.entries(data.summary.decision_types).map(([type, count]) => (
-                <Badge key={type} variant="secondary" className="text-xs">
+                <Badge key={type} variant={decisionTypeBadgeVariant(type)} className="text-xs">
                   {type}: {count}
                 </Badge>
               ))}
@@ -114,12 +114,12 @@ export default function SessionTimeline() {
             <CardTitle className="text-sm font-medium">Decisions</CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="relative space-y-4 pl-6 before:absolute before:left-[11px] before:top-2 before:h-[calc(100%-16px)] before:w-px before:bg-border">
+            <div className="relative space-y-4 pl-6 before:absolute before:left-[11px] before:top-2 before:h-[calc(100%-16px)] before:w-px before:bg-gradient-to-b before:from-primary/60 before:to-border">
               {data.decisions.map((decision) => (
                 <Link
                   key={decision.id}
                   to={`/decisions/${decision.run_id}`}
-                  className="relative block rounded-md border p-4 transition-colors hover:bg-accent"
+                  className="animate-list-item relative block rounded-md border p-4 transition-all duration-200 hover:bg-accent hover:shadow-glow-sm"
                 >
                   <div className="absolute -left-6 top-5 h-2.5 w-2.5 rounded-full border-2 border-background bg-primary" />
                   <div className="space-y-2">
@@ -128,7 +128,7 @@ export default function SessionTimeline() {
                         <Badge variant="outline" className="font-mono text-xs">
                           {decision.agent_id}
                         </Badge>
-                        <Badge variant="secondary" className="text-xs">
+                        <Badge variant={decisionTypeBadgeVariant(decision.decision_type)} className="text-xs">
                           {decision.decision_type}
                         </Badge>
                       </div>

--- a/ui/tailwind.config.ts
+++ b/ui/tailwind.config.ts
@@ -45,6 +45,51 @@ export default {
         md: "calc(var(--radius) - 2px)",
         sm: "calc(var(--radius) - 4px)",
       },
+      animation: {
+        "fade-in-up": "fade-in-up 0.35s ease-out",
+        "fade-in": "fade-in 0.3s ease-out",
+        "slide-in-left": "slide-in-left 0.3s ease-out",
+        "pulse-glow": "pulse-glow 2s ease-in-out infinite",
+        shimmer: "shimmer 2s ease-in-out infinite",
+      },
+      keyframes: {
+        "fade-in-up": {
+          from: { opacity: "0", transform: "translateY(8px)" },
+          to: { opacity: "1", transform: "translateY(0)" },
+        },
+        "fade-in": {
+          from: { opacity: "0" },
+          to: { opacity: "1" },
+        },
+        "slide-in-left": {
+          from: { opacity: "0", transform: "translateX(-8px)" },
+          to: { opacity: "1", transform: "translateX(0)" },
+        },
+        "pulse-glow": {
+          "0%, 100%": { boxShadow: "0 0 4px 0px currentColor" },
+          "50%": { boxShadow: "0 0 12px 2px currentColor" },
+        },
+        shimmer: {
+          "0%": { backgroundPosition: "200% 0" },
+          "100%": { backgroundPosition: "-200% 0" },
+        },
+      },
+      boxShadow: {
+        "glow-sm":
+          "0 0 10px -3px hsl(var(--glow-blue) / 0.2)",
+        "glow-md":
+          "0 0 20px -4px hsl(var(--glow-blue) / 0.3)",
+        "glow-lg":
+          "0 0 30px -4px hsl(var(--glow-blue) / 0.35)",
+        "card-hover":
+          "0 4px 24px -4px hsl(var(--card-glow) / 0.15), 0 0 0 1px hsl(var(--card-glow) / 0.1)",
+        "card-elevated":
+          "0 8px 32px -8px hsl(var(--card-glow) / 0.2), 0 0 0 1px hsl(var(--card-glow) / 0.08)",
+      },
+      transitionDuration: {
+        "250": "250ms",
+        "350": "350ms",
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary

- Adds a comprehensive visual polish layer to the Akashi dark-mode UI: glow color palette, gradient borders, atmospheric backgrounds, shimmer/entrance animations, and decision-type color coding across all pages
- Pure CSS/Tailwind — zero new dependencies, no component API changes, light mode unaffected
- Touches 18 files across foundation (index.css, tailwind.config), shared components (card, badge, button, table, skeleton), layout, and all 9 pages

## Test plan

- [ ] `cd ui && npm run build` passes (TypeScript + Vite)
- [ ] `go build -tags ui ./...` passes (Go embed)
- [ ] Visual check in dark mode: dashboard metric cards have gradient borders, ProgressRing has SVG glow, decisions table has type-colored row borders and gradient progress bars, sidebar has gradient active bar with icon glow, login card has gradient border
- [ ] Visual check in light mode: everything still looks clean (glows are dark-mode-only)
- [ ] Page transitions: all pages animate in smoothly, list items stagger entrance