### PR TITLE
reposition: "version control for AI decisions" replaces "git blame"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # ashita-ai/akashi
 
-Decision trace layer for multi-agent AI systems ("git blame for AI decisions").
+Decision coordination layer for multi-agent AI systems ("version control for AI decisions").
 
 ## Tech stack
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 [![Go](https://img.shields.io/badge/Go-1.25-00ADD8.svg)](https://go.dev/)
 [![PostgreSQL](https://img.shields.io/badge/PostgreSQL-18-336791.svg)](https://www.postgresql.org/)
 
-**Git blame for AI decisions.**
+**Version control for AI decisions.**
 
-Multi-agent AI systems are moving from demos to production, but their decisions are invisible. When something goes wrong, nobody can answer: *who decided what, when, why, and what alternatives were considered?*
+Multi-agent AI systems are moving from demos to production, but their decisions are invisible and uncoordinated. Agents contradict each other, relitigate settled work, and have no shared memory of what's already been decided. When something goes wrong, nobody can answer: *who decided what, when, why, and what alternatives were considered?*
 
-Akashi is the decision audit trail. Every agent decision gets recorded with its full reasoning chain, the alternatives that were weighed, the evidence that informed it, and the confidence level. When the CTO asks "why did the AI do that?" or an auditor asks for proof of decision traceability, you have the answer.
+Akashi is the decision coordination layer. Every agent checks for precedents before deciding and records its full reasoning after. When agents diverge on the same topic, Akashi detects it semantically — and when the CTO asks "why did the AI do that?" or an auditor asks for proof of decision traceability, you have the answer.
 
 ## How it works
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2,12 +2,12 @@ openapi: "3.1.0"
 info:
   title: Akashi API
   description: |
-    Decision trace layer for multi-agent AI systems.
-
-    Akashi records, queries, and audits every decision made by AI agents —
-    providing "git blame for AI decisions." It captures the full decision
-    lifecycle: what was decided, why, what alternatives were considered,
-    and what evidence was used.
+    Version control for AI decisions. Akashi is the decision coordination
+    layer for multi-agent AI systems — recording, querying, and auditing
+    every agent decision. Check before deciding to surface precedents and
+    active conflicts. Trace after deciding to record reasoning, alternatives,
+    and confidence. Captures the full decision lifecycle: outcome, reasoning,
+    alternatives considered, evidence, and confidence level.
 
     ## Authentication
 

--- a/internal/mcp/prompts.go
+++ b/internal/mcp/prompts.go
@@ -8,10 +8,10 @@ import (
 )
 
 func (s *Server) registerPrompts() {
-	// before-decision — guides the agent through checking the black box for precedents first.
+	// before-decision — guides the agent through checking the audit trail for precedents first.
 	s.mcpServer.AddPrompt(
 		mcplib.NewPrompt("before-decision",
-			mcplib.WithPromptDescription("Check the black box for precedents before making a decision"),
+			mcplib.WithPromptDescription("Check the decision audit trail for precedents before making a decision"),
 			mcplib.WithArgument("decision_type",
 				mcplib.ArgumentDescription("The type of decision you're about to make (e.g., model_selection, architecture, data_source)"),
 				mcplib.RequiredArgument(),
@@ -20,10 +20,10 @@ func (s *Server) registerPrompts() {
 		s.handleBeforeDecisionPrompt,
 	)
 
-	// after-decision — reminds the agent to record the decision to the black box.
+	// after-decision — reminds the agent to record the decision to the audit trail.
 	s.mcpServer.AddPrompt(
 		mcplib.NewPrompt("after-decision",
-			mcplib.WithPromptDescription("Record a decision to the black box after making it"),
+			mcplib.WithPromptDescription("Record a decision to the audit trail after making it"),
 			mcplib.WithArgument("decision_type",
 				mcplib.ArgumentDescription("The type of decision that was made"),
 				mcplib.RequiredArgument(),
@@ -99,7 +99,7 @@ func (s *Server) handleAfterDecisionPrompt(ctx context.Context, request mcplib.G
 				Role: mcplib.RoleUser,
 				Content: mcplib.TextContent{
 					Type: "text",
-					Text: fmt.Sprintf(`You just made a decision. Record it to the black box now so there is proof of why, and other agents can learn from it.
+					Text: fmt.Sprintf(`You just made a decision. Record it to the audit trail now — there is proof of why, and other agents can learn from it.
 
 CALL akashi_trace with:
 - decision_type: "%s"
@@ -131,7 +131,7 @@ func (s *Server) handleAgentSetupPrompt(ctx context.Context, request mcplib.GetP
 				Role: mcplib.RoleUser,
 				Content: mcplib.TextContent{
 					Type: "text",
-					Text: `You have access to Akashi, a black box recorder for AI decisions. It captures
+					Text: `You have access to Akashi, the decision coordination layer for multi-agent AI. It captures
 why every decision was made -- what was chosen, what was rejected, and what
 evidence supported it -- so there is always proof when someone asks "why?"
 
@@ -141,7 +141,7 @@ Every non-trivial decision should follow this workflow:
 
 ### Before deciding:
 Call akashi_check with the decision_type you're about to make.
-This checks the black box for existing precedents and any conflicts.
+This checks the audit trail for existing precedents and any conflicts.
 Use this information to make a more informed decision and avoid
 contradicting prior work.
 
@@ -152,8 +152,8 @@ can learn from it, and so the decision is provable later.
 
 ## Available Tools
 
-- akashi_check: Check the black box for precedents before deciding (use FIRST; pass query for semantic search)
-- akashi_trace: Record a decision to the black box (use AFTER deciding)
+- akashi_check: Check the audit trail for precedents before deciding (use FIRST; pass query for semantic search)
+- akashi_trace: Record a decision to the audit trail (use AFTER deciding)
 - akashi_query: Query the audit trail — structured filters or natural-language query for semantic search
 - akashi_conflicts: List open conflicts between agents
 - akashi_assess: Record whether a past decision turned out to be correct

--- a/internal/model/event.go
+++ b/internal/model/event.go
@@ -36,7 +36,7 @@ const (
 )
 
 // AgentEvent is an append-only event in the event log.
-// Source of truth for the black box recorder. Never mutated or deleted.
+// Source of truth for the decision audit record. Never mutated or deleted.
 type AgentEvent struct {
 	ID          uuid.UUID      `json:"id"`
 	RunID       uuid.UUID      `json:"run_id"`

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -1,6 +1,6 @@
 # Akashi Go SDK
 
-Go client for the [Akashi](../../README.md) decision audit API -- the black box recorder for AI decisions. Uses `net/http` with no dependencies beyond `github.com/google/uuid`.
+Go client for the [Akashi](../../README.md) decision audit API -- version control for AI decisions. Uses `net/http` with no dependencies beyond `github.com/google/uuid`.
 
 ## Install
 

--- a/sdk/integrations/crewai/README.md
+++ b/sdk/integrations/crewai/README.md
@@ -1,6 +1,6 @@
 # akashi-crewai
 
-CrewAI integration that traces task decisions to [Akashi](../../../README.md) -- the black box recorder for AI decisions.
+CrewAI integration that traces task decisions to [Akashi](../../../README.md) -- version control for AI decisions.
 
 All tracing is **fire-and-forget**: Akashi errors are logged at `DEBUG` level and never interrupt your crew execution.
 

--- a/sdk/integrations/langchain/README.md
+++ b/sdk/integrations/langchain/README.md
@@ -1,6 +1,6 @@
 # akashi-langchain
 
-LangChain callback handler that traces agent decisions to [Akashi](../../../README.md) -- the black box recorder for AI decisions.
+LangChain callback handler that traces agent decisions to [Akashi](../../../README.md) -- version control for AI decisions.
 
 Hooks into the LangChain agent lifecycle to automatically call `check()` before each tool use and `trace()` after each tool call and final answer, with zero changes to your agent or chain code.
 

--- a/sdk/integrations/vercel-ai/README.md
+++ b/sdk/integrations/vercel-ai/README.md
@@ -1,6 +1,6 @@
 # akashi-vercel-ai
 
-Vercel AI SDK middleware that traces LLM calls to [Akashi](../../../README.md) -- the black box recorder for AI decisions.
+Vercel AI SDK middleware that traces LLM calls to [Akashi](../../../README.md) -- version control for AI decisions.
 
 Wraps any `LanguageModelV1`-compatible model so that every `generateText`, `generateObject`, `streamText`, and `streamObject` call automatically:
 1. Calls `check()` before generation to surface relevant precedents.

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1,6 +1,6 @@
 # Akashi Python SDK
 
-Python client for the [Akashi](../../README.md) decision audit API -- the black box recorder for AI decisions. Provides both async and sync clients, with middleware for the check-before/record-after pattern.
+Python client for the [Akashi](../../README.md) decision audit API -- version control for AI decisions. Provides both async and sync clients, with middleware for the check-before/record-after pattern.
 
 **Requirements:** Python 3.10+, httpx, pydantic v2
 

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -1,6 +1,6 @@
 # Akashi TypeScript SDK
 
-TypeScript client for the [Akashi](../../README.md) decision audit API -- the black box recorder for AI decisions. Uses native `fetch` with zero runtime dependencies.
+TypeScript client for the [Akashi](../../README.md) decision audit API -- version control for AI decisions. Uses native `fetch` with zero runtime dependencies.
 
 **Requirements:** Node.js 18+ or any runtime with global `fetch` (Deno, Bun, Cloudflare Workers)
 


### PR DESCRIPTION
## Summary

- Replaces "git blame for AI decisions" with "version control for AI decisions" across all OSS-facing copy
- Updates README.md, OpenAPI description, MCP prompts, SDK READMEs (Go/Python/TypeScript), integration READMEs (LangChain/CrewAI/Vercel AI), and CLAUDE.md
- Removes all remaining "black box recorder" language from MCP prompts (replaced with "audit trail" / "decision coordination layer")

## Rationale

Five-expert adversarial debate (Christensen, Porter, Godin, Taleb, Meadows) across six resolution questions reached consensus:

- **"git blame"** frames Akashi as retrospective/forensic only — correct for J3 (audit) but actively misrepresents J1 (prevent incoherence via `akashi_check`) and J2 (institutional memory)
- **"version control"** extends the git mental model developers already trust, covers all three jobs, and targets the uncontested coordination-infrastructure category rather than the crowded AI-observability arena
- **"black box recorder"** (aviation metaphor) was eliminated: "black box" in AI/ML means unexplainable/opaque AI — the exact problem Akashi solves. Semantic collision is a disqualifier.
- **"coordination infrastructure"** retained as the enterprise/B2B frame; "version control" leads for developer-facing copy

## Files changed

| File | Change |
|------|--------|
| `README.md` | Tagline + opening paragraph rewritten to foreground `akashi_check` |
| `api/openapi.yaml` | API description updated |
| `internal/mcp/prompts.go` | 9 replacements: "black box" → "audit trail"/"coordination layer" |
| `sdk/go/README.md` | Subtitle updated |
| `sdk/python/README.md` | Subtitle updated |
| `sdk/typescript/README.md` | Subtitle updated |
| `sdk/integrations/langchain/README.md` | Subtitle updated |
| `sdk/integrations/crewai/README.md` | Subtitle updated |
| `sdk/integrations/vercel-ai/README.md` | Subtitle updated |
| `internal/model/event.go` | Comment updated |
| `CLAUDE.md` | Project description updated |

## Test plan

- [ ] `go build ./...` passes ✅
- [ ] `go vet ./...` passes ✅
- [ ] No functional code changed — pure documentation/copy update
- [ ] Verify MCP prompts still read naturally (no broken references)

🤖 Generated with [Claude Code](https://claude.com/claude-code)