### PR TITLE
feat: add fuzz tests for critical input parsing paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,14 @@ jobs:
       - name: Security scan
         run: govulncheck ./...
 
+      - name: Fuzz (crash detection)
+        run: |
+          go test -run='^$' -fuzz=FuzzComputeContentHash -fuzztime=10s ./internal/integrity/
+          go test -run='^$' -fuzz=FuzzBuildMerkleRoot    -fuzztime=10s ./internal/integrity/
+          go test -run='^$' -fuzz=FuzzValidateToken      -fuzztime=10s ./internal/auth/
+          go test -run='^$' -fuzz=FuzzValidateAgentID    -fuzztime=10s ./internal/model/
+          go test -run='^$' -fuzz=FuzzDecodeJSON         -fuzztime=10s ./internal/server/
+
       - name: Test
         run: go test -race -count=1 -coverprofile=coverage.out ./...
 

--- a/internal/auth/auth_fuzz_test.go
+++ b/internal/auth/auth_fuzz_test.go
@@ -1,0 +1,45 @@
+package auth_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ashita-ai/akashi/internal/auth"
+	"github.com/ashita-ai/akashi/internal/model"
+)
+
+func FuzzValidateToken(f *testing.F) {
+	// Create a manager to issue seed tokens and validate fuzzed ones.
+	mgr, err := auth.NewJWTManager("", "", 1*time.Hour)
+	if err != nil {
+		f.Fatalf("failed to create JWT manager: %v", err)
+	}
+
+	// Seed with a valid token.
+	agent := model.Agent{
+		AgentID: "test-agent",
+		Name:    "Test",
+		Role:    model.RoleAgent,
+	}
+	agent.ID = [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	validToken, _, err := mgr.IssueToken(agent)
+	if err != nil {
+		f.Fatalf("failed to issue seed token: %v", err)
+	}
+	f.Add(validToken)
+
+	// Seed with various malformed inputs.
+	f.Add("")
+	f.Add("not-a-jwt")
+	f.Add("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.invalid")
+	f.Add("eyJhbGciOiJFZERTQSJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.invalid")
+	f.Add("a]]]]].......")
+	f.Add("eyJhbGciOiJub25lIn0.eyJzdWIiOiIxMjM0NTY3ODkwIn0.") // alg=none attack
+	f.Add("eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiIxIn0.AAAA")        // wrong algorithm
+	f.Add("\x00\x01\x02\x03")                                 // binary garbage
+
+	f.Fuzz(func(t *testing.T, tokenStr string) {
+		// Must not panic. Errors are expected for fuzzed inputs.
+		_, _ = mgr.ValidateToken(tokenStr)
+	})
+}

--- a/internal/integrity/integrity_fuzz_test.go
+++ b/internal/integrity/integrity_fuzz_test.go
@@ -1,0 +1,172 @@
+package integrity
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func FuzzComputeContentHash(f *testing.F) {
+	// Seed with known-good inputs from existing unit tests.
+	f.Add(
+		"11111111-1111-1111-1111-111111111111",
+		"architecture",
+		"microservices",
+		float32(0.85),
+		"chose microservices for scalability",
+		true,              // hasReasoning
+		int64(1737020400), // 2026-01-16
+	)
+	f.Add(
+		"22222222-2222-2222-2222-222222222222",
+		"deploy",
+		"production",
+		float32(0.9),
+		"",
+		false, // nil reasoning
+		int64(1738368000),
+	)
+	// Edge: pipe characters in fields (v2 should handle this).
+	f.Add(
+		"66666666-6666-6666-6666-666666666666",
+		"type|extra",
+		"outcome",
+		float32(0.5),
+		"",
+		false,
+		int64(1748736000),
+	)
+	// Edge: zero confidence.
+	f.Add(
+		"33333333-3333-3333-3333-333333333333",
+		"trade_off",
+		"option_a",
+		float32(0.0),
+		"",
+		true,
+		int64(0),
+	)
+	// Edge: max confidence.
+	f.Add(
+		"44444444-4444-4444-4444-444444444444",
+		"security",
+		"deny",
+		float32(1.0),
+		"absolute certainty",
+		true,
+		int64(math.MaxInt32),
+	)
+	// Edge: unicode content.
+	f.Add(
+		"55555555-5555-5555-5555-555555555555",
+		"日本語",
+		"決定した",
+		float32(0.75),
+		"理由は明確です🎯",
+		true,
+		int64(1700000000),
+	)
+
+	f.Fuzz(func(t *testing.T, idStr, decisionType, outcome string, confidence float32, reasoning string, hasReasoning bool, unixSec int64) {
+		id, err := uuid.Parse(idStr)
+		if err != nil {
+			// Use a fixed UUID for invalid UUID strings so we still exercise
+			// the hashing logic with the fuzzed text fields.
+			id = uuid.MustParse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+		}
+
+		// Skip NaN/Inf — these are not valid confidence values and produce
+		// non-deterministic formatting.
+		if math.IsNaN(float64(confidence)) || math.IsInf(float64(confidence), 0) {
+			return
+		}
+
+		validFrom := time.Unix(unixSec, 0).UTC()
+
+		var rPtr *string
+		if hasReasoning {
+			rPtr = &reasoning
+		}
+
+		// Must not panic.
+		h1 := ComputeContentHash(id, decisionType, outcome, confidence, rPtr, validFrom)
+
+		// Determinism: same inputs → same hash.
+		h2 := ComputeContentHash(id, decisionType, outcome, confidence, rPtr, validFrom)
+		if h1 != h2 {
+			t.Fatalf("non-deterministic hash: %q != %q", h1, h2)
+		}
+
+		// Must have v2 prefix.
+		if len(h1) < 3 || h1[:3] != "v2:" {
+			t.Fatalf("missing v2: prefix in hash %q", h1)
+		}
+
+		// Total length: 3 (prefix) + 64 (hex SHA-256) = 67.
+		if len(h1) != 67 {
+			t.Fatalf("unexpected hash length %d, want 67", len(h1))
+		}
+
+		// Verify round-trips.
+		if !VerifyContentHash(h1, id, decisionType, outcome, confidence, rPtr, validFrom) {
+			t.Fatal("VerifyContentHash returned false for freshly computed hash")
+		}
+	})
+}
+
+func FuzzBuildMerkleRoot(f *testing.F) {
+	f.Add("hash_a\nhash_b\nhash_c\nhash_d")
+	f.Add("single_leaf")
+	f.Add("")
+	f.Add("a\nb\nc")
+	f.Add("x\nx") // duplicates
+
+	f.Fuzz(func(t *testing.T, joined string) {
+		var leaves []string
+		if joined != "" {
+			// Split on newlines to get variable-length leaf slices.
+			for _, part := range splitOnNewline(joined) {
+				if part != "" {
+					leaves = append(leaves, part)
+				}
+			}
+		}
+
+		// Must not panic.
+		root := BuildMerkleRoot(leaves)
+
+		if len(leaves) == 0 && root != "" {
+			t.Fatal("empty leaves should produce empty root")
+		}
+		if len(leaves) == 1 && root != leaves[0] {
+			t.Fatalf("single leaf should be the root, got %q want %q", root, leaves[0])
+		}
+		if len(leaves) > 1 {
+			if len(root) != 64 {
+				t.Fatalf("merkle root should be 64 hex chars, got %d", len(root))
+			}
+			// Determinism.
+			root2 := BuildMerkleRoot(leaves)
+			if root != root2 {
+				t.Fatalf("non-deterministic merkle root")
+			}
+		}
+	})
+}
+
+// splitOnNewline splits s on "\n". We avoid importing strings for this
+// internal test helper to keep the fuzz corpus self-contained.
+func splitOnNewline(s string) []string {
+	var parts []string
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\n' {
+			parts = append(parts, s[start:i])
+			start = i + 1
+		}
+	}
+	parts = append(parts, s[start:])
+	return parts
+}

--- a/internal/model/agent_fuzz_test.go
+++ b/internal/model/agent_fuzz_test.go
@@ -1,0 +1,79 @@
+package model_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ashita-ai/akashi/internal/model"
+)
+
+func FuzzValidateAgentID(f *testing.F) {
+	// Seed from existing unit tests.
+	f.Add("agent")
+	f.Add("test-agent")
+	f.Add("agent.v2")
+	f.Add("Agent_01")
+	f.Add("user@example")
+	f.Add("a")
+	f.Add(strings.Repeat("a", 255))
+
+	// Invalid seeds.
+	f.Add("")
+	f.Add(strings.Repeat("a", 256))
+	f.Add("has space")
+	f.Add("path/agent")
+	f.Add("agen\u00e9")
+	f.Add("agent\t1")
+	f.Add("agent\n1")
+	f.Add("agent:1")
+
+	// Injection / adversarial seeds.
+	f.Add("'; DROP TABLE agents;--")
+	f.Add("<script>alert(1)</script>")
+	f.Add("../../../etc/passwd")
+	f.Add("\x00null\x00byte")
+	f.Add(strings.Repeat("\xff", 300))
+
+	f.Fuzz(func(t *testing.T, id string) {
+		err := model.ValidateAgentID(id)
+
+		// Invariant 1: empty → error.
+		if len(id) == 0 && err == nil {
+			t.Fatal("empty agent_id should be rejected")
+		}
+
+		// Invariant 2: >255 bytes → error.
+		if len(id) > 255 && err == nil {
+			t.Fatal("agent_id over 255 characters should be rejected")
+		}
+
+		// Invariant 3: if accepted, every byte must be in the allowed set.
+		if err == nil {
+			for i := 0; i < len(id); i++ {
+				c := id[i]
+				if !isAllowedAgentIDChar(c) {
+					t.Fatalf("accepted agent_id contains invalid character %q at position %d", c, i)
+				}
+			}
+		}
+
+		// Invariant 4: if all characters are allowed and length is 1-255, it must be accepted.
+		if len(id) >= 1 && len(id) <= 255 && allAllowed(id) && err != nil {
+			t.Fatalf("agent_id %q should have been accepted but got: %v", id, err)
+		}
+	})
+}
+
+func isAllowedAgentIDChar(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') ||
+		c == '.' || c == '-' || c == '_' || c == '@'
+}
+
+func allAllowed(id string) bool {
+	for i := 0; i < len(id); i++ {
+		if !isAllowedAgentIDChar(id[i]) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/server/middleware_fuzz_test.go
+++ b/internal/server/middleware_fuzz_test.go
@@ -1,0 +1,65 @@
+package server
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// FuzzDecodeJSON exercises JSON decoding with arbitrary payloads.
+// This covers malformed JSON, oversized bodies, type mismatches, and
+// unexpected field shapes without requiring a live server.
+func FuzzDecodeJSON(f *testing.F) {
+	// Seed with valid JSON matching a common request shape.
+	f.Add([]byte(`{"decision_type":"architecture","outcome":"microservices","confidence":0.85}`), int64(1048576))
+	f.Add([]byte(`{}`), int64(1048576))
+	f.Add([]byte(`{"nested":{"a":1}}`), int64(1048576))
+
+	// Malformed JSON.
+	f.Add([]byte(`{`), int64(1048576))
+	f.Add([]byte(`{"key": `), int64(1048576))
+	f.Add([]byte(``), int64(1048576))
+	f.Add([]byte(`null`), int64(1048576))
+	f.Add([]byte(`[1,2,3]`), int64(1048576))
+
+	// Oversized body (small limit).
+	f.Add([]byte(`{"decision_type":"architecture","outcome":"microservices"}`), int64(10))
+
+	// Type mismatches.
+	f.Add([]byte(`{"confidence":"not_a_number"}`), int64(1048576))
+	f.Add([]byte(`{"confidence":999999999999999999999999}`), int64(1048576))
+
+	// Binary garbage.
+	f.Add([]byte{0x00, 0x01, 0xFF, 0xFE}, int64(1048576))
+
+	// Deeply nested.
+	f.Add([]byte(`{"a":{"b":{"c":{"d":{"e":"deep"}}}}}`), int64(1048576))
+
+	type traceRequest struct {
+		DecisionType string   `json:"decision_type"`
+		Outcome      string   `json:"outcome"`
+		Confidence   *float64 `json:"confidence"`
+		Reasoning    *string  `json:"reasoning"`
+	}
+
+	f.Fuzz(func(t *testing.T, body []byte, maxBytes int64) {
+		// Clamp maxBytes to reasonable range.
+		if maxBytes < 1 {
+			maxBytes = 1
+		}
+		if maxBytes > 16<<20 {
+			maxBytes = 16 << 20
+		}
+
+		w := httptest.NewRecorder()
+		r := &http.Request{
+			Body: io.NopCloser(bytes.NewReader(body)),
+		}
+
+		var target traceRequest
+		// Must not panic. Errors are expected for fuzzed inputs.
+		_ = decodeJSON(w, r, &target, maxBytes)
+	})
+}


### PR DESCRIPTION
## Summary

- Adds Go native fuzz tests (`testing.F`) for 5 critical input parsing paths identified in issue #177
- **integrity.ComputeContentHash** — boundary values, unicode, nil reasoning, determinism + round-trip invariants
- **integrity.BuildMerkleRoot** — variable leaf counts, empty/single/odd cases
- **auth.ValidateToken** — malformed tokens, wrong algorithms, `alg=none` attack, binary garbage
- **model.ValidateAgentID** — injection characters, length boundaries, null bytes, adversarial payloads
- **server.decodeJSON** — malformed JSON, oversized bodies, type mismatches, binary garbage
- Adds CI step running each fuzzer for 10s per PR (crash detection mode)

Covers 4 of 5 priority targets (all except WAL binary format, which requires filesystem setup). Adds `decodeJSON` as the 4th target instead, which is explicitly listed in the issue.

## Test plan

- [x] All 5 fuzz tests pass locally with `-fuzztime=5s` (no crashes)
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` clean
- [x] `go test -race -count=1` passes for all affected packages
- [x] `atlas migrate validate` passes
- [ ] CI fuzz step runs successfully on PR

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)