### PR TITLE
Pass AKASHI_HOOKS_API_KEY to complete stack akashi container

### DIFF
--- a/docker-compose.complete.yml
+++ b/docker-compose.complete.yml
@@ -158,6 +158,9 @@ services:
       AKASHI_JWT_PUBLIC_KEY: /data/jwt_public.pem
       AKASHI_JWT_EXPIRATION: ${AKASHI_JWT_EXPIRATION:-24h}
 
+      # Hooks API key — set by dev-setup.sh or manually in .env.
+      AKASHI_HOOKS_API_KEY: ${AKASHI_HOOKS_API_KEY:-}
+
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}
       OTEL_SERVICE_NAME: ${OTEL_SERVICE_NAME:-akashi}
     volumes:


### PR DESCRIPTION
## Summary

- `docker-compose.complete.yml` was not passing `AKASHI_HOOKS_API_KEY` into the akashi container — there's no `env_file:` directive in the complete stack and the key wasn't listed in the service's `environment:` block
- The cloud compose (`docker-compose.yml`) already picked this up via `env_file: .env`, but the complete stack silently dropped it, causing hook requests to the local instance to fail
- Fix: add `AKASHI_HOOKS_API_KEY: ${AKASHI_HOOKS_API_KEY:-}` to the akashi service environment in the complete stack; docker compose auto-reads `.env` for interpolation, so dev-setup.sh writing the key to `.env` is sufficient

## Test plan

- [ ] Run `dev-setup.sh` and confirm both stacks start
- [ ] Send a hook request to `http://localhost:8081` and confirm it's accepted (no 401)
- [ ] Confirm `http://localhost:8080` hook requests still work
- [ ] `docker compose -f docker-compose.complete.yml config` — verify `AKASHI_HOOKS_API_KEY` appears in the rendered akashi service environment