### PR TITLE
feat(conflicts): add conflict trend analytics endpoint

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1040,6 +1040,66 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
+  /v1/conflicts/analytics:
+    get:
+      operationId: getConflictAnalytics
+      tags: [Query]
+      summary: Conflict trend analytics
+      description: |
+        Returns aggregated conflict metrics over a time window: summary stats,
+        breakdowns by agent pair / decision type / severity, and a daily
+        detected-vs-resolved trend.
+        Requires `reader` role or higher.
+      parameters:
+        - name: period
+          in: query
+          schema:
+            type: string
+            enum: [7d, 30d, 90d]
+            default: "7d"
+          description: |
+            Convenience period relative to now. Ignored when both `from` and
+            `to` are provided.
+        - name: from
+          in: query
+          schema:
+            type: string
+            format: date-time
+          description: Start of time range (RFC 3339). Requires `to`.
+        - name: to
+          in: query
+          schema:
+            type: string
+            format: date-time
+          description: End of time range (RFC 3339). Requires `from`.
+        - name: agent_id
+          in: query
+          schema:
+            type: string
+          description: Filter to conflicts involving this agent.
+        - name: decision_type
+          in: query
+          schema:
+            type: string
+          description: Filter to conflicts involving this decision type.
+        - name: conflict_kind
+          in: query
+          schema:
+            type: string
+            enum: [cross_agent, self_contradiction]
+          description: Filter by conflict kind.
+      responses:
+        "200":
+          description: Conflict analytics.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/APIResponse_ConflictAnalytics"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
   /v1/conflicts:
     get:
       operationId: listConflicts
@@ -3331,6 +3391,95 @@ components:
           $ref: "#/components/schemas/RecentDecisionsResponse"
         meta:
           $ref: "#/components/schemas/ResponseMeta"
+
+    APIResponse_ConflictAnalytics:
+      type: object
+      required: [data, meta]
+      properties:
+        data:
+          $ref: "#/components/schemas/ConflictAnalytics"
+        meta:
+          $ref: "#/components/schemas/ResponseMeta"
+
+    ConflictAnalytics:
+      type: object
+      required: [period, summary, by_agent_pair, by_decision_type, by_severity, trend]
+      properties:
+        period:
+          type: object
+          required: [start, end]
+          properties:
+            start:
+              type: string
+              format: date-time
+            end:
+              type: string
+              format: date-time
+        summary:
+          type: object
+          required: [total_detected, total_resolved, mean_time_to_resolution_hours, false_positive_rate]
+          properties:
+            total_detected:
+              type: integer
+            total_resolved:
+              type: integer
+            mean_time_to_resolution_hours:
+              type: number
+              nullable: true
+            false_positive_rate:
+              type: number
+        by_agent_pair:
+          type: array
+          items:
+            type: object
+            required: [agent_a, agent_b, count, open, resolved]
+            properties:
+              agent_a:
+                type: string
+              agent_b:
+                type: string
+              count:
+                type: integer
+              open:
+                type: integer
+              resolved:
+                type: integer
+        by_decision_type:
+          type: array
+          items:
+            type: object
+            required: [decision_type, count, avg_significance]
+            properties:
+              decision_type:
+                type: string
+              count:
+                type: integer
+              avg_significance:
+                type: number
+        by_severity:
+          type: array
+          items:
+            type: object
+            required: [severity, count]
+            properties:
+              severity:
+                type: string
+                enum: [critical, high, medium, low]
+              count:
+                type: integer
+        trend:
+          type: array
+          items:
+            type: object
+            required: [date, detected, resolved]
+            properties:
+              date:
+                type: string
+                format: date
+              detected:
+                type: integer
+              resolved:
+                type: integer
 
     APIResponse_ConflictsResponse:
       type: object

--- a/internal/model/analytics.go
+++ b/internal/model/analytics.go
@@ -1,0 +1,58 @@
+package model
+
+import "time"
+
+// ConflictAnalytics is the response for GET /v1/conflicts/analytics.
+// It aggregates conflict data over a time period into summary stats,
+// breakdowns by agent pair / decision type / severity, and a daily trend.
+type ConflictAnalytics struct {
+	Period         TimePeriod                  `json:"period"`
+	Summary        ConflictAnalyticsSummary    `json:"summary"`
+	ByAgentPair    []AgentPairConflictStats    `json:"by_agent_pair"`
+	ByDecisionType []DecisionTypeConflictStats `json:"by_decision_type"`
+	BySeverity     []SeverityConflictStats     `json:"by_severity"`
+	Trend          []ConflictTrendPoint        `json:"trend"`
+}
+
+// TimePeriod defines the start and end of an analytics window.
+type TimePeriod struct {
+	Start time.Time `json:"start"`
+	End   time.Time `json:"end"`
+}
+
+// ConflictAnalyticsSummary holds top-level aggregate metrics for the period.
+type ConflictAnalyticsSummary struct {
+	TotalDetected             int      `json:"total_detected"`
+	TotalResolved             int      `json:"total_resolved"`
+	MeanTimeToResolutionHours *float64 `json:"mean_time_to_resolution_hours"`
+	FalsePositiveRate         float64  `json:"false_positive_rate"`
+}
+
+// AgentPairConflictStats shows conflict counts for one agent pair.
+type AgentPairConflictStats struct {
+	AgentA   string `json:"agent_a"`
+	AgentB   string `json:"agent_b"`
+	Count    int    `json:"count"`
+	Open     int    `json:"open"`
+	Resolved int    `json:"resolved"`
+}
+
+// DecisionTypeConflictStats shows conflict counts and average significance for one decision type.
+type DecisionTypeConflictStats struct {
+	DecisionType    string  `json:"decision_type"`
+	Count           int     `json:"count"`
+	AvgSignificance float64 `json:"avg_significance"`
+}
+
+// SeverityConflictStats shows the number of conflicts at a given severity level.
+type SeverityConflictStats struct {
+	Severity string `json:"severity"`
+	Count    int    `json:"count"`
+}
+
+// ConflictTrendPoint holds detected and resolved counts for a single day.
+type ConflictTrendPoint struct {
+	Date     string `json:"date"` // YYYY-MM-DD
+	Detected int    `json:"detected"`
+	Resolved int    `json:"resolved"`
+}

--- a/internal/server/handlers_decisions.go
+++ b/internal/server/handlers_decisions.go
@@ -938,6 +938,86 @@ func (h *Handlers) computeRecommendation(ctx context.Context, c model.DecisionCo
 	})
 }
 
+// validAnalyticsPeriods maps convenience period strings to durations.
+var validAnalyticsPeriods = map[string]time.Duration{
+	"7d":  7 * 24 * time.Hour,
+	"30d": 30 * 24 * time.Hour,
+	"90d": 90 * 24 * time.Hour,
+}
+
+const maxAnalyticsRangeDays = 365
+
+// HandleConflictAnalytics handles GET /v1/conflicts/analytics.
+// Returns aggregated conflict metrics over a time window: summary stats,
+// breakdowns by agent pair / decision type / severity, and a daily trend.
+func (h *Handlers) HandleConflictAnalytics(w http.ResponseWriter, r *http.Request) {
+	orgID := OrgIDFromContext(r.Context())
+
+	// Determine time range from query parameters.
+	var from, to time.Time
+	now := time.Now().UTC()
+
+	fromParam, err := queryTime(r, "from")
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, err.Error())
+		return
+	}
+	toParam, err := queryTime(r, "to")
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, err.Error())
+		return
+	}
+
+	if fromParam != nil && toParam != nil {
+		from = *fromParam
+		to = *toParam
+	} else {
+		period := r.URL.Query().Get("period")
+		if period == "" {
+			period = "7d"
+		}
+		dur, ok := validAnalyticsPeriods[period]
+		if !ok {
+			writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput,
+				"invalid period: must be one of 7d, 30d, 90d")
+			return
+		}
+		from = now.Add(-dur)
+		to = now
+	}
+
+	if !from.Before(to) {
+		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput,
+			"from must be before to")
+		return
+	}
+	if to.Sub(from).Hours() > float64(maxAnalyticsRangeDays*24) {
+		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput,
+			"time range must not exceed 365 days")
+		return
+	}
+
+	// Build filters.
+	filters := storage.ConflictAnalyticsFilters{From: from, To: to}
+	if v := r.URL.Query().Get("agent_id"); v != "" {
+		filters.AgentID = &v
+	}
+	if v := r.URL.Query().Get("decision_type"); v != "" {
+		filters.DecisionType = &v
+	}
+	if v := r.URL.Query().Get("conflict_kind"); v != "" {
+		filters.ConflictKind = &v
+	}
+
+	analytics, err := h.db.GetConflictAnalytics(r.Context(), orgID, filters)
+	if err != nil {
+		h.writeInternalError(w, r, "failed to get conflict analytics", err)
+		return
+	}
+
+	writeJSON(w, r, http.StatusOK, analytics)
+}
+
 // HandleDecisionRevisions handles GET /v1/decisions/{id}/revisions.
 // Returns the full revision chain for a decision (all versions, ordered by valid_from).
 func (h *Handlers) HandleDecisionRevisions(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -190,7 +190,8 @@ func New(cfg ServerConfig) *Server {
 	mux.Handle("POST /v1/grants", writeRole(http.HandlerFunc(h.HandleCreateGrant)))
 	mux.Handle("DELETE /v1/grants/{grant_id}", writeRole(http.HandlerFunc(h.HandleDeleteGrant)))
 
-	// Conflicts (reader+ for list/detail, agent+ for adjudicate/patch/resolve).
+	// Conflicts (reader+ for list/detail/analytics, agent+ for adjudicate/patch/resolve).
+	mux.Handle("GET /v1/conflicts/analytics", readRole(http.HandlerFunc(h.HandleConflictAnalytics)))
 	mux.Handle("GET /v1/conflicts", readRole(http.HandlerFunc(h.HandleListConflicts)))
 	mux.Handle("GET /v1/conflicts/{id}", readRole(http.HandlerFunc(h.HandleGetConflict)))
 	mux.Handle("GET /v1/conflict-groups", readRole(http.HandlerFunc(h.HandleListConflictGroups)))

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -3653,3 +3653,157 @@ func TestHandleEraseDecision(t *testing.T) {
 		assert.True(t, found, "expected a DecisionErased event in the run's event log")
 	})
 }
+
+func TestConflictAnalytics(t *testing.T) {
+	orgID := uuid.Nil
+
+	// Trace four decisions so we can create conflicts referencing them.
+	traceDecision := func(agentID, outcome string, confidence float32) uuid.UUID {
+		t.Helper()
+		resp, tErr := authedRequest("POST", testSrv.URL+"/v1/trace", adminToken, model.TraceRequest{
+			AgentID: agentID,
+			Decision: model.TraceDecision{
+				DecisionType: "architecture",
+				Outcome:      outcome,
+				Confidence:   confidence,
+			},
+		})
+		require.NoError(t, tErr)
+		defer func() { _ = resp.Body.Close() }()
+		require.Contains(t, []int{http.StatusOK, http.StatusCreated, http.StatusAccepted}, resp.StatusCode)
+		var result struct {
+			Data struct {
+				DecisionID uuid.UUID `json:"decision_id"`
+			} `json:"data"`
+		}
+		b, _ := io.ReadAll(resp.Body)
+		require.NoError(t, json.Unmarshal(b, &result))
+		return result.Data.DecisionID
+	}
+
+	d1 := traceDecision("alpha", "analytics-test: use Postgres", 0.9)
+	d2 := traceDecision("beta", "analytics-test: use MySQL", 0.8)
+	d3 := traceDecision("alpha", "analytics-test: use Redis", 0.7)
+	d4 := traceDecision("gamma", "analytics-test: use Memcached", 0.6)
+	require.NoError(t, testBuf.FlushNow(context.Background()))
+
+	now := time.Now().UTC()
+	threeDaysAgo := now.Add(-3 * 24 * time.Hour)
+	fiveDaysAgo := now.Add(-5 * 24 * time.Hour)
+
+	severity := func(s string) *string { return &s }
+
+	// Insert two conflicts with different agents, severities, and dates.
+	c1 := model.DecisionConflict{
+		OrgID:         orgID,
+		ConflictKind:  model.ConflictKindCrossAgent,
+		DecisionAID:   d1,
+		DecisionBID:   d2,
+		AgentA:        "alpha",
+		AgentB:        "beta",
+		DecisionTypeA: "architecture",
+		DecisionTypeB: "architecture",
+		OutcomeA:      "analytics-test: use Postgres",
+		OutcomeB:      "analytics-test: use MySQL",
+		Status:        "open",
+		Severity:      severity("high"),
+	}
+	id1, err := testDB.InsertScoredConflict(context.Background(), c1)
+	require.NoError(t, err)
+
+	c2 := model.DecisionConflict{
+		OrgID:         orgID,
+		ConflictKind:  model.ConflictKindCrossAgent,
+		DecisionAID:   d3,
+		DecisionBID:   d4,
+		AgentA:        "alpha",
+		AgentB:        "gamma",
+		DecisionTypeA: "architecture",
+		DecisionTypeB: "architecture",
+		OutcomeA:      "analytics-test: use Redis",
+		OutcomeB:      "analytics-test: use Memcached",
+		Status:        "resolved",
+		Severity:      severity("medium"),
+	}
+	id2, err := testDB.InsertScoredConflict(context.Background(), c2)
+	require.NoError(t, err)
+
+	// Backdate detected_at and set resolved_at for the second conflict.
+	_, err = testDB.Pool().Exec(context.Background(),
+		`UPDATE scored_conflicts SET detected_at = $1 WHERE id = $2`, fiveDaysAgo, id1)
+	require.NoError(t, err)
+	_, err = testDB.Pool().Exec(context.Background(),
+		`UPDATE scored_conflicts SET detected_at = $1, resolved_at = $2, resolved_by = 'test', status = 'resolved' WHERE id = $3`,
+		threeDaysAgo, now, id2)
+	require.NoError(t, err)
+
+	t.Run("default period returns analytics", func(t *testing.T) {
+		resp, err := authedRequest("GET", testSrv.URL+"/v1/conflicts/analytics", adminToken, nil)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var result struct {
+			Data model.ConflictAnalytics `json:"data"`
+		}
+		body, _ := io.ReadAll(resp.Body)
+		require.NoError(t, json.Unmarshal(body, &result))
+		analytics := result.Data
+
+		assert.False(t, analytics.Period.Start.IsZero())
+		assert.False(t, analytics.Period.End.IsZero())
+		// Both conflicts are within the default 7d window.
+		assert.GreaterOrEqual(t, analytics.Summary.TotalDetected, 2)
+		assert.GreaterOrEqual(t, analytics.Summary.TotalResolved, 1)
+		assert.NotNil(t, analytics.ByAgentPair)
+		assert.NotNil(t, analytics.BySeverity)
+		assert.NotNil(t, analytics.ByDecisionType)
+		assert.NotNil(t, analytics.Trend)
+		// Trend should have 7 entries for a 7d period (one per day).
+		assert.Len(t, analytics.Trend, 7)
+	})
+
+	t.Run("explicit from/to", func(t *testing.T) {
+		from := fiveDaysAgo.Add(-1 * time.Hour).Format(time.RFC3339)
+		to := now.Add(1 * time.Hour).Format(time.RFC3339)
+		resp, err := authedRequest("GET",
+			testSrv.URL+"/v1/conflicts/analytics?from="+from+"&to="+to, adminToken, nil)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("agent_id filter", func(t *testing.T) {
+		resp, err := authedRequest("GET",
+			testSrv.URL+"/v1/conflicts/analytics?agent_id=alpha", adminToken, nil)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var result struct {
+			Data model.ConflictAnalytics `json:"data"`
+		}
+		body, _ := io.ReadAll(resp.Body)
+		require.NoError(t, json.Unmarshal(body, &result))
+		// alpha appears in both conflicts.
+		assert.GreaterOrEqual(t, result.Data.Summary.TotalDetected, 2)
+	})
+
+	t.Run("invalid period returns 400", func(t *testing.T) {
+		resp, err := authedRequest("GET",
+			testSrv.URL+"/v1/conflicts/analytics?period=999d", adminToken, nil)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	t.Run("from after to returns 400", func(t *testing.T) {
+		from := now.Format(time.RFC3339)
+		to := fiveDaysAgo.Format(time.RFC3339)
+		resp, err := authedRequest("GET",
+			testSrv.URL+"/v1/conflicts/analytics?from="+from+"&to="+to, adminToken, nil)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+}

--- a/internal/storage/conflicts.go
+++ b/internal/storage/conflicts.go
@@ -970,3 +970,224 @@ func (db *DB) GetAgentWinRates(ctx context.Context, orgID uuid.UUID, agentIDs []
 	}
 	return result, rows.Err()
 }
+
+// ConflictAnalyticsFilters holds the time range and optional filters
+// for the conflict analytics aggregation queries.
+type ConflictAnalyticsFilters struct {
+	From         time.Time
+	To           time.Time
+	AgentID      *string
+	DecisionType *string
+	ConflictKind *string
+}
+
+// analyticsWhere appends WHERE conditions for analytics filters.
+// argOffset is the next positional parameter ($N) to use.
+func analyticsWhere(f ConflictAnalyticsFilters, argOffset int) (string, []any) {
+	var clause string
+	var args []any
+	if f.AgentID != nil {
+		clause += fmt.Sprintf(" AND (sc.agent_a = $%d OR sc.agent_b = $%d)", argOffset, argOffset)
+		args = append(args, *f.AgentID)
+		argOffset++
+	}
+	if f.DecisionType != nil {
+		clause += fmt.Sprintf(" AND (LOWER(TRIM(sc.decision_type_a)) = LOWER(TRIM($%d)) OR LOWER(TRIM(sc.decision_type_b)) = LOWER(TRIM($%d)))", argOffset, argOffset)
+		args = append(args, *f.DecisionType)
+		argOffset++
+	}
+	if f.ConflictKind != nil {
+		clause += fmt.Sprintf(" AND sc.conflict_kind = $%d", argOffset)
+		args = append(args, *f.ConflictKind)
+	}
+	return clause, args
+}
+
+// GetConflictAnalytics computes aggregate conflict metrics for the given
+// org and time window. It returns summary stats, breakdowns by agent pair /
+// decision type / severity, and a daily detected-vs-resolved trend.
+func (db *DB) GetConflictAnalytics(ctx context.Context, orgID uuid.UUID, filters ConflictAnalyticsFilters) (model.ConflictAnalytics, error) {
+	var result model.ConflictAnalytics
+	result.Period = model.TimePeriod{Start: filters.From, End: filters.To}
+
+	baseWhere := "sc.org_id = $1 AND sc.detected_at >= $2 AND sc.detected_at < $3"
+	extraClause, extraArgs := analyticsWhere(filters, 4)
+	where := baseWhere + extraClause
+
+	// Build args slice without mutating a shared base (gocritic: appendAssign).
+	args := make([]any, 0, 3+len(extraArgs))
+	args = append(args, orgID, filters.From, filters.To)
+	args = append(args, extraArgs...)
+
+	// 1. Summary: total detected, resolved, MTTR, false-positive rate.
+	summaryQuery := fmt.Sprintf(`
+		SELECT
+			count(*),
+			count(*) FILTER (WHERE sc.status IN ('resolved', 'wont_fix')),
+			avg(EXTRACT(EPOCH FROM (sc.resolved_at - sc.detected_at)) / 3600)
+				FILTER (WHERE sc.resolved_at IS NOT NULL),
+			COALESCE(
+				count(*) FILTER (WHERE sc.status = 'wont_fix')::double precision
+				/ NULLIF(count(*) FILTER (WHERE sc.status IN ('resolved', 'wont_fix')), 0),
+				0
+			)
+		FROM scored_conflicts sc
+		WHERE %s`, where)
+
+	if err := db.pool.QueryRow(ctx, summaryQuery, args...).Scan(
+		&result.Summary.TotalDetected,
+		&result.Summary.TotalResolved,
+		&result.Summary.MeanTimeToResolutionHours,
+		&result.Summary.FalsePositiveRate,
+	); err != nil {
+		return result, fmt.Errorf("storage: conflict analytics summary: %w", err)
+	}
+
+	// 2. By agent pair (top 50).
+	pairQuery := fmt.Sprintf(`
+		SELECT sc.agent_a, sc.agent_b,
+			count(*),
+			count(*) FILTER (WHERE sc.status IN ('open', 'acknowledged')),
+			count(*) FILTER (WHERE sc.status IN ('resolved', 'wont_fix'))
+		FROM scored_conflicts sc
+		WHERE %s
+		GROUP BY sc.agent_a, sc.agent_b
+		ORDER BY count(*) DESC
+		LIMIT 50`, where)
+
+	pairRows, err := db.pool.Query(ctx, pairQuery, args...)
+	if err != nil {
+		return result, fmt.Errorf("storage: conflict analytics by agent pair: %w", err)
+	}
+	defer pairRows.Close()
+
+	result.ByAgentPair = []model.AgentPairConflictStats{}
+	for pairRows.Next() {
+		var s model.AgentPairConflictStats
+		if err := pairRows.Scan(&s.AgentA, &s.AgentB, &s.Count, &s.Open, &s.Resolved); err != nil {
+			return result, fmt.Errorf("storage: scan conflict analytics agent pair: %w", err)
+		}
+		result.ByAgentPair = append(result.ByAgentPair, s)
+	}
+	if err := pairRows.Err(); err != nil {
+		return result, fmt.Errorf("storage: conflict analytics agent pair rows: %w", err)
+	}
+
+	// 3. By decision type (top 50, using decision_type_a as canonical).
+	typeQuery := fmt.Sprintf(`
+		SELECT sc.decision_type_a,
+			count(*),
+			COALESCE(avg(sc.significance), 0)
+		FROM scored_conflicts sc
+		WHERE %s
+		GROUP BY sc.decision_type_a
+		ORDER BY count(*) DESC
+		LIMIT 50`, where)
+
+	typeRows, err := db.pool.Query(ctx, typeQuery, args...)
+	if err != nil {
+		return result, fmt.Errorf("storage: conflict analytics by decision type: %w", err)
+	}
+	defer typeRows.Close()
+
+	result.ByDecisionType = []model.DecisionTypeConflictStats{}
+	for typeRows.Next() {
+		var s model.DecisionTypeConflictStats
+		if err := typeRows.Scan(&s.DecisionType, &s.Count, &s.AvgSignificance); err != nil {
+			return result, fmt.Errorf("storage: scan conflict analytics decision type: %w", err)
+		}
+		result.ByDecisionType = append(result.ByDecisionType, s)
+	}
+	if err := typeRows.Err(); err != nil {
+		return result, fmt.Errorf("storage: conflict analytics decision type rows: %w", err)
+	}
+
+	// 4. By severity (ordered by rank).
+	sevQuery := fmt.Sprintf(`
+		SELECT sc.severity, count(*)
+		FROM scored_conflicts sc
+		WHERE %s AND sc.severity IS NOT NULL
+		GROUP BY sc.severity
+		ORDER BY CASE sc.severity
+			WHEN 'critical' THEN 1
+			WHEN 'high'     THEN 2
+			WHEN 'medium'   THEN 3
+			WHEN 'low'      THEN 4
+		END`, where)
+
+	sevRows, err := db.pool.Query(ctx, sevQuery, args...)
+	if err != nil {
+		return result, fmt.Errorf("storage: conflict analytics by severity: %w", err)
+	}
+	defer sevRows.Close()
+
+	result.BySeverity = []model.SeverityConflictStats{}
+	for sevRows.Next() {
+		var s model.SeverityConflictStats
+		if err := sevRows.Scan(&s.Severity, &s.Count); err != nil {
+			return result, fmt.Errorf("storage: scan conflict analytics severity: %w", err)
+		}
+		result.BySeverity = append(result.BySeverity, s)
+	}
+	if err := sevRows.Err(); err != nil {
+		return result, fmt.Errorf("storage: conflict analytics severity rows: %w", err)
+	}
+
+	// 5. Daily trend: detected and resolved counts per day.
+	// Uses generate_series to produce a row for every day in the range,
+	// then left-joins detected (by detected_at) and resolved (by resolved_at).
+	// The resolved subquery matches on resolved_at within the period,
+	// regardless of when the conflict was detected.
+	nextArg := 4 + len(extraArgs)
+	resolvedWhere := "sc.org_id = $1 AND sc.resolved_at >= $2 AND sc.resolved_at < $3"
+	resolvedWhere += extraClause // same agent/type/kind filters apply
+	// We need a second copy of from/to for the resolved subquery's generate_series args.
+	trendQuery := fmt.Sprintf(`
+		WITH days AS (
+			SELECT d::date AS date
+			FROM generate_series($%d::date, ($%d::date - interval '1 day')::date, '1 day') d
+		),
+		detected AS (
+			SELECT date_trunc('day', sc.detected_at)::date AS date, count(*) AS cnt
+			FROM scored_conflicts sc
+			WHERE %s
+			GROUP BY 1
+		),
+		resolved AS (
+			SELECT date_trunc('day', sc.resolved_at)::date AS date, count(*) AS cnt
+			FROM scored_conflicts sc
+			WHERE %s
+			GROUP BY 1
+		)
+		SELECT days.date, COALESCE(det.cnt, 0), COALESCE(res.cnt, 0)
+		FROM days
+		LEFT JOIN detected det ON days.date = det.date
+		LEFT JOIN resolved res ON days.date = res.date
+		ORDER BY days.date`,
+		nextArg, nextArg+1, where, resolvedWhere)
+
+	// Args: base args (orgID, from, to, extraArgs...) + from, to for generate_series.
+	trendArgs := append(args, filters.From, filters.To) //nolint:gocritic // intentional append to new slice
+
+	trendRows, err := db.pool.Query(ctx, trendQuery, trendArgs...)
+	if err != nil {
+		return result, fmt.Errorf("storage: conflict analytics trend: %w", err)
+	}
+	defer trendRows.Close()
+
+	result.Trend = []model.ConflictTrendPoint{}
+	for trendRows.Next() {
+		var s model.ConflictTrendPoint
+		var d time.Time
+		if err := trendRows.Scan(&d, &s.Detected, &s.Resolved); err != nil {
+			return result, fmt.Errorf("storage: scan conflict analytics trend: %w", err)
+		}
+		s.Date = d.Format("2006-01-02")
+		result.Trend = append(result.Trend, s)
+	}
+	if err := trendRows.Err(); err != nil {
+		return result, fmt.Errorf("storage: conflict analytics trend rows: %w", err)
+	}
+
+	return result, nil
+}


### PR DESCRIPTION
## Summary

- Adds `GET /v1/conflicts/analytics` endpoint that aggregates conflict data over a configurable time window (#296)
- Returns summary stats (total detected/resolved, MTTR, false-positive rate), breakdowns by agent pair, decision type, and severity, plus a daily detected-vs-resolved trend
- Supports `?period=7d|30d|90d`, explicit `?from=&to=` RFC3339 overrides, and optional `?agent_id`, `?decision_type`, `?conflict_kind` filters

## Changes

| File | What |
|------|------|
| `internal/model/analytics.go` | New response types (`ConflictAnalytics`, breakdowns, trend points) |
| `internal/storage/conflicts.go` | `GetConflictAnalytics` with 5 aggregation queries (summary, by agent pair, by decision type, by severity, daily trend via `generate_series`) |
| `internal/server/handlers_decisions.go` | `HandleConflictAnalytics` handler with period/time-range parsing and validation |
| `internal/server/server.go` | Route registration with `readRole` |
| `api/openapi.yaml` | Full endpoint spec with query parameters and response schema |
| `internal/server/server_test.go` | Integration test covering happy path, filters, and validation errors |

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `golangci-lint run ./...` — 0 issues
- [x] `atlas migrate validate` passes (no migration changes)
- [x] `go test -race -count=1 ./internal/server/...` passes
- [x] Test subtests: default period, explicit from/to, agent_id filter, invalid period (400), from > to (400)

Closes #296