### PR TITLE
feat(conflicts): resolution cascade on conflict resolution

### DIFF
--- a/internal/server/handlers_conflicts.go
+++ b/internal/server/handlers_conflicts.go
@@ -98,6 +98,12 @@ func (h *Handlers) HandleListConflictGroups(w http.ResponseWriter, r *http.Reque
 	writeListJSON(w, r, groups, &total, hasMore, limit, offset)
 }
 
+// cascadeSimilarityThreshold is the minimum cosine similarity between a
+// winning decision's outcome_embedding and a candidate conflict's side for
+// the cascade to auto-resolve that conflict. 0.80 is conservative enough to
+// avoid false matches while catching genuine variants of the same disagreement.
+const cascadeSimilarityThreshold = 0.80
+
 // validConflictStatuses defines the allowed values for conflict status transitions.
 var validConflictStatuses = map[string]bool{
 	"acknowledged": true,
@@ -179,6 +185,33 @@ func (h *Handlers) HandlePatchConflict(w http.ResponseWriter, r *http.Request) {
 
 	if h.resolutionRecorder != nil {
 		h.resolutionRecorder.RecordResolution(r.Context(), req.Status, string(conflict.ConflictKind), 1)
+	}
+
+	// Resolution cascade: when a conflict is resolved with a winner and belongs
+	// to a group, auto-resolve other open conflicts in the same group whose
+	// outcome embeddings align with the winning decision.
+	if req.Status == "resolved" && req.WinningDecisionID != nil && conflict.GroupID != nil {
+		cascadeAudit := h.buildAuditEntry(r, orgID,
+			"conflict_cascade_resolved", "conflict", id.String(),
+			nil, nil,
+			map[string]any{"trigger_conflict_id": id.String(), "winning_decision_id": req.WinningDecisionID.String()},
+		)
+		cascaded, cascadeErr := h.db.CascadeResolveByOutcome(
+			r.Context(), orgID, *conflict.GroupID, *req.WinningDecisionID, id,
+			cascadeSimilarityThreshold, cascadeAudit,
+		)
+		if cascadeErr != nil {
+			h.logger.Warn("resolution cascade failed", "conflict_id", id, "error", cascadeErr)
+		} else if cascaded > 0 {
+			h.logger.Info("resolution cascade resolved conflicts",
+				"trigger_conflict_id", id,
+				"group_id", conflict.GroupID,
+				"cascade_resolved", cascaded,
+			)
+			if h.resolutionRecorder != nil {
+				h.resolutionRecorder.RecordResolution(r.Context(), "resolved", string(conflict.ConflictKind), cascaded)
+			}
+		}
 	}
 
 	writeJSON(w, r, http.StatusOK, conflict)
@@ -355,6 +388,31 @@ func (h *Handlers) HandleAdjudicateConflict(w http.ResponseWriter, r *http.Reque
 
 	if h.resolutionRecorder != nil {
 		h.resolutionRecorder.RecordResolution(r.Context(), "resolved", string(conflict.ConflictKind), 1)
+	}
+
+	// Resolution cascade: auto-resolve related conflicts in the same group.
+	if req.WinningDecisionID != nil && conflict.GroupID != nil {
+		cascadeAudit := h.buildAuditEntry(r, orgID,
+			"conflict_cascade_resolved", "conflict", id.String(),
+			nil, nil,
+			map[string]any{"trigger_conflict_id": id.String(), "winning_decision_id": req.WinningDecisionID.String()},
+		)
+		cascaded, cascadeErr := h.db.CascadeResolveByOutcome(
+			r.Context(), orgID, *conflict.GroupID, *req.WinningDecisionID, id,
+			cascadeSimilarityThreshold, cascadeAudit,
+		)
+		if cascadeErr != nil {
+			h.logger.Warn("adjudication cascade failed", "conflict_id", id, "error", cascadeErr)
+		} else if cascaded > 0 {
+			h.logger.Info("adjudication cascade resolved conflicts",
+				"trigger_conflict_id", id,
+				"group_id", conflict.GroupID,
+				"cascade_resolved", cascaded,
+			)
+			if h.resolutionRecorder != nil {
+				h.resolutionRecorder.RecordResolution(r.Context(), "resolved", string(conflict.ConflictKind), cascaded)
+			}
+		}
 	}
 
 	// Return the updated conflict.

--- a/internal/storage/conflicts.go
+++ b/internal/storage/conflicts.go
@@ -893,6 +893,113 @@ func AutoResolveSupersededConflictsTx(ctx context.Context, tx pgx.Tx, orgID, sup
 	return int(tag.RowsAffected()), nil
 }
 
+// CascadeResolveByOutcome auto-resolves open conflicts in the same conflict
+// group when their outcome embeddings align with the winning decision's outcome.
+// For each candidate conflict, cosine similarity is computed between the
+// winning decision's outcome_embedding and each side's outcome_embedding.
+// If one side exceeds the threshold (typically 0.80), that conflict is resolved
+// with the aligned side as winner.
+//
+// The triggering conflict (triggerID) is excluded from the cascade.
+// Returns the number of conflicts auto-resolved.
+func (db *DB) CascadeResolveByOutcome(
+	ctx context.Context,
+	orgID, groupID, winningDecisionID, triggerID uuid.UUID,
+	threshold float64,
+	audit MutationAuditEntry,
+) (int, error) {
+	tx, err := db.pool.Begin(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("storage: begin cascade resolve tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	note := fmt.Sprintf(
+		"Auto-resolved via cascade from conflict %s. Aligned with winning decision %s (threshold %.2f).",
+		triggerID, winningDecisionID, threshold,
+	)
+
+	// Use pgvector's cosine distance operator (<=>). Cosine similarity = 1 - distance.
+	// For each open conflict in the group, compare both sides' outcome_embeddings
+	// against the winner. If exactly one side exceeds the threshold, resolve with
+	// that side as winner. If both exceed, pick the more aligned side.
+	tag, err := tx.Exec(ctx, `
+		WITH winning AS (
+			SELECT outcome_embedding
+			FROM decisions
+			WHERE id = $1 AND org_id = $2
+		),
+		candidates AS (
+			SELECT
+				sc.id,
+				sc.decision_a_id,
+				sc.decision_b_id,
+				CASE
+					WHEN da.outcome_embedding IS NOT NULL AND w.outcome_embedding IS NOT NULL
+					THEN 1.0 - (da.outcome_embedding <=> w.outcome_embedding)
+					ELSE 0.0
+				END AS sim_a,
+				CASE
+					WHEN db.outcome_embedding IS NOT NULL AND w.outcome_embedding IS NOT NULL
+					THEN 1.0 - (db.outcome_embedding <=> w.outcome_embedding)
+					ELSE 0.0
+				END AS sim_b
+			FROM scored_conflicts sc
+			JOIN decisions da ON da.id = sc.decision_a_id AND da.org_id = $2
+			JOIN decisions db ON db.id = sc.decision_b_id AND db.org_id = $2
+			CROSS JOIN winning w
+			WHERE sc.group_id = $3
+			  AND sc.org_id = $2
+			  AND sc.id != $4
+			  AND sc.status IN ('open', 'acknowledged')
+		)
+		UPDATE scored_conflicts sc
+		SET status = 'resolved',
+		    resolved_by = 'cascade',
+		    resolved_at = now(),
+		    resolution_note = $5,
+		    winning_decision_id = CASE
+		        WHEN c.sim_a >= c.sim_b THEN c.decision_a_id
+		        ELSE c.decision_b_id
+		    END
+		FROM candidates c
+		WHERE sc.id = c.id
+		  AND (c.sim_a >= $6 OR c.sim_b >= $6)`,
+		winningDecisionID, orgID, groupID, triggerID, note, threshold,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("storage: cascade resolve by outcome: %w", err)
+	}
+
+	affected := int(tag.RowsAffected())
+	if affected == 0 {
+		// Nothing cascaded — skip audit entry and commit.
+		if err := tx.Commit(ctx); err != nil {
+			return 0, fmt.Errorf("storage: commit cascade resolve tx: %w", err)
+		}
+		return 0, nil
+	}
+
+	audit.BeforeData = map[string]any{
+		"trigger_conflict_id":  triggerID.String(),
+		"winning_decision_id":  winningDecisionID.String(),
+		"group_id":             groupID.String(),
+		"similarity_threshold": threshold,
+	}
+	audit.AfterData = map[string]any{
+		"cascade_resolved": affected,
+		"resolved_by":      "cascade",
+	}
+	if err := InsertMutationAuditTx(ctx, tx, audit); err != nil {
+		return 0, fmt.Errorf("storage: audit in cascade resolve tx: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return 0, fmt.Errorf("storage: commit cascade resolve tx: %w", err)
+	}
+	return affected, nil
+}
+
 // AgentWinRate holds an agent's historical resolution win rate for a decision type.
 type AgentWinRate struct {
 	AgentID  string

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -5687,6 +5687,265 @@ func TestResolveConflictGroup_NotFound(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Tests: CascadeResolveByOutcome
+// ---------------------------------------------------------------------------
+
+func TestCascadeResolveByOutcome(t *testing.T) {
+	ctx := context.Background()
+	suffix := uuid.New().String()[:8]
+
+	agentA := "cascade-a-" + suffix
+	agentB := "cascade-b-" + suffix
+	decisionType := "cascade_type_" + suffix
+
+	runA, err := testDB.CreateRun(ctx, model.CreateRunRequest{AgentID: agentA})
+	require.NoError(t, err)
+	runB, err := testDB.CreateRun(ctx, model.CreateRunRequest{AgentID: agentB})
+	require.NoError(t, err)
+
+	// Create a "winning" embedding direction and an opposing direction.
+	// 1024-dim vectors: winning points in +x, loser points in -x.
+	winEmb := make([]float32, 1024)
+	winEmb[0] = 1.0
+	loseEmb := make([]float32, 1024)
+	loseEmb[0] = -1.0
+	// An aligned embedding (slight perturbation of winner).
+	alignedEmb := make([]float32, 1024)
+	alignedEmb[0] = 0.95
+	alignedEmb[1] = 0.05
+	// An unrelated embedding (orthogonal).
+	unrelatedEmb := make([]float32, 1024)
+	unrelatedEmb[2] = 1.0
+
+	// Decision A1 (winner) — outcome aligns with winEmb.
+	dA1, err := testDB.CreateDecision(ctx, model.Decision{
+		RunID: runA.ID, AgentID: agentA,
+		DecisionType:     decisionType,
+		Outcome:          "use Redis for caching",
+		Confidence:       0.9,
+		Metadata:         map[string]any{},
+		OutcomeEmbedding: ptrVec(winEmb),
+	})
+	require.NoError(t, err)
+
+	// Decision B1 (loser) — outcome opposes winner.
+	dB1, err := testDB.CreateDecision(ctx, model.Decision{
+		RunID: runB.ID, AgentID: agentB,
+		DecisionType:     decisionType,
+		Outcome:          "use Memcached for caching",
+		Confidence:       0.8,
+		Metadata:         map[string]any{},
+		OutcomeEmbedding: ptrVec(loseEmb),
+	})
+	require.NoError(t, err)
+
+	// Decision A2 (aligned with winner).
+	dA2, err := testDB.CreateDecision(ctx, model.Decision{
+		RunID: runA.ID, AgentID: agentA,
+		DecisionType:     decisionType,
+		Outcome:          "Redis cluster for sessions",
+		Confidence:       0.85,
+		Metadata:         map[string]any{},
+		OutcomeEmbedding: ptrVec(alignedEmb),
+	})
+	require.NoError(t, err)
+
+	// Decision B2 (opposes winner).
+	dB2, err := testDB.CreateDecision(ctx, model.Decision{
+		RunID: runB.ID, AgentID: agentB,
+		DecisionType:     decisionType,
+		Outcome:          "Memcached with mcrouter",
+		Confidence:       0.75,
+		Metadata:         map[string]any{},
+		OutcomeEmbedding: ptrVec(loseEmb),
+	})
+	require.NoError(t, err)
+
+	// Decision A3 and B3: unrelated topic (orthogonal embeddings).
+	dA3, err := testDB.CreateDecision(ctx, model.Decision{
+		RunID: runA.ID, AgentID: agentA,
+		DecisionType:     decisionType,
+		Outcome:          "unrelated topic A",
+		Confidence:       0.7,
+		Metadata:         map[string]any{},
+		OutcomeEmbedding: ptrVec(unrelatedEmb),
+	})
+	require.NoError(t, err)
+
+	dB3, err := testDB.CreateDecision(ctx, model.Decision{
+		RunID: runB.ID, AgentID: agentB,
+		DecisionType:     decisionType,
+		Outcome:          "unrelated topic B",
+		Confidence:       0.7,
+		Metadata:         map[string]any{},
+		OutcomeEmbedding: ptrVec(unrelatedEmb),
+	})
+	require.NoError(t, err)
+
+	// Insert 3 conflicts in the same group (same agents, same decision_type).
+	topicSim := 0.90
+	outcomeDiv := 0.80
+	sig := topicSim * outcomeDiv
+
+	conflict1ID, err := testDB.InsertScoredConflict(ctx, model.DecisionConflict{
+		ConflictKind: model.ConflictKindCrossAgent, OrgID: uuid.Nil,
+		DecisionAID: dA1.ID, DecisionBID: dB1.ID,
+		AgentA: agentA, AgentB: agentB,
+		DecisionTypeA: decisionType, DecisionTypeB: decisionType,
+		OutcomeA: "use Redis", OutcomeB: "use Memcached",
+		TopicSimilarity: &topicSim, OutcomeDivergence: &outcomeDiv, Significance: &sig,
+		ScoringMethod: "text",
+	})
+	require.NoError(t, err)
+
+	conflict2ID, err := testDB.InsertScoredConflict(ctx, model.DecisionConflict{
+		ConflictKind: model.ConflictKindCrossAgent, OrgID: uuid.Nil,
+		DecisionAID: dA2.ID, DecisionBID: dB2.ID,
+		AgentA: agentA, AgentB: agentB,
+		DecisionTypeA: decisionType, DecisionTypeB: decisionType,
+		OutcomeA: "Redis cluster", OutcomeB: "Memcached mcrouter",
+		TopicSimilarity: &topicSim, OutcomeDivergence: &outcomeDiv, Significance: &sig,
+		ScoringMethod: "text",
+	})
+	require.NoError(t, err)
+
+	conflict3ID, err := testDB.InsertScoredConflict(ctx, model.DecisionConflict{
+		ConflictKind: model.ConflictKindCrossAgent, OrgID: uuid.Nil,
+		DecisionAID: dA3.ID, DecisionBID: dB3.ID,
+		AgentA: agentA, AgentB: agentB,
+		DecisionTypeA: decisionType, DecisionTypeB: decisionType,
+		OutcomeA: "unrelated A", OutcomeB: "unrelated B",
+		TopicSimilarity: &topicSim, OutcomeDivergence: &outcomeDiv, Significance: &sig,
+		ScoringMethod: "text",
+	})
+	require.NoError(t, err)
+
+	// Verify all 3 conflicts share a group.
+	c1, err := testDB.GetConflict(ctx, conflict1ID, uuid.Nil)
+	require.NoError(t, err)
+	require.NotNil(t, c1.GroupID)
+	groupID := *c1.GroupID
+
+	c2, err := testDB.GetConflict(ctx, conflict2ID, uuid.Nil)
+	require.NoError(t, err)
+	require.NotNil(t, c2.GroupID)
+	assert.Equal(t, groupID, *c2.GroupID, "all conflicts should share a group")
+
+	c3, err := testDB.GetConflict(ctx, conflict3ID, uuid.Nil)
+	require.NoError(t, err)
+	require.NotNil(t, c3.GroupID)
+	assert.Equal(t, groupID, *c3.GroupID, "all conflicts should share a group")
+
+	// Now cascade from conflict1 with dA1 as winner (winEmb direction).
+	cascaded, err := testDB.CascadeResolveByOutcome(ctx,
+		uuid.Nil, groupID, dA1.ID, conflict1ID,
+		0.80, // threshold
+		storage.MutationAuditEntry{
+			RequestID:    uuid.New().String(),
+			OrgID:        uuid.Nil,
+			ActorAgentID: "test-admin",
+			ActorRole:    "admin",
+			HTTPMethod:   "PATCH",
+			Endpoint:     "/v1/conflicts/" + conflict1ID.String(),
+			Operation:    "conflict_cascade_resolved",
+			ResourceType: "conflict",
+			ResourceID:   conflict1ID.String(),
+		})
+	require.NoError(t, err)
+
+	// Conflict2 should be cascade-resolved: dA2 has alignedEmb which is similar
+	// to winEmb (cosine sim ~0.998), while dB2 has loseEmb (cosine sim = -1.0).
+	// So dA2 should win.
+	assert.Equal(t, 1, cascaded, "only conflict2 should cascade (conflict3 has unrelated embeddings)")
+
+	// Verify conflict2 was resolved with dA2 as winner.
+	c2After, err := testDB.GetConflict(ctx, conflict2ID, uuid.Nil)
+	require.NoError(t, err)
+	assert.Equal(t, "resolved", c2After.Status)
+	assert.Equal(t, "cascade", *c2After.ResolvedBy)
+	require.NotNil(t, c2After.WinningDecisionID)
+	assert.Equal(t, dA2.ID, *c2After.WinningDecisionID, "aligned side (A) should win")
+	require.NotNil(t, c2After.ResolutionNote)
+	assert.Contains(t, *c2After.ResolutionNote, "cascade")
+
+	// Verify conflict3 is still open (unrelated embeddings, no side exceeds 0.80).
+	c3After, err := testDB.GetConflict(ctx, conflict3ID, uuid.Nil)
+	require.NoError(t, err)
+	assert.Equal(t, "open", c3After.Status, "conflict3 should remain open (unrelated topic)")
+
+	// Suppress unused variable warnings.
+	_ = dB1
+	_ = dB3
+	_ = conflict3ID
+}
+
+func TestCascadeResolveByOutcome_NoEmbeddings(t *testing.T) {
+	ctx := context.Background()
+	suffix := uuid.New().String()[:8]
+
+	agentA := "casc-noemb-a-" + suffix
+	agentB := "casc-noemb-b-" + suffix
+	decisionType := "casc_noemb_" + suffix
+
+	runA, err := testDB.CreateRun(ctx, model.CreateRunRequest{AgentID: agentA})
+	require.NoError(t, err)
+	runB, err := testDB.CreateRun(ctx, model.CreateRunRequest{AgentID: agentB})
+	require.NoError(t, err)
+
+	// Decisions without outcome embeddings.
+	dA, err := testDB.CreateDecision(ctx, model.Decision{
+		RunID: runA.ID, AgentID: agentA,
+		DecisionType: decisionType, Outcome: "opt_x",
+		Confidence: 0.8, Metadata: map[string]any{},
+	})
+	require.NoError(t, err)
+
+	dB, err := testDB.CreateDecision(ctx, model.Decision{
+		RunID: runB.ID, AgentID: agentB,
+		DecisionType: decisionType, Outcome: "opt_y",
+		Confidence: 0.9, Metadata: map[string]any{},
+	})
+	require.NoError(t, err)
+
+	conflictID, err := testDB.InsertScoredConflict(ctx, model.DecisionConflict{
+		ConflictKind: model.ConflictKindCrossAgent, OrgID: uuid.Nil,
+		DecisionAID: dA.ID, DecisionBID: dB.ID,
+		AgentA: agentA, AgentB: agentB,
+		DecisionTypeA: decisionType, DecisionTypeB: decisionType,
+		OutcomeA: "opt_x", OutcomeB: "opt_y",
+		ScoringMethod: "text",
+	})
+	require.NoError(t, err)
+
+	c, err := testDB.GetConflict(ctx, conflictID, uuid.Nil)
+	require.NoError(t, err)
+	require.NotNil(t, c.GroupID)
+
+	// Cascade should resolve 0 — no embeddings to compare.
+	cascaded, err := testDB.CascadeResolveByOutcome(ctx,
+		uuid.Nil, *c.GroupID, dA.ID, uuid.New(), // trigger is a different ID
+		0.80,
+		storage.MutationAuditEntry{
+			RequestID:    uuid.New().String(),
+			OrgID:        uuid.Nil,
+			ActorAgentID: "test-admin",
+			ActorRole:    "admin",
+			HTTPMethod:   "PATCH",
+			Endpoint:     "/v1/conflicts/test",
+			Operation:    "conflict_cascade_resolved",
+			ResourceType: "conflict",
+		})
+	require.NoError(t, err)
+	assert.Equal(t, 0, cascaded, "no cascade without embeddings")
+}
+
+// ptrVec returns a pointer to a pgvector.Vector from a float32 slice.
+func ptrVec(v []float32) *pgvector.Vector {
+	vec := pgvector.NewVector(v)
+	return &vec
+}
+
+// ---------------------------------------------------------------------------
 // Tests: CreateTraceAndAdjudicateConflictTx (0% -> full coverage)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- When a conflict is resolved with a `winning_decision_id`, automatically resolves other open conflicts in the same conflict group whose outcome embeddings align with the winner (cosine similarity >= 0.80)
- Uses pgvector's `<=>` operator for server-side similarity in a single SQL round-trip — no embedding deserialization in Go
- Triggered from both `PATCH /v1/conflicts/{id}` and `POST /v1/conflicts/{id}/adjudicate`
- Records `resolved_by = 'cascade'` with full audit trail linking back to the triggering conflict
- Cascade failures are logged but don't fail the original resolution (graceful degradation)

Closes #359

## Changes

| File | What |
|------|------|
| `internal/storage/conflicts.go` | `CascadeResolveByOutcome()` — SQL CTE computing cosine similarity via pgvector, batch-updating aligned conflicts |
| `internal/server/handlers_conflicts.go` | Cascade call after resolution in `HandlePatchConflict` and `HandleAdjudicateConflict` |
| `internal/storage/storage_test.go` | Integration tests: cascade with aligned/unrelated embeddings, no-embedding edge case |

## Test plan

- [x] `TestCascadeResolveByOutcome` — 3 conflicts in a group: resolving one cascades to the aligned conflict, leaves the unrelated one open
- [x] `TestCascadeResolveByOutcome_NoEmbeddings` — decisions without outcome embeddings produce 0 cascades (no crash)
- [x] Full test suite passes with `-race`
- [x] `go vet`, `golangci-lint`, `atlas migrate validate` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)