### PR TITLE
example: Vercel AI SDK end-to-end walkthrough

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -40,6 +40,7 @@ docker compose -f docker-compose.complete.yml logs -f ollama-init
 | `typescript/middleware.ts` | TypeScript | `withAkashi()` — automatic check/trace | No (Postgres only) |
 | `python/multi_agent_conflicts.py` | Python | Two agents, conflicting decisions, conflict detection | Yes (Qdrant + Ollama) |
 | `crewai/sdk_example.py` | Python | CrewAI integration with `make_hooks` + `run_with_akashi` | No (Postgres only) + `OPENAI_API_KEY` |
+| `vercel-ai/main.ts` | TypeScript | Vercel AI SDK middleware — automatic check/trace | No (Postgres only) + `OPENAI_API_KEY` |
 
 ## Setup by language
 
@@ -72,6 +73,14 @@ go run ./quickstart
 pip install -e sdk/python
 pip install -e sdk/integrations/crewai
 OPENAI_API_KEY=... python examples/crewai/sdk_example.py
+```
+
+### Vercel AI SDK
+
+```sh
+cd examples/vercel-ai
+npm install
+OPENAI_API_KEY=... npm start
 ```
 
 ## Framework integrations

--- a/examples/vercel-ai/README.md
+++ b/examples/vercel-ai/README.md
@@ -1,0 +1,68 @@
+# Vercel AI SDK + Akashi Example
+
+Automatic decision tracing for Vercel AI SDK calls using `createAkashiMiddleware`. Every `generateText` and `streamText` call is recorded to the Akashi audit trail — no manual `trace()` calls needed.
+
+## What it demonstrates
+
+1. Wrapping an OpenAI model with `createAkashiMiddleware`
+2. Non-streaming generation (`generateText`) with automatic check + trace
+3. Streaming generation (`streamText`) with automatic check + trace on stream close
+4. Querying the audit trail to verify decisions were recorded
+
+## Prerequisites
+
+- A running Akashi instance (local or remote)
+- An OpenAI API key
+
+Start the local stack from the repo root:
+
+```sh
+docker compose -f docker-compose.complete.yml up -d
+```
+
+## Setup
+
+```sh
+cd examples/vercel-ai
+npm install
+```
+
+## Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `AKASHI_URL` | `http://localhost:8080` | Akashi server URL |
+| `AKASHI_ADMIN_API_KEY` | `admin` | Admin API key (matches docker-compose) |
+| `OPENAI_API_KEY` | *(required)* | OpenAI API key for `gpt-4o-mini` |
+
+## Run
+
+```sh
+OPENAI_API_KEY=sk-... npm start
+```
+
+## Expected output
+
+```
+==> Connected to Akashi v0.x.x (postgres: ok)
+==> Created agent 'vercel-ai-example'
+
+--- generateText (non-streaming) ---
+
+Response: The CAP theorem states that a distributed system can only...
+
+--- streamText (streaming) ---
+
+Response: Decision audit trails provide accountability by...
+
+--- Verifying audit trail ---
+
+Found 2 auto-traced decision(s):
+  - [llm_call] Decision audit trails provide accountability by...
+    confidence=0.80, agent=vercel-ai-example
+  - [llm_call] The CAP theorem states that a distributed system can only...
+    confidence=0.80, agent=vercel-ai-example
+
+==> Done. No explicit trace() calls were made — the middleware handled it.
+==> View your decisions at http://localhost:8080
+```

--- a/examples/vercel-ai/main.ts
+++ b/examples/vercel-ai/main.ts
@@ -1,0 +1,116 @@
+/**
+ * Akashi + Vercel AI SDK — automatic decision tracing via middleware.
+ *
+ * Demonstrates createAkashiMiddleware, which wraps any Vercel AI SDK model
+ * so that every generateText / streamText call is automatically traced to
+ * Akashi without any explicit trace() calls.
+ *
+ * Prerequisites:
+ *   docker compose -f docker-compose.complete.yml up -d
+ *   export OPENAI_API_KEY=sk-...
+ *   cd examples/vercel-ai && npm install
+ *
+ * Run:
+ *   cd examples/vercel-ai && npm start
+ */
+
+import { generateText, streamText, wrapLanguageModel } from "ai";
+import { openai } from "@ai-sdk/openai";
+import { AkashiClient, ConflictError } from "akashi";
+import { createAkashiMiddleware } from "akashi-vercel-ai";
+
+const AKASHI_URL = process.env.AKASHI_URL ?? "http://localhost:8080";
+const ADMIN_KEY = process.env.AKASHI_ADMIN_API_KEY ?? "admin";
+const AGENT_ID = "vercel-ai-example";
+const AGENT_KEY = "vercel-ai-secret";
+
+async function main(): Promise<void> {
+  // -----------------------------------------------------------------------
+  // 1. Connect to Akashi and create a demo agent
+  // -----------------------------------------------------------------------
+  const admin = new AkashiClient({ baseUrl: AKASHI_URL, agentId: "admin", apiKey: ADMIN_KEY });
+  const health = await admin.health();
+  console.log(`==> Connected to Akashi ${health.version} (postgres: ${health.postgres})`);
+
+  try {
+    await admin.createAgent({
+      agentId: AGENT_ID,
+      name: "Vercel AI Example Agent",
+      role: "agent",
+      apiKey: AGENT_KEY,
+    });
+    console.log(`==> Created agent '${AGENT_ID}'`);
+  } catch (err) {
+    if (err instanceof ConflictError) {
+      console.log(`==> Agent '${AGENT_ID}' already exists`);
+    } else {
+      throw err;
+    }
+  }
+
+  const client = new AkashiClient({
+    baseUrl: AKASHI_URL,
+    agentId: AGENT_ID,
+    apiKey: AGENT_KEY,
+  });
+
+  // -----------------------------------------------------------------------
+  // 2. Wrap the OpenAI model with Akashi middleware
+  // -----------------------------------------------------------------------
+  const model = wrapLanguageModel({
+    model: openai("gpt-4o-mini"),
+    middleware: createAkashiMiddleware(client, {
+      decisionType: "llm_call",
+      confidence: 0.8,
+    }),
+  });
+
+  console.log("\n--- generateText (non-streaming) ---\n");
+
+  // -----------------------------------------------------------------------
+  // 3. generateText — middleware calls check() before and trace() after
+  // -----------------------------------------------------------------------
+  const { text } = await generateText({
+    model,
+    prompt: "In one sentence, what is the CAP theorem?",
+  });
+  console.log(`Response: ${text}`);
+
+  console.log("\n--- streamText (streaming) ---\n");
+
+  // -----------------------------------------------------------------------
+  // 4. streamText — middleware traces after the stream closes
+  // -----------------------------------------------------------------------
+  process.stdout.write("Response: ");
+  const stream = await streamText({
+    model,
+    prompt: "List three benefits of decision audit trails in two sentences.",
+  });
+  for await (const chunk of stream.textStream) {
+    process.stdout.write(chunk);
+  }
+  console.log("\n");
+
+  // -----------------------------------------------------------------------
+  // 5. Verify — query the audit trail to confirm auto-traced decisions
+  // -----------------------------------------------------------------------
+  // Small delay so async trace from stream flush completes.
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+
+  console.log("--- Verifying audit trail ---\n");
+  const recent = await client.recent({ limit: 5, decisionType: "llm_call" });
+  console.log(`Found ${recent.length} auto-traced decision(s):`);
+  for (const d of recent) {
+    const outcome = d.outcome.length > 80 ? d.outcome.slice(0, 80) + "..." : d.outcome;
+    console.log(`  - [${d.decision_type}] ${outcome}`);
+    console.log(`    confidence=${d.confidence.toFixed(2)}, agent=${d.agent_id}`);
+  }
+
+  console.log(`\n==> Done. No explicit trace() calls were made — the middleware handled it.`);
+  console.log(`==> View your decisions at ${AKASHI_URL}`);
+}
+
+main().catch((err) => {
+  console.error("Error:", err);
+  process.exit(1);
+});

--- a/examples/vercel-ai/package.json
+++ b/examples/vercel-ai/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "akashi-vercel-ai-example",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "npx tsx main.ts"
+  },
+  "dependencies": {
+    "akashi": "file:../../sdk/typescript",
+    "akashi-vercel-ai": "file:../../sdk/integrations/vercel-ai"
+  },
+  "devDependencies": {
+    "@ai-sdk/openai": "^1.0.0",
+    "@types/node": "^25.3.5",
+    "ai": "^4.0.0",
+    "tsx": "^4",
+    "typescript": "^5.9.3"
+  }
+}

--- a/examples/vercel-ai/tsconfig.json
+++ b/examples/vercel-ai/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["*.ts"]
+}


### PR DESCRIPTION
## Summary

- Adds `examples/vercel-ai/` with a standalone Node.js script demonstrating `createAkashiMiddleware` wrapping an OpenAI model via the Vercel AI SDK
- Shows both `generateText` (non-streaming) and `streamText` (streaming) being automatically traced to Akashi — no explicit `trace()` calls needed
- Queries the audit trail afterward to verify decisions were auto-recorded
- Updates root `examples/README.md` with the new entry and setup instructions

Closes #262

## Test plan

- [ ] `cd examples/vercel-ai && npm install && OPENAI_API_KEY=... npm start` runs and produces streamed output + audit trail verification
- [ ] `npx tsc --noEmit` passes with zero errors (verified locally)
- [ ] README accurately describes setup, env vars, and expected output

🤖 Generated with [Claude Code](https://claude.com/claude-code)