### PR TITLE
fix: QdrantRank gap, early-exit floor disable, config validation

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -307,6 +307,13 @@ func (c Config) Validate() error {
 			errs = append(errs, errors.New("config: AKASHI_RATE_LIMIT_BURST must be positive when rate limiting is enabled"))
 		}
 	}
+	// Early-exit floor must not exceed the significance threshold, otherwise
+	// the early exit prunes candidates that would pass the threshold check.
+	if c.ConflictEarlyExitFloor > 0 && c.ConflictEarlyExitFloor > c.ConflictSignificanceThreshold {
+		errs = append(errs, fmt.Errorf("config: AKASHI_CONFLICT_EARLY_EXIT_FLOOR (%.2f) must not exceed AKASHI_CONFLICT_SIGNIFICANCE_THRESHOLD (%.2f)",
+			c.ConflictEarlyExitFloor, c.ConflictSignificanceThreshold))
+	}
+
 	// JWT keys must be both set or both empty (ephemeral mode). Mismatched config
 	// would cause token validation to fail for all clients.
 	privSet := c.JWTPrivateKeyPath != ""

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -344,6 +344,33 @@ func TestLoad_ConflictScoringThresholdInvalid(t *testing.T) {
 	}
 }
 
+func TestLoad_EarlyExitFloorExceedsThreshold(t *testing.T) {
+	t.Setenv("AKASHI_CONFLICT_EARLY_EXIT_FLOOR", "0.50")
+	t.Setenv("AKASHI_CONFLICT_SIGNIFICANCE_THRESHOLD", "0.30")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected Load() to fail when early exit floor exceeds significance threshold")
+	}
+	got := err.Error()
+	if !contains(got, "AKASHI_CONFLICT_EARLY_EXIT_FLOOR") {
+		t.Fatalf("error should mention AKASHI_CONFLICT_EARLY_EXIT_FLOOR, got: %s", got)
+	}
+	if !contains(got, "AKASHI_CONFLICT_SIGNIFICANCE_THRESHOLD") {
+		t.Fatalf("error should mention AKASHI_CONFLICT_SIGNIFICANCE_THRESHOLD, got: %s", got)
+	}
+}
+
+func TestLoad_EarlyExitFloorEqualsThreshold(t *testing.T) {
+	t.Setenv("AKASHI_CONFLICT_EARLY_EXIT_FLOOR", "0.30")
+	t.Setenv("AKASHI_CONFLICT_SIGNIFICANCE_THRESHOLD", "0.30")
+
+	_, err := Load()
+	if err != nil {
+		t.Fatalf("expected Load() to succeed when floor equals threshold, got: %v", err)
+	}
+}
+
 func TestLoad_AllEnvVarsHonored(t *testing.T) {
 	t.Setenv("AKASHI_PORT", "9090")
 	t.Setenv("DATABASE_URL", "postgres://test:test@db:5432/testdb")

--- a/internal/conflicts/scorer.go
+++ b/internal/conflicts/scorer.go
@@ -143,9 +143,9 @@ func (s *Scorer) WithPairwiseScorer(ps PairwiseScorer) *Scorer {
 // exit optimisation. Candidates are sorted by significance descending; once a
 // candidate drops below this floor (and does not qualify for the
 // directToScorer bypass), the remaining candidates are skipped. Set to 0 to
-// disable early exit. Default: 0.25.
+// disable early exit. Negative values are ignored. Default: 0.25.
 func (s *Scorer) WithEarlyExitFloor(floor float64) *Scorer {
-	if floor > 0 {
+	if floor >= 0 {
 		s.earlyExitFloor = floor
 	}
 	return s

--- a/internal/conflicts/scorer_test.go
+++ b/internal/conflicts/scorer_test.go
@@ -1028,10 +1028,10 @@ func TestWithEarlyExitFloor(t *testing.T) {
 	assert.Equal(t, 0.5, scorer.earlyExitFloor, "should accept 0.5")
 
 	scorer = scorer.WithEarlyExitFloor(0)
-	assert.Equal(t, 0.5, scorer.earlyExitFloor, "0 should be ignored (preserves previous)")
+	assert.Equal(t, 0.0, scorer.earlyExitFloor, "0 should disable early exit")
 
 	scorer = scorer.WithEarlyExitFloor(-0.1)
-	assert.Equal(t, 0.5, scorer.earlyExitFloor, "negative should be ignored")
+	assert.Equal(t, 0.0, scorer.earlyExitFloor, "negative should be ignored")
 }
 
 func TestWithCandidateLimit(t *testing.T) {

--- a/internal/search/qdrant.go
+++ b/internal/search/qdrant.go
@@ -207,7 +207,6 @@ func (q *QdrantIndex) FindSimilar(ctx context.Context, orgID uuid.UUID, embeddin
 	}
 
 	results := make([]Result, 0, len(scored))
-	qdrantPos := 0
 	for _, sp := range scored {
 		idStr := sp.Id.GetUuid()
 		if idStr == "" {
@@ -218,12 +217,10 @@ func (q *QdrantIndex) FindSimilar(ctx context.Context, orgID uuid.UUID, embeddin
 			q.logger.Warn("qdrant: invalid UUID in point ID", "id", idStr)
 			continue
 		}
-		rank := qdrantPos
-		qdrantPos++
 		if decisionID == excludeID {
 			continue // Strip the source decision from its own neighbor list.
 		}
-		results = append(results, Result{DecisionID: decisionID, Score: sp.Score, QdrantRank: rank})
+		results = append(results, Result{DecisionID: decisionID, Score: sp.Score, QdrantRank: len(results)})
 		if len(results) == limit {
 			break
 		}


### PR DESCRIPTION
## Summary

- Fixed QdrantRank gap when excluded items (invalid UUIDs or self-references) were filtered from results. Rank now reflects position in output list, not Qdrant's original list, eliminating gaps.
- Changed `WithEarlyExitFloor(0)` to disable early exit (was previously a no-op). Aligns setter behavior with documented "Set to 0 to disable early exit".
- Added config validation: early-exit floor must not exceed significance threshold, otherwise early exit would prune candidates that should pass the threshold check.

## Verification

- [x] I ran relevant tests locally (`go test ./...` or targeted package tests).
- [ ] I updated docs/openapi for any API or behavior changes.
- [ ] If I changed config vars in `internal/config/config.go`, I also updated:
  - [ ] `docs/configuration.md`
  - [ ] `docs/runbook.md` (operational subset, if relevant)
  - [ ] `.env.example` (if baseline local/dev defaults changed)
  - [ ] `docs/consistency-manifest.json` (only if policy/coverage rules changed)
- [ ] `python3 scripts/check_doc_config_consistency.py` passes.

## Risk / Rollout Notes

- **QdrantRank change**: 0-based rank now reflects filtered output position. Internal tie-breaking logic unaffected (relative order preserved). API consumers expecting Qdrant's original ANN position may see different rank values if results were filtered.
- **Config validation**: Default values (floor=0.25, threshold=0.30) pass validation. Misconfigured deployments with floor > threshold will now fail on startup with clear error message.