### PR TITLE
feat: auto-resolve conflicts on decision revision

### DIFF
--- a/internal/storage/conflicts.go
+++ b/internal/storage/conflicts.go
@@ -874,3 +874,35 @@ func (db *DB) ResolveConflictGroup(
 	}
 	return affected, nil
 }
+
+// AutoResolveSupersededConflictsTx resolves all open/acknowledged conflicts
+// involving the superseded decision, within the caller's transaction. This is
+// called from ReviseDecision so the auto-resolution is atomic with the
+// revision itself.
+//
+// Each resolved conflict gets:
+//   - status = "resolved"
+//   - resolved_by = "system:revision"
+//   - resolution_decision_id = revisedID (the new decision)
+//   - resolution_note explaining the supersession
+//
+// Returns the number of conflicts auto-resolved.
+func AutoResolveSupersededConflictsTx(ctx context.Context, tx pgx.Tx, orgID, supersededID, revisedID uuid.UUID) (int, error) {
+	note := fmt.Sprintf("Auto-resolved: decision %s superseded by revision %s", supersededID, revisedID)
+	tag, err := tx.Exec(ctx,
+		`UPDATE scored_conflicts
+		 SET status = 'resolved',
+		     resolved_by = 'system:revision',
+		     resolved_at = now(),
+		     resolution_note = $1,
+		     resolution_decision_id = $2
+		 WHERE org_id = $3
+		   AND (decision_a_id = $4 OR decision_b_id = $4)
+		   AND status IN ('open', 'acknowledged')`,
+		note, revisedID, orgID, supersededID,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("storage: auto-resolve superseded conflicts: %w", err)
+	}
+	return int(tag.RowsAffected()), nil
+}

--- a/internal/storage/decisions.go
+++ b/internal/storage/decisions.go
@@ -204,6 +204,14 @@ func (db *DB) ReviseDecision(ctx context.Context, originalID uuid.UUID, revised 
 		}
 	}
 
+	// Auto-resolve open conflicts involving the superseded decision. The revised
+	// decision replaces the old one, so stale conflicts should not persist.
+	// If the revision still conflicts, the scorer will create a new conflict.
+	autoResolved, err := AutoResolveSupersededConflictsTx(ctx, tx, revised.OrgID, originalID, revised.ID)
+	if err != nil {
+		return model.Decision{}, fmt.Errorf("storage: auto-resolve in revision tx: %w", err)
+	}
+
 	// Insert revision audit entry (same tx — atomic with the revision).
 	if audit != nil {
 		audit.Operation = "decision_revised"
@@ -211,8 +219,9 @@ func (db *DB) ReviseDecision(ctx context.Context, originalID uuid.UUID, revised 
 		audit.ResourceID = originalID.String()
 		audit.BeforeData = map[string]any{"valid_to": nil}
 		audit.AfterData = map[string]any{
-			"superseded_by": revised.ID.String(),
-			"valid_to":      now,
+			"superseded_by":           revised.ID.String(),
+			"valid_to":                now,
+			"conflicts_auto_resolved": autoResolved,
 		}
 		if err := InsertMutationAuditTx(ctx, tx, *audit); err != nil {
 			return model.Decision{}, fmt.Errorf("storage: audit in revision tx: %w", err)

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -314,6 +314,93 @@ func TestReviseDecision(t *testing.T) {
 	assert.Nil(t, rev.ValidTo)
 }
 
+func TestReviseDecision_AutoResolvesConflicts(t *testing.T) {
+	ctx := context.Background()
+
+	run, err := testDB.CreateRun(ctx, model.CreateRunRequest{AgentID: "auto-resolve-test"})
+	require.NoError(t, err)
+
+	// Create two decisions that will conflict.
+	dA, err := testDB.CreateDecision(ctx, model.Decision{
+		RunID: run.ID, AgentID: "auto-resolve-test",
+		DecisionType: "autoresolve_test", Outcome: "approach_A", Confidence: 0.8,
+	})
+	require.NoError(t, err)
+	dB, err := testDB.CreateDecision(ctx, model.Decision{
+		RunID: run.ID, AgentID: "auto-resolve-counterpart",
+		DecisionType: "autoresolve_test", Outcome: "approach_B", Confidence: 0.7,
+	})
+	require.NoError(t, err)
+
+	// Insert a scored conflict between dA and dB.
+	topicSim := 0.90
+	outcomeDiv := 0.80
+	sig := topicSim * outcomeDiv
+	conflictID, err := testDB.InsertScoredConflict(ctx, model.DecisionConflict{
+		ConflictKind:      model.ConflictKindCrossAgent,
+		DecisionAID:       dA.ID,
+		DecisionBID:       dB.ID,
+		OrgID:             uuid.Nil,
+		AgentA:            "auto-resolve-test",
+		AgentB:            "auto-resolve-counterpart",
+		DecisionTypeA:     "autoresolve_test",
+		DecisionTypeB:     "autoresolve_test",
+		OutcomeA:          "approach_A",
+		OutcomeB:          "approach_B",
+		TopicSimilarity:   &topicSim,
+		OutcomeDivergence: &outcomeDiv,
+		Significance:      &sig,
+		ScoringMethod:     "text",
+	})
+	require.NoError(t, err)
+	require.NotEqual(t, uuid.Nil, conflictID)
+
+	// Verify conflict is open before revision.
+	conflicts, err := testDB.ListConflicts(ctx, uuid.Nil, storage.ConflictFilters{}, 50, 0)
+	require.NoError(t, err)
+	var foundOpen bool
+	for _, c := range conflicts {
+		if c.ID == conflictID {
+			assert.Equal(t, "open", c.Status, "conflict should be open before revision")
+			foundOpen = true
+			break
+		}
+	}
+	require.True(t, foundOpen, "should find the seeded conflict")
+
+	// Revise decision A — this should auto-resolve the conflict.
+	revised, err := testDB.ReviseDecision(ctx, dA.ID, model.Decision{
+		RunID: run.ID, AgentID: "auto-resolve-test",
+		DecisionType: "autoresolve_test", Outcome: "approach_A_v2", Confidence: 0.9,
+		Metadata: map[string]any{},
+	}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "approach_A_v2", revised.Outcome)
+
+	// Verify the conflict is now resolved.
+	resolvedStatus := "resolved"
+	allConflicts, err := testDB.ListConflicts(ctx, uuid.Nil, storage.ConflictFilters{
+		Status: &resolvedStatus,
+	}, 50, 0)
+	require.NoError(t, err)
+	var foundResolved bool
+	for _, c := range allConflicts {
+		if c.ID == conflictID {
+			assert.Equal(t, "resolved", c.Status, "conflict should be auto-resolved after revision")
+			require.NotNil(t, c.ResolvedBy, "resolved_by should be set")
+			assert.Equal(t, "system:revision", *c.ResolvedBy, "resolved_by should indicate system revision")
+			require.NotNil(t, c.ResolutionNote, "resolution_note should be set")
+			assert.Contains(t, *c.ResolutionNote, dA.ID.String(), "resolution_note should reference superseded decision")
+			assert.Contains(t, *c.ResolutionNote, revised.ID.String(), "resolution_note should reference new decision")
+			assert.NotNil(t, c.ResolutionDecisionID, "resolution_decision_id should be set to revised decision")
+			assert.Equal(t, revised.ID, *c.ResolutionDecisionID)
+			foundResolved = true
+			break
+		}
+	}
+	require.True(t, foundResolved, "should find the auto-resolved conflict")
+}
+
 func TestQueryDecisions(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
## Summary

- When a decision is revised, open/acknowledged conflicts involving the superseded decision are now auto-resolved atomically within the same transaction
- Each auto-resolved conflict records `resolved_by: "system:revision"` and `resolution_decision_id` pointing to the new decision
- Auto-resolution count is included in the mutation audit entry for traceability

## Details

**Storage layer:**
- `AutoResolveSupersededConflictsTx()` — standalone helper that takes a `pgx.Tx`, called from within `ReviseDecision`
- Single UPDATE with `WHERE (decision_a_id = $4 OR decision_b_id = $4) AND status IN ('open', 'acknowledged')`

**Why this approach:**
- Atomic with the revision (same tx) — no window where stale conflicts are visible
- If the revised decision still conflicts, the scorer will independently create a new conflict
- The scorer already excludes revision chains from conflict detection (scorer.go line 240)

## Test plan

- [x] `TestReviseDecision_AutoResolvesConflicts`: seeds a conflict, revises one side, verifies conflict status flips to `resolved` with correct `resolved_by`, `resolution_note`, and `resolution_decision_id`
- [x] Existing `TestReviseDecision` still passes (no regression)
- [x] Full test suite passes with `-race`
- [x] golangci-lint clean

Closes #293