### PR TITLE
fix: five reliability and correctness fixes from codebase review

### DIFF
--- a/internal/conflicts/scorer.go
+++ b/internal/conflicts/scorer.go
@@ -765,7 +765,13 @@ func (s *Scorer) Validator() Validator {
 // Only open/acknowledged conflicts are removed; resolved and wont_fix conflicts
 // represent explicit human decisions and are preserved.
 func (s *Scorer) ClearUnvalidatedConflicts(ctx context.Context) (int, error) {
-	tag, err := s.db.Pool().Exec(ctx,
+	tx, err := s.db.Pool().Begin(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("conflicts: begin clear unvalidated tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	tag, err := tx.Exec(ctx,
 		`DELETE FROM scored_conflicts
 		 WHERE scoring_method NOT IN ('llm_v2')
 		   AND status IN ('open', 'acknowledged')`)
@@ -773,6 +779,24 @@ func (s *Scorer) ClearUnvalidatedConflicts(ctx context.Context) (int, error) {
 		return 0, fmt.Errorf("conflicts: clear unvalidated: %w", err)
 	}
 	n := int(tag.RowsAffected())
+
+	if n > 0 {
+		if err := storage.InsertMutationAuditTx(ctx, tx, storage.MutationAuditEntry{
+			ActorAgentID: "system",
+			ActorRole:    "platform_admin",
+			Operation:    "clear_unvalidated_conflicts",
+			ResourceType: "scored_conflicts",
+			BeforeData:   map[string]any{"count": n},
+			AfterData:    map[string]any{"deleted": n},
+			Metadata:     map[string]any{"reason": "scoring_method_migration_to_llm_v2"},
+		}); err != nil {
+			return 0, fmt.Errorf("conflicts: audit clear unvalidated: %w", err)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return 0, fmt.Errorf("conflicts: commit clear unvalidated: %w", err)
+	}
 	s.logger.Warn("startup: cleared unvalidated conflicts", "deleted", n, "reason", "scoring_method_migration_to_llm_v2")
 	return n, nil
 }
@@ -802,12 +826,36 @@ func cosineSimilarity(a, b []float32) float64 {
 // SECURITY: Intentionally global — one-time startup operation across all orgs.
 // Set AKASHI_FORCE_CONFLICT_RESCORE=true to trigger.
 func (s *Scorer) ClearAllConflicts(ctx context.Context) (int, error) {
-	tag, err := s.db.Pool().Exec(ctx,
+	tx, err := s.db.Pool().Begin(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("conflicts: begin clear all tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	tag, err := tx.Exec(ctx,
 		`DELETE FROM scored_conflicts WHERE status IN ('open', 'acknowledged')`)
 	if err != nil {
 		return 0, fmt.Errorf("conflicts: clear all: %w", err)
 	}
 	n := int(tag.RowsAffected())
+
+	if n > 0 {
+		if err := storage.InsertMutationAuditTx(ctx, tx, storage.MutationAuditEntry{
+			ActorAgentID: "system",
+			ActorRole:    "platform_admin",
+			Operation:    "clear_all_conflicts",
+			ResourceType: "scored_conflicts",
+			BeforeData:   map[string]any{"count": n},
+			AfterData:    map[string]any{"deleted": n},
+			Metadata:     map[string]any{"reason": "AKASHI_FORCE_CONFLICT_RESCORE"},
+		}); err != nil {
+			return 0, fmt.Errorf("conflicts: audit clear all: %w", err)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return 0, fmt.Errorf("conflicts: commit clear all: %w", err)
+	}
 	s.logger.Warn("startup: cleared all open/acknowledged conflicts", "deleted", n, "reason", "AKASHI_FORCE_CONFLICT_RESCORE")
 	return n, nil
 }

--- a/internal/service/trace/buffer.go
+++ b/internal/service/trace/buffer.go
@@ -40,8 +40,9 @@ type Buffer struct {
 	flushTimeout time.Duration
 	wal          *WAL // nil when WAL is disabled
 
-	mu     sync.Mutex
-	events []model.AgentEvent
+	mu        sync.Mutex
+	events    []model.AgentEvent
+	walMaxLSN uint64 // highest WAL LSN for buffered events (valid only when wal != nil)
 
 	droppedEvents atomic.Int64 // total events rejected (capacity or drain in progress)
 	draining      atomic.Bool  // true after Drain is initiated; rejects new appends
@@ -80,7 +81,7 @@ func (b *Buffer) Start(ctx context.Context) {
 
 	// Recover un-flushed events from WAL before accepting new traffic.
 	if b.wal != nil {
-		recovered, err := b.wal.Recover()
+		recovered, maxLSN, err := b.wal.Recover()
 		if err != nil {
 			b.logger.Error("trace: wal recovery failed", "error", err)
 			// Continue without recovered events. They are not lost — the WAL
@@ -97,7 +98,7 @@ func (b *Buffer) Start(ctx context.Context) {
 					"recovered", len(recovered), "new_inserts", inserted,
 					"duplicates_skipped", int64(len(recovered))-inserted)
 				// Advance the WAL checkpoint now that events are in Postgres.
-				if err := b.wal.Checkpoint(recovered); err != nil {
+				if err := b.wal.CheckpointLSN(maxLSN); err != nil {
 					b.logger.Warn("trace: wal checkpoint after recovery failed (events are safe in postgres)",
 						"error", err)
 				}
@@ -161,9 +162,11 @@ func (b *Buffer) Append(ctx context.Context, runID uuid.UUID, agentID string, or
 
 	// Write to WAL before buffering in memory for crash durability.
 	if b.wal != nil {
-		if err := b.wal.Write(events); err != nil {
+		maxLSN, err := b.wal.Write(events)
+		if err != nil {
 			return nil, fmt.Errorf("trace: wal write: %w", err)
 		}
+		b.walMaxLSN = maxLSN
 	}
 
 	b.events = append(b.events, events...)
@@ -273,6 +276,7 @@ func (b *Buffer) flushOnce(ctx context.Context) (bool, error) {
 	// This avoids data loss on transient flush failures.
 	batch := make([]model.AgentEvent, len(b.events))
 	copy(batch, b.events)
+	batchWALLSN := b.walMaxLSN // snapshot the highest LSN for this batch
 	b.mu.Unlock()
 
 	start := time.Now()
@@ -296,8 +300,8 @@ func (b *Buffer) flushOnce(ctx context.Context) (bool, error) {
 	b.mu.Unlock()
 
 	// Advance WAL checkpoint after successful COPY.
-	if b.wal != nil {
-		if err := b.wal.Checkpoint(batch); err != nil {
+	if b.wal != nil && batchWALLSN > 0 {
+		if err := b.wal.CheckpointLSN(batchWALLSN); err != nil {
 			// Non-fatal: events are in Postgres. The WAL will replay them on
 			// next startup, and the idempotent recovery path handles duplicates.
 			b.logger.Warn("trace: wal checkpoint failed (events are durable in postgres)", "error", err)

--- a/internal/service/trace/wal.go
+++ b/internal/service/trace/wal.go
@@ -185,20 +185,24 @@ func NewWAL(logger *slog.Logger, cfg WALConfig) (*WAL, error) {
 
 // Write appends events to the WAL. In "full" sync mode, the segment is synced
 // before returning. In "batch" or "none" mode, writes go to the OS page cache.
-func (w *WAL) Write(events []model.AgentEvent) error {
+// Returns the highest LSN assigned to the written events. The caller should
+// track this value and pass it to CheckpointLSN after a successful flush.
+func (w *WAL) Write(events []model.AgentEvent) (uint64, error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
+	var maxLSN uint64
 	for i := range events {
 		payload, err := json.Marshal(&events[i])
 		if err != nil {
-			return fmt.Errorf("wal: marshal event: %w", err)
+			return 0, fmt.Errorf("wal: marshal event: %w", err)
 		}
 		if len(payload) > walMaxPayload {
-			return fmt.Errorf("wal: event payload too large (%d bytes, max %d)", len(payload), walMaxPayload)
+			return 0, fmt.Errorf("wal: event payload too large (%d bytes, max %d)", len(payload), walMaxPayload)
 		}
 
 		lsn := w.nextLSN.Add(1) - 1
+		maxLSN = lsn
 
 		// Write record: [LSN(8) | payloadLen(4) | payload(N) | CRC32C(4)]
 		var head [walRecordHead]byte
@@ -214,13 +218,13 @@ func (w *WAL) Write(events []model.AgentEvent) error {
 		binary.BigEndian.PutUint32(crcBuf[:], crc)
 
 		if _, err := w.current.Write(head[:]); err != nil {
-			return fmt.Errorf("wal: write record head: %w", err)
+			return 0, fmt.Errorf("wal: write record head: %w", err)
 		}
 		if _, err := w.current.Write(payload); err != nil {
-			return fmt.Errorf("wal: write payload: %w", err)
+			return 0, fmt.Errorf("wal: write payload: %w", err)
 		}
 		if _, err := w.current.Write(crcBuf[:]); err != nil {
-			return fmt.Errorf("wal: write crc: %w", err)
+			return 0, fmt.Errorf("wal: write crc: %w", err)
 		}
 
 		recordSize := int64(walRecordHead + len(payload) + walCRCSize)
@@ -230,38 +234,30 @@ func (w *WAL) Write(events []model.AgentEvent) error {
 		// Rotate if needed.
 		if w.segmentSize >= w.maxSegSize || w.segmentRecs >= w.maxSegRecs {
 			if err := w.rotateSegment(); err != nil {
-				return fmt.Errorf("wal: rotate segment: %w", err)
+				return 0, fmt.Errorf("wal: rotate segment: %w", err)
 			}
 		}
 	}
 
 	if w.syncMode == "full" {
 		if err := w.current.Sync(); err != nil {
-			return fmt.Errorf("wal: fsync: %w", err)
+			return 0, fmt.Errorf("wal: fsync: %w", err)
 		}
 	}
 
-	return nil
+	return maxLSN, nil
 }
 
-// Checkpoint advances the flushed position and deletes old segments.
-// Call after a successful COPY flush to Postgres.
-func (w *WAL) Checkpoint(flushedEvents []model.AgentEvent) error {
-	if len(flushedEvents) == 0 {
+// CheckpointLSN advances the flushed position to the given LSN and deletes
+// old segments. Call after a successful COPY flush to Postgres, passing the
+// max LSN returned by Write for the flushed batch.
+func (w *WAL) CheckpointLSN(flushedLSN uint64) error {
+	if flushedLSN == 0 {
 		return nil
 	}
 
-	// Determine the highest LSN among flushed events by scanning WAL records.
-	// Since we don't store LSN on AgentEvent, we track by count: the checkpoint
-	// advances by len(flushedEvents) records past the last checkpoint.
-	cp, err := w.loadCheckpoint()
-	if err != nil {
-		return fmt.Errorf("wal: load checkpoint for advance: %w", err)
-	}
-
-	newLSN := cp.FlushedLSN + uint64(len(flushedEvents))
 	newCP := checkpoint{
-		FlushedLSN: newLSN,
+		FlushedLSN: flushedLSN,
 		FlushedAt:  time.Now().UTC(),
 		Segment:    w.segmentNum,
 	}
@@ -271,39 +267,43 @@ func (w *WAL) Checkpoint(flushedEvents []model.AgentEvent) error {
 	}
 
 	// Delete segments whose records are all below the flushed LSN.
-	return w.cleanupSegments(newLSN)
+	return w.cleanupSegments(flushedLSN)
 }
 
 // Recover reads un-flushed events from WAL files. Returns events that were
-// written to the WAL but not yet confirmed flushed to Postgres.
-func (w *WAL) Recover() ([]model.AgentEvent, error) {
+// written to the WAL but not yet confirmed flushed to Postgres, along with
+// the highest LSN among recovered events (for passing to CheckpointLSN).
+func (w *WAL) Recover() ([]model.AgentEvent, uint64, error) {
 	cp, err := w.loadCheckpoint()
 	if err != nil {
-		return nil, fmt.Errorf("wal: load checkpoint for recovery: %w", err)
+		return nil, 0, fmt.Errorf("wal: load checkpoint for recovery: %w", err)
 	}
 
 	segments, err := w.listSegments()
 	if err != nil {
-		return nil, fmt.Errorf("wal: list segments for recovery: %w", err)
+		return nil, 0, fmt.Errorf("wal: list segments for recovery: %w", err)
 	}
 
 	var recovered []model.AgentEvent
+	var maxLSN uint64
 	for _, seg := range segments {
-		events, highLSN, err := w.readSegment(seg)
+		events, _, err := w.readSegment(seg)
 		if err != nil {
 			w.logger.Warn("wal: recovery: error reading segment, skipping remainder",
 				"segment", seg, "error", err, "recovered_so_far", len(recovered))
 			break
 		}
-		_ = highLSN
 		for _, e := range events {
 			if e.lsn > cp.FlushedLSN {
 				recovered = append(recovered, e.event)
+				if e.lsn > maxLSN {
+					maxLSN = e.lsn
+				}
 			}
 		}
 	}
 
-	return recovered, nil
+	return recovered, maxLSN, nil
 }
 
 // Close syncs and closes the current segment file. Stops the batch sync goroutine.
@@ -406,6 +406,17 @@ func (w *WAL) saveCheckpoint(cp checkpoint) error {
 	if err := os.Rename(tmp, w.checkpointPath()); err != nil {
 		return fmt.Errorf("wal: rename checkpoint: %w", err)
 	}
+
+	// Fsync the parent directory to ensure the rename is durable across crashes.
+	dir, err := os.Open(w.dir) //nolint:gosec // path is the WAL directory configured at startup
+	if err != nil {
+		return fmt.Errorf("wal: open dir for fsync: %w", err)
+	}
+	if err := dir.Sync(); err != nil {
+		_ = dir.Close()
+		return fmt.Errorf("wal: fsync dir after checkpoint rename: %w", err)
+	}
+	_ = dir.Close()
 	return nil
 }
 

--- a/internal/service/trace/wal_test.go
+++ b/internal/service/trace/wal_test.go
@@ -59,7 +59,9 @@ func TestWAL_WriteAndRecover(t *testing.T) {
 	require.NoError(t, err)
 
 	events := testEvents(5)
-	require.NoError(t, w.Write(events))
+	maxLSN, err := w.Write(events)
+	require.NoError(t, err)
+	assert.Greater(t, maxLSN, uint64(0), "Write should return a positive LSN")
 	require.NoError(t, w.Close())
 
 	// Reopen and recover — all 5 should come back.
@@ -67,9 +69,10 @@ func TestWAL_WriteAndRecover(t *testing.T) {
 	require.NoError(t, err)
 	defer closeWAL(t, w2)
 
-	recovered, err := w2.Recover()
+	recovered, recoveredLSN, err := w2.Recover()
 	require.NoError(t, err)
 	assert.Len(t, recovered, 5)
+	assert.Equal(t, maxLSN, recoveredLSN, "recovered max LSN should match written max LSN")
 	for i, r := range recovered {
 		assert.Equal(t, events[i].ID, r.ID, "event %d ID mismatch", i)
 		assert.Equal(t, events[i].AgentID, r.AgentID, "event %d AgentID mismatch", i)
@@ -82,10 +85,14 @@ func TestWAL_CheckpointAdvancesRecovery(t *testing.T) {
 	require.NoError(t, err)
 
 	events := testEvents(10)
-	require.NoError(t, w.Write(events))
+	maxLSN, err := w.Write(events)
+	require.NoError(t, err)
 
-	// Checkpoint first 6 events.
-	require.NoError(t, w.Checkpoint(events[:6]))
+	// Checkpoint first 6 events by LSN. LSNs are 1-based and sequential,
+	// so the 6th event has LSN = baseLSN + 5. With a fresh WAL (baseLSN=1),
+	// that's LSN 6. We compute it as maxLSN - (total - checkpointed).
+	checkpointLSN := maxLSN - uint64(len(events)-6) //nolint:gosec // test values are small and well-bounded
+	require.NoError(t, w.CheckpointLSN(checkpointLSN))
 	require.NoError(t, w.Close())
 
 	// Recover — should get only the last 4.
@@ -93,7 +100,7 @@ func TestWAL_CheckpointAdvancesRecovery(t *testing.T) {
 	require.NoError(t, err)
 	defer closeWAL(t, w2)
 
-	recovered, err := w2.Recover()
+	recovered, _, err := w2.Recover()
 	require.NoError(t, err)
 	assert.Len(t, recovered, 4, "should recover only un-checkpointed events")
 	for i, r := range recovered {
@@ -107,15 +114,16 @@ func TestWAL_CheckpointAll_EmptyRecovery(t *testing.T) {
 	require.NoError(t, err)
 
 	events := testEvents(3)
-	require.NoError(t, w.Write(events))
-	require.NoError(t, w.Checkpoint(events))
+	maxLSN, err := w.Write(events)
+	require.NoError(t, err)
+	require.NoError(t, w.CheckpointLSN(maxLSN))
 	require.NoError(t, w.Close())
 
 	w2, err := NewWAL(testLogger(), cfg)
 	require.NoError(t, err)
 	defer closeWAL(t, w2)
 
-	recovered, err := w2.Recover()
+	recovered, _, err := w2.Recover()
 	require.NoError(t, err)
 	assert.Empty(t, recovered, "all events checkpointed, nothing to recover")
 }
@@ -126,9 +134,10 @@ func TestWAL_EmptyRecovery(t *testing.T) {
 	require.NoError(t, err)
 	defer closeWAL(t, w)
 
-	recovered, err := w.Recover()
+	recovered, maxLSN, err := w.Recover()
 	require.NoError(t, err)
 	assert.Empty(t, recovered, "fresh WAL should have nothing to recover")
+	assert.Equal(t, uint64(0), maxLSN, "no recovered events means zero LSN")
 }
 
 func TestWAL_SegmentRotation(t *testing.T) {
@@ -140,7 +149,8 @@ func TestWAL_SegmentRotation(t *testing.T) {
 
 	// Write 250 events — should span at least 2 segments.
 	events := testEvents(250)
-	require.NoError(t, w.Write(events))
+	_, err = w.Write(events)
+	require.NoError(t, err)
 	require.NoError(t, w.Close())
 
 	segCount := countWALFiles(t, cfg.Dir)
@@ -151,7 +161,7 @@ func TestWAL_SegmentRotation(t *testing.T) {
 	require.NoError(t, err)
 	defer closeWAL(t, w2)
 
-	recovered, err := w2.Recover()
+	recovered, _, err := w2.Recover()
 	require.NoError(t, err)
 	assert.Len(t, recovered, 250, "all events should be recoverable across segments")
 }
@@ -164,13 +174,14 @@ func TestWAL_SegmentCleanup(t *testing.T) {
 	require.NoError(t, err)
 
 	events := testEvents(250)
-	require.NoError(t, w.Write(events))
+	maxLSN, err := w.Write(events)
+	require.NoError(t, err)
 
 	beforeCleanup := countWALFiles(t, cfg.Dir)
 	require.GreaterOrEqual(t, beforeCleanup, 2)
 
 	// Checkpoint all events — old segments should be cleaned.
-	require.NoError(t, w.Checkpoint(events))
+	require.NoError(t, w.CheckpointLSN(maxLSN))
 
 	afterCleanup := countWALFiles(t, cfg.Dir)
 	assert.Less(t, afterCleanup, beforeCleanup,
@@ -185,7 +196,8 @@ func TestWAL_CorruptedRecord(t *testing.T) {
 	require.NoError(t, err)
 
 	events := testEvents(5)
-	require.NoError(t, w.Write(events))
+	_, err = w.Write(events)
+	require.NoError(t, err)
 	require.NoError(t, w.Close())
 
 	// Corrupt a byte in the last segment file. This should cause
@@ -208,7 +220,7 @@ func TestWAL_CorruptedRecord(t *testing.T) {
 	require.NoError(t, err)
 	defer closeWAL(t, w2)
 
-	recovered, err := w2.Recover()
+	recovered, _, err := w2.Recover()
 	require.NoError(t, err)
 	assert.Less(t, len(recovered), 5, "corrupted record should truncate recovery")
 }
@@ -229,7 +241,7 @@ func TestWAL_ConcurrentWrites(t *testing.T) {
 		go func(g int) {
 			defer wg.Done()
 			events := testEvents(eventsPerGo)
-			if err := w.Write(events); err != nil {
+			if _, err := w.Write(events); err != nil {
 				errCh <- err
 			}
 		}(g)
@@ -248,7 +260,7 @@ func TestWAL_ConcurrentWrites(t *testing.T) {
 	require.NoError(t, err)
 	defer closeWAL(t, w2)
 
-	recovered, err := w2.Recover()
+	recovered, _, err := w2.Recover()
 	require.NoError(t, err)
 	assert.Equal(t, goroutines*eventsPerGo, len(recovered),
 		"all concurrently-written events should be recoverable")
@@ -296,7 +308,8 @@ func TestWAL_BatchSyncMode(t *testing.T) {
 	require.NoError(t, err)
 
 	events := testEvents(3)
-	require.NoError(t, w.Write(events))
+	_, err = w.Write(events)
+	require.NoError(t, err)
 
 	// Let the sync goroutine fire at least once.
 	time.Sleep(100 * time.Millisecond)
@@ -308,7 +321,7 @@ func TestWAL_BatchSyncMode(t *testing.T) {
 	require.NoError(t, err)
 	defer closeWAL(t, w2)
 
-	recovered, err := w2.Recover()
+	recovered, _, err := w2.Recover()
 	require.NoError(t, err)
 	assert.Len(t, recovered, 3)
 }
@@ -321,14 +334,15 @@ func TestWAL_FullSyncMode(t *testing.T) {
 	require.NoError(t, err)
 
 	events := testEvents(3)
-	require.NoError(t, w.Write(events))
+	_, err = w.Write(events)
+	require.NoError(t, err)
 	require.NoError(t, w.Close())
 
 	w2, err := NewWAL(testLogger(), cfg)
 	require.NoError(t, err)
 	defer closeWAL(t, w2)
 
-	recovered, err := w2.Recover()
+	recovered, _, err := w2.Recover()
 	require.NoError(t, err)
 	assert.Len(t, recovered, 3)
 }
@@ -342,7 +356,8 @@ func TestWAL_PendingBytesAndSegmentCount(t *testing.T) {
 	assert.GreaterOrEqual(t, w.SegmentCount(), 1, "should have at least the initial segment")
 
 	events := testEvents(10)
-	require.NoError(t, w.Write(events))
+	_, err = w.Write(events)
+	require.NoError(t, err)
 	assert.Greater(t, w.PendingBytes(), int64(0), "pending bytes should be > 0 after writes")
 }
 
@@ -352,9 +367,8 @@ func TestWAL_CheckpointEmptyIsNoop(t *testing.T) {
 	require.NoError(t, err)
 	defer closeWAL(t, w)
 
-	// Checkpointing an empty slice should be a no-op, not an error.
-	require.NoError(t, w.Checkpoint(nil))
-	require.NoError(t, w.Checkpoint([]model.AgentEvent{}))
+	// Checkpointing LSN 0 should be a no-op, not an error.
+	require.NoError(t, w.CheckpointLSN(0))
 }
 
 func TestWAL_BadMagicRejected(t *testing.T) {
@@ -363,7 +377,8 @@ func TestWAL_BadMagicRejected(t *testing.T) {
 	require.NoError(t, err)
 
 	events := testEvents(3)
-	require.NoError(t, w.Write(events))
+	_, err = w.Write(events)
+	require.NoError(t, err)
 	require.NoError(t, w.Close())
 
 	// Corrupt the magic bytes of the first segment.
@@ -379,7 +394,7 @@ func TestWAL_BadMagicRejected(t *testing.T) {
 	require.NoError(t, err)
 	defer closeWAL(t, w2)
 
-	recovered, err := w2.Recover()
+	recovered, _, err := w2.Recover()
 	require.NoError(t, err)
 	// The corrupted segment should be skipped; recovery stops.
 	assert.Empty(t, recovered, "bad magic should prevent recovery from that segment")
@@ -391,7 +406,8 @@ func TestWAL_TruncatedRecord(t *testing.T) {
 	require.NoError(t, err)
 
 	events := testEvents(5)
-	require.NoError(t, w.Write(events))
+	_, err = w.Write(events)
+	require.NoError(t, err)
 	require.NoError(t, w.Close())
 
 	// Truncate the last segment mid-record.
@@ -411,7 +427,7 @@ func TestWAL_TruncatedRecord(t *testing.T) {
 	require.NoError(t, err)
 	defer closeWAL(t, w2)
 
-	recovered, err := w2.Recover()
+	recovered, _, err := w2.Recover()
 	require.NoError(t, err)
 	// Should recover some but not all events.
 	assert.Less(t, len(recovered), 5, "truncated segment should lose at least the last record")

--- a/internal/storage/decisions.go
+++ b/internal/storage/decisions.go
@@ -67,14 +67,16 @@ func (db *DB) CreateDecision(ctx context.Context, d model.Decision) (model.Decis
 	}
 
 	// Queue search index update inside the same transaction.
-	if d.Embedding != nil {
-		if _, err := tx.Exec(ctx,
-			`INSERT INTO search_outbox (decision_id, org_id, operation)
-			 VALUES ($1, $2, 'upsert')
-			 ON CONFLICT (decision_id, operation) DO UPDATE SET created_at = now(), attempts = 0, locked_until = NULL`,
-			d.ID, d.OrgID); err != nil {
-			return model.Decision{}, fmt.Errorf("storage: queue search outbox in create decision: %w", err)
-		}
+	// Always queue regardless of embedding status — the outbox worker will
+	// generate embeddings asynchronously if needed. Without this, decisions
+	// created without an embedding (e.g. via the REST API) are permanently
+	// invisible to search.
+	if _, err := tx.Exec(ctx,
+		`INSERT INTO search_outbox (decision_id, org_id, operation)
+		 VALUES ($1, $2, 'upsert')
+		 ON CONFLICT (decision_id, operation) DO UPDATE SET created_at = now(), attempts = 0, locked_until = NULL`,
+		d.ID, d.OrgID); err != nil {
+		return model.Decision{}, fmt.Errorf("storage: queue search outbox in create decision: %w", err)
 	}
 
 	if err := tx.Commit(ctx); err != nil {
@@ -196,14 +198,12 @@ func (db *DB) ReviseDecision(ctx context.Context, originalID uuid.UUID, revised 
 		originalID, revised.OrgID); err != nil {
 		return model.Decision{}, fmt.Errorf("storage: queue search outbox delete in revision: %w", err)
 	}
-	if revised.Embedding != nil {
-		if _, err := tx.Exec(ctx,
-			`INSERT INTO search_outbox (decision_id, org_id, operation)
-			 VALUES ($1, $2, 'upsert')
-			 ON CONFLICT (decision_id, operation) DO UPDATE SET created_at = now(), attempts = 0, locked_until = NULL`,
-			revised.ID, revised.OrgID); err != nil {
-			return model.Decision{}, fmt.Errorf("storage: queue search outbox upsert in revision: %w", err)
-		}
+	if _, err := tx.Exec(ctx,
+		`INSERT INTO search_outbox (decision_id, org_id, operation)
+		 VALUES ($1, $2, 'upsert')
+		 ON CONFLICT (decision_id, operation) DO UPDATE SET created_at = now(), attempts = 0, locked_until = NULL`,
+		revised.ID, revised.OrgID); err != nil {
+		return model.Decision{}, fmt.Errorf("storage: queue search outbox upsert in revision: %w", err)
 	}
 
 	// Auto-resolve open conflicts involving the superseded decision. The revised

--- a/internal/storage/retention.go
+++ b/internal/storage/retention.go
@@ -425,22 +425,22 @@ func (db *DB) deleteBatch(ctx context.Context, orgID uuid.UUID, ids []uuid.UUID)
 
 	var cnt PurgeCount
 
-	// 1. Delete evidence.
-	tag, err := tx.Exec(ctx, `DELETE FROM evidence WHERE decision_id = ANY($1)`, ids)
+	// 1. Delete evidence (scoped by org_id for defense in depth).
+	tag, err := tx.Exec(ctx, `DELETE FROM evidence WHERE decision_id = ANY($1) AND org_id = $2`, ids, orgID)
 	if err != nil {
 		return cnt, fmt.Errorf("storage: delete evidence batch: %w", err)
 	}
 	cnt.Evidence = tag.RowsAffected()
 
-	// 2. Delete alternatives.
+	// 2. Delete alternatives (no org_id column; decision_id FK provides scoping).
 	tag, err = tx.Exec(ctx, `DELETE FROM alternatives WHERE decision_id = ANY($1)`, ids)
 	if err != nil {
 		return cnt, fmt.Errorf("storage: delete alternatives batch: %w", err)
 	}
 	cnt.Alternatives = tag.RowsAffected()
 
-	// 3. Delete decision_claims.
-	tag, err = tx.Exec(ctx, `DELETE FROM decision_claims WHERE decision_id = ANY($1)`, ids)
+	// 3. Delete decision_claims (scoped by org_id for defense in depth).
+	tag, err = tx.Exec(ctx, `DELETE FROM decision_claims WHERE decision_id = ANY($1) AND org_id = $2`, ids, orgID)
 	if err != nil {
 		return cnt, fmt.Errorf("storage: delete claims batch: %w", err)
 	}


### PR DESCRIPTION
## Summary

Staff-level codebase review identified five correctness and reliability issues across the ingestion, storage, and conflict subsystems. All five are fixed in this PR:

- **Search outbox silent data loss** — `CreateDecision` and `ReviseDecision` conditionally queued outbox entries only when embeddings were present, making decisions without pre-computed embeddings permanently invisible to Qdrant search. Outbox entries are now always queued.
- **Conflict deletion lacks audit trail** — `ClearUnvalidatedConflicts` and `ClearAllConflicts` performed bulk DELETEs with no record. Both now run in transactions with atomic `mutation_audit_log` entries.
- **Retention dependent DELETEs missing org_id** — `deleteBatch` deleted evidence and decision_claims by `decision_id` alone, relying on FK integrity instead of defense-in-depth org scoping. Added `AND org_id = $N` to both.
- **WAL checkpoint drift** — Event-count-based `Checkpoint` could diverge from actual LSN under concurrent writes. Replaced with `CheckpointLSN(uint64)` keyed on the LSN returned by `Write`. Added directory fsync after checkpoint rename for crash durability.
- **Buffer ↔ WAL LSN tracking** — Buffer now captures `walMaxLSN` from `Write` and passes it through the flush pipeline to `CheckpointLSN` after successful COPY.

## Files changed

| File | Change |
|------|--------|
| `internal/storage/decisions.go` | Remove embedding guard on outbox INSERT |
| `internal/conflicts/scorer.go` | Wrap clears in tx + audit log |
| `internal/storage/retention.go` | Add org_id to dependent DELETEs |
| `internal/service/trace/wal.go` | LSN-based checkpoint + dir fsync |
| `internal/service/trace/buffer.go` | Track walMaxLSN through flush |
| `internal/service/trace/wal_test.go` | Update tests for new WAL API |

## Test plan

- [x] All 17 WAL tests updated and passing (`go test -race -count=1 ./internal/service/trace/...`)
- [x] Full test suite passes (`go test -race -count=1 ./...`)
- [x] Pre-commit checks clean: `go build`, `go vet`, `golangci-lint`, `atlas migrate validate`, `go mod tidy`
- [ ] CI should confirm all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)