### PR TITLE
feat(quality): outcome_score from assessments, anti-gaming for alternatives

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2395,6 +2395,15 @@ components:
             Completeness score (0.0–1.0) measuring how thoroughly the trace was filled in at
             write time (reasoning length, alternatives, evidence, etc.). Does not measure
             whether the decision was correct or adopted.
+        outcome_score:
+          type: number
+          format: float
+          nullable: true
+          description: >
+            Outcome score (0.0–1.0) reflecting ground-truth assessment feedback.
+            Computed as (correct + 0.5 * partially_correct) / total from the
+            decision_assessments table. Null when no assessments exist. Updated
+            on each new assessment via POST /v1/decisions/{id}/assess.
         quality_score:
           type: number
           format: float

--- a/internal/model/decision.go
+++ b/internal/model/decision.go
@@ -27,6 +27,11 @@ type Decision struct {
 	// It does NOT measure whether the decision was correct or adopted.
 	CompletenessScore float32 `json:"completeness_score"`
 
+	// OutcomeScore (0.0-1.0) reflects ground-truth assessment feedback.
+	// Computed from decision_assessments: (correct + 0.5*partial) / total.
+	// nil when no assessments exist. Updated on each new assessment.
+	OutcomeScore *float32 `json:"outcome_score,omitempty"`
+
 	// QualityScore is a deprecated alias for CompletenessScore. It is emitted
 	// alongside completeness_score for one release cycle to give API clients
 	// time to migrate. Do not use in new code.

--- a/internal/server/handlers_decisions.go
+++ b/internal/server/handlers_decisions.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ashita-ai/akashi/internal/integrity"
 	"github.com/ashita-ai/akashi/internal/model"
 	"github.com/ashita-ai/akashi/internal/service/decisions"
+	"github.com/ashita-ai/akashi/internal/service/quality"
 	"github.com/ashita-ai/akashi/internal/service/tracehealth"
 	"github.com/ashita-ai/akashi/internal/storage"
 )
@@ -1334,6 +1335,17 @@ func (h *Handlers) HandleAssessDecision(w http.ResponseWriter, r *http.Request) 
 		}
 		h.writeInternalError(w, r, "failed to save assessment", err)
 		return
+	}
+
+	// Recompute outcome_score from the latest assessment summary.
+	summary, err := h.db.GetAssessmentSummaryBatch(r.Context(), orgID, []uuid.UUID{decisionID})
+	if err == nil {
+		if s, ok := summary[decisionID]; ok {
+			outcomeScore := quality.ComputeOutcomeScore(s)
+			if updateErr := h.db.UpdateOutcomeScore(r.Context(), orgID, decisionID, outcomeScore); updateErr != nil {
+				h.logger.Error("failed to update outcome score", "decision_id", decisionID, "err", updateErr)
+			}
+		}
 	}
 
 	_ = h.db.Notify(r.Context(), storage.ChannelDecisions,

--- a/internal/service/quality/quality.go
+++ b/internal/service/quality/quality.go
@@ -30,18 +30,20 @@ var StandardDecisionTypes = map[string]bool{
 // Score computes a completeness score (0.0-1.0) for a trace decision.
 // Higher scores indicate more complete traces (more fields populated).
 //
+// All weights below are uncalibrated — chosen by hand without empirical basis.
+// See issue #252 (Tier 2) for the plan to fit weights against assessed data.
+//
 // Scoring factors:
-//   - Confidence present and reasonable (0.05-0.95): 0.15
-//   - Reasoning substantive (>50 chars): up to 0.25
-//   - Alternatives provided (>=2): up to 0.20
-//   - Rejection reason on any alternative: 0.10
-//   - Evidence provided: up to 0.15
-//   - Standard decision type: 0.10
-//   - Outcome substantive (>20 chars): 0.05
+//   - Confidence present and reasonable (0.05-0.95): 0.15 (uncalibrated)
+//   - Reasoning substantive (>50 chars): up to 0.25 (uncalibrated)
+//   - Alternatives with substantive rejection reasons: up to 0.20 (uncalibrated)
+//   - Evidence provided: up to 0.15 (uncalibrated)
+//   - Standard decision type: 0.10 (uncalibrated)
+//   - Outcome substantive (>20 chars): 0.05 (uncalibrated)
 func Score(d model.TraceDecision) float32 {
 	var score float32
 
-	// Factor 1: Confidence is present and reasonable.
+	// Factor 1: Confidence is present and reasonable (uncalibrated: 0.15).
 	// Extreme values (exactly 0 or 1) are often defaults, so we reward mid-range.
 	// Strict inequality: exactly 0.05 and 0.95 fall to edge tier (0.10).
 	if d.Confidence > 0.05 && d.Confidence < 0.95 {
@@ -50,7 +52,7 @@ func Score(d model.TraceDecision) float32 {
 		score += 0.10
 	}
 
-	// Factor 2: Reasoning is substantive.
+	// Factor 2: Reasoning is substantive (uncalibrated: up to 0.25).
 	if d.Reasoning != nil {
 		reasoningLen := len(strings.TrimSpace(*d.Reasoning))
 		switch {
@@ -63,40 +65,62 @@ func Score(d model.TraceDecision) float32 {
 		}
 	}
 
-	// Factor 3: Alternatives provided.
+	// Factor 3: Alternatives with substantive rejection reasons (uncalibrated: up to 0.20).
+	// Only non-selected alternatives with rejection reasons > 20 chars count.
+	// This prevents gaming by providing empty alternatives with no explanation.
+	substantiveAlts := countSubstantiveRejections(d.Alternatives)
 	switch {
-	case len(d.Alternatives) >= 3:
+	case substantiveAlts >= 3:
 		score += 0.20
-	case len(d.Alternatives) >= 2:
+	case substantiveAlts >= 2:
 		score += 0.15
-	case len(d.Alternatives) >= 1:
-		score += 0.05
+	case substantiveAlts >= 1:
+		score += 0.10
 	}
 
-	// Factor 4: At least one alternative has a rejection reason.
-	for _, alt := range d.Alternatives {
-		if alt.RejectionReason != nil && len(strings.TrimSpace(*alt.RejectionReason)) > 10 {
-			score += 0.10
-			break
-		}
-	}
-
-	// Factor 5: Evidence provided.
+	// Factor 4: Evidence provided (uncalibrated: up to 0.15).
 	if len(d.Evidence) >= 2 {
 		score += 0.15
 	} else if len(d.Evidence) >= 1 {
 		score += 0.10
 	}
 
-	// Factor 6: Decision type is from standard taxonomy.
+	// Factor 5: Decision type is from standard taxonomy (uncalibrated: 0.10).
 	if StandardDecisionTypes[d.DecisionType] {
 		score += 0.10
 	}
 
-	// Factor 7: Outcome is substantive.
+	// Factor 6: Outcome is substantive (uncalibrated: 0.05).
 	if len(strings.TrimSpace(d.Outcome)) > 20 {
 		score += 0.05
 	}
 
 	return score
+}
+
+// countSubstantiveRejections counts non-selected alternatives that have a
+// rejection reason longer than 20 characters (after trimming). Selected
+// alternatives are excluded — they don't need rejection reasons.
+func countSubstantiveRejections(alts []model.TraceAlternative) int {
+	count := 0
+	for _, alt := range alts {
+		if alt.Selected {
+			continue
+		}
+		if alt.RejectionReason != nil && len(strings.TrimSpace(*alt.RejectionReason)) > 20 {
+			count++
+		}
+	}
+	return count
+}
+
+// ComputeOutcomeScore computes an outcome score (0.0-1.0) from assessment counts.
+// Formula: (correct + 0.5 * partially_correct) / total.
+// Returns nil when total == 0 (no assessments).
+func ComputeOutcomeScore(summary model.AssessmentSummary) *float32 {
+	if summary.Total == 0 {
+		return nil
+	}
+	score := float32(float64(summary.Correct)+0.5*float64(summary.PartiallyCorrect)) / float32(summary.Total)
+	return &score
 }

--- a/internal/service/quality/quality_test.go
+++ b/internal/service/quality/quality_test.go
@@ -30,15 +30,16 @@ func TestScore_MaximumScore(t *testing.T) {
 		Reasoning:    strPtr(repeat('x', 101)),              // >100 chars → 0.25
 		Alternatives: []model.TraceAlternative{
 			{Label: "a", Selected: true},
-			{Label: "b", Selected: false, RejectionReason: strPtr("not viable because of latency overhead")}, // >10 chars → 0.10
-			{Label: "c", Selected: false},
-		}, // >=3 alts → 0.20
+			{Label: "b", Selected: false, RejectionReason: strPtr("not viable because of latency overhead issues")},
+			{Label: "c", Selected: false, RejectionReason: strPtr("rejected due to licensing incompatibility")},
+			{Label: "d", Selected: false, RejectionReason: strPtr("does not meet security requirements for production")},
+		}, // >=3 substantive rejections → 0.20
 		Evidence: []model.TraceEvidence{
 			{SourceType: "document", Content: "evidence one"},
 			{SourceType: "api_response", Content: "evidence two"},
 		}, // >=2 evidence → 0.15
 	}
-	assert.InDelta(t, float32(1.0), Score(d), 0.001, "fully populated decision should score 1.0")
+	assert.InDelta(t, float32(0.90), Score(d), 0.001, "fully populated decision should score 0.90")
 }
 
 // ---------------------------------------------------------------------------
@@ -63,28 +64,45 @@ func TestScore_Factor2_ReasoningLong(t *testing.T) {
 	assert.InDelta(t, float32(0.25), Score(d), 0.001)
 }
 
-func TestScore_Factor3_ThreeAlternatives(t *testing.T) {
+func TestScore_Factor3_SubstantiveRejections(t *testing.T) {
+	// Three non-selected alternatives with substantive rejection reasons (>20 chars).
 	d := model.TraceDecision{
 		Alternatives: []model.TraceAlternative{
-			{Label: "a"}, {Label: "b"}, {Label: "c"},
+			{Label: "a", Selected: true},
+			{Label: "b", Selected: false, RejectionReason: strPtr("this option was rejected for good reason")},
+			{Label: "c", Selected: false, RejectionReason: strPtr("too slow for production usage patterns")},
+			{Label: "d", Selected: false, RejectionReason: strPtr("licensing issues prevent adoption here")},
 		},
 	}
 	assert.InDelta(t, float32(0.20), Score(d), 0.001)
 }
 
-func TestScore_Factor4_RejectionReason(t *testing.T) {
-	// One alternative with a substantive (>10 char) rejection reason.
-	// Also includes 1 alternative → factor 3 contributes 0.05.
+func TestScore_Factor3_AlternativesWithoutRejections_NoCredit(t *testing.T) {
+	// Three alternatives but no rejection reasons → no credit (anti-gaming).
 	d := model.TraceDecision{
 		Alternatives: []model.TraceAlternative{
-			{Label: "x", RejectionReason: strPtr("this option is too slow for production use")},
+			{Label: "a", Selected: true},
+			{Label: "b", Selected: false},
+			{Label: "c", Selected: false},
 		},
 	}
-	// factor 3: 1 alt → 0.05, factor 4: rejection reason → 0.10
-	assert.InDelta(t, float32(0.15), Score(d), 0.001)
+	assert.InDelta(t, float32(0.0), Score(d), 0.001,
+		"alternatives without rejection reasons should not contribute to score")
 }
 
-func TestScore_Factor5_TwoEvidence(t *testing.T) {
+func TestScore_Factor3_SelectedAlternativeIgnored(t *testing.T) {
+	// Selected alternatives are ignored — only non-selected with rejections count.
+	d := model.TraceDecision{
+		Alternatives: []model.TraceAlternative{
+			{Label: "a", Selected: true, RejectionReason: strPtr("this was selected so rejection is irrelevant")},
+			{Label: "b", Selected: false, RejectionReason: strPtr("this option was rejected for good reason")},
+		},
+	}
+	// 1 substantive rejection → 0.10
+	assert.InDelta(t, float32(0.10), Score(d), 0.001)
+}
+
+func TestScore_Factor4_TwoEvidence(t *testing.T) {
 	d := model.TraceDecision{
 		Evidence: []model.TraceEvidence{
 			{SourceType: "document", Content: "a"},
@@ -94,12 +112,12 @@ func TestScore_Factor5_TwoEvidence(t *testing.T) {
 	assert.InDelta(t, float32(0.15), Score(d), 0.001)
 }
 
-func TestScore_Factor6_StandardType(t *testing.T) {
+func TestScore_Factor5_StandardType(t *testing.T) {
 	d := model.TraceDecision{DecisionType: "security"}
 	assert.InDelta(t, float32(0.10), Score(d), 0.001)
 }
 
-func TestScore_Factor7_SubstantiveOutcome(t *testing.T) {
+func TestScore_Factor6_SubstantiveOutcome(t *testing.T) {
 	d := model.TraceDecision{Outcome: "chose Redis for session caching now"} // >20 chars
 	assert.InDelta(t, float32(0.05), Score(d), 0.001)
 }
@@ -174,14 +192,18 @@ func TestScore_ReasoningWhitespaceOnly(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Alternatives count boundary tests
+// Substantive rejection tests (replaces old alternatives count tests)
 // ---------------------------------------------------------------------------
 
-func TestScore_AlternativesCount(t *testing.T) {
-	makeAlts := func(n int) []model.TraceAlternative {
-		alts := make([]model.TraceAlternative, n)
-		for i := range alts {
-			alts[i] = model.TraceAlternative{Label: repeat('a'+byte(i%26), 1)}
+func TestScore_SubstantiveRejectionCount(t *testing.T) {
+	makeAltsWithRejections := func(n int) []model.TraceAlternative {
+		alts := []model.TraceAlternative{{Label: "selected", Selected: true}}
+		for i := range n {
+			alts = append(alts, model.TraceAlternative{
+				Label:           repeat('a'+byte(i%26), 1),
+				Selected:        false,
+				RejectionReason: strPtr("this alternative was rejected because of reason " + repeat('x', 10)),
+			})
 		}
 		return alts
 	}
@@ -191,15 +213,15 @@ func TestScore_AlternativesCount(t *testing.T) {
 		count int
 		want  float32
 	}{
-		{"0 alternatives", 0, 0.0},
-		{"1 alternative", 1, 0.05},
-		{"2 alternatives", 2, 0.15},
-		{"3 alternatives", 3, 0.20},
-		{"5 alternatives", 5, 0.20},
+		{"0 substantive rejections", 0, 0.0},
+		{"1 substantive rejection", 1, 0.10},
+		{"2 substantive rejections", 2, 0.15},
+		{"3 substantive rejections", 3, 0.20},
+		{"5 substantive rejections", 5, 0.20},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			d := model.TraceDecision{Alternatives: makeAlts(tt.count)}
+			d := model.TraceDecision{Alternatives: makeAltsWithRejections(tt.count)}
 			assert.InDelta(t, tt.want, Score(d), 0.001)
 		})
 	}
@@ -212,65 +234,62 @@ func TestScore_AlternativesCount(t *testing.T) {
 func TestScore_RejectionReasonTooShort(t *testing.T) {
 	d := model.TraceDecision{
 		Alternatives: []model.TraceAlternative{
-			{Label: "a", RejectionReason: strPtr("too short")}, // 9 chars, not > 10
+			{Label: "a", Selected: false, RejectionReason: strPtr("too short")}, // 9 chars, not > 20
 		},
 	}
-	// factor 3: 1 alt → 0.05, factor 4: rejection too short → 0
-	assert.InDelta(t, float32(0.05), Score(d), 0.001)
+	// rejection too short → 0
+	assert.InDelta(t, float32(0.0), Score(d), 0.001)
 }
 
-func TestScore_RejectionReasonExactly10(t *testing.T) {
+func TestScore_RejectionReasonExactly20(t *testing.T) {
 	d := model.TraceDecision{
 		Alternatives: []model.TraceAlternative{
-			{Label: "a", RejectionReason: strPtr("exactly 10")}, // 10 chars, not > 10
+			{Label: "a", Selected: false, RejectionReason: strPtr(repeat('x', 20))}, // 20 chars, not > 20
 		},
 	}
-	// factor 3: 1 alt → 0.05, factor 4: len == 10 not > 10 → 0
-	assert.InDelta(t, float32(0.05), Score(d), 0.001)
+	assert.InDelta(t, float32(0.0), Score(d), 0.001)
 }
 
-func TestScore_RejectionReasonExactly11(t *testing.T) {
+func TestScore_RejectionReasonExactly21(t *testing.T) {
 	d := model.TraceDecision{
 		Alternatives: []model.TraceAlternative{
-			{Label: "a", RejectionReason: strPtr("exactly 11!")}, // 11 chars, > 10 → credit
+			{Label: "a", Selected: false, RejectionReason: strPtr(repeat('x', 21))}, // 21 chars, > 20 → credit
 		},
 	}
-	// factor 3: 1 alt → 0.05, factor 4: rejection → 0.10
-	assert.InDelta(t, float32(0.15), Score(d), 0.001)
+	// 1 substantive rejection → 0.10
+	assert.InDelta(t, float32(0.10), Score(d), 0.001)
 }
 
 func TestScore_RejectionReasonNil(t *testing.T) {
 	d := model.TraceDecision{
 		Alternatives: []model.TraceAlternative{
-			{Label: "a", RejectionReason: nil},
+			{Label: "a", Selected: false, RejectionReason: nil},
 		},
 	}
-	// factor 3: 1 alt → 0.05, factor 4: nil → 0
-	assert.InDelta(t, float32(0.05), Score(d), 0.001)
+	assert.InDelta(t, float32(0.0), Score(d), 0.001)
 }
 
 func TestScore_RejectionReasonWhitespace(t *testing.T) {
-	// 15 chars of whitespace trims to 0 → no credit.
-	ws := strings.Repeat(" ", 15)
+	// 25 chars of whitespace trims to 0 → no credit.
+	ws := strings.Repeat(" ", 25)
 	d := model.TraceDecision{
 		Alternatives: []model.TraceAlternative{
-			{Label: "a", RejectionReason: &ws},
+			{Label: "a", Selected: false, RejectionReason: &ws},
 		},
 	}
-	// factor 3: 1 alt → 0.05, factor 4: trimmed len 0 → 0
-	assert.InDelta(t, float32(0.05), Score(d), 0.001)
+	assert.InDelta(t, float32(0.0), Score(d), 0.001)
 }
 
-func TestScore_RejectionReasonOnlyOneNeeded(t *testing.T) {
-	// Two alternatives: one without rejection, one with. Factor 4 should fire once.
+func TestScore_RejectionReasonMixed(t *testing.T) {
+	// Two non-selected alternatives: one without rejection, one with substantive rejection.
 	d := model.TraceDecision{
 		Alternatives: []model.TraceAlternative{
-			{Label: "a", RejectionReason: nil},
-			{Label: "b", RejectionReason: strPtr("this option was rejected for good reason")},
+			{Label: "a", Selected: false, RejectionReason: nil},
+			{Label: "b", Selected: false, RejectionReason: strPtr("this option was rejected for good reason")},
 		},
 	}
-	// factor 3: 2 alts → 0.15, factor 4: rejection → 0.10
-	assert.InDelta(t, float32(0.25), Score(d), 0.001)
+	// 1 substantive rejection → 0.10
+	assert.InDelta(t, float32(0.10), Score(d), 0.001)
 }
 
 // ---------------------------------------------------------------------------
@@ -394,4 +413,43 @@ func TestStandardDecisionTypes_ExcludesUnknown(t *testing.T) {
 	for _, dt := range bogus {
 		assert.False(t, StandardDecisionTypes[dt], "%q should not be a standard decision type", dt)
 	}
+}
+
+// ---------------------------------------------------------------------------
+// ComputeOutcomeScore tests
+// ---------------------------------------------------------------------------
+
+func TestComputeOutcomeScore_NoAssessments(t *testing.T) {
+	s := model.AssessmentSummary{Total: 0}
+	assert.Nil(t, ComputeOutcomeScore(s), "no assessments should return nil")
+}
+
+func TestComputeOutcomeScore_AllCorrect(t *testing.T) {
+	s := model.AssessmentSummary{Total: 3, Correct: 3}
+	score := ComputeOutcomeScore(s)
+	assert.NotNil(t, score)
+	assert.InDelta(t, float32(1.0), *score, 0.001)
+}
+
+func TestComputeOutcomeScore_AllIncorrect(t *testing.T) {
+	s := model.AssessmentSummary{Total: 2, Incorrect: 2}
+	score := ComputeOutcomeScore(s)
+	assert.NotNil(t, score)
+	assert.InDelta(t, float32(0.0), *score, 0.001)
+}
+
+func TestComputeOutcomeScore_Mixed(t *testing.T) {
+	// 1 correct + 1 partial + 1 incorrect = (1 + 0.5) / 3 = 0.5
+	s := model.AssessmentSummary{Total: 3, Correct: 1, PartiallyCorrect: 1, Incorrect: 1}
+	score := ComputeOutcomeScore(s)
+	assert.NotNil(t, score)
+	assert.InDelta(t, float32(0.5), *score, 0.001)
+}
+
+func TestComputeOutcomeScore_AllPartial(t *testing.T) {
+	// 4 partial = (0 + 0.5*4) / 4 = 0.5
+	s := model.AssessmentSummary{Total: 4, PartiallyCorrect: 4}
+	score := ComputeOutcomeScore(s)
+	assert.NotNil(t, score)
+	assert.InDelta(t, float32(0.5), *score, 0.001)
 }

--- a/internal/storage/assessments.go
+++ b/internal/storage/assessments.go
@@ -46,6 +46,19 @@ func (db *DB) CreateAssessment(ctx context.Context, orgID uuid.UUID, a model.Dec
 	return out, nil
 }
 
+// UpdateOutcomeScore sets the outcome_score on a decision row.
+// Called after recording an assessment to reflect the latest ground-truth feedback.
+func (db *DB) UpdateOutcomeScore(ctx context.Context, orgID, decisionID uuid.UUID, score *float32) error {
+	_, err := db.pool.Exec(ctx,
+		`UPDATE decisions SET outcome_score = $1 WHERE id = $2 AND org_id = $3 AND valid_to IS NULL`,
+		score, decisionID, orgID,
+	)
+	if err != nil {
+		return fmt.Errorf("storage: update outcome score: %w", err)
+	}
+	return nil
+}
+
 // ListAssessments returns the full assessment history for a decision, newest first.
 // Multiple rows from the same assessor reflect verdict changes over time.
 // Returns ErrNotFound if the decision does not exist in the org.

--- a/internal/storage/decisions.go
+++ b/internal/storage/decisions.go
@@ -53,11 +53,11 @@ func (db *DB) CreateDecision(ctx context.Context, d model.Decision) (model.Decis
 
 	_, err = tx.Exec(ctx,
 		`INSERT INTO decisions (id, run_id, agent_id, org_id, decision_type, outcome, confidence,
-		 reasoning, embedding, outcome_embedding, metadata, completeness_score, precedent_ref, supersedes_id, content_hash,
+		 reasoning, embedding, outcome_embedding, metadata, completeness_score, outcome_score, precedent_ref, supersedes_id, content_hash,
 		 valid_from, valid_to, transaction_time, created_at, session_id, agent_context, api_key_id)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22)`,
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23)`,
 		d.ID, d.RunID, d.AgentID, d.OrgID, d.DecisionType, d.Outcome, d.Confidence,
-		d.Reasoning, d.Embedding, d.OutcomeEmbedding, d.Metadata, d.CompletenessScore, d.PrecedentRef,
+		d.Reasoning, d.Embedding, d.OutcomeEmbedding, d.Metadata, d.CompletenessScore, d.OutcomeScore, d.PrecedentRef,
 		d.SupersedesID, d.ContentHash,
 		d.ValidFrom, d.ValidTo, d.TransactionTime, d.CreatedAt,
 		d.SessionID, d.AgentContext, d.APIKeyID,
@@ -93,7 +93,7 @@ type GetDecisionOpts struct {
 // GetDecision retrieves a decision by ID with configurable includes and filtering.
 func (db *DB) GetDecision(ctx context.Context, orgID, id uuid.UUID, opts GetDecisionOpts) (model.Decision, error) {
 	query := `SELECT id, run_id, agent_id, org_id, decision_type, outcome, confidence, reasoning,
-		 metadata, completeness_score, precedent_ref, supersedes_id, content_hash,
+		 metadata, completeness_score, outcome_score, precedent_ref, supersedes_id, content_hash,
 		 valid_from, valid_to, transaction_time, created_at, session_id, agent_context, api_key_id, tool, model, project
 		 FROM decisions WHERE id = $1 AND org_id = $2`
 	if opts.CurrentOnly {
@@ -103,7 +103,7 @@ func (db *DB) GetDecision(ctx context.Context, orgID, id uuid.UUID, opts GetDeci
 	var d model.Decision
 	err := db.pool.QueryRow(ctx, query, id, orgID).Scan(
 		&d.ID, &d.RunID, &d.AgentID, &d.OrgID, &d.DecisionType, &d.Outcome, &d.Confidence,
-		&d.Reasoning, &d.Metadata, &d.CompletenessScore, &d.PrecedentRef,
+		&d.Reasoning, &d.Metadata, &d.CompletenessScore, &d.OutcomeScore, &d.PrecedentRef,
 		&d.SupersedesID, &d.ContentHash,
 		&d.ValidFrom, &d.ValidTo, &d.TransactionTime, &d.CreatedAt,
 		&d.SessionID, &d.AgentContext, &d.APIKeyID,
@@ -175,12 +175,12 @@ func (db *DB) ReviseDecision(ctx context.Context, originalID uuid.UUID, revised 
 
 	_, err = tx.Exec(ctx,
 		`INSERT INTO decisions (id, run_id, agent_id, org_id, decision_type, outcome, confidence,
-		 reasoning, embedding, outcome_embedding, metadata, completeness_score, precedent_ref, supersedes_id, content_hash,
+		 reasoning, embedding, outcome_embedding, metadata, completeness_score, outcome_score, precedent_ref, supersedes_id, content_hash,
 		 valid_from, valid_to, transaction_time, created_at, session_id, agent_context, api_key_id)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22)`,
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23)`,
 		revised.ID, revised.RunID, revised.AgentID, revised.OrgID, revised.DecisionType, revised.Outcome,
 		revised.Confidence, revised.Reasoning, revised.Embedding, revised.OutcomeEmbedding, revised.Metadata,
-		revised.CompletenessScore, revised.PrecedentRef, revised.SupersedesID, revised.ContentHash,
+		revised.CompletenessScore, revised.OutcomeScore, revised.PrecedentRef, revised.SupersedesID, revised.ContentHash,
 		revised.ValidFrom, revised.ValidTo, revised.TransactionTime, revised.CreatedAt,
 		revised.SessionID, revised.AgentContext, revised.APIKeyID,
 	)
@@ -561,7 +561,7 @@ func (db *DB) QueryDecisions(ctx context.Context, orgID uuid.UUID, req model.Que
 	orderBy := "valid_from"
 	if req.OrderBy != "" {
 		switch req.OrderBy {
-		case "confidence", "valid_from", "decision_type", "outcome", "completeness_score", "quality_score":
+		case "confidence", "valid_from", "decision_type", "outcome", "completeness_score", "outcome_score", "quality_score":
 			// quality_score accepted as deprecated alias; maps to the renamed column.
 			if req.OrderBy == "quality_score" {
 				orderBy = "completeness_score"
@@ -589,7 +589,7 @@ func (db *DB) QueryDecisions(ctx context.Context, orgID uuid.UUID, req model.Que
 
 	selectQuery := fmt.Sprintf(
 		`SELECT id, run_id, agent_id, org_id, decision_type, outcome, confidence, reasoning,
-		 metadata, completeness_score, precedent_ref, supersedes_id, content_hash,
+		 metadata, completeness_score, outcome_score, precedent_ref, supersedes_id, content_hash,
 		 valid_from, valid_to, transaction_time, created_at, session_id, agent_context, api_key_id, tool, model, project
 		 FROM decisions%s ORDER BY %s %s LIMIT %d OFFSET %d`,
 		where, orderBy, orderDir, limit, offset,
@@ -663,7 +663,7 @@ func (db *DB) QueryDecisionsTemporal(ctx context.Context, orgID uuid.UUID, req m
 	args = append(args, limit)
 
 	query := `SELECT id, run_id, agent_id, org_id, decision_type, outcome, confidence, reasoning,
-		 metadata, completeness_score, precedent_ref, supersedes_id, content_hash,
+		 metadata, completeness_score, outcome_score, precedent_ref, supersedes_id, content_hash,
 		 valid_from, valid_to, transaction_time, created_at, session_id, agent_context, api_key_id, tool, model, project
 		 FROM decisions` + where + ` ORDER BY valid_from DESC` + limitClause
 
@@ -741,10 +741,10 @@ func (db *DB) searchByFTS(ctx context.Context, orgID uuid.UUID, query string, fi
 
 	sql := fmt.Sprintf(
 		`SELECT id, run_id, agent_id, org_id, decision_type, outcome, confidence, reasoning,
-		 metadata, completeness_score, precedent_ref, supersedes_id, content_hash,
+		 metadata, completeness_score, outcome_score, precedent_ref, supersedes_id, content_hash,
 		 valid_from, valid_to, transaction_time, created_at, session_id, agent_context,
 		 ts_rank(search_vector, websearch_to_tsquery('english', $%d))
-		   * (0.6 + 0.3 * COALESCE(completeness_score, 0))
+		   * (0.5 + 0.2 * COALESCE(completeness_score, 0) + 0.3 * COALESCE(outcome_score, 0))
 		   * (1.0 / (1.0 + EXTRACT(EPOCH FROM (NOW() - valid_from)) / 86400.0 / 90.0))
 		   AS relevance
 		 FROM decisions%s
@@ -783,9 +783,9 @@ func (db *DB) searchByILIKE(ctx context.Context, orgID uuid.UUID, query string, 
 
 	sql := fmt.Sprintf(
 		`SELECT id, run_id, agent_id, org_id, decision_type, outcome, confidence, reasoning,
-		 metadata, completeness_score, precedent_ref, supersedes_id, content_hash,
+		 metadata, completeness_score, outcome_score, precedent_ref, supersedes_id, content_hash,
 		 valid_from, valid_to, transaction_time, created_at, session_id, agent_context,
-		 (0.6 + 0.3 * COALESCE(completeness_score, 0))
+		 (0.5 + 0.2 * COALESCE(completeness_score, 0) + 0.3 * COALESCE(outcome_score, 0))
 		   * (1.0 / (1.0 + EXTRACT(EPOCH FROM (NOW() - valid_from)) / 86400.0 / 90.0))
 		   AS relevance
 		 FROM decisions%s
@@ -810,7 +810,7 @@ func (db *DB) execSearchQuery(ctx context.Context, sql string, args []any) ([]mo
 		var relevance float32
 		if err := rows.Scan(
 			&d.ID, &d.RunID, &d.AgentID, &d.OrgID, &d.DecisionType, &d.Outcome, &d.Confidence,
-			&d.Reasoning, &d.Metadata, &d.CompletenessScore, &d.PrecedentRef,
+			&d.Reasoning, &d.Metadata, &d.CompletenessScore, &d.OutcomeScore, &d.PrecedentRef,
 			&d.SupersedesID, &d.ContentHash,
 			&d.ValidFrom, &d.ValidTo, &d.TransactionTime, &d.CreatedAt,
 			&d.SessionID, &d.AgentContext,
@@ -853,7 +853,7 @@ func (db *DB) GetDecisionsByAgent(ctx context.Context, orgID uuid.UUID, agentID 
 
 	query := fmt.Sprintf(
 		`SELECT id, run_id, agent_id, org_id, decision_type, outcome, confidence, reasoning,
-		 metadata, completeness_score, precedent_ref, supersedes_id, content_hash,
+		 metadata, completeness_score, outcome_score, precedent_ref, supersedes_id, content_hash,
 		 valid_from, valid_to, transaction_time, created_at, session_id, agent_context, api_key_id, tool, model, project
 		 FROM decisions%s ORDER BY valid_from DESC LIMIT %d OFFSET %d`,
 		where, limit, offset,
@@ -958,7 +958,7 @@ func (db *DB) ExportDecisionsCursor(ctx context.Context, orgID uuid.UUID, filter
 
 	query := fmt.Sprintf(
 		`SELECT id, run_id, agent_id, org_id, decision_type, outcome, confidence, reasoning,
-		 metadata, completeness_score, precedent_ref, supersedes_id, content_hash,
+		 metadata, completeness_score, outcome_score, precedent_ref, supersedes_id, content_hash,
 		 valid_from, valid_to, transaction_time, created_at, session_id, agent_context, api_key_id, tool, model, project
 		 FROM decisions%s ORDER BY valid_from ASC, id ASC LIMIT %d`,
 		where, limit,
@@ -1011,7 +1011,7 @@ func scanDecisions(rows pgx.Rows) ([]model.Decision, error) {
 		var d model.Decision
 		if err := rows.Scan(
 			&d.ID, &d.RunID, &d.AgentID, &d.OrgID, &d.DecisionType, &d.Outcome, &d.Confidence,
-			&d.Reasoning, &d.Metadata, &d.CompletenessScore, &d.PrecedentRef,
+			&d.Reasoning, &d.Metadata, &d.CompletenessScore, &d.OutcomeScore, &d.PrecedentRef,
 			&d.SupersedesID, &d.ContentHash,
 			&d.ValidFrom, &d.ValidTo, &d.TransactionTime, &d.CreatedAt,
 			&d.SessionID, &d.AgentContext, &d.APIKeyID,
@@ -1035,7 +1035,7 @@ func (db *DB) GetDecisionsByIDs(ctx context.Context, orgID uuid.UUID, ids []uuid
 
 	rows, err := db.pool.Query(ctx,
 		`SELECT id, run_id, agent_id, org_id, decision_type, outcome, confidence, reasoning,
-		 metadata, completeness_score, precedent_ref, supersedes_id, content_hash,
+		 metadata, completeness_score, outcome_score, precedent_ref, supersedes_id, content_hash,
 		 valid_from, valid_to, transaction_time, created_at, session_id, agent_context, api_key_id, tool, model, project
 		 FROM decisions
 		 WHERE org_id = $1 AND id = ANY($2) AND valid_to IS NULL`,
@@ -1074,7 +1074,7 @@ func (db *DB) GetDecisionRevisions(ctx context.Context, orgID, id uuid.UUID) ([]
 	forward_chain AS (
 		-- Anchor: the target decision.
 		SELECT id, run_id, agent_id, org_id, decision_type, outcome, confidence, reasoning,
-		       metadata, completeness_score, precedent_ref, supersedes_id, content_hash,
+		       metadata, completeness_score, outcome_score, precedent_ref, supersedes_id, content_hash,
 		       valid_from, valid_to, transaction_time, created_at, session_id, agent_context, api_key_id, tool, model, project, 0 AS depth
 		FROM decisions
 		WHERE id = $1 AND org_id = $2
@@ -1083,7 +1083,7 @@ func (db *DB) GetDecisionRevisions(ctx context.Context, orgID, id uuid.UUID) ([]
 
 		-- Walk forward: find decisions that supersede the current one.
 		SELECT d.id, d.run_id, d.agent_id, d.org_id, d.decision_type, d.outcome, d.confidence, d.reasoning,
-		       d.metadata, d.completeness_score, d.precedent_ref, d.supersedes_id, d.content_hash,
+		       d.metadata, d.completeness_score, d.outcome_score, d.precedent_ref, d.supersedes_id, d.content_hash,
 		       d.valid_from, d.valid_to, d.transaction_time, d.created_at, d.session_id, d.agent_context, d.api_key_id, d.tool, d.model, d.project, fc.depth + 1
 		FROM decisions d
 		INNER JOIN forward_chain fc ON d.supersedes_id = fc.id
@@ -1092,7 +1092,7 @@ func (db *DB) GetDecisionRevisions(ctx context.Context, orgID, id uuid.UUID) ([]
 	backward_chain AS (
 		-- Anchor: the target decision.
 		SELECT id, run_id, agent_id, org_id, decision_type, outcome, confidence, reasoning,
-		       metadata, completeness_score, precedent_ref, supersedes_id, content_hash,
+		       metadata, completeness_score, outcome_score, precedent_ref, supersedes_id, content_hash,
 		       valid_from, valid_to, transaction_time, created_at, session_id, agent_context, api_key_id, tool, model, project, 0 AS depth
 		FROM decisions
 		WHERE id = $1 AND org_id = $2
@@ -1101,7 +1101,7 @@ func (db *DB) GetDecisionRevisions(ctx context.Context, orgID, id uuid.UUID) ([]
 
 		-- Walk backward: follow supersedes_id links.
 		SELECT d.id, d.run_id, d.agent_id, d.org_id, d.decision_type, d.outcome, d.confidence, d.reasoning,
-		       d.metadata, d.completeness_score, d.precedent_ref, d.supersedes_id, d.content_hash,
+		       d.metadata, d.completeness_score, d.outcome_score, d.precedent_ref, d.supersedes_id, d.content_hash,
 		       d.valid_from, d.valid_to, d.transaction_time, d.created_at, d.session_id, d.agent_context, d.api_key_id, d.tool, d.model, d.project, bc.depth + 1
 		FROM decisions d
 		INNER JOIN backward_chain bc ON bc.supersedes_id = d.id
@@ -1109,17 +1109,17 @@ func (db *DB) GetDecisionRevisions(ctx context.Context, orgID, id uuid.UUID) ([]
 	),
 	all_revisions AS (
 		SELECT id, run_id, agent_id, org_id, decision_type, outcome, confidence, reasoning,
-		       metadata, completeness_score, precedent_ref, supersedes_id, content_hash,
+		       metadata, completeness_score, outcome_score, precedent_ref, supersedes_id, content_hash,
 		       valid_from, valid_to, transaction_time, created_at, session_id, agent_context, api_key_id, tool, model, project
 		FROM forward_chain
 		UNION
 		SELECT id, run_id, agent_id, org_id, decision_type, outcome, confidence, reasoning,
-		       metadata, completeness_score, precedent_ref, supersedes_id, content_hash,
+		       metadata, completeness_score, outcome_score, precedent_ref, supersedes_id, content_hash,
 		       valid_from, valid_to, transaction_time, created_at, session_id, agent_context, api_key_id, tool, model, project
 		FROM backward_chain
 	)
 	SELECT DISTINCT ON (id) id, run_id, agent_id, org_id, decision_type, outcome, confidence, reasoning,
-	       metadata, completeness_score, precedent_ref, supersedes_id, content_hash,
+	       metadata, completeness_score, outcome_score, precedent_ref, supersedes_id, content_hash,
 	       valid_from, valid_to, transaction_time, created_at, session_id, agent_context, api_key_id, tool, model, project
 	FROM all_revisions
 	ORDER BY id, valid_from ASC`

--- a/internal/storage/sessions.go
+++ b/internal/storage/sessions.go
@@ -16,7 +16,7 @@ import (
 func (db *DB) GetSessionDecisions(ctx context.Context, orgID, sessionID uuid.UUID) ([]model.Decision, error) {
 	rows, err := db.pool.Query(ctx,
 		`SELECT id, run_id, agent_id, org_id, decision_type, outcome, confidence, reasoning,
-		 metadata, completeness_score, precedent_ref, supersedes_id, content_hash,
+		 metadata, completeness_score, outcome_score, precedent_ref, supersedes_id, content_hash,
 		 valid_from, valid_to, transaction_time, created_at, session_id, agent_context, api_key_id, tool, model, project
 		 FROM decisions
 		 WHERE org_id = $1 AND session_id = $2 AND valid_to IS NULL

--- a/internal/storage/sqlite/assessments.go
+++ b/internal/storage/sqlite/assessments.go
@@ -51,6 +51,18 @@ func (l *LiteDB) CreateAssessment(ctx context.Context, orgID uuid.UUID, a model.
 	return a, nil
 }
 
+// UpdateOutcomeScore sets the outcome_score on a decision row.
+func (l *LiteDB) UpdateOutcomeScore(ctx context.Context, orgID, decisionID uuid.UUID, score *float32) error {
+	_, err := l.db.ExecContext(ctx,
+		`UPDATE decisions SET outcome_score = ? WHERE id = ? AND org_id = ? AND valid_to IS NULL`,
+		score, uuidStr(decisionID), uuidStr(orgID),
+	)
+	if err != nil {
+		return fmt.Errorf("sqlite: update outcome score: %w", err)
+	}
+	return nil
+}
+
 // GetAssessmentSummaryBatch returns assessment counts per decision.
 func (l *LiteDB) GetAssessmentSummaryBatch(ctx context.Context, orgID uuid.UUID, decisionIDs []uuid.UUID) (map[uuid.UUID]model.AssessmentSummary, error) {
 	if len(decisionIDs) == 0 {

--- a/internal/storage/sqlite/decisions.go
+++ b/internal/storage/sqlite/decisions.go
@@ -141,10 +141,10 @@ func createTraceInTx(ctx context.Context, tx *sql.Tx, p storage.CreateTraceParam
 	_, err = tx.ExecContext(ctx,
 		`INSERT INTO decisions
 		 (id, run_id, agent_id, org_id, decision_type, outcome, confidence, reasoning,
-		  embedding, outcome_embedding, metadata, completeness_score, precedent_ref,
+		  embedding, outcome_embedding, metadata, completeness_score, outcome_score, precedent_ref,
 		  supersedes_id, content_hash, valid_from, valid_to, transaction_time, created_at,
 		  session_id, agent_context, api_key_id, tool, model, project)
-		 VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+		 VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
 		uuidStr(d.ID),
 		uuidStr(d.RunID),
 		d.AgentID,
@@ -157,6 +157,7 @@ func createTraceInTx(ctx context.Context, tx *sql.Tx, p storage.CreateTraceParam
 		vectorToBlob(d.OutcomeEmbedding),
 		jsonStr(d.Metadata),
 		d.CompletenessScore,
+		d.OutcomeScore,
 		nullUUIDStr(d.PrecedentRef),
 		nullUUIDStr(d.SupersedesID),
 		d.ContentHash,
@@ -260,7 +261,7 @@ func createTraceInTx(ctx context.Context, tx *sql.Tx, p storage.CreateTraceParam
 
 // decisionCols is the SELECT column list used by all decision queries.
 const decisionCols = `id, run_id, agent_id, org_id, decision_type, outcome, confidence, reasoning,
-	metadata, completeness_score, precedent_ref, supersedes_id, content_hash,
+	metadata, completeness_score, outcome_score, precedent_ref, supersedes_id, content_hash,
 	valid_from, valid_to, transaction_time, created_at, session_id, agent_context,
 	api_key_id, tool, model, project`
 
@@ -469,7 +470,7 @@ func (l *LiteDB) SearchDecisionsByText(ctx context.Context, orgID uuid.UUID, que
 	q := fmt.Sprintf( //nolint:gosec // G201
 		`SELECT d.id, d.run_id, d.agent_id, d.org_id, d.decision_type, d.outcome,
 		        d.confidence, d.reasoning, d.metadata, d.completeness_score,
-		        d.precedent_ref, d.supersedes_id, d.content_hash,
+		        d.outcome_score, d.precedent_ref, d.supersedes_id, d.content_hash,
 		        d.valid_from, d.valid_to, d.transaction_time, d.created_at,
 		        d.session_id, d.agent_context, d.api_key_id, d.tool, d.model, d.project,
 		        -rank AS relevance
@@ -518,7 +519,7 @@ func (l *LiteDB) SearchDecisionsByText(ctx context.Context, orgID uuid.UUID, que
 		)
 		err := rows.Scan(&idStr, &runIDStr, &d.AgentID, &orgIDStr, &d.DecisionType,
 			&d.Outcome, &d.Confidence, &d.Reasoning, &metaJSON, &d.CompletenessScore,
-			&precedent, &supersedes, &d.ContentHash,
+			&d.OutcomeScore, &precedent, &supersedes, &d.ContentHash,
 			&validFromStr, &validToStr, &txTimeStr, &createdStr,
 			&sessionStr, &ctxJSON, &apiKeyStr, &tool, &modelStr, &project,
 			&relevance)
@@ -572,7 +573,7 @@ func (l *LiteDB) searchDecisionsByLike(ctx context.Context, orgID uuid.UUID, que
 	q := fmt.Sprintf( //nolint:gosec // G201
 		`SELECT d.id, d.run_id, d.agent_id, d.org_id, d.decision_type, d.outcome,
 		        d.confidence, d.reasoning, d.metadata, d.completeness_score,
-		        d.precedent_ref, d.supersedes_id, d.content_hash,
+		        d.outcome_score, d.precedent_ref, d.supersedes_id, d.content_hash,
 		        d.valid_from, d.valid_to, d.transaction_time, d.created_at,
 		        d.session_id, d.agent_context, d.api_key_id, d.tool, d.model, d.project,
 		        1.0 AS relevance
@@ -619,7 +620,7 @@ func (l *LiteDB) searchDecisionsByLike(ctx context.Context, orgID uuid.UUID, que
 		)
 		err := rows.Scan(&idStr, &runIDStr, &d.AgentID, &orgIDStr, &d.DecisionType,
 			&d.Outcome, &d.Confidence, &d.Reasoning, &metaJSON, &d.CompletenessScore,
-			&precedent, &supersedes, &d.ContentHash,
+			&d.OutcomeScore, &precedent, &supersedes, &d.ContentHash,
 			&validFromStr, &validToStr, &txTimeStr, &createdStr,
 			&sessionStr, &ctxJSON, &apiKeyStr, &tool, &modelStr, &project,
 			&relevance)
@@ -776,7 +777,7 @@ func buildDecisionFilterWhere(alias string, orgID uuid.UUID, f model.QueryFilter
 // sanitizeOrderCol restricts order columns to known-safe values.
 func sanitizeOrderCol(col string) string {
 	switch strings.ToLower(col) {
-	case "valid_from", "created_at", "confidence", "completeness_score", "decision_type":
+	case "valid_from", "created_at", "confidence", "completeness_score", "outcome_score", "decision_type":
 		return col
 	default:
 		return "valid_from"
@@ -809,7 +810,7 @@ type rowScanner interface {
 	Scan(dest ...any) error
 }
 
-// scanOneDecision scans the 23-column decisionCols from a row.
+// scanOneDecision scans the 24-column decisionCols from a row.
 func scanOneDecision(row rowScanner) (model.Decision, error) {
 	var (
 		d            model.Decision
@@ -832,7 +833,7 @@ func scanOneDecision(row rowScanner) (model.Decision, error) {
 	)
 	err := row.Scan(&idStr, &runIDStr, &d.AgentID, &orgIDStr, &d.DecisionType,
 		&d.Outcome, &d.Confidence, &d.Reasoning, &metaJSON, &d.CompletenessScore,
-		&precedent, &supersedes, &d.ContentHash,
+		&d.OutcomeScore, &precedent, &supersedes, &d.ContentHash,
 		&validFromStr, &validToStr, &txTimeStr, &createdStr,
 		&sessionStr, &ctxJSON, &apiKeyStr, &tool, &modelStr, &project)
 	if err != nil {

--- a/internal/storage/sqlite/schema.sql
+++ b/internal/storage/sqlite/schema.sql
@@ -60,6 +60,7 @@ CREATE TABLE IF NOT EXISTS decisions (
     outcome_embedding  BLOB,
     metadata           TEXT NOT NULL DEFAULT '{}',
     completeness_score REAL NOT NULL DEFAULT 0,
+    outcome_score REAL,
     precedent_ref      TEXT,
     supersedes_id      TEXT,
     content_hash       TEXT,

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -81,6 +81,7 @@ type Store interface {
 	GetDecisionOutcomeSignalsBatch(ctx context.Context, ids []uuid.UUID, orgID uuid.UUID) (map[uuid.UUID]model.OutcomeSignals, error)
 	GetAssessmentSummaryBatch(ctx context.Context, orgID uuid.UUID, decisionIDs []uuid.UUID) (map[uuid.UUID]model.AssessmentSummary, error)
 	CreateAssessment(ctx context.Context, orgID uuid.UUID, a model.DecisionAssessment) (model.DecisionAssessment, error)
+	UpdateOutcomeScore(ctx context.Context, orgID, decisionID uuid.UUID, score *float32) error
 
 	// ---- Claims ----
 

--- a/internal/storage/trace.go
+++ b/internal/storage/trace.go
@@ -144,11 +144,11 @@ func (db *DB) createTraceInTx(ctx context.Context, tx pgx.Tx, params CreateTrace
 	d.ContentHash = integrity.ComputeContentHash(d.ID, d.DecisionType, d.Outcome, d.Confidence, d.Reasoning, d.ValidFrom)
 	if _, err := tx.Exec(ctx,
 		`INSERT INTO decisions (id, run_id, agent_id, org_id, decision_type, outcome, confidence,
-		 reasoning, embedding, outcome_embedding, metadata, completeness_score, precedent_ref, supersedes_id, content_hash,
+		 reasoning, embedding, outcome_embedding, metadata, completeness_score, outcome_score, precedent_ref, supersedes_id, content_hash,
 		 valid_from, valid_to, transaction_time, created_at, session_id, agent_context, api_key_id)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22)`,
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23)`,
 		d.ID, d.RunID, d.AgentID, d.OrgID, d.DecisionType, d.Outcome, d.Confidence,
-		d.Reasoning, d.Embedding, d.OutcomeEmbedding, d.Metadata, d.CompletenessScore, d.PrecedentRef,
+		d.Reasoning, d.Embedding, d.OutcomeEmbedding, d.Metadata, d.CompletenessScore, d.OutcomeScore, d.PrecedentRef,
 		d.SupersedesID, d.ContentHash,
 		d.ValidFrom, d.ValidTo, d.TransactionTime, d.CreatedAt,
 		d.SessionID, d.AgentContext, d.APIKeyID,

--- a/migrations/059_outcome_score.sql
+++ b/migrations/059_outcome_score.sql
@@ -1,0 +1,8 @@
+-- 059: Add outcome_score column to decisions table.
+--
+-- outcome_score (0.0–1.0) reflects ground-truth assessment feedback:
+-- how often assessors judged this decision correct. Computed from the
+-- decision_assessments table and updated whenever a new assessment is recorded.
+-- Separate from completeness_score, which measures trace form at write time.
+
+ALTER TABLE decisions ADD COLUMN outcome_score REAL;

--- a/migrations/atlas.sum
+++ b/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:84p6sybep5yX77JdJLAZw2urEU/qVMZMshmOvpyWiXY=
+h1:soLPAdSf5ZGP7lWpzWLNpCbMPmI/W8XYD1vsFzSVzOo=
 001_initial.sql h1:uhyGXto+QacAaGYb9ZTGjsBs5chlKi8O0eHz9aCQsrY=
 022_full_text_search.sql h1:9iwtA8MgCzAxDV9YkUBn0CLT9ePSmj3GcPoMGg8TXf0=
 023_fix_outbox_index.sql h1:OtMEFBcMRWej02+ghnBXlPr6BVq+LoA62Id9XUWfDNI=
@@ -37,3 +37,4 @@ h1:84p6sybep5yX77JdJLAZw2urEU/qVMZMshmOvpyWiXY=
 056_claim_embedding_retries.sql h1:8bwFdN/QTzh7k2YnebWjplmgeNNLsDw4+pmkmkBwkUc=
 057_signup.sql h1:iLBroAU9X37qpUQrq5STsZTKOh6yb9ZNDtrAfXgH2nM=
 058_claim_text_on_conflicts.sql h1:EU/RrSMkAkTYbdGySaqoEw0w1BCtJWyi6/QXIDSfd4k=
+059_outcome_score.sql h1:/wqeIHuBxscT6mFa+JxFga9lzsmVYxMd0RuoMQYp9rs=

--- a/sdk/go/akashi/types.go
+++ b/sdk/go/akashi/types.go
@@ -19,7 +19,8 @@ type Decision struct {
 	Confidence   float32        `json:"confidence"`
 	Reasoning    *string        `json:"reasoning,omitempty"`
 	Metadata     map[string]any `json:"metadata"`
-	CompletenessScore float64 `json:"completeness_score"`
+	CompletenessScore float64  `json:"completeness_score"`
+	OutcomeScore      *float64 `json:"outcome_score,omitempty"`
 	PrecedentRef *uuid.UUID     `json:"precedent_ref,omitempty"`
 	SupersedesID *uuid.UUID     `json:"supersedes_id,omitempty"`
 	ContentHash  string         `json:"content_hash,omitempty"`

--- a/sdk/python/src/akashi/types.py
+++ b/sdk/python/src/akashi/types.py
@@ -23,6 +23,7 @@ class Decision(BaseModel):
     reasoning: str | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
     completeness_score: float = 0.0
+    outcome_score: float | None = None
     precedent_ref: UUID | None = None
     supersedes_id: UUID | None = None
     content_hash: str = ""

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -10,6 +10,7 @@ export interface Decision {
   reasoning?: string;
   metadata: Record<string, unknown>;
   completeness_score: number;
+  outcome_score?: number | null;
   precedent_ref?: string;
   supersedes_id?: string;
   content_hash?: string;

--- a/ui/src/types/api.ts
+++ b/ui/src/types/api.ts
@@ -67,6 +67,7 @@ export interface Decision {
   reasoning: string | null;
   metadata: Record<string, unknown> | null;
   completeness_score: number;
+  outcome_score: number | null;
   precedent_ref: string | null;
   valid_from: string;
   valid_to: string | null;


### PR DESCRIPTION
## Summary

Closes #252 (Tiers 1 and 3; Tier 4 deferred).

- **outcome_score column** (Tier 1): New nullable `REAL` on `decisions`, computed as `(correct + 0.5 * partially_correct) / total` from `decision_assessments`. Updated in `HandleAssessDecision` after each new assessment. Exposed in API, all three SDKs, and UI types. Feeds into text search relevance: `(0.5 + 0.2 * completeness + 0.3 * outcome) * recency_decay`.
- **Anti-gaming for alternatives** (Tier 3): Alternative count bonuses now require substantive rejection reasons (>20 chars) on non-selected alternatives. Previously, 3 empty alternatives scored +0.20 with no explanation. Selected alternatives are excluded from the count.
- **Weight annotation**: All completeness weights marked `// uncalibrated` pending empirical fitting (Tier 2).

## Files changed (19)

| Area | Files |
|------|-------|
| Migration | `migrations/059_outcome_score.sql` |
| Model | `internal/model/decision.go` |
| Scoring | `internal/service/quality/quality.go`, `quality_test.go` |
| Storage (Postgres) | `internal/storage/assessments.go`, `decisions.go`, `sessions.go`, `trace.go`, `store.go` |
| Storage (SQLite) | `internal/storage/sqlite/assessments.go`, `decisions.go`, `schema.sql` |
| Handler | `internal/server/handlers_decisions.go` |
| API spec | `api/openapi.yaml` |
| SDKs | `sdk/go/akashi/types.go`, `sdk/python/src/akashi/types.py`, `sdk/typescript/src/types.ts` |
| UI | `ui/src/types/api.ts` |

## Test plan

- [x] `go test -race -count=1 ./...` — all packages pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] `atlas migrate validate` — passes
- [x] Quality tests updated: new `ComputeOutcomeScore` tests, anti-gaming tests for alternatives without rejection reasons, max score test updated for new factor structure
- [ ] Manual: create a decision, assess it via `POST /v1/decisions/{id}/assess`, verify `outcome_score` appears on `GET /v1/decisions/{id}`
- [ ] Manual: verify text search ranks assessed-correct decisions higher

🤖 Generated with [Claude Code](https://claude.com/claude-code)