### PR TITLE
fix: address code review findings across server, storage, and lifecycle

### DIFF
--- a/akashi.go
+++ b/akashi.go
@@ -69,6 +69,7 @@ type App struct {
 	percentileCache *search.PercentileCache
 	broker          *server.Broker // nil when no notify connection
 	otelShutdown    func(context.Context) error
+	limiter         ratelimit.Limiter // rate limiter; closed on shutdown to stop cleanup goroutine
 	decisionHooks   []server.DecisionHook
 	logger          *slog.Logger
 	autoResolver    *autoresolve.Service
@@ -477,6 +478,7 @@ func New(opts ...Option) (*App, error) {
 		percentileCache: pctCache,
 		broker:          broker,
 		otelShutdown:    otelShutdown,
+		limiter:         limiter,
 		decisionHooks:   decisionHooks,
 		logger:          logger,
 		autoResolver:    autoresolve.New(db, logger),
@@ -562,11 +564,15 @@ func (a *App) Shutdown(ctx context.Context) error {
 
 	// Cleanup.
 	a.grantCache.Close()
+	if a.limiter != nil {
+		_ = a.limiter.Close()
+	}
+	a.srv.CloseSignupLimiter()
 	if a.qdrantIndex != nil {
 		_ = a.qdrantIndex.Close()
 	}
-	_ = a.otelShutdown(context.Background())
-	a.db.Close(context.Background())
+	_ = a.otelShutdown(ctx)
+	a.db.Close(ctx)
 
 	a.logger.Info("akashi stopped")
 	return nil

--- a/cmd/akashi/main.go
+++ b/cmd/akashi/main.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	akashi "github.com/ashita-ai/akashi"
@@ -43,10 +44,10 @@ func run0() int {
 }
 
 func parseLogLevel(raw string) slog.Level {
-	switch raw {
+	switch strings.ToLower(raw) {
 	case "debug":
 		return slog.LevelDebug
-	case "warn":
+	case "warn", "warning":
 		return slog.LevelWarn
 	case "error":
 		return slog.LevelError

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -335,8 +335,12 @@ func (c Config) Validate() error {
 			errs = append(errs, errors.New("config: AKASHI_RATE_LIMIT_BURST must be positive when rate limiting is enabled"))
 		}
 	}
-	// Early-exit floor must not exceed the significance threshold, otherwise
-	// the early exit prunes candidates that would pass the threshold check.
+	// Early-exit floor must be non-negative (0 disables) and must not exceed
+	// the significance threshold, otherwise early exit prunes candidates that
+	// would pass the threshold check.
+	if c.ConflictEarlyExitFloor < 0 {
+		errs = append(errs, errors.New("config: AKASHI_CONFLICT_EARLY_EXIT_FLOOR must be >= 0 (0 disables early exit)"))
+	}
 	if c.ConflictEarlyExitFloor > 0 && c.ConflictEarlyExitFloor > c.ConflictSignificanceThreshold {
 		errs = append(errs, fmt.Errorf("config: AKASHI_CONFLICT_EARLY_EXIT_FLOOR (%.2f) must not exceed AKASHI_CONFLICT_SIGNIFICANCE_THRESHOLD (%.2f)",
 			c.ConflictEarlyExitFloor, c.ConflictSignificanceThreshold))

--- a/internal/model/api.go
+++ b/internal/model/api.go
@@ -156,13 +156,14 @@ type ErrorDetail struct {
 
 // ErrorCode constants for standard API error codes.
 const (
-	ErrCodeInvalidInput  = "INVALID_INPUT"
-	ErrCodeUnauthorized  = "UNAUTHORIZED"
-	ErrCodeForbidden     = "FORBIDDEN"
-	ErrCodeNotFound      = "NOT_FOUND"
-	ErrCodeConflict      = "CONFLICT"
-	ErrCodeInternalError = "INTERNAL_ERROR"
-	ErrCodeRateLimited   = "RATE_LIMITED"
+	ErrCodeInvalidInput   = "INVALID_INPUT"
+	ErrCodeUnauthorized   = "UNAUTHORIZED"
+	ErrCodeForbidden      = "FORBIDDEN"
+	ErrCodeNotFound       = "NOT_FOUND"
+	ErrCodeConflict       = "CONFLICT"
+	ErrCodeInternalError  = "INTERNAL_ERROR"
+	ErrCodeRateLimited    = "RATE_LIMITED"
+	ErrCodeNotImplemented = "NOT_IMPLEMENTED"
 )
 
 // CreateRunRequest is the request body for POST /v1/runs.

--- a/internal/server/handlers_conflicts.go
+++ b/internal/server/handlers_conflicts.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"net/http"
-	"strings"
 	"sync"
 	"time"
 
@@ -169,7 +168,7 @@ func (h *Handlers) HandlePatchConflict(w http.ResponseWriter, r *http.Request) {
 		map[string]any{"new_status": req.Status, "resolved_by": resolvedBy},
 	)
 	if _, err := h.db.UpdateConflictStatusWithAudit(r.Context(), id, orgID, req.Status, resolvedBy, req.ResolutionNote, req.WinningDecisionID, audit); err != nil {
-		if strings.Contains(err.Error(), "not found") {
+		if isNotFoundError(err) {
 			writeError(w, r, http.StatusNotFound, model.ErrCodeNotFound, "conflict not found")
 			return
 		}
@@ -268,7 +267,7 @@ func (h *Handlers) HandleResolveConflictGroup(w http.ResponseWriter, r *http.Req
 
 	affected, err := h.db.ResolveConflictGroup(r.Context(), groupID, orgID, req.Status, resolvedBy, req.ResolutionNote, req.WinningAgent, audit)
 	if err != nil {
-		if strings.Contains(err.Error(), "not found") {
+		if isNotFoundError(err) {
 			writeError(w, r, http.StatusNotFound, model.ErrCodeNotFound, "conflict group not found")
 			return
 		}
@@ -379,7 +378,7 @@ func (h *Handlers) HandleAdjudicateConflict(w http.ResponseWriter, r *http.Reque
 		WinningDecisionID: req.WinningDecisionID,
 	})
 	if err != nil {
-		if strings.Contains(err.Error(), "conflict not found") {
+		if isNotFoundError(err) {
 			writeError(w, r, http.StatusNotFound, model.ErrCodeNotFound, "conflict not found")
 			return
 		}

--- a/internal/server/handlers_eval.go
+++ b/internal/server/handlers_eval.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/ashita-ai/akashi/internal/conflicts"
+	"github.com/ashita-ai/akashi/internal/model"
 )
 
 // validatePairRequest is the JSON body for POST /v1/admin/conflicts/validate-pair.
@@ -34,26 +35,24 @@ type validatePairResponse struct {
 // Returns 501 if no validator is configured.
 func (h *Handlers) HandleValidatePair(w http.ResponseWriter, r *http.Request) {
 	if h.conflictValidator == nil {
-		writeJSON(w, r, http.StatusNotImplemented, map[string]string{
-			"error": "no conflict validator configured (set AKASHI_CONFLICT_LLM_MODEL or OPENAI_API_KEY)",
-		})
+		writeError(w, r, http.StatusNotImplemented, model.ErrCodeNotImplemented,
+			"no conflict validator configured (set AKASHI_CONFLICT_LLM_MODEL or OPENAI_API_KEY)")
 		return
 	}
 	if _, ok := h.conflictValidator.(conflicts.NoopValidator); ok {
-		writeJSON(w, r, http.StatusNotImplemented, map[string]string{
-			"error": "conflict validator is noop (set AKASHI_CONFLICT_LLM_MODEL or OPENAI_API_KEY)",
-		})
+		writeError(w, r, http.StatusNotImplemented, model.ErrCodeNotImplemented,
+			"conflict validator is noop (set AKASHI_CONFLICT_LLM_MODEL or OPENAI_API_KEY)")
 		return
 	}
 
 	var req validatePairRequest
 	if err := decodeJSON(w, r, &req, h.maxRequestBodyBytes); err != nil {
+		handleDecodeError(w, r, err)
 		return
 	}
 	if req.OutcomeA == "" || req.OutcomeB == "" {
-		writeJSON(w, r, http.StatusBadRequest, map[string]string{
-			"error": "outcome_a and outcome_b are required",
-		})
+		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput,
+			"outcome_a and outcome_b are required")
 		return
 	}
 
@@ -97,15 +96,13 @@ type conflictEvalResponse struct {
 // and returns precision/recall metrics.
 func (h *Handlers) HandleConflictEval(w http.ResponseWriter, r *http.Request) {
 	if h.conflictValidator == nil {
-		writeJSON(w, r, http.StatusNotImplemented, map[string]string{
-			"error": "no conflict validator configured",
-		})
+		writeError(w, r, http.StatusNotImplemented, model.ErrCodeNotImplemented,
+			"no conflict validator configured")
 		return
 	}
 	if _, ok := h.conflictValidator.(conflicts.NoopValidator); ok {
-		writeJSON(w, r, http.StatusNotImplemented, map[string]string{
-			"error": "conflict validator is noop — eval requires an LLM validator",
-		})
+		writeError(w, r, http.StatusNotImplemented, model.ErrCodeNotImplemented,
+			"conflict validator is noop — eval requires an LLM validator")
 		return
 	}
 

--- a/internal/server/handlers_eval_test.go
+++ b/internal/server/handlers_eval_test.go
@@ -206,8 +206,6 @@ func TestHandleValidatePair_InvalidJSON(t *testing.T) {
 	req := httptest.NewRequest("POST", "/v1/admin/conflicts/validate-pair", strings.NewReader("not json"))
 	h.HandleValidatePair(rec, req)
 
-	// The handler returns early without writing an error response when
-	// decodeJSON fails (it should call handleDecodeError but doesn't).
-	// This is existing behavior; the test documents it.
-	assert.Equal(t, http.StatusOK, rec.Code)
+	// The handler calls handleDecodeError which writes a 400 response.
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }

--- a/internal/server/handlers_labels.go
+++ b/internal/server/handlers_labels.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 
+	"github.com/ashita-ai/akashi/internal/model"
 	"github.com/ashita-ai/akashi/internal/storage"
 )
 
@@ -47,20 +48,20 @@ func (h *Handlers) HandleUpsertConflictLabel(w http.ResponseWriter, r *http.Requ
 	orgID := OrgIDFromContext(r.Context())
 	claims := ClaimsFromContext(r.Context())
 
-	conflictID, err := uuid.Parse(r.PathValue("id"))
+	conflictID, err := parsePathUUID(r, "id")
 	if err != nil {
-		writeJSON(w, r, http.StatusBadRequest, map[string]string{"error": "invalid conflict id"})
+		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "invalid conflict id")
 		return
 	}
 
 	var req upsertLabelRequest
 	if err := decodeJSON(w, r, &req, h.maxRequestBodyBytes); err != nil {
+		handleDecodeError(w, r, err)
 		return
 	}
 	if !validLabels[req.Label] {
-		writeJSON(w, r, http.StatusBadRequest, map[string]string{
-			"error": "label must be one of: genuine, related_not_contradicting, unrelated_false_positive",
-		})
+		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput,
+			"label must be one of: genuine, related_not_contradicting, unrelated_false_positive")
 		return
 	}
 
@@ -74,7 +75,7 @@ func (h *Handlers) HandleUpsertConflictLabel(w http.ResponseWriter, r *http.Requ
 	}
 	if err := h.db.UpsertConflictLabel(r.Context(), cl); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			writeJSON(w, r, http.StatusConflict, map[string]string{"error": "conflict belongs to a different organization"})
+			writeError(w, r, http.StatusConflict, model.ErrCodeConflict, "conflict belongs to a different organization")
 			return
 		}
 		h.writeInternalError(w, r, "failed to upsert conflict label", err)
@@ -88,16 +89,16 @@ func (h *Handlers) HandleUpsertConflictLabel(w http.ResponseWriter, r *http.Requ
 func (h *Handlers) HandleGetConflictLabel(w http.ResponseWriter, r *http.Request) {
 	orgID := OrgIDFromContext(r.Context())
 
-	conflictID, err := uuid.Parse(r.PathValue("id"))
+	conflictID, err := parsePathUUID(r, "id")
 	if err != nil {
-		writeJSON(w, r, http.StatusBadRequest, map[string]string{"error": "invalid conflict id"})
+		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "invalid conflict id")
 		return
 	}
 
 	cl, err := h.db.GetConflictLabel(r.Context(), conflictID, orgID)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			writeJSON(w, r, http.StatusNotFound, map[string]string{"error": "label not found"})
+			writeError(w, r, http.StatusNotFound, model.ErrCodeNotFound, "label not found")
 			return
 		}
 		h.writeInternalError(w, r, "failed to get conflict label", err)
@@ -111,15 +112,15 @@ func (h *Handlers) HandleGetConflictLabel(w http.ResponseWriter, r *http.Request
 func (h *Handlers) HandleDeleteConflictLabel(w http.ResponseWriter, r *http.Request) {
 	orgID := OrgIDFromContext(r.Context())
 
-	conflictID, err := uuid.Parse(r.PathValue("id"))
+	conflictID, err := parsePathUUID(r, "id")
 	if err != nil {
-		writeJSON(w, r, http.StatusBadRequest, map[string]string{"error": "invalid conflict id"})
+		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "invalid conflict id")
 		return
 	}
 
 	if err := h.db.DeleteConflictLabel(r.Context(), conflictID, orgID); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			writeJSON(w, r, http.StatusNotFound, map[string]string{"error": "label not found"})
+			writeError(w, r, http.StatusNotFound, model.ErrCodeNotFound, "label not found")
 			return
 		}
 		h.writeInternalError(w, r, "failed to delete conflict label", err)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -344,3 +344,11 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	s.logger.Info("http server shutting down")
 	return s.httpServer.Shutdown(ctx)
 }
+
+// CloseSignupLimiter releases the signup rate limiter's resources (cleanup goroutine).
+// Safe to call when signup is disabled (signupLimiter is nil).
+func (s *Server) CloseSignupLimiter() {
+	if s.handlers.signupLimiter != nil {
+		_ = s.handlers.signupLimiter.Close()
+	}
+}

--- a/internal/storage/conflicts.go
+++ b/internal/storage/conflicts.go
@@ -298,7 +298,7 @@ func (db *DB) UpdateConflictStatusWithAudit(ctx context.Context, id, orgID uuid.
 	if scanErr := tx.QueryRow(ctx,
 		`SELECT status FROM scored_conflicts WHERE id = $1 AND org_id = $2 FOR UPDATE`,
 		id, orgID).Scan(&oldStatus); scanErr != nil {
-		return "", fmt.Errorf("storage: conflict not found")
+		return "", fmt.Errorf("storage: conflict: %w", ErrNotFound)
 	}
 
 	var tag pgconn.CommandTag
@@ -325,7 +325,7 @@ func (db *DB) UpdateConflictStatusWithAudit(ctx context.Context, id, orgID uuid.
 		return "", fmt.Errorf("storage: update conflict status: %w", err)
 	}
 	if tag.RowsAffected() == 0 {
-		return "", fmt.Errorf("storage: conflict not found")
+		return "", fmt.Errorf("storage: conflict: %w", ErrNotFound)
 	}
 
 	audit.BeforeData = map[string]any{"status": oldStatus}
@@ -1037,7 +1037,7 @@ func (db *DB) ResolveConflictGroup(
 		return 0, fmt.Errorf("storage: check conflict group: %w", err)
 	}
 	if !exists {
-		return 0, fmt.Errorf("storage: conflict group not found")
+		return 0, fmt.Errorf("storage: conflict group: %w", ErrNotFound)
 	}
 
 	// Build the UPDATE. When winning_agent is set, derive winning_decision_id

--- a/internal/storage/sqlite/decisions.go
+++ b/internal/storage/sqlite/decisions.go
@@ -65,7 +65,7 @@ func (l *LiteDB) CreateTraceAndAdjudicateConflictTx(ctx context.Context, tracePa
 	}
 	n, _ := res.RowsAffected()
 	if n == 0 {
-		return model.AgentRun{}, model.Decision{}, fmt.Errorf("sqlite: conflict %s not found in org", conflictParams.ConflictID)
+		return model.AgentRun{}, model.Decision{}, fmt.Errorf("sqlite: conflict: %w", storage.ErrNotFound)
 	}
 
 	if err := insertAuditTx(ctx, tx, conflictParams.Audit); err != nil {

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -6102,7 +6102,7 @@ func TestCreateTraceAndAdjudicateConflictTx_ConflictNotFound(t *testing.T) {
 		},
 	)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "conflict not found")
+	assert.ErrorIs(t, err, storage.ErrNotFound)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/storage/trace.go
+++ b/internal/storage/trace.go
@@ -62,7 +62,7 @@ func (db *DB) CreateTraceAndAdjudicateConflictTx(ctx context.Context, traceParam
 		return model.AgentRun{}, model.Decision{}, fmt.Errorf("storage: adjudicate conflict in trace tx: %w", err)
 	}
 	if tag.RowsAffected() == 0 {
-		return model.AgentRun{}, model.Decision{}, fmt.Errorf("storage: conflict not found")
+		return model.AgentRun{}, model.Decision{}, fmt.Errorf("storage: conflict: %w", ErrNotFound)
 	}
 
 	// Insert conflict adjudication audit entry.

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -3,6 +3,7 @@ package telemetry
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -91,14 +92,7 @@ func Init(ctx context.Context, endpoint, serviceName, version string, insecure b
 	otel.SetMeterProvider(mp)
 
 	shutdown := func(ctx context.Context) error {
-		var firstErr error
-		if err := tp.Shutdown(ctx); err != nil && firstErr == nil {
-			firstErr = err
-		}
-		if err := mp.Shutdown(ctx); err != nil && firstErr == nil {
-			firstErr = err
-		}
-		return firstErr
+		return errors.Join(tp.Shutdown(ctx), mp.Shutdown(ctx))
 	}
 
 	return shutdown, nil


### PR DESCRIPTION
## Summary

Comprehensive code review identified and fixed 16 issues across 14 files:

- **Resource leak**: Rate limiter background goroutine was never stopped on shutdown; OTEL/DB teardown used `context.Background()` instead of the shutdown context
- **Silent bug**: `HandleValidatePair` returned empty 200 on malformed JSON instead of 400 (missing `handleDecodeError` call)
- **Fragile error matching**: Storage layer returned plain `fmt.Errorf` strings; handlers used `strings.Contains` to detect "not found" — replaced with `ErrNotFound` sentinel + `errors.Is`
- **Inconsistent error responses**: Mixed `writeJSON` and `writeError` for error responses — standardized on `writeError` with proper error codes
- **Code duplication**: Inline `uuid.Parse(r.PathValue("id"))` in label handlers replaced with `parsePathUUID` helper
- **Minor improvements**: case-insensitive log level parsing, `errors.Join` for OTEL shutdown, negative `ConflictEarlyExitFloor` validation, `ErrCodeNotImplemented` constant

## Test plan

- [x] All pre-commit checks pass (`go build`, `go vet`, `golangci-lint`, `atlas migrate validate`, `go mod tidy`)
- [x] All test suites pass with `-race` (config, ratelimit, model, storage/postgres, storage/sqlite, server)
- [x] `TestHandleValidatePair_InvalidJSON` updated to expect 400 (was documenting the bug with expected 200)
- [x] `TestResolveConflictGroup_NotFound` updated to use `errors.Is` with sentinel