### PR TITLE
fix(shutdown): prevent audit trail gaps during graceful shutdown

### DIFF
--- a/akashi.go
+++ b/akashi.go
@@ -540,6 +540,16 @@ func (a *App) Shutdown(ctx context.Context) error {
 	}
 	httpCancel()
 
+	// Phase 1.5: wait for in-flight post-trace async work (claim generation,
+	// conflict scoring) so goroutines finish their DB writes before pool close.
+	asyncCtx, asyncCancel := contextWithOptionalTimeout(ctx, 30*time.Second)
+	if err := a.decisionSvc.DrainAsync(asyncCtx); err != nil {
+		a.logger.Warn("async post-trace drain incomplete — some claims or conflict scores may be missing",
+			"error", err,
+		)
+	}
+	asyncCancel()
+
 	// Phase 2: buffer drain.
 	bufCtx, bufCancel := contextWithOptionalTimeout(ctx, a.cfg.ShutdownBufferDrainTimeout)
 	if err := a.buf.Drain(bufCtx); err != nil {
@@ -557,6 +567,12 @@ func (a *App) Shutdown(ctx context.Context) error {
 	if a.outbox != nil {
 		outboxCtx, outboxCancel := contextWithOptionalTimeout(ctx, a.cfg.ShutdownOutboxDrainTimeout)
 		a.outbox.Drain(outboxCtx)
+		if outboxCtx.Err() != nil {
+			a.logger.Warn("search outbox drain did not complete within timeout",
+				"error", outboxCtx.Err(),
+				"configured_timeout", a.cfg.ShutdownOutboxDrainTimeout,
+			)
+		}
 		outboxCancel()
 	}
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -185,7 +185,7 @@ Existing deployments that set `AKASHI_WAL_DIR` explicitly will continue to work 
 | `AKASHI_INTEGRITY_PROOF_INTERVAL` | `5m` | How often Merkle tree proofs are built for new decisions |
 | `AKASHI_ENABLE_DESTRUCTIVE_DELETE` | `false` | Enables irreversible `DELETE /v1/agents/{agent_id}`. Keep `false` in production unless explicitly needed for GDPR workflows |
 | `AKASHI_SHUTDOWN_HTTP_TIMEOUT` | `10s` | HTTP shutdown grace timeout (`0` = wait indefinitely) |
-| `AKASHI_SHUTDOWN_BUFFER_DRAIN_TIMEOUT` | `0` | Maximum time to flush in-memory events to Postgres during shutdown. `0` = wait indefinitely (default, durability-first). Non-zero values bound the drain but risk losing unflushed events — process exits non-zero if events remain. |
+| `AKASHI_SHUTDOWN_BUFFER_DRAIN_TIMEOUT` | `30s` | Maximum time to flush in-memory events to Postgres during shutdown. `0` = wait indefinitely. The 30s default prevents process hang on unreachable database while giving the WAL time to recover unflushed events on restart. |
 | `AKASHI_SHUTDOWN_OUTBOX_DRAIN_TIMEOUT` | `0` | Outbox drain timeout (`0` = wait indefinitely) |
 | `AKASHI_PERCENTILE_REFRESH_INTERVAL` | `1h` | How often to refresh per-org signal percentile caches used for distribution-aware ReScore normalization. Set to `0` to disable |
 | `AKASHI_AUTO_RESOLVE_INTERVAL` | `1h` | How often the background auto-resolution worker runs to resolve eligible conflicts per org policy. Set to `0` to disable |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -216,7 +216,7 @@ func Load() (Config, error) {
 	cfg.EventFlushTimeout, errs = collectDuration(errs, "AKASHI_EVENT_FLUSH_TIMEOUT", 100*time.Millisecond)
 	cfg.WALSyncInterval, errs = collectDuration(errs, "AKASHI_WAL_SYNC_INTERVAL", 10*time.Millisecond)
 	cfg.ShutdownHTTPTimeout, errs = collectDuration(errs, "AKASHI_SHUTDOWN_HTTP_TIMEOUT", 10*time.Second)
-	cfg.ShutdownBufferDrainTimeout, errs = collectDuration(errs, "AKASHI_SHUTDOWN_BUFFER_DRAIN_TIMEOUT", 0)
+	cfg.ShutdownBufferDrainTimeout, errs = collectDuration(errs, "AKASHI_SHUTDOWN_BUFFER_DRAIN_TIMEOUT", 30*time.Second)
 	cfg.ShutdownOutboxDrainTimeout, errs = collectDuration(errs, "AKASHI_SHUTDOWN_OUTBOX_DRAIN_TIMEOUT", 0)
 	cfg.IdempotencyCleanupInterval, errs = collectDuration(errs, "AKASHI_IDEMPOTENCY_CLEANUP_INTERVAL", time.Hour)
 	cfg.IdempotencyCompletedTTL, errs = collectDuration(errs, "AKASHI_IDEMPOTENCY_COMPLETED_TTL", 7*24*time.Hour)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -747,7 +747,7 @@ func validBaseConfig() Config {
 		EventBufferSize:            1000,
 		EventFlushTimeout:          100 * time.Millisecond,
 		ShutdownHTTPTimeout:        10 * time.Second,
-		ShutdownBufferDrainTimeout: 0,
+		ShutdownBufferDrainTimeout: 30 * time.Second,
 		ShutdownOutboxDrainTimeout: 0,
 		OutboxPollInterval:         1 * time.Second,
 		ConflictRefreshInterval:    30 * time.Second,

--- a/internal/service/decisions/service.go
+++ b/internal/service/decisions/service.go
@@ -52,6 +52,15 @@ type Service struct {
 
 	percentileCache *search.PercentileCache // nil = use log fallback in ReScore.
 	rescoreMetrics  *search.ReScoreMetrics  // nil = skip signal contribution recording.
+
+	// asyncWg tracks in-flight post-trace goroutines (claim generation,
+	// conflict scoring) so Shutdown can wait for them before closing the DB.
+	asyncWg sync.WaitGroup
+	// shutdownCtx is cancelled during DrainAsync to signal background
+	// goroutines to abandon work. Replaces context.Background() in
+	// postTraceAsync so goroutines respect shutdown.
+	shutdownCtx  context.Context
+	shutdownStop context.CancelFunc
 }
 
 // SetPercentileCache configures the percentile cache used by ReScore for
@@ -65,6 +74,25 @@ func (s *Service) SetReScoreMetrics(m *search.ReScoreMetrics) { s.rescoreMetrics
 // generateClaims uses the extractor instead of regex-based SplitClaims,
 // producing categorized claims (finding, recommendation, assessment, status).
 func (s *Service) SetClaimExtractor(e conflicts.ClaimExtractor) { s.claimExtractor = e }
+
+// DrainAsync waits for in-flight post-trace goroutines (claim generation and
+// conflict scoring) to complete. If ctx expires first, it cancels the
+// goroutines' shared context and returns ctx.Err(). Call this during shutdown
+// before closing the database pool.
+func (s *Service) DrainAsync(ctx context.Context) error {
+	done := make(chan struct{})
+	go func() {
+		s.asyncWg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		s.shutdownStop()
+		return ctx.Err()
+	}
+}
 
 // New creates a new decision Service.
 // searcher may be nil if Qdrant is not configured (falls back to text search).
@@ -82,6 +110,7 @@ func New(db storage.Store, embedder embedding.Provider, searcher search.Searcher
 	claimFail, _ := meter.Int64Counter("akashi.claims.embedding_failures",
 		metric.WithDescription("Claim embedding generation failures"),
 	)
+	shutdownCtx, shutdownStop := context.WithCancel(context.Background())
 	return &Service{
 		db:                     db,
 		embedder:               embedder,
@@ -91,6 +120,8 @@ func New(db storage.Store, embedder embedding.Provider, searcher search.Searcher
 		embeddingDuration:      embDur,
 		searchDuration:         searchDur,
 		claimEmbeddingFailures: claimFail,
+		shutdownCtx:            shutdownCtx,
+		shutdownStop:           shutdownStop,
 	}
 }
 
@@ -354,20 +385,22 @@ func (s *Service) postTraceAsync(ctx context.Context, orgID uuid.UUID, input Tra
 	// Generate claim-level embeddings for fine-grained conflict detection.
 	// Must complete BEFORE conflict scoring so the scorer can use claims.
 	if decision.Embedding != nil {
+		s.asyncWg.Add(1)
 		go func() {
+			defer s.asyncWg.Done()
 			defer func() {
 				if rec := recover(); rec != nil {
 					s.logger.Error("trace: claim generation panicked", "panic", rec, "decision_id", decision.ID)
 				}
 			}()
-			claimCtx, cancelClaims := context.WithTimeout(context.Background(), 60*time.Second)
+			claimCtx, cancelClaims := context.WithTimeout(s.shutdownCtx, 60*time.Second)
 			defer cancelClaims()
 			if err := s.generateClaims(claimCtx, decision.ID, orgID, input.Decision.Outcome); err != nil {
 				s.logger.Warn("trace: claim generation failed", "decision_id", decision.ID, "error", err)
 				s.claimEmbeddingFailures.Add(claimCtx, 1, metric.WithAttributes(
 					attribute.Int("attempt_number", 1),
 				))
-				markCtx, markCancel := context.WithTimeout(context.Background(), 5*time.Second)
+				markCtx, markCancel := context.WithTimeout(s.shutdownCtx, 5*time.Second)
 				if markErr := s.db.MarkClaimEmbeddingFailed(markCtx, decision.ID, orgID); markErr != nil {
 					s.logger.Error("trace: failed to mark claim embedding failure", "decision_id", decision.ID, "error", markErr)
 				}
@@ -376,20 +409,22 @@ func (s *Service) postTraceAsync(ctx context.Context, orgID uuid.UUID, input Tra
 			if s.conflictScorer != nil {
 				// Scoring can include local LLM validation (Ollama), which may take
 				// longer than claim generation on CPU-only machines.
-				scoreCtx, cancelScore := context.WithTimeout(context.Background(), 2*time.Minute)
+				scoreCtx, cancelScore := context.WithTimeout(s.shutdownCtx, 2*time.Minute)
 				defer cancelScore()
 				s.conflictScorer.ScoreForDecision(scoreCtx, decision.ID, orgID)
 			}
 		}()
 	} else if s.conflictScorer != nil {
 		// No embeddings available — still try conflict scoring (it will use full-outcome only).
+		s.asyncWg.Add(1)
 		go func() {
+			defer s.asyncWg.Done()
 			defer func() {
 				if rec := recover(); rec != nil {
 					s.logger.Error("trace: conflict scorer panicked", "panic", rec, "decision_id", decision.ID, "org_id", orgID)
 				}
 			}()
-			scoreCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+			scoreCtx, cancel := context.WithTimeout(s.shutdownCtx, 2*time.Minute)
 			defer cancel()
 			s.conflictScorer.ScoreForDecision(scoreCtx, decision.ID, orgID)
 		}()

--- a/internal/service/decisions/service_test.go
+++ b/internal/service/decisions/service_test.go
@@ -1258,3 +1258,30 @@ func TestSearch_SemanticFalseSkipsQdrant(t *testing.T) {
 	require.NoError(t, err, "semantic=false should use text search directly")
 	assert.NotEmpty(t, results, "text search should find the decision")
 }
+
+func TestDrainAsync_CompletesImmediatelyWhenIdle(t *testing.T) {
+	embedder := embedding.NewNoopProvider(1024)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	svc := decisions.New(testDB, embedder, nil, logger, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := svc.DrainAsync(ctx)
+	require.NoError(t, err, "DrainAsync should return immediately when no goroutines are in flight")
+}
+
+func TestDrainAsync_ReturnsErrorOnTimeout(t *testing.T) {
+	embedder := embedding.NewNoopProvider(1024)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	svc := decisions.New(testDB, embedder, nil, logger, nil)
+
+	// Simulate an in-flight goroutine by calling the exported method
+	// with an already-expired context.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled
+
+	err := svc.DrainAsync(ctx)
+	require.Error(t, err, "DrainAsync should return error when context is already cancelled")
+	assert.ErrorIs(t, err, context.Canceled)
+}


### PR DESCRIPTION
## Summary

- **Post-trace goroutine tracking**: Claim generation and conflict scoring goroutines now use a shared `shutdownCtx` (instead of `context.Background()`) and are tracked via `sync.WaitGroup`. New `DrainAsync()` method waits for in-flight goroutines during shutdown (Phase 1.5, 30s timeout), preventing silent audit trail gaps when the DB pool closes.
- **Outbox drain observability**: Outbox drain timeout is now detected and logged instead of being silently swallowed.
- **Buffer drain timeout default**: Changed from `0` (infinite wait) to `30s` to prevent process hang when the database is unreachable during shutdown. WAL recovers unflushed events on restart. Operators can still set `0` explicitly.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test -race -count=1 ./internal/config/` passes (default change verified)
- [x] `go test -race -count=1 ./internal/service/decisions/` passes (new DrainAsync tests)
- [ ] Manual: verify shutdown log output includes Phase 1.5 drain and outbox timeout warnings under load

🤖 Generated with [Claude Code](https://claude.com/claude-code)