### PR TITLE
feat(conflicts): persist winning claim pairs on scored_conflicts

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2751,6 +2751,20 @@ components:
             ID of the decision judged to be correct when this conflict was adjudicated.
             Must be either decision_a_id or decision_b_id. Optional — resolution is
             valid without declaring a winner.
+        claim_text_a:
+          type: string
+          description: |
+            The specific claim fragment from decision A that produced the highest
+            significance during claim-level scoring. Present only when scoring_method
+            originated from claim-level analysis. NULL when the winning scoring
+            method was not "claim".
+        claim_text_b:
+          type: string
+          description: |
+            The specific claim fragment from decision B that produced the highest
+            significance during claim-level scoring. Present only when scoring_method
+            originated from claim-level analysis. NULL when the winning scoring
+            method was not "claim".
 
     ConflictDetail:
       description: |

--- a/internal/conflicts/scorer.go
+++ b/internal/conflicts/scorer.go
@@ -340,6 +340,7 @@ func (s *Scorer) scoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 		bestOutcomeB := cand.Outcome
 
 		// --- Pass 2: claim-level scoring for high topic-similarity pairs ---
+		var claimFragA, claimFragB *string
 		if topicSim >= s.decisionTopicSimFloor {
 			claimSig, claimDiv, claimA, claimB := s.bestClaimConflict(ctx, d.ID, cand.ID, orgID, topicSim)
 			if claimSig > bestSig {
@@ -348,6 +349,8 @@ func (s *Scorer) scoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 				bestMethod = "claim"
 				bestOutcomeA = claimA
 				bestOutcomeB = claimB
+				claimFragA = &claimA
+				claimFragB = &claimB
 				s.metrics.claimLevelWins.Add(ctx, 1)
 			}
 		}
@@ -539,6 +542,8 @@ func (s *Scorer) scoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 			ConfidenceWeight:  ptr(confWeight),
 			TemporalDecay:     ptr(decay),
 			Status:            "open",
+			ClaimTextA:        claimFragA,
+			ClaimTextB:        claimFragB,
 		}
 		if _, err := s.db.InsertScoredConflict(ctx, c); err != nil {
 			s.logger.Warn("conflict scorer: insert failed", "decision_a", decisionID, "decision_b", cand.ID, "error", err)

--- a/internal/conflicts/scorer_test.go
+++ b/internal/conflicts/scorer_test.go
@@ -969,11 +969,21 @@ func TestScoreForDecision_ClaimMethodWinsOverEmbedding(t *testing.T) {
 			found = true
 			assert.Equal(t, "claim", c.ScoringMethod,
 				"claim method should win when it produces higher significance than embedding")
-			// Verify the outcomes are the claim texts, not the full outcomes.
+			// Full outcomes are always stored in outcome_a/outcome_b.
 			assert.Contains(t, c.OutcomeA, "ReScore",
-				"claim-level conflict should use claim text as outcome")
+				"full outcomes should still be present")
 			assert.Contains(t, c.OutcomeB, "ReScore",
-				"claim-level conflict should use claim text as outcome")
+				"full outcomes should still be present")
+			// Claim fragments should be persisted in dedicated fields.
+			require.NotNil(t, c.ClaimTextA, "claim_text_a should be populated when claim method wins")
+			require.NotNil(t, c.ClaimTextB, "claim_text_b should be populated when claim method wins")
+			// The canonical pair ordering may swap A/B, so check both claim texts
+			// contain the expected fragments regardless of order.
+			claims := []string{*c.ClaimTextA, *c.ClaimTextB}
+			assert.Contains(t, claims, "ReScore formula can exceed 1.0 bounds.",
+				"claim_text should contain the exact claim fragment from decision A")
+			assert.Contains(t, claims, "ReScore is correctly bounded within [0,1].",
+				"claim_text should contain the exact claim fragment from decision B")
 			break
 		}
 	}

--- a/internal/model/decision.go
+++ b/internal/model/decision.go
@@ -198,6 +198,12 @@ type DecisionConflict struct {
 	// GroupID (migration 054): canonical conflict group this pair belongs to.
 	// All pairwise conflicts between the same agents on the same decision_type share a group.
 	GroupID *uuid.UUID `json:"group_id,omitempty"`
+
+	// Claim fragments (migration 058): the specific claim texts that produced
+	// the highest significance when claim-level scoring won. NULL when the
+	// winning scoring method was not "claim".
+	ClaimTextA *string `json:"claim_text_a,omitempty"`
+	ClaimTextB *string `json:"claim_text_b,omitempty"`
 }
 
 // ConflictGroup is a canonical conflict cluster: one row per

--- a/internal/storage/conflicts.go
+++ b/internal/storage/conflicts.go
@@ -169,6 +169,7 @@ const conflictSelectBase = `SELECT sc.id, sc.conflict_kind, sc.decision_a_id, sc
 		 sc.resolved_by, sc.resolved_at, sc.resolution_note,
 		 sc.relationship, sc.confidence_weight, sc.temporal_decay, sc.resolution_decision_id,
 		 sc.winning_decision_id, sc.group_id,
+		 sc.claim_text_a, sc.claim_text_b,
 		 da.run_id, db.run_id, da.confidence, db.confidence, da.reasoning, db.reasoning, da.valid_from, db.valid_from
 		 FROM scored_conflicts sc
 		 LEFT JOIN decisions da ON da.id = sc.decision_a_id
@@ -191,6 +192,7 @@ func scanConflictRows(rows pgx.Rows) ([]model.DecisionConflict, error) {
 			&c.ResolvedBy, &c.ResolvedAt, &c.ResolutionNote,
 			&c.Relationship, &c.ConfidenceWeight, &c.TemporalDecay, &c.ResolutionDecisionID,
 			&c.WinningDecisionID, &c.GroupID,
+			&c.ClaimTextA, &c.ClaimTextB,
 			&runA, &runB, &confA, &confB, &reasonA, &reasonB, &validA, &validB,
 		); err != nil {
 			return nil, fmt.Errorf("storage: scan conflict: %w", err)
@@ -367,11 +369,13 @@ func (db *DB) InsertScoredConflict(ctx context.Context, c model.DecisionConflict
 	agentA, agentB := c.AgentA, c.AgentB
 	typeA, typeB := c.DecisionTypeA, c.DecisionTypeB
 	outcomeA, outcomeB := c.OutcomeA, c.OutcomeB
+	claimTextA, claimTextB := c.ClaimTextA, c.ClaimTextB
 	if bytes.Compare(da[:], dbID[:]) > 0 {
 		da, dbID = dbID, da
 		agentA, agentB = agentB, agentA
 		typeA, typeB = typeB, typeA
 		outcomeA, outcomeB = outcomeB, outcomeA
+		claimTextA, claimTextB = claimTextB, claimTextA
 	}
 	// Normalize the agent pair for the group key: LEAST first.
 	grpAgentA, grpAgentB := agentA, agentB
@@ -418,10 +422,11 @@ func (db *DB) InsertScoredConflict(ctx context.Context, c model.DecisionConflict
 		     (decision_a_id, decision_b_id, org_id, conflict_kind,
 		      agent_a, agent_b, decision_type_a, decision_type_b, outcome_a, outcome_b,
 		      topic_similarity, outcome_divergence, significance, scoring_method, explanation,
-		      category, severity, relationship, confidence_weight, temporal_decay, group_id)
+		      category, severity, relationship, confidence_weight, temporal_decay,
+		      claim_text_a, claim_text_b, group_id)
 		 SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
 		        $11, $12, $13, $14, $15, $16, $17, $18, $19, $20,
-		        grp.id
+		        $21, $22, grp.id
 		 FROM grp
 		 ON CONFLICT (decision_a_id, decision_b_id) DO UPDATE SET
 		     topic_similarity    = EXCLUDED.topic_similarity,
@@ -434,6 +439,8 @@ func (db *DB) InsertScoredConflict(ctx context.Context, c model.DecisionConflict
 		     relationship        = EXCLUDED.relationship,
 		     confidence_weight   = EXCLUDED.confidence_weight,
 		     temporal_decay      = EXCLUDED.temporal_decay,
+		     claim_text_a        = EXCLUDED.claim_text_a,
+		     claim_text_b        = EXCLUDED.claim_text_b,
 		     group_id            = EXCLUDED.group_id,
 		     detected_at         = now(),
 		     -- Re-open previously resolved conflicts: re-detection falsifies the
@@ -452,6 +459,7 @@ func (db *DB) InsertScoredConflict(ctx context.Context, c model.DecisionConflict
 		grpAgentA, grpAgentB, typeA, typeB, outcomeA, outcomeB,
 		topicSim, outcomeDiv, sig, method, c.Explanation,
 		c.Category, c.Severity, c.Relationship, c.ConfidenceWeight, c.TemporalDecay,
+		claimTextA, claimTextB,
 	).Scan(&id)
 	if err != nil {
 		return uuid.Nil, err
@@ -581,6 +589,7 @@ func (db *DB) ListConflictGroups(ctx context.Context, orgID uuid.UUID, f Conflic
 		    rep.resolved_by, rep.resolved_at, rep.resolution_note,
 		    rep.relationship, rep.confidence_weight, rep.temporal_decay,
 		    rep.resolution_decision_id, rep.winning_decision_id, rep.group_id,
+		    rep.claim_text_a, rep.claim_text_b,
 		    rep_da.run_id, rep_db.run_id,
 		    rep_da.confidence, rep_db.confidence,
 		    rep_da.reasoning, rep_db.reasoning,
@@ -621,6 +630,7 @@ func (db *DB) ListConflictGroups(ctx context.Context, orgID uuid.UUID, f Conflic
 		    rep.resolved_by, rep.resolved_at, rep.resolution_note,
 		    rep.relationship, rep.confidence_weight, rep.temporal_decay,
 		    rep.resolution_decision_id, rep.winning_decision_id, rep.group_id,
+		    rep.claim_text_a, rep.claim_text_b,
 		    rep_da.run_id, rep_db.run_id,
 		    rep_da.confidence, rep_db.confidence,
 		    rep_da.reasoning, rep_db.reasoning,
@@ -659,6 +669,7 @@ func (db *DB) ListConflictGroups(ctx context.Context, orgID uuid.UUID, f Conflic
 		var repRelationship *string
 		var repConfWeight, repTempDecay *float64
 		var repResDecID, repWinDecID, repGroupID *uuid.UUID
+		var repClaimTextA, repClaimTextB *string
 
 		if err := rows.Scan(
 			&g.ID, &g.OrgID, &g.AgentA, &g.AgentB, &g.ConflictKind, &g.DecisionType,
@@ -674,6 +685,7 @@ func (db *DB) ListConflictGroups(ctx context.Context, orgID uuid.UUID, f Conflic
 			&repResolvedBy, &repResolvedAt, &repResolutionNote,
 			&repRelationship, &repConfWeight, &repTempDecay,
 			&repResDecID, &repWinDecID, &repGroupID,
+			&repClaimTextA, &repClaimTextB,
 			&repRunA, &repRunB,
 			&repConfA, &repConfB,
 			&repReasonA, &repReasonB,
@@ -737,6 +749,8 @@ func (db *DB) ListConflictGroups(ctx context.Context, orgID uuid.UUID, f Conflic
 			rep.ResolutionDecisionID = repResDecID
 			rep.WinningDecisionID = repWinDecID
 			rep.GroupID = repGroupID
+			rep.ClaimTextA = repClaimTextA
+			rep.ClaimTextB = repClaimTextB
 			if repRunA != nil {
 				rep.RunA = *repRunA
 			}

--- a/migrations/058_claim_text_on_conflicts.sql
+++ b/migrations/058_claim_text_on_conflicts.sql
@@ -1,0 +1,7 @@
+-- 058: Add claim fragment columns to scored_conflicts for claim-level audit trail.
+-- When claim-level scoring produces a higher significance than full-outcome scoring,
+-- the specific claim texts that were compared are stored here. NULL when the winning
+-- scoring method was not "claim".
+ALTER TABLE scored_conflicts
+  ADD COLUMN claim_text_a TEXT,
+  ADD COLUMN claim_text_b TEXT;

--- a/migrations/atlas.sum
+++ b/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:i/r7QYHzcgebuCvVwg8DmGZkah3MSNz1jAKkChxIIBU=
+h1:84p6sybep5yX77JdJLAZw2urEU/qVMZMshmOvpyWiXY=
 001_initial.sql h1:uhyGXto+QacAaGYb9ZTGjsBs5chlKi8O0eHz9aCQsrY=
 022_full_text_search.sql h1:9iwtA8MgCzAxDV9YkUBn0CLT9ePSmj3GcPoMGg8TXf0=
 023_fix_outbox_index.sql h1:OtMEFBcMRWej02+ghnBXlPr6BVq+LoA62Id9XUWfDNI=
@@ -36,3 +36,4 @@ h1:i/r7QYHzcgebuCvVwg8DmGZkah3MSNz1jAKkChxIIBU=
 055_decision_erasures.sql h1:Q5WLJVIEB0BQTE4K9JJltpY7IFfntX4PYU6Y+f3gkLs=
 056_claim_embedding_retries.sql h1:8bwFdN/QTzh7k2YnebWjplmgeNNLsDw4+pmkmkBwkUc=
 057_signup.sql h1:iLBroAU9X37qpUQrq5STsZTKOh6yb9ZNDtrAfXgH2nM=
+058_claim_text_on_conflicts.sql h1:EU/RrSMkAkTYbdGySaqoEw0w1BCtJWyi6/QXIDSfd4k=


### PR DESCRIPTION
## Summary

- Adds `claim_text_a` and `claim_text_b` nullable TEXT columns to `scored_conflicts` (migration 058) so that when claim-level scoring produces higher significance than full-outcome scoring, the specific claim fragments are persisted alongside the full outcomes
- Updates the scorer to populate these fields when the claim method wins, the storage layer to carry them through insert/select/scan/group queries, and the OpenAPI spec to document them
- Adds test assertions verifying exact claim fragment round-trip through the database

## Test plan

- [x] `atlas migrate validate` passes
- [x] `go build ./...` compiles cleanly
- [x] `go vet ./...` — no issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test -race -count=1 ./...` — all 20 test packages pass
- [x] `TestScoreForDecision_ClaimMethodWinsOverEmbedding` asserts `ClaimTextA`/`ClaimTextB` contain exact claim fragments

Closes #289