### PR TITLE
feat(conflicts): add OpenTelemetry metrics for conflict detection pipeline

### DIFF
--- a/akashi.go
+++ b/akashi.go
@@ -406,6 +406,7 @@ func New(opts ...Option) (*App, error) {
 		HooksAPIKey:             cfg.HooksAPIKey,
 		AutoTrace:               cfg.AutoTrace,
 		SignupEnabled:           cfg.SignupEnabled,
+		ResolutionRecorder:      conflictScorer,
 	})
 
 	// Seed admin agent.

--- a/internal/conflicts/metrics.go
+++ b/internal/conflicts/metrics.go
@@ -1,0 +1,177 @@
+package conflicts
+
+import (
+	"context"
+	"log/slog"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/ashita-ai/akashi/internal/telemetry"
+)
+
+// Metrics holds pre-created OpenTelemetry instruments for conflict detection.
+type Metrics struct {
+	detected            metric.Int64Counter
+	resolved            metric.Int64Counter
+	llmCalls            metric.Int64Counter
+	candidatesEvaluated metric.Int64Counter
+	claimLevelWins      metric.Int64Counter
+
+	scoringDuration  metric.Float64Histogram
+	llmCallDuration  metric.Float64Histogram
+	significanceDist metric.Float64Histogram
+}
+
+// ResolutionRecorder records conflict resolution events for OpenTelemetry metrics.
+// Implemented by the Scorer; used by HTTP handlers that resolve conflicts
+// without going through the scoring pipeline.
+type ResolutionRecorder interface {
+	RecordResolution(ctx context.Context, status, conflictKind string, count int)
+}
+
+// RecordResolution implements ResolutionRecorder, incrementing the resolved counter
+// with the given status and conflict_kind labels.
+func (s *Scorer) RecordResolution(ctx context.Context, status, conflictKind string, count int) {
+	s.metrics.resolved.Add(ctx, int64(count), metric.WithAttributes(
+		attribute.String("status", status),
+		attribute.String("conflict_kind", conflictKind),
+	))
+}
+
+// validatorTypeLabel returns a low-cardinality label for the configured validator.
+func validatorTypeLabel(v Validator) string {
+	switch v.(type) {
+	case NoopValidator:
+		return "noop"
+	case *OllamaValidator:
+		return "ollama"
+	case *OpenAIValidator:
+		return "openai"
+	default:
+		return "custom"
+	}
+}
+
+// registerMetrics creates all OTel instruments for the conflict pipeline.
+// Called once from NewScorer.
+func (s *Scorer) registerMetrics() {
+	meter := telemetry.Meter("akashi/conflicts")
+
+	var err error
+
+	// --- Counters ---
+
+	s.metrics.detected, err = meter.Int64Counter("akashi.conflicts.detected",
+		metric.WithDescription("Total conflicts detected by the scoring pipeline"),
+	)
+	if err != nil {
+		s.logger.Warn("conflicts: failed to create akashi.conflicts.detected metric", "error", err)
+		s.metrics.detected, _ = meter.Int64Counter("akashi.conflicts.detected.fallback")
+	}
+
+	s.metrics.resolved, err = meter.Int64Counter("akashi.conflicts.resolved",
+		metric.WithDescription("Total conflicts resolved (resolved, wont_fix, or acknowledged)"),
+	)
+	if err != nil {
+		s.logger.Warn("conflicts: failed to create akashi.conflicts.resolved metric", "error", err)
+		s.metrics.resolved, _ = meter.Int64Counter("akashi.conflicts.resolved.fallback")
+	}
+
+	s.metrics.llmCalls, err = meter.Int64Counter("akashi.conflicts.llm_calls",
+		metric.WithDescription("Total LLM validation calls for conflict classification"),
+	)
+	if err != nil {
+		s.logger.Warn("conflicts: failed to create akashi.conflicts.llm_calls metric", "error", err)
+		s.metrics.llmCalls, _ = meter.Int64Counter("akashi.conflicts.llm_calls.fallback")
+	}
+
+	s.metrics.candidatesEvaluated, err = meter.Int64Counter("akashi.conflicts.candidates_evaluated",
+		metric.WithDescription("Total candidate pairs evaluated for conflict scoring"),
+	)
+	if err != nil {
+		s.logger.Warn("conflicts: failed to create akashi.conflicts.candidates_evaluated metric", "error", err)
+		s.metrics.candidatesEvaluated, _ = meter.Int64Counter("akashi.conflicts.candidates_evaluated.fallback")
+	}
+
+	s.metrics.claimLevelWins, err = meter.Int64Counter("akashi.conflicts.claim_level_wins",
+		metric.WithDescription("Times claim-level scoring produced higher significance than full-outcome scoring"),
+	)
+	if err != nil {
+		s.logger.Warn("conflicts: failed to create akashi.conflicts.claim_level_wins metric", "error", err)
+		s.metrics.claimLevelWins, _ = meter.Int64Counter("akashi.conflicts.claim_level_wins.fallback")
+	}
+
+	// --- Histograms ---
+
+	s.metrics.scoringDuration, err = meter.Float64Histogram("akashi.conflicts.scoring_duration_ms",
+		metric.WithDescription("Per-decision conflict scoring latency"),
+		metric.WithUnit("ms"),
+	)
+	if err != nil {
+		s.logger.Warn("conflicts: failed to create akashi.conflicts.scoring_duration_ms metric", "error", err)
+		s.metrics.scoringDuration, _ = meter.Float64Histogram("akashi.conflicts.scoring_duration_ms.fallback")
+	}
+
+	s.metrics.llmCallDuration, err = meter.Float64Histogram("akashi.conflicts.llm_call_duration_ms",
+		metric.WithDescription("Per-call LLM validation latency for conflict classification"),
+		metric.WithUnit("ms"),
+	)
+	if err != nil {
+		s.logger.Warn("conflicts: failed to create akashi.conflicts.llm_call_duration_ms metric", "error", err)
+		s.metrics.llmCallDuration, _ = meter.Float64Histogram("akashi.conflicts.llm_call_duration_ms.fallback")
+	}
+
+	s.metrics.significanceDist, err = meter.Float64Histogram("akashi.conflicts.significance_distribution",
+		metric.WithDescription("Significance scores of detected conflicts"),
+	)
+	if err != nil {
+		s.logger.Warn("conflicts: failed to create akashi.conflicts.significance_distribution metric", "error", err)
+		s.metrics.significanceDist, _ = meter.Float64Histogram("akashi.conflicts.significance_distribution.fallback")
+	}
+
+	// --- Observable gauges ---
+
+	registerObservableGauges(meter, s.db, s.logger)
+}
+
+// registerObservableGauges registers callback-driven gauges that query the database.
+func registerObservableGauges(meter metric.Meter, db gaugeQuerier, logger *slog.Logger) {
+	_, err := meter.Int64ObservableGauge("akashi.conflicts.open_total",
+		metric.WithDescription("Current total of open and acknowledged conflicts"),
+		metric.WithInt64Callback(func(ctx context.Context, o metric.Int64Observer) error {
+			count, err := db.GetGlobalOpenConflictCount(ctx)
+			if err != nil {
+				logger.Debug("conflicts: open_total gauge query failed", "error", err)
+				return nil // non-fatal: skip this observation
+			}
+			o.Observe(count)
+			return nil
+		}),
+	)
+	if err != nil {
+		logger.Warn("conflicts: failed to create akashi.conflicts.open_total gauge", "error", err)
+	}
+
+	_, err = meter.Int64ObservableGauge("akashi.conflicts.backfill_remaining",
+		metric.WithDescription("Decisions with embeddings not yet conflict-scored"),
+		metric.WithInt64Callback(func(ctx context.Context, o metric.Int64Observer) error {
+			count, err := db.CountUnscoredDecisions(ctx)
+			if err != nil {
+				logger.Debug("conflicts: backfill_remaining gauge query failed", "error", err)
+				return nil // non-fatal: skip this observation
+			}
+			o.Observe(count)
+			return nil
+		}),
+	)
+	if err != nil {
+		logger.Warn("conflicts: failed to create akashi.conflicts.backfill_remaining gauge", "error", err)
+	}
+}
+
+// gaugeQuerier is the subset of storage.DB needed by observable gauge callbacks.
+type gaugeQuerier interface {
+	GetGlobalOpenConflictCount(ctx context.Context) (int64, error)
+	CountUnscoredDecisions(ctx context.Context) (int64, error)
+}

--- a/internal/conflicts/scorer.go
+++ b/internal/conflicts/scorer.go
@@ -4,13 +4,17 @@ package conflicts
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"math"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/google/uuid"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/ashita-ai/akashi/internal/model"
@@ -62,6 +66,7 @@ type Scorer struct {
 	logger          *slog.Logger
 	threshold       float64
 	validator       Validator
+	validatorLabel  string // low-cardinality label for OTel attributes
 	backfillWorkers int
 	decayLambda     float64 // Temporal decay rate. 0 disables decay.
 	candidateLimit  int     // Max candidates retrieved from Qdrant per decision.
@@ -69,6 +74,7 @@ type Scorer struct {
 	// pairwiseScorer is an optional external override for the confirmation step.
 	// When non-nil, it replaces the built-in Validator-backed scoring for each candidate pair.
 	pairwiseScorer PairwiseScorer
+	metrics        Metrics
 
 	// Scoring thresholds (configurable via env vars, defaults match package constants).
 	claimTopicSimFloor    float64
@@ -149,11 +155,12 @@ func NewScorer(db *storage.DB, logger *slog.Logger, significanceThreshold float6
 	if backfillWorkers <= 0 {
 		backfillWorkers = 4
 	}
-	return &Scorer{
+	s := &Scorer{
 		db:                    db,
 		logger:                logger,
 		threshold:             significanceThreshold,
 		validator:             validator,
+		validatorLabel:        validatorTypeLabel(validator),
 		backfillWorkers:       backfillWorkers,
 		decayLambda:           decayLambda,
 		candidateLimit:        50,
@@ -161,6 +168,8 @@ func NewScorer(db *storage.DB, logger *slog.Logger, significanceThreshold float6
 		claimDivFloor:         claimDivFloor,
 		decisionTopicSimFloor: decisionTopicSimFloor,
 	}
+	s.registerMetrics()
+	return s
 }
 
 // claimTopicSimFloor is the minimum cosine similarity for two claims to be
@@ -222,6 +231,11 @@ func (s *Scorer) ScoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 // prevents duplicate LLM calls during backfill when multiple goroutines
 // process different decisions that find each other as candidates.
 func (s *Scorer) scoreForDecision(ctx context.Context, decisionID, orgID uuid.UUID, cache *pairCache) {
+	start := time.Now()
+	defer func() {
+		s.metrics.scoringDuration.Record(ctx, float64(time.Since(start).Milliseconds()))
+	}()
+
 	d, err := s.db.GetDecisionForScoring(ctx, decisionID, orgID)
 	if err != nil {
 		s.logger.Debug("conflict scorer: skip decision", "decision_id", decisionID, "error", err)
@@ -311,6 +325,7 @@ func (s *Scorer) scoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 		}
 
 		topicSim := cosineSimilarity(d.Embedding.Slice(), cand.Embedding.Slice())
+		s.metrics.candidatesEvaluated.Add(ctx, 1)
 
 		// --- Pass 1: full-outcome scoring (existing behavior) ---
 		outcomeSim := cosineSimilarity(d.OutcomeEmbedding.Slice(), cand.OutcomeEmbedding.Slice())
@@ -333,6 +348,7 @@ func (s *Scorer) scoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 				bestMethod = "claim"
 				bestOutcomeA = claimA
 				bestOutcomeB = claimB
+				s.metrics.claimLevelWins.Add(ctx, 1)
 			}
 		}
 
@@ -397,12 +413,26 @@ func (s *Scorer) scoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 					"decision_a", decisionID, "decision_b", cand.ID)
 				continue
 			}
+			llmStart := time.Now()
 			extScore, extExpl, err := s.pairwiseScorer.ScorePair(ctx, d, cand)
+			s.metrics.llmCallDuration.Record(ctx, float64(time.Since(llmStart).Milliseconds()))
 			if err != nil {
+				result := "error"
+				if errors.Is(err, context.DeadlineExceeded) {
+					result = "timeout"
+				}
+				s.metrics.llmCalls.Add(ctx, 1, metric.WithAttributes(
+					attribute.String("result", result),
+					attribute.String("validator", "external"),
+				))
 				s.logger.Warn("conflict scorer: external pairwise scorer failed, skipping candidate",
 					"error", err, "decision_a", decisionID, "decision_b", cand.ID)
 				continue // fail-safe: don't insert unscored conflicts
 			}
+			s.metrics.llmCalls.Add(ctx, 1, metric.WithAttributes(
+				attribute.String("result", "success"),
+				attribute.String("validator", "external"),
+			))
 			if extScore <= 0 {
 				s.logger.Debug("conflict scorer: external scorer classified as non-conflict",
 					"decision_a", decisionID, "decision_b", cand.ID)
@@ -421,6 +451,7 @@ func (s *Scorer) scoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 				continue
 			}
 
+			llmStart := time.Now()
 			result, err := s.validator.Validate(ctx, ValidateInput{
 				OutcomeA:        bestOutcomeA,
 				OutcomeB:        bestOutcomeB,
@@ -442,11 +473,24 @@ func (s *Scorer) scoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 				FullOutcomeB:    cand.Outcome,
 				TopicSimilarity: topicSim,
 			})
+			s.metrics.llmCallDuration.Record(ctx, float64(time.Since(llmStart).Milliseconds()))
 			if err != nil {
+				llmResult := "error"
+				if errors.Is(err, context.DeadlineExceeded) {
+					llmResult = "timeout"
+				}
+				s.metrics.llmCalls.Add(ctx, 1, metric.WithAttributes(
+					attribute.String("result", llmResult),
+					attribute.String("validator", s.validatorLabel),
+				))
 				s.logger.Warn("conflict scorer: LLM validation failed, skipping candidate",
 					"error", err, "decision_a", decisionID, "decision_b", cand.ID)
 				continue // fail-safe: don't insert unvalidated conflicts
 			}
+			s.metrics.llmCalls.Add(ctx, 1, metric.WithAttributes(
+				attribute.String("result", "success"),
+				attribute.String("validator", s.validatorLabel),
+			))
 			if !result.IsConflict() {
 				s.logger.Debug("conflict scorer: LLM classified as non-conflict",
 					"decision_a", decisionID, "decision_b", cand.ID,
@@ -500,6 +544,13 @@ func (s *Scorer) scoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 			s.logger.Warn("conflict scorer: insert failed", "decision_a", decisionID, "decision_b", cand.ID, "error", err)
 			continue
 		}
+		s.metrics.detected.Add(ctx, 1, metric.WithAttributes(
+			attribute.String("scoring_method", bestMethod),
+			attribute.String("relationship", derefOrUnknown(relationship)),
+			attribute.String("conflict_kind", string(kind)),
+			attribute.String("severity", derefOrUnknown(severity)),
+		))
+		s.metrics.significanceDist.Record(ctx, bestSig)
 		inserted++
 		if err := s.db.Notify(ctx, storage.ChannelConflicts, `{"source":"scorer","org_id":"`+orgID.String()+`"}`); err != nil {
 			s.logger.Debug("conflict scorer: notify failed", "error", err)
@@ -682,3 +733,11 @@ func derefString(s *string) string {
 }
 
 func ptr[T any](v T) *T { return &v }
+
+// derefOrUnknown returns the dereferenced string, or "unknown" if nil.
+func derefOrUnknown(s *string) string {
+	if s == nil {
+		return "unknown"
+	}
+	return *s
+}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/ashita-ai/akashi/internal/auth"
 	"github.com/ashita-ai/akashi/internal/authz"
+	"github.com/ashita-ai/akashi/internal/conflicts"
 	"github.com/ashita-ai/akashi/internal/model"
 	"github.com/ashita-ai/akashi/internal/ratelimit"
 	"github.com/ashita-ai/akashi/internal/search"
@@ -49,6 +50,9 @@ type Handlers struct {
 	signupLimiter ratelimit.Limiter
 	// trustProxy controls whether to read client IP from X-Forwarded-For.
 	trustProxy bool
+	// resolutionRecorder records conflict resolution events for OTel metrics.
+	// Nil-safe: callers check before use.
+	resolutionRecorder conflicts.ResolutionRecorder
 }
 
 // HandlersDeps holds all dependencies for constructing Handlers.
@@ -70,6 +74,7 @@ type HandlersDeps struct {
 	DecisionHooks           []DecisionHook
 	AutoTrace               bool
 	TrustProxy              bool
+	ResolutionRecorder      conflicts.ResolutionRecorder
 }
 
 // NewHandlers creates a new Handlers with all dependencies.
@@ -93,6 +98,7 @@ func NewHandlers(d HandlersDeps) *Handlers {
 		hookChecks:              newHookCheckStore(),
 		autoTrace:               d.AutoTrace,
 		trustProxy:              d.TrustProxy,
+		resolutionRecorder:      d.ResolutionRecorder,
 	}
 }
 

--- a/internal/server/handlers_decisions.go
+++ b/internal/server/handlers_decisions.go
@@ -680,6 +680,10 @@ func (h *Handlers) HandlePatchConflict(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if h.resolutionRecorder != nil {
+		h.resolutionRecorder.RecordResolution(r.Context(), req.Status, string(conflict.ConflictKind), 1)
+	}
+
 	writeJSON(w, r, http.StatusOK, conflict)
 }
 
@@ -740,6 +744,13 @@ func (h *Handlers) HandleResolveConflictGroup(w http.ResponseWriter, r *http.Req
 		}
 		h.writeInternalError(w, r, "failed to resolve conflict group", err)
 		return
+	}
+
+	if h.resolutionRecorder != nil && affected > 0 {
+		groupKind, kindErr := h.db.GetConflictGroupKind(r.Context(), groupID, orgID)
+		if kindErr == nil {
+			h.resolutionRecorder.RecordResolution(r.Context(), req.Status, groupKind, affected)
+		}
 	}
 
 	writeJSON(w, r, http.StatusOK, model.ConflictGroupResolveResult{
@@ -845,6 +856,10 @@ func (h *Handlers) HandleAdjudicateConflict(w http.ResponseWriter, r *http.Reque
 		}
 		h.writeInternalError(w, r, "failed to adjudicate conflict", err)
 		return
+	}
+
+	if h.resolutionRecorder != nil {
+		h.resolutionRecorder.RecordResolution(r.Context(), "resolved", string(conflict.ConflictKind), 1)
 	}
 
 	// Return the updated conflict.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/ashita-ai/akashi/internal/auth"
 	"github.com/ashita-ai/akashi/internal/authz"
+	"github.com/ashita-ai/akashi/internal/conflicts"
 	"github.com/ashita-ai/akashi/internal/model"
 	"github.com/ashita-ai/akashi/internal/ratelimit"
 	"github.com/ashita-ai/akashi/internal/search"
@@ -89,6 +90,9 @@ type ServerConfig struct {
 	HooksEnabled bool   // Enable /hooks/* IDE integration endpoints.
 	HooksAPIKey  string // Optional API key for non-localhost hook access.
 	AutoTrace    bool   // Auto-trace git commits from PostToolUse hooks.
+
+	// Conflict metrics.
+	ResolutionRecorder conflicts.ResolutionRecorder
 }
 
 // New creates a new HTTP server with all routes configured.
@@ -110,6 +114,7 @@ func New(cfg ServerConfig) *Server {
 		DecisionHooks:           cfg.DecisionHooks,
 		AutoTrace:               cfg.AutoTrace,
 		TrustProxy:              cfg.TrustProxy,
+		ResolutionRecorder:      cfg.ResolutionRecorder,
 	})
 
 	mux := http.NewServeMux()

--- a/internal/storage/conflicts.go
+++ b/internal/storage/conflicts.go
@@ -1191,3 +1191,30 @@ func (db *DB) GetConflictAnalytics(ctx context.Context, orgID uuid.UUID, filters
 
 	return result, nil
 }
+
+// GetGlobalOpenConflictCount returns the total number of open and acknowledged
+// conflicts across all organizations. Used by the OpenTelemetry observable
+// gauge callback (runs every ~15s).
+// SECURITY: Intentionally global — aggregate metric with no tenant data exposed.
+func (db *DB) GetGlobalOpenConflictCount(ctx context.Context) (int64, error) {
+	var count int64
+	err := db.pool.QueryRow(ctx,
+		`SELECT count(*) FROM scored_conflicts WHERE status IN ('open', 'acknowledged')`).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("storage: global open conflict count: %w", err)
+	}
+	return count, nil
+}
+
+// GetConflictGroupKind returns the conflict_kind for a conflict group.
+// Used by HTTP handlers that need the kind label for resolution metrics.
+func (db *DB) GetConflictGroupKind(ctx context.Context, groupID, orgID uuid.UUID) (string, error) {
+	var kind string
+	err := db.pool.QueryRow(ctx,
+		`SELECT conflict_kind FROM conflict_groups WHERE id = $1 AND org_id = $2`,
+		groupID, orgID).Scan(&kind)
+	if err != nil {
+		return "", fmt.Errorf("storage: get conflict group kind: %w", err)
+	}
+	return kind, nil
+}

--- a/internal/storage/decisions.go
+++ b/internal/storage/decisions.go
@@ -1525,6 +1525,24 @@ func (db *DB) MarkDecisionConflictScored(ctx context.Context, id, orgID uuid.UUI
 	return nil
 }
 
+// CountUnscoredDecisions returns the number of decisions that have embeddings
+// but have not yet been conflict-scored. Used by the OpenTelemetry observable
+// gauge callback to report backfill progress.
+// SECURITY: Intentionally global — aggregate metric with no tenant data exposed.
+func (db *DB) CountUnscoredDecisions(ctx context.Context) (int64, error) {
+	var count int64
+	err := db.pool.QueryRow(ctx,
+		`SELECT count(*) FROM decisions
+		 WHERE valid_to IS NULL
+		   AND embedding IS NOT NULL
+		   AND outcome_embedding IS NOT NULL
+		   AND conflict_scored_at IS NULL`).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("storage: count unscored decisions: %w", err)
+	}
+	return count, nil
+}
+
 // ResetConflictScoredAt clears conflict_scored_at for all decisions, forcing
 // the next backfill to re-score everything. Used when transitioning from
 // embedding-only to LLM-validated scoring so all pairs get re-evaluated.


### PR DESCRIPTION
## Summary

- Adds 10 OpenTelemetry metrics to the conflict detection pipeline: 5 counters (`detected`, `resolved`, `llm_calls`, `candidates_evaluated`, `claim_level_wins`), 3 histograms (`scoring_duration_ms`, `llm_call_duration_ms`, `significance_distribution`), and 2 observable gauges (`open_total`, `backfill_remaining`)
- Introduces `ResolutionRecorder` interface so HTTP handlers can record resolution metrics without importing the scorer directly
- All attribute values are bounded enums (no high-cardinality labels) keeping time series count manageable

## Details

**New file:** `internal/conflicts/metrics.go` — `Metrics` struct, `ResolutionRecorder` interface, `registerMetrics()` with observable gauge callbacks, `validatorTypeLabel()` helper.

**Instrumented scorer.go:** timing defer for per-decision latency, candidate evaluation counting, claim-level win tracking, LLM call duration/result/timeout recording, conflict detection counting with scoring_method/relationship/conflict_kind/severity labels, significance distribution histogram.

**Instrumented handlers:** `HandlePatchConflict`, `HandleResolveConflictGroup`, and `HandleAdjudicateConflict` record the `resolved` counter via `ResolutionRecorder`.

**Storage queries:** `GetGlobalOpenConflictCount()` and `CountUnscoredDecisions()` for gauge callbacks; `GetConflictGroupKind()` for group resolution labels.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `golangci-lint run ./...` — 0 issues
- [x] `atlas migrate validate` passes
- [x] `go test -race -count=1 ./...` — all tests pass (2 pre-existing flaky failures confirmed on main)
- [ ] Manual verification with `OTEL_EXPORTER_OTLP_ENDPOINT` set to confirm metrics export

Closes #295