### PR TITLE
fix(storage): add missing org_id filters in deleteBatch

### DIFF
--- a/internal/storage/retention.go
+++ b/internal/storage/retention.go
@@ -447,10 +447,10 @@ func (db *DB) deleteBatch(ctx context.Context, orgID uuid.UUID, ids []uuid.UUID)
 	cnt.Claims = tag.RowsAffected()
 
 	// 4. Null out precedent_ref / supersedes_id references to these decisions.
-	if _, err = tx.Exec(ctx, `UPDATE decisions SET precedent_ref = NULL WHERE precedent_ref = ANY($1)`, ids); err != nil {
+	if _, err = tx.Exec(ctx, `UPDATE decisions SET precedent_ref = NULL WHERE precedent_ref = ANY($1) AND org_id = $2`, ids, orgID); err != nil {
 		return cnt, fmt.Errorf("storage: clear precedent refs batch: %w", err)
 	}
-	if _, err = tx.Exec(ctx, `UPDATE decisions SET supersedes_id = NULL WHERE supersedes_id = ANY($1)`, ids); err != nil {
+	if _, err = tx.Exec(ctx, `UPDATE decisions SET supersedes_id = NULL WHERE supersedes_id = ANY($1) AND org_id = $2`, ids, orgID); err != nil {
 		return cnt, fmt.Errorf("storage: clear supersedes refs batch: %w", err)
 	}
 
@@ -466,7 +466,7 @@ func (db *DB) deleteBatch(ctx context.Context, orgID uuid.UUID, ids []uuid.UUID)
 
 	// 6. Delete scored conflicts referencing these decisions.
 	if _, err = tx.Exec(ctx,
-		`DELETE FROM scored_conflicts WHERE decision_a_id = ANY($1) OR decision_b_id = ANY($1)`, ids,
+		`DELETE FROM scored_conflicts WHERE (decision_a_id = ANY($1) OR decision_b_id = ANY($1)) AND org_id = $2`, ids, orgID,
 	); err != nil {
 		return cnt, fmt.Errorf("storage: delete conflicts batch: %w", err)
 	}


### PR DESCRIPTION
## Summary

- Added missing `org_id` filters to three SQL queries in `deleteBatch()` that update/delete cross-references between decisions and conflicts. This prevents data leaks where changes to one org's decisions could affect another org's data.

## Verification

- [x] I ran relevant tests locally (`go test ./...` or targeted package tests).
- [ ] I updated docs/openapi for any API or behavior changes.
- [ ] If I changed config vars in `internal/config/config.go`, I also updated:
  - [ ] `docs/configuration.md`
  - [ ] `docs/runbook.md` (operational subset, if relevant)
  - [ ] `.env.example` (if baseline local/dev defaults changed)
  - [ ] `docs/consistency-manifest.json` (only if policy/coverage rules changed)
- [ ] `python3 scripts/check_doc_config_consistency.py` passes.

## Risk / Rollout Notes

- No migration or backward compatibility impact. This is a pure security hardening—these three queries now correctly scope mutations to the requesting org only.