### PR TITLE
feat(conflicts): make Qdrant candidate limit configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -118,6 +118,11 @@ AKASHI_EMBEDDING_DIMENSIONS=1024
 # AKASHI_CONFLICT_LLM_MODEL=qwen3.5:9b
 AKASHI_CONFLICT_LLM_MODEL=
 
+# Max candidates retrieved from Qdrant per decision for conflict scoring.
+# Lower values (e.g. 20) reduce LLM cost; higher values (e.g. 200) improve
+# recall when using embedding-only scoring (noop validator).
+# AKASHI_CONFLICT_CANDIDATE_LIMIT=50
+
 
 # ── Write-Ahead Log ───────────────────────────────────────────────────────────
 #

--- a/akashi.go
+++ b/akashi.go
@@ -217,7 +217,8 @@ func New(opts ...Option) (*App, error) {
 		backfillWorkers = 1
 		logger.Info("conflict backfill: capped workers to 1 (Ollama is serial)")
 	}
-	conflictScorer := conflicts.NewScorer(db, logger, cfg.ConflictSignificanceThreshold, conflictValidator, backfillWorkers, cfg.ConflictDecayLambda)
+	conflictScorer := conflicts.NewScorer(db, logger, cfg.ConflictSignificanceThreshold, conflictValidator, backfillWorkers, cfg.ConflictDecayLambda).
+		WithCandidateLimit(cfg.ConflictCandidateLimit)
 	if qdrantIndex != nil {
 		conflictScorer = conflictScorer.WithCandidateFinder(qdrantIndex)
 	}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -104,6 +104,7 @@ The OSS distribution uses an in-memory token bucket. Enterprise deployments can 
 
 | Variable | Default | Description |
 |----------|---------|-------------|
+| `AKASHI_CONFLICT_CANDIDATE_LIMIT` | `50` | Max candidates retrieved from Qdrant per decision. Lower values reduce LLM cost; higher values improve recall for embedding-only scoring |
 | `AKASHI_CONFLICT_SIGNIFICANCE_THRESHOLD` | `0.30` | Min significance (topic_sim × outcome_div) to store a conflict |
 | `AKASHI_CONFLICT_REFRESH_INTERVAL` | `30s` | Interval for broker to poll new conflicts (SSE push). Conflicts are populated event-driven on trace. |
 | `AKASHI_CONFLICT_LLM_MODEL` | _(empty)_ | LLM model for conflict validation. Set to an Ollama model name (e.g. `qwen3.5:9b`) to use local validation, or leave empty to auto-detect (OpenAI if `OPENAI_API_KEY` is set, otherwise noop). |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -62,6 +62,7 @@ type Config struct {
 	// Conflict LLM validation.
 	ConflictLLMModel        string  // Text generation model for conflict validation (e.g. "qwen3.5:9b" for Ollama).
 	ConflictLLMThreads      int     // CPU threads Ollama may use per inference call (default: floor(NumCPU/3), min 1). 0 = let Ollama decide.
+	ConflictCandidateLimit  int     // Max candidates retrieved from Qdrant per decision for conflict scoring (default: 50).
 	ConflictBackfillWorkers int     // Parallel workers for conflict scoring backfill (default: 4).
 	ConflictDecayLambda     float64 // Temporal decay rate for conflict significance (default: 0.01, 0 disables).
 	ForceConflictRescore    bool    // When true (and LLM validator configured), clear all conflicts and re-score at startup.
@@ -127,6 +128,7 @@ func Load() (Config, error) {
 	cfg.OutboxBatchSize, errs = collectInt(errs, "AKASHI_OUTBOX_BATCH_SIZE", 100)
 	cfg.EventBufferSize, errs = collectInt(errs, "AKASHI_EVENT_BUFFER_SIZE", 1000)
 	cfg.RateLimitBurst, errs = collectInt(errs, "AKASHI_RATE_LIMIT_BURST", 200)
+	cfg.ConflictCandidateLimit, errs = collectInt(errs, "AKASHI_CONFLICT_CANDIDATE_LIMIT", 50)
 	cfg.ConflictBackfillWorkers, errs = collectInt(errs, "AKASHI_CONFLICT_BACKFILL_WORKERS", 4)
 	defaultLLMThreads := max(1, runtime.NumCPU()/3)
 	cfg.ConflictLLMThreads, errs = collectInt(errs, "AKASHI_CONFLICT_LLM_THREADS", defaultLLMThreads)

--- a/internal/conflicts/scorer.go
+++ b/internal/conflicts/scorer.go
@@ -64,10 +64,22 @@ type Scorer struct {
 	validator       Validator
 	backfillWorkers int
 	decayLambda     float64 // Temporal decay rate. 0 disables decay.
+	candidateLimit  int     // Max candidates retrieved from Qdrant per decision.
 	finder          search.CandidateFinder
 	// pairwiseScorer is an optional external override for the confirmation step.
 	// When non-nil, it replaces the built-in Validator-backed scoring for each candidate pair.
 	pairwiseScorer PairwiseScorer
+}
+
+// WithCandidateLimit overrides the maximum number of candidates retrieved from
+// Qdrant per decision (default: 50). Lower values reduce LLM cost when an
+// expensive validator is configured; higher values improve recall when using
+// embedding-only scoring.
+func (s *Scorer) WithCandidateLimit(n int) *Scorer {
+	if n > 0 {
+		s.candidateLimit = n
+	}
+	return s
 }
 
 // WithCandidateFinder wires a Qdrant-backed CandidateFinder for conflict candidate
@@ -109,6 +121,7 @@ func NewScorer(db *storage.DB, logger *slog.Logger, significanceThreshold float6
 		validator:       validator,
 		backfillWorkers: backfillWorkers,
 		decayLambda:     decayLambda,
+		candidateLimit:  50,
 	}
 }
 
@@ -186,7 +199,7 @@ func (s *Scorer) scoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 		return
 	}
 
-	qdrantResults, err := s.finder.FindSimilar(ctx, orgID, d.Embedding.Slice(), decisionID, d.Project, 50)
+	qdrantResults, err := s.finder.FindSimilar(ctx, orgID, d.Embedding.Slice(), decisionID, d.Project, s.candidateLimit)
 	if err != nil {
 		s.logger.Warn("conflict scorer: qdrant find similar failed", "decision_id", decisionID, "error", err)
 		return

--- a/internal/conflicts/scorer_test.go
+++ b/internal/conflicts/scorer_test.go
@@ -1016,6 +1016,27 @@ func TestNewScorer_DefaultWorkers(t *testing.T) {
 	assert.Equal(t, 8, scorer.backfillWorkers, "explicit value should be respected")
 }
 
+func TestNewScorer_DefaultCandidateLimit(t *testing.T) {
+	scorer := NewScorer(nil, slog.Default(), 0.3, nil, 0, 0)
+	assert.Equal(t, 50, scorer.candidateLimit, "default should be 50")
+}
+
+func TestWithCandidateLimit(t *testing.T) {
+	scorer := NewScorer(nil, slog.Default(), 0.3, nil, 0, 0)
+
+	scorer = scorer.WithCandidateLimit(20)
+	assert.Equal(t, 20, scorer.candidateLimit, "should accept 20")
+
+	scorer = scorer.WithCandidateLimit(200)
+	assert.Equal(t, 200, scorer.candidateLimit, "should accept 200")
+
+	scorer = scorer.WithCandidateLimit(0)
+	assert.Equal(t, 200, scorer.candidateLimit, "0 should be ignored")
+
+	scorer = scorer.WithCandidateLimit(-5)
+	assert.Equal(t, 200, scorer.candidateLimit, "negative should be ignored")
+}
+
 func TestBackfillScoring_MarksDecisionsScored(t *testing.T) {
 	ctx := context.Background()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))


### PR DESCRIPTION
## Summary

- Adds `AKASHI_CONFLICT_CANDIDATE_LIMIT` env var (default: 50) to control how many candidates the conflict scorer retrieves from Qdrant per decision
- Uses the existing `WithCandidateLimit` builder pattern to avoid constructor signature changes and test churn
- Documents in `configuration.md` and `.env.example`

Closes #297

## Test plan

- [x] New unit tests: `TestNewScorer_DefaultCandidateLimit` and `TestWithCandidateLimit` verify default (50), custom values, and rejection of non-positive values
- [x] `go build ./...`, `go vet ./...`, `golangci-lint run ./...` all pass
- [x] `atlas migrate validate` passes (no migration changes)