### PR TITLE
perf(conflicts): early exit and adaptive pruning for candidate pipeline

### DIFF
--- a/akashi.go
+++ b/akashi.go
@@ -220,7 +220,8 @@ func New(opts ...Option) (*App, error) {
 	}
 	conflictScorer := conflicts.NewScorer(db, logger, cfg.ConflictSignificanceThreshold, conflictValidator, backfillWorkers, cfg.ConflictDecayLambda).
 		WithScoringThresholds(cfg.ConflictClaimTopicSimFloor, cfg.ConflictClaimDivFloor, cfg.ConflictDecisionTopicSimFloor).
-		WithCandidateLimit(cfg.ConflictCandidateLimit)
+		WithCandidateLimit(cfg.ConflictCandidateLimit).
+		WithEarlyExitFloor(cfg.ConflictEarlyExitFloor)
 	if qdrantIndex != nil {
 		conflictScorer = conflictScorer.WithCandidateFinder(qdrantIndex)
 	}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -105,8 +105,9 @@ The OSS distribution uses an in-memory token bucket. Enterprise deployments can 
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `AKASHI_CONFLICT_CANDIDATE_LIMIT` | `50` | Max candidates retrieved from Qdrant per decision. Lower values reduce LLM cost; higher values improve recall for embedding-only scoring |
+| `AKASHI_CONFLICT_CANDIDATE_LIMIT` | `20` | Max candidates retrieved from Qdrant per decision. Lower values reduce LLM cost; higher values improve recall for embedding-only scoring |
 | `AKASHI_CONFLICT_SIGNIFICANCE_THRESHOLD` | `0.30` | Min significance (topic_sim × outcome_div) to store a conflict |
+| `AKASHI_CONFLICT_EARLY_EXIT_FLOOR` | `0.25` | Min pre-LLM significance for early exit pruning. Candidates are sorted by significance descending; once significance drops below this floor (and the candidate doesn't qualify for the bi-encoder bypass), remaining candidates are skipped. Set to `0` to disable early exit |
 | `AKASHI_CONFLICT_CLAIM_TOPIC_SIM_FLOOR` | `0.60` | Min cosine similarity for two claims to be considered "about the same thing." Below this, claims are too unrelated to constitute a conflict |
 | `AKASHI_CONFLICT_CLAIM_DIV_FLOOR` | `0.15` | Min outcome divergence between two claims to count as a genuine disagreement. Below this, claims effectively agree |
 | `AKASHI_CONFLICT_DECISION_TOPIC_SIM_FLOOR` | `0.70` | Min decision-level topic similarity to activate claim-level scoring. Below this, decisions are about different enough topics that claim analysis adds noise |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -62,12 +62,13 @@ type Config struct {
 	// Conflict LLM validation.
 	ConflictLLMModel              string  // Text generation model for conflict validation (e.g. "qwen3.5:9b" for Ollama).
 	ConflictLLMThreads            int     // CPU threads Ollama may use per inference call (default: floor(NumCPU/3), min 1). 0 = let Ollama decide.
-	ConflictCandidateLimit        int     // Max candidates retrieved from Qdrant per decision for conflict scoring (default: 50).
+	ConflictCandidateLimit        int     // Max candidates retrieved from Qdrant per decision for conflict scoring (default: 20).
 	ConflictBackfillWorkers       int     // Parallel workers for conflict scoring backfill (default: 4).
 	ConflictDecayLambda           float64 // Temporal decay rate for conflict significance (default: 0.01, 0 disables).
 	ConflictClaimTopicSimFloor    float64 // Min cosine similarity for two claims to be "about the same thing" (default: 0.60).
 	ConflictClaimDivFloor         float64 // Min outcome divergence for claims to count as disagreeing (default: 0.15).
 	ConflictDecisionTopicSimFloor float64 // Min decision-level topic similarity to activate claim-level scoring (default: 0.70).
+	ConflictEarlyExitFloor        float64 // Min pre-LLM significance for early exit pruning (default: 0.25, 0 disables).
 	CrossEncoderURL               string  // URL of the cross-encoder reranking service (empty = disabled).
 	CrossEncoderThreshold         float64 // Min cross-encoder score to proceed to LLM validation (default: 0.50).
 	ForceConflictRescore          bool    // When true (and LLM validator configured), clear all conflicts and re-score at startup.
@@ -144,7 +145,7 @@ func Load() (Config, error) {
 	cfg.OutboxBatchSize, errs = collectInt(errs, "AKASHI_OUTBOX_BATCH_SIZE", 100)
 	cfg.EventBufferSize, errs = collectInt(errs, "AKASHI_EVENT_BUFFER_SIZE", 1000)
 	cfg.RateLimitBurst, errs = collectInt(errs, "AKASHI_RATE_LIMIT_BURST", 200)
-	cfg.ConflictCandidateLimit, errs = collectInt(errs, "AKASHI_CONFLICT_CANDIDATE_LIMIT", 50)
+	cfg.ConflictCandidateLimit, errs = collectInt(errs, "AKASHI_CONFLICT_CANDIDATE_LIMIT", 20)
 	cfg.ConflictBackfillWorkers, errs = collectInt(errs, "AKASHI_CONFLICT_BACKFILL_WORKERS", 4)
 	defaultLLMThreads := max(1, runtime.NumCPU()/3)
 	cfg.ConflictLLMThreads, errs = collectInt(errs, "AKASHI_CONFLICT_LLM_THREADS", defaultLLMThreads)
@@ -162,6 +163,7 @@ func Load() (Config, error) {
 	cfg.ConflictClaimTopicSimFloor, errs = collectFloat64(errs, "AKASHI_CONFLICT_CLAIM_TOPIC_SIM_FLOOR", 0.60)
 	cfg.ConflictClaimDivFloor, errs = collectFloat64(errs, "AKASHI_CONFLICT_CLAIM_DIV_FLOOR", 0.15)
 	cfg.ConflictDecisionTopicSimFloor, errs = collectFloat64(errs, "AKASHI_CONFLICT_DECISION_TOPIC_SIM_FLOOR", 0.70)
+	cfg.ConflictEarlyExitFloor, errs = collectFloat64(errs, "AKASHI_CONFLICT_EARLY_EXIT_FLOOR", 0.25)
 	cfg.CrossEncoderThreshold, errs = collectFloat64(errs, "AKASHI_CONFLICT_CROSS_ENCODER_THRESHOLD", 0.50)
 
 	// Boolean fields.

--- a/internal/conflicts/metrics.go
+++ b/internal/conflicts/metrics.go
@@ -18,9 +18,10 @@ type Metrics struct {
 	candidatesEvaluated metric.Int64Counter
 	claimLevelWins      metric.Int64Counter
 
-	scoringDuration  metric.Float64Histogram
-	llmCallDuration  metric.Float64Histogram
-	significanceDist metric.Float64Histogram
+	scoringDuration    metric.Float64Histogram
+	llmCallDuration    metric.Float64Histogram
+	significanceDist   metric.Float64Histogram
+	candidatesExamined metric.Float64Histogram
 }
 
 // ResolutionRecorder records conflict resolution events for OpenTelemetry metrics.
@@ -128,6 +129,14 @@ func (s *Scorer) registerMetrics() {
 	if err != nil {
 		s.logger.Warn("conflicts: failed to create akashi.conflicts.significance_distribution metric", "error", err)
 		s.metrics.significanceDist, _ = meter.Float64Histogram("akashi.conflicts.significance_distribution.fallback")
+	}
+
+	s.metrics.candidatesExamined, err = meter.Float64Histogram("akashi.conflicts.candidates_examined",
+		metric.WithDescription("Number of candidates examined (past early-exit pruning) per decision scoring run"),
+	)
+	if err != nil {
+		s.logger.Warn("conflicts: failed to create akashi.conflicts.candidates_examined metric", "error", err)
+		s.metrics.candidatesExamined, _ = meter.Float64Histogram("akashi.conflicts.candidates_examined.fallback")
 	}
 
 	// --- Observable gauges ---

--- a/internal/conflicts/scorer.go
+++ b/internal/conflicts/scorer.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -87,6 +88,12 @@ type Scorer struct {
 	// pairs before LLM validation. Pairs below crossEncoderThreshold are skipped.
 	crossEncoder          CrossEncoder
 	crossEncoderThreshold float64
+
+	// earlyExitFloor is the minimum pre-LLM significance score for a candidate
+	// to be worth examining. Candidates below this floor are skipped during
+	// sorted iteration (unless they qualify for the directToScorer bypass).
+	// 0 disables early exit. Default: 0.25.
+	earlyExitFloor float64
 }
 
 // WithCandidateFinder wires a Qdrant-backed CandidateFinder for conflict candidate
@@ -132,6 +139,18 @@ func (s *Scorer) WithPairwiseScorer(ps PairwiseScorer) *Scorer {
 	return s
 }
 
+// WithEarlyExitFloor overrides the minimum pre-LLM significance for the early
+// exit optimisation. Candidates are sorted by significance descending; once a
+// candidate drops below this floor (and does not qualify for the
+// directToScorer bypass), the remaining candidates are skipped. Set to 0 to
+// disable early exit. Default: 0.25.
+func (s *Scorer) WithEarlyExitFloor(floor float64) *Scorer {
+	if floor > 0 {
+		s.earlyExitFloor = floor
+	}
+	return s
+}
+
 // WithCrossEncoder configures a cross-encoder reranking step between significance
 // scoring and LLM validation. Pairs scoring below the threshold are skipped
 // without an LLM call, reducing validation cost. Only active when using the
@@ -165,7 +184,8 @@ func NewScorer(db *storage.DB, logger *slog.Logger, significanceThreshold float6
 		validatorLabel:        validatorTypeLabel(validator),
 		backfillWorkers:       backfillWorkers,
 		decayLambda:           decayLambda,
-		candidateLimit:        50,
+		candidateLimit:        20,
+		earlyExitFloor:        0.25,
 		claimTopicSimFloor:    claimTopicSimFloor,
 		claimDivFloor:         claimDivFloor,
 		decisionTopicSimFloor: decisionTopicSimFloor,
@@ -313,15 +333,30 @@ func (s *Scorer) scoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 	// Check once whether an LLM validator is active. Used both for the
 	// directToLLM bypass below and for the validation gate further down.
 	_, isNoop := s.validator.(NoopValidator)
+	hasScorer := s.pairwiseScorer != nil || !isNoop
 
-	inserted := 0
+	// --- Pre-computation pass: compute cheap significance for all candidates,
+	// then sort descending so the most promising pairs are examined first and
+	// early exit can prune the tail. ---
+	type candidateScore struct {
+		cand       model.Decision
+		topicSim   float64
+		bestSig    float64
+		bestDiv    float64
+		bestMethod string
+		bestOutA   string
+		bestOutB   string
+		claimFragA *string
+		claimFragB *string
+		confWeight float64
+		decay      float64
+	}
+
+	scored := make([]candidateScore, 0, len(candidates))
 	for _, cand := range candidates {
 		if cand.OutcomeEmbedding == nil {
 			continue
 		}
-
-		// Skip decisions in the same revision chain — intentional
-		// replacements should not be flagged as conflicts.
 		if revisionChain[cand.ID] {
 			continue
 		}
@@ -329,19 +364,18 @@ func (s *Scorer) scoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 		topicSim := cosineSimilarity(d.Embedding.Slice(), cand.Embedding.Slice())
 		s.metrics.candidatesEvaluated.Add(ctx, 1)
 
-		// --- Pass 1: full-outcome scoring (existing behavior) ---
+		// Full-outcome scoring.
 		outcomeSim := cosineSimilarity(d.OutcomeEmbedding.Slice(), cand.OutcomeEmbedding.Slice())
 		outcomeDiv := math.Max(0, 1.0-outcomeSim)
 		outcomeSig := topicSim * outcomeDiv
 
-		// Track the best signal across both passes.
 		bestSig := outcomeSig
 		bestDiv := outcomeDiv
 		bestMethod := "embedding"
-		bestOutcomeA := d.Outcome
-		bestOutcomeB := cand.Outcome
+		bestOutA := d.Outcome
+		bestOutB := cand.Outcome
 
-		// --- Pass 2: claim-level scoring for high topic-similarity pairs ---
+		// Claim-level scoring for high topic-similarity pairs.
 		var claimFragA, claimFragB *string
 		if topicSim >= s.decisionTopicSimFloor {
 			claimSig, claimDiv, claimA, claimB := s.bestClaimConflict(ctx, d.ID, cand.ID, orgID, topicSim)
@@ -349,45 +383,89 @@ func (s *Scorer) scoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 				bestSig = claimSig
 				bestDiv = claimDiv
 				bestMethod = "claim"
-				bestOutcomeA = claimA
-				bestOutcomeB = claimB
+				bestOutA = claimA
+				bestOutB = claimB
 				claimFragA = &claimA
 				claimFragB = &claimB
 				s.metrics.claimLevelWins.Add(ctx, 1)
 			}
 		}
 
-		// Confidence weighting: low-confidence decisions get lower significance.
+		// Confidence weighting.
 		confWeight := math.Sqrt(float64(d.Confidence) * float64(cand.Confidence))
 		bestSig *= confWeight
 
-		// Temporal decay: older decision pairs get lower significance.
-		var decay = 1.0
+		// Temporal decay.
+		decay := 1.0
 		if s.decayLambda > 0 {
 			daysBetween := math.Abs(d.ValidFrom.Sub(cand.ValidFrom).Hours() / 24)
 			decay = math.Exp(-s.decayLambda * daysBetween)
 			bestSig *= decay
 		}
 
-		// High-topic-similarity pairs bypass the cosine-divergence significance gate
-		// when an LLM validator or external pairwise scorer is active. This applies
-		// to both cross-agent and same-agent pairs: bi-encoders cannot detect stance
-		// opposition for same-topic decisions ("X is correct" vs "X is wrong" embed
-		// close together because they share domain vocabulary). The LLM is the right
-		// classifier for this, regardless of whether the two decisions came from the
-		// same agent or different agents. See: NLI literature on bi-encoder limits.
-		hasScorer := s.pairwiseScorer != nil || !isNoop
-		directToScorer := hasScorer && topicSim >= s.decisionTopicSimFloor
+		scored = append(scored, candidateScore{
+			cand:       cand,
+			topicSim:   topicSim,
+			bestSig:    bestSig,
+			bestDiv:    bestDiv,
+			bestMethod: bestMethod,
+			bestOutA:   bestOutA,
+			bestOutB:   bestOutB,
+			claimFragA: claimFragA,
+			claimFragB: claimFragB,
+			confWeight: confWeight,
+			decay:      decay,
+		})
+	}
 
-		if bestSig < s.threshold && !directToScorer {
+	// Sort candidates by pre-computed significance descending so the
+	// most promising pairs are examined first and early exit is effective.
+	sort.Slice(scored, func(i, j int) bool {
+		return scored[i].bestSig > scored[j].bestSig
+	})
+
+	// --- Sorted iteration with early exit ---
+	examined := 0
+	inserted := 0
+	for _, sc := range scored {
+		// High-topic-similarity pairs bypass the cosine-divergence significance
+		// gate when an LLM validator or external pairwise scorer is active.
+		// Bi-encoders cannot detect stance opposition for same-topic decisions
+		// ("X is correct" vs "X is wrong" embed close together). The LLM is the
+		// right classifier for this. See: NLI literature on bi-encoder limits.
+		directToScorer := hasScorer && sc.topicSim >= s.decisionTopicSimFloor
+
+		// Early exit: if significance is below the early-exit floor AND this
+		// candidate does not qualify for the directToScorer bypass, skip it.
+		// When no scorer is active, no candidate can bypass, so we can break
+		// immediately (all remaining candidates are worse). When a scorer IS
+		// active, later candidates with high topicSim might still qualify via
+		// the bypass, so we continue instead of break.
+		if s.earlyExitFloor > 0 && sc.bestSig < s.earlyExitFloor && !directToScorer {
+			if !hasScorer {
+				s.logger.Debug("conflict scorer: early exit (no scorer)",
+					"decision_id", decisionID,
+					"significance", sc.bestSig,
+					"floor", s.earlyExitFloor,
+					"remaining", len(scored)-examined)
+				break
+			}
 			continue
 		}
+
+		if sc.bestSig < s.threshold && !directToScorer {
+			continue
+		}
+
+		examined++
+
+		cand := sc.cand
 
 		// Cross-encoder reranking: pre-filter before expensive LLM validation.
 		// Only applies to the built-in LLM path — skipped when using the
 		// enterprise pairwise scorer or when no LLM validator is configured.
 		if s.crossEncoder != nil && s.pairwiseScorer == nil && !isNoop {
-			ceScore, ceErr := s.crossEncoder.ScoreContradiction(ctx, bestOutcomeA, bestOutcomeB)
+			ceScore, ceErr := s.crossEncoder.ScoreContradiction(ctx, sc.bestOutA, sc.bestOutB)
 			switch {
 			case ceErr != nil:
 				// Fail-open: cross-encoder failure means proceed to LLM as fallback.
@@ -408,6 +486,7 @@ func (s *Scorer) scoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 		// Confirmation gate: classify the candidate pair as conflict or not.
 		// Priority: (1) external pairwise scorer, (2) built-in LLM validator, (3) noop.
 		// NoopValidator always returns "contradiction" (preserving legacy embedding-only behavior).
+		bestMethod := sc.bestMethod
 		var explanation *string
 		var category, severity, relationship *string
 
@@ -458,8 +537,8 @@ func (s *Scorer) scoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 
 			llmStart := time.Now()
 			result, err := s.validator.Validate(ctx, ValidateInput{
-				OutcomeA:        bestOutcomeA,
-				OutcomeB:        bestOutcomeB,
+				OutcomeA:        sc.bestOutA,
+				OutcomeB:        sc.bestOutB,
 				TypeA:           d.DecisionType,
 				TypeB:           cand.DecisionType,
 				AgentA:          d.AgentID,
@@ -476,7 +555,7 @@ func (s *Scorer) scoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 				SessionIDB:      uuidString(cand.SessionID),
 				FullOutcomeA:    d.Outcome,
 				FullOutcomeB:    cand.Outcome,
-				TopicSimilarity: topicSim,
+				TopicSimilarity: sc.topicSim,
 			})
 			s.metrics.llmCallDuration.Record(ctx, float64(time.Since(llmStart).Milliseconds()))
 			if err != nil {
@@ -533,19 +612,19 @@ func (s *Scorer) scoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 			DecisionTypeB:     cand.DecisionType,
 			OutcomeA:          d.Outcome,
 			OutcomeB:          cand.Outcome,
-			TopicSimilarity:   ptr(topicSim),
-			OutcomeDivergence: ptr(bestDiv),
-			Significance:      ptr(bestSig),
+			TopicSimilarity:   ptr(sc.topicSim),
+			OutcomeDivergence: ptr(sc.bestDiv),
+			Significance:      ptr(sc.bestSig),
 			ScoringMethod:     bestMethod,
 			Explanation:       explanation,
 			Category:          category,
 			Severity:          severity,
 			Relationship:      relationship,
-			ConfidenceWeight:  ptr(confWeight),
-			TemporalDecay:     ptr(decay),
+			ConfidenceWeight:  ptr(sc.confWeight),
+			TemporalDecay:     ptr(sc.decay),
 			Status:            "open",
-			ClaimTextA:        claimFragA,
-			ClaimTextB:        claimFragB,
+			ClaimTextA:        sc.claimFragA,
+			ClaimTextB:        sc.claimFragB,
 		}
 		if _, err := s.db.InsertScoredConflict(ctx, c); err != nil {
 			s.logger.Warn("conflict scorer: insert failed", "decision_a", decisionID, "decision_b", cand.ID, "error", err)
@@ -557,12 +636,13 @@ func (s *Scorer) scoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 			attribute.String("conflict_kind", string(kind)),
 			attribute.String("severity", derefOrUnknown(severity)),
 		))
-		s.metrics.significanceDist.Record(ctx, bestSig)
+		s.metrics.significanceDist.Record(ctx, sc.bestSig)
 		inserted++
 		if err := s.db.Notify(ctx, storage.ChannelConflicts, `{"source":"scorer","org_id":"`+orgID.String()+`"}`); err != nil {
 			s.logger.Debug("conflict scorer: notify failed", "error", err)
 		}
 	}
+	s.metrics.candidatesExamined.Record(ctx, float64(examined))
 	if inserted > 0 {
 		s.logger.Info("conflict scorer: scored conflicts", "decision_id", decisionID, "inserted", inserted)
 	}

--- a/internal/conflicts/scorer_test.go
+++ b/internal/conflicts/scorer_test.go
@@ -1053,7 +1053,28 @@ func TestNewScorer_DefaultWorkers(t *testing.T) {
 
 func TestNewScorer_DefaultCandidateLimit(t *testing.T) {
 	scorer := NewScorer(nil, slog.Default(), 0.3, nil, 0, 0)
-	assert.Equal(t, 50, scorer.candidateLimit, "default should be 50")
+	assert.Equal(t, 20, scorer.candidateLimit, "default should be 20")
+}
+
+func TestNewScorer_DefaultEarlyExitFloor(t *testing.T) {
+	scorer := NewScorer(nil, slog.Default(), 0.3, nil, 0, 0)
+	assert.Equal(t, 0.25, scorer.earlyExitFloor, "default should be 0.25")
+}
+
+func TestWithEarlyExitFloor(t *testing.T) {
+	scorer := NewScorer(nil, slog.Default(), 0.3, nil, 0, 0)
+
+	scorer = scorer.WithEarlyExitFloor(0.15)
+	assert.Equal(t, 0.15, scorer.earlyExitFloor, "should accept 0.15")
+
+	scorer = scorer.WithEarlyExitFloor(0.5)
+	assert.Equal(t, 0.5, scorer.earlyExitFloor, "should accept 0.5")
+
+	scorer = scorer.WithEarlyExitFloor(0)
+	assert.Equal(t, 0.5, scorer.earlyExitFloor, "0 should be ignored (preserves previous)")
+
+	scorer = scorer.WithEarlyExitFloor(-0.1)
+	assert.Equal(t, 0.5, scorer.earlyExitFloor, "negative should be ignored")
 }
 
 func TestWithCandidateLimit(t *testing.T) {
@@ -1660,4 +1681,161 @@ func TestWithCrossEncoder(t *testing.T) {
 	scorer = scorer.WithCrossEncoder(ce, 0.60)
 	assert.Equal(t, ce, scorer.crossEncoder)
 	assert.InDelta(t, 0.60, scorer.crossEncoderThreshold, 1e-9)
+}
+
+func TestScoreForDecision_EarlyExitSkipsLowSignificance(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	orgID := uuid.Nil
+
+	suffix := uuid.New().String()[:8]
+	agentID := "earlyexit-" + suffix
+	_, err := testDB.CreateAgent(ctx, model.Agent{
+		AgentID: agentID, OrgID: orgID, Name: agentID, Role: model.RoleAgent,
+	})
+	require.NoError(t, err)
+
+	runA := createRun(t, agentID, orgID)
+	runB := createRun(t, agentID, orgID)
+	runC := createRun(t, agentID, orgID)
+
+	// Use unique embedding indices to avoid cross-test contamination via PgCandidateFinder.
+	topicEmb := makeEmbedding(800, 1.0)
+	outcomeTarget := makeEmbedding(801, 1.0)
+
+	target, err := testDB.CreateDecision(ctx, model.Decision{
+		RunID: runA.ID, AgentID: agentID, OrgID: orgID,
+		DecisionType: "architecture", Outcome: "chose Redis",
+		Confidence: 0.9, Embedding: &topicEmb, OutcomeEmbedding: &outcomeTarget,
+	})
+	require.NoError(t, err)
+
+	// Candidate 1: high significance (orthogonal outcome, same topic).
+	outcomeHigh := makeEmbedding(802, 1.0)
+	highCand, err := testDB.CreateDecision(ctx, model.Decision{
+		RunID: runB.ID, AgentID: agentID, OrgID: orgID,
+		DecisionType: "architecture", Outcome: "chose Memcached",
+		Confidence: 0.9, Embedding: &topicEmb, OutcomeEmbedding: &outcomeHigh,
+	})
+	require.NoError(t, err)
+
+	// Candidate 2: low significance (nearly identical outcome → low divergence).
+	// outcome is same as target → outcomeSim ≈ 1.0, outcomeDiv ≈ 0.
+	outcomeLow := makeEmbedding(801, 1.0)
+	_, err = testDB.CreateDecision(ctx, model.Decision{
+		RunID: runC.ID, AgentID: agentID, OrgID: orgID,
+		DecisionType: "architecture", Outcome: "also chose Redis",
+		Confidence: 0.9, Embedding: &topicEmb, OutcomeEmbedding: &outcomeLow,
+	})
+	require.NoError(t, err)
+
+	// Set a high early exit floor. With NoopValidator, hasScorer is false,
+	// so early exit will break (not continue). The high-significance candidate
+	// should still produce a conflict, but the low-significance one should not
+	// (it has significance ≈ 0 which is below the floor AND below the threshold).
+	scorer := NewScorer(testDB, logger, 0.1, nil, 0, 0).
+		WithCandidateFinder(storage.NewPgCandidateFinder(testDB)).
+		WithEarlyExitFloor(0.3)
+
+	scorer.ScoreForDecision(ctx, target.ID, orgID)
+
+	conflicts, err := testDB.ListConflicts(ctx, orgID, storage.ConflictFilters{}, 100, 0)
+	require.NoError(t, err)
+
+	// Only the high-significance candidate should be detected.
+	var foundHigh bool
+	for _, c := range conflicts {
+		aMatches := (c.DecisionAID == target.ID && c.DecisionBID == highCand.ID)
+		bMatches := (c.DecisionAID == highCand.ID && c.DecisionBID == target.ID)
+		if aMatches || bMatches {
+			foundHigh = true
+			break
+		}
+	}
+	assert.True(t, foundHigh,
+		"high-significance candidate should produce a conflict")
+}
+
+func TestScoreForDecision_PreSortProcessesMostSignificantFirst(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	orgID := uuid.Nil
+
+	suffix := uuid.New().String()[:8]
+	agentID := "presort-" + suffix
+	_, err := testDB.CreateAgent(ctx, model.Agent{
+		AgentID: agentID, OrgID: orgID, Name: agentID, Role: model.RoleAgent,
+	})
+	require.NoError(t, err)
+
+	runA := createRun(t, agentID, orgID)
+	runB := createRun(t, agentID, orgID)
+	runC := createRun(t, agentID, orgID)
+
+	// Use unique embedding indices to avoid cross-test contamination.
+	topicEmb := makeEmbedding(810, 1.0)
+	outcomeTarget := makeEmbedding(811, 1.0)
+
+	target, err := testDB.CreateDecision(ctx, model.Decision{
+		RunID: runA.ID, AgentID: agentID, OrgID: orgID,
+		DecisionType: "architecture", Outcome: "chose Redis",
+		Confidence: 0.9, Embedding: &topicEmb, OutcomeEmbedding: &outcomeTarget,
+	})
+	require.NoError(t, err)
+
+	// Candidate with moderate divergence (partial overlap with target outcome).
+	outcomeMod := pgvector.NewVector(func() []float32 {
+		v := make([]float32, 1024)
+		v[811] = 0.5 // partial similarity to target outcome
+		v[813] = 0.5 // partial divergence
+		return v
+	}())
+	modCand, err := testDB.CreateDecision(ctx, model.Decision{
+		RunID: runB.ID, AgentID: agentID, OrgID: orgID,
+		DecisionType: "architecture", Outcome: "considered Redis but chose hybrid",
+		Confidence: 0.9, Embedding: &topicEmb, OutcomeEmbedding: &outcomeMod,
+	})
+	require.NoError(t, err)
+
+	// Candidate with high divergence (orthogonal).
+	outcomeHigh := makeEmbedding(812, 1.0)
+	highCand, err := testDB.CreateDecision(ctx, model.Decision{
+		RunID: runC.ID, AgentID: agentID, OrgID: orgID,
+		DecisionType: "architecture", Outcome: "chose Memcached",
+		Confidence: 0.9, Embedding: &topicEmb, OutcomeEmbedding: &outcomeHigh,
+	})
+	require.NoError(t, err)
+
+	scorer := NewScorer(testDB, logger, 0.1, nil, 0, 0).
+		WithCandidateFinder(storage.NewPgCandidateFinder(testDB))
+
+	scorer.ScoreForDecision(ctx, target.ID, orgID)
+
+	// Both candidates should produce conflicts since they're above threshold.
+	conflicts, err := testDB.ListConflicts(ctx, orgID, storage.ConflictFilters{}, 100, 0)
+	require.NoError(t, err)
+
+	pairMatch := func(c model.DecisionConflict, a, b uuid.UUID) bool {
+		return (c.DecisionAID == a && c.DecisionBID == b) || (c.DecisionAID == b && c.DecisionBID == a)
+	}
+	var highSig, modSig float64
+	var foundHigh, foundMod bool
+	for _, c := range conflicts {
+		if pairMatch(c, target.ID, highCand.ID) && c.Significance != nil {
+			foundHigh = true
+			highSig = *c.Significance
+		}
+		if pairMatch(c, target.ID, modCand.ID) && c.Significance != nil {
+			foundMod = true
+			modSig = *c.Significance
+		}
+	}
+	assert.True(t, foundHigh, "orthogonal candidate should produce a conflict")
+	assert.True(t, foundMod, "moderate-divergence candidate should produce a conflict")
+
+	// The orthogonal outcome should have higher significance than the partial one.
+	if foundHigh && foundMod {
+		assert.Greater(t, highSig, modSig,
+			"orthogonal outcome (sig=%.3f) should have higher significance than partial (sig=%.3f)", highSig, modSig)
+	}
 }


### PR DESCRIPTION
## Summary

- Pre-compute cheap significance scores for all conflict candidates and sort descending before the LLM validation gate, so the most promising pairs are examined first
- Add configurable early-exit floor (`AKASHI_CONFLICT_EARLY_EXIT_FLOOR`, default `0.25`) that skips remaining candidates once significance drops below the threshold, while preserving the bi-encoder bypass for high-topic-similarity pairs
- Reduce default candidate limit from 50 to 20 (`AKASHI_CONFLICT_CANDIDATE_LIMIT`) — the previous value had no empirical basis
- Add `akashi.conflicts.candidates_examined` histogram metric tracking how many candidates pass the early-exit gate per decision

Closes #263

## Test plan

- [x] `go build ./...` compiles clean
- [x] `go vet ./...` passes
- [x] `golangci-lint run ./...` — 0 issues
- [x] `atlas migrate validate` passes
- [x] All existing conflict detection integration tests pass
- [x] New tests: `TestNewScorer_DefaultEarlyExitFloor`, `TestWithEarlyExitFloor`, `TestScoreForDecision_EarlyExitSkipsLowSignificance`, `TestScoreForDecision_PreSortProcessesMostSignificantFirst`
- [x] Full `go test -race -count=1 ./...` passes (only pre-existing flaky `TestMemoryLimiterConcurrent` in ratelimit fails)