### PR TITLE
Fix #415: dx: add make new-migration helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: all build build-local build-ui build-with-ui test lint fmt vet clean docker-up docker-down ci security tidy \
-       dev-ui migrate-apply migrate-lint migrate-hash migrate-diff migrate-status migrate-validate \
+       dev-ui migrate-apply migrate-lint migrate-hash migrate-diff migrate-status migrate-validate new-migration \
        check-doc-consistency verify-restore reconcile-qdrant reconcile-qdrant-repair \
        archive-events-dry-run archive-events verify-exit-criteria install-hooks coverage
 
@@ -101,6 +101,17 @@ migrate-status: ## Show migration status
 
 migrate-validate: ## Validate migration file integrity (checksums + SQL)
 	$(ATLAS) migrate validate --dir file://migrations
+
+new-migration: ## Create a new migration file (usage: make new-migration name=add_foo_index)
+	@test -n "$(name)" || (echo "usage: make new-migration name=<migration_name>" && exit 1)
+	@LAST=$$(ls migrations/*.sql 2>/dev/null | sed 's|.*/||' | grep -o '^[0-9]*' | sort -n | tail -1); \
+	LAST=$${LAST:-0}; \
+	NEXT=$$(printf '%03d' $$((10#$$LAST + 1))); \
+	DESC=$$(echo "$(name)" | tr '_' ' '); \
+	FILE="migrations/$${NEXT}_$(name).sql"; \
+	echo "-- $${NEXT}: $${DESC}" > "$$FILE"; \
+	echo "Created $$FILE"; \
+	$(ATLAS) migrate hash --dir file://migrations
 
 verify-restore: ## Run post-restore DB verification checks (requires DATABASE_URL)
 	bash scripts/verify_restore.sh


### PR DESCRIPTION
## Summary

Add a `new-migration` Makefile target that automates creating new migration files with correct sequential numbering, comment headers, and atlas hash updates.

## Approach

Add a `new-migration` target to the existing Makefile that: (1) checks that the `name` variable is provided, erroring if not; (2) scans the `migrations/*.sql` directory to find the highest existing migration number using shell commands (ls, grep, sort, tail); (3) increments that number and zero-pads it to 3 digits; (4) creates the new file at `migrations/NNN_<name>.sql` with the comment header `-- NNN: <description>` (where description is derived from name by replacing underscores with spaces); (5) runs `atlas migrate hash --dir file://migrations` to update `atlas.sum`; (6) prints the created file path. The target will use standard shell utilities available on Linux/macOS and follow the existing Makefile conventions in the project.

## Files Changed

- `Makefile`

## Related Issue

Fixes #415

## Testing

No tests were added with this change. Happy to add them if needed.
