### PR TITLE
refactor: consolidate UUID path parsing to shared helper

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -491,6 +491,11 @@ func (h *Handlers) HandleConfig(w http.ResponseWriter, r *http.Request) {
 
 // --- Shared helpers ---
 
+// parsePathUUID extracts and parses a UUID path parameter from the request.
+func parsePathUUID(r *http.Request, name string) (uuid.UUID, error) {
+	return uuid.Parse(r.PathValue(name))
+}
+
 func parseRunID(r *http.Request) (uuid.UUID, error) {
 	runIDStr := r.PathValue("run_id")
 	if runIDStr == "" {

--- a/internal/server/handlers_admin.go
+++ b/internal/server/handlers_admin.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 
@@ -280,8 +279,7 @@ func (h *Handlers) HandleDeleteGrant(w http.ResponseWriter, r *http.Request) {
 	claims := ClaimsFromContext(r.Context())
 	orgID := OrgIDFromContext(r.Context())
 
-	grantIDStr := r.PathValue("grant_id")
-	grantID, err := uuid.Parse(grantIDStr)
+	grantID, err := parsePathUUID(r, "grant_id")
 	if err != nil {
 		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "invalid grant_id")
 		return

--- a/internal/server/handlers_conflicts.go
+++ b/internal/server/handlers_conflicts.go
@@ -660,11 +660,6 @@ func (h *Handlers) HandleDecisionConflicts(w http.ResponseWriter, r *http.Reques
 	writeListJSON(w, r, conflicts, ptotal, hasMore, limit, offset)
 }
 
-// parsePathUUID extracts and parses a UUID path parameter from the request.
-func parsePathUUID(r *http.Request, name string) (uuid.UUID, error) {
-	return uuid.Parse(r.PathValue(name))
-}
-
 // parseConflictFilters extracts conflict filter parameters from the request query string.
 func parseConflictFilters(r *http.Request) storage.ConflictFilters {
 	filters := storage.ConflictFilters{}

--- a/internal/server/handlers_decisions.go
+++ b/internal/server/handlers_decisions.go
@@ -229,8 +229,7 @@ func (h *Handlers) HandleGetDecision(w http.ResponseWriter, r *http.Request) {
 	claims := ClaimsFromContext(r.Context())
 	orgID := OrgIDFromContext(r.Context())
 
-	idStr := r.PathValue("id")
-	id, err := uuid.Parse(idStr)
+	id, err := parsePathUUID(r, "id")
 	if err != nil {
 		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "invalid decision ID")
 		return
@@ -582,8 +581,7 @@ func (h *Handlers) HandleDecisionRevisions(w http.ResponseWriter, r *http.Reques
 	claims := ClaimsFromContext(r.Context())
 	orgID := OrgIDFromContext(r.Context())
 
-	idStr := r.PathValue("id")
-	id, err := uuid.Parse(idStr)
+	id, err := parsePathUUID(r, "id")
 	if err != nil {
 		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "invalid decision ID")
 		return
@@ -613,8 +611,7 @@ func (h *Handlers) HandleDecisionRevisions(w http.ResponseWriter, r *http.Reques
 func (h *Handlers) HandleVerifyDecision(w http.ResponseWriter, r *http.Request) {
 	orgID := OrgIDFromContext(r.Context())
 
-	idStr := r.PathValue("id")
-	id, err := uuid.Parse(idStr)
+	id, err := parsePathUUID(r, "id")
 	if err != nil {
 		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "invalid decision ID")
 		return
@@ -710,8 +707,7 @@ func (h *Handlers) HandleSessionView(w http.ResponseWriter, r *http.Request) {
 	claims := ClaimsFromContext(r.Context())
 	orgID := OrgIDFromContext(r.Context())
 
-	sidStr := r.PathValue("session_id")
-	sid, err := uuid.Parse(sidStr)
+	sid, err := parsePathUUID(r, "session_id")
 	if err != nil {
 		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "invalid session_id")
 		return
@@ -782,8 +778,7 @@ func (h *Handlers) HandleSessionView(w http.ResponseWriter, r *http.Request) {
 func (h *Handlers) HandleRetractDecision(w http.ResponseWriter, r *http.Request) {
 	orgID := OrgIDFromContext(r.Context())
 
-	idStr := r.PathValue("id")
-	id, err := uuid.Parse(idStr)
+	id, err := parsePathUUID(r, "id")
 	if err != nil {
 		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "invalid decision id")
 		return
@@ -837,8 +832,7 @@ func (h *Handlers) HandleRetractDecision(w http.ResponseWriter, r *http.Request)
 func (h *Handlers) HandleEraseDecision(w http.ResponseWriter, r *http.Request) {
 	orgID := OrgIDFromContext(r.Context())
 
-	idStr := r.PathValue("id")
-	id, err := uuid.Parse(idStr)
+	id, err := parsePathUUID(r, "id")
 	if err != nil {
 		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "invalid decision id")
 		return

--- a/internal/server/handlers_keys.go
+++ b/internal/server/handlers_keys.go
@@ -125,14 +125,13 @@ func (h *Handlers) HandleListKeys(w http.ResponseWriter, r *http.Request) {
 func (h *Handlers) HandleRevokeKey(w http.ResponseWriter, r *http.Request) {
 	orgID := OrgIDFromContext(r.Context())
 
-	keyIDStr := r.PathValue("id")
-	keyID, err := uuid.Parse(keyIDStr)
+	keyID, err := parsePathUUID(r, "id")
 	if err != nil {
 		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "invalid key id")
 		return
 	}
 
-	audit := h.buildAuditEntry(r, orgID, "revoke_api_key", "api_key", keyIDStr, nil, nil, nil)
+	audit := h.buildAuditEntry(r, orgID, "revoke_api_key", "api_key", keyID.String(), nil, nil, nil)
 	if err := h.db.RevokeAPIKeyWithAudit(r.Context(), orgID, keyID, audit); err != nil {
 		if isNotFoundError(err) {
 			writeError(w, r, http.StatusNotFound, model.ErrCodeNotFound, "api key not found")
@@ -152,8 +151,7 @@ func (h *Handlers) HandleRotateKey(w http.ResponseWriter, r *http.Request) {
 	claims := ClaimsFromContext(r.Context())
 	orgID := OrgIDFromContext(r.Context())
 
-	oldKeyIDStr := r.PathValue("id")
-	oldKeyID, err := uuid.Parse(oldKeyIDStr)
+	oldKeyID, err := parsePathUUID(r, "id")
 	if err != nil {
 		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "invalid key id")
 		return
@@ -196,7 +194,7 @@ func (h *Handlers) HandleRotateKey(w http.ResponseWriter, r *http.Request) {
 		ExpiresAt: oldKey.ExpiresAt, // Inherit expiration.
 	}
 
-	audit := h.buildAuditEntry(r, orgID, "rotate_api_key", "api_key", oldKeyIDStr, nil, nil, nil)
+	audit := h.buildAuditEntry(r, orgID, "rotate_api_key", "api_key", oldKeyID.String(), nil, nil, nil)
 	created, err := h.db.RotateAPIKeyWithAudit(r.Context(), orgID, oldKeyID, newKey, audit)
 	if err != nil {
 		if isNotFoundError(err) {

--- a/internal/server/handlers_labels.go
+++ b/internal/server/handlers_labels.go
@@ -47,7 +47,7 @@ func (h *Handlers) HandleUpsertConflictLabel(w http.ResponseWriter, r *http.Requ
 	orgID := OrgIDFromContext(r.Context())
 	claims := ClaimsFromContext(r.Context())
 
-	conflictID, err := uuid.Parse(r.PathValue("id"))
+	conflictID, err := parsePathUUID(r, "id")
 	if err != nil {
 		writeJSON(w, r, http.StatusBadRequest, map[string]string{"error": "invalid conflict id"})
 		return
@@ -88,7 +88,7 @@ func (h *Handlers) HandleUpsertConflictLabel(w http.ResponseWriter, r *http.Requ
 func (h *Handlers) HandleGetConflictLabel(w http.ResponseWriter, r *http.Request) {
 	orgID := OrgIDFromContext(r.Context())
 
-	conflictID, err := uuid.Parse(r.PathValue("id"))
+	conflictID, err := parsePathUUID(r, "id")
 	if err != nil {
 		writeJSON(w, r, http.StatusBadRequest, map[string]string{"error": "invalid conflict id"})
 		return
@@ -111,7 +111,7 @@ func (h *Handlers) HandleGetConflictLabel(w http.ResponseWriter, r *http.Request
 func (h *Handlers) HandleDeleteConflictLabel(w http.ResponseWriter, r *http.Request) {
 	orgID := OrgIDFromContext(r.Context())
 
-	conflictID, err := uuid.Parse(r.PathValue("id"))
+	conflictID, err := parsePathUUID(r, "id")
 	if err != nil {
 		writeJSON(w, r, http.StatusBadRequest, map[string]string{"error": "invalid conflict id"})
 		return

--- a/internal/server/handlers_project_links.go
+++ b/internal/server/handlers_project_links.go
@@ -3,8 +3,6 @@ package server
 import (
 	"net/http"
 
-	"github.com/google/uuid"
-
 	"github.com/ashita-ai/akashi/internal/model"
 )
 
@@ -82,8 +80,7 @@ func (h *Handlers) HandleListProjectLinks(w http.ResponseWriter, r *http.Request
 func (h *Handlers) HandleDeleteProjectLink(w http.ResponseWriter, r *http.Request) {
 	orgID := OrgIDFromContext(r.Context())
 
-	idStr := r.PathValue("id")
-	id, err := uuid.Parse(idStr)
+	id, err := parsePathUUID(r, "id")
 	if err != nil {
 		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "invalid id")
 		return

--- a/internal/server/handlers_retention.go
+++ b/internal/server/handlers_retention.go
@@ -4,8 +4,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/google/uuid"
-
 	"github.com/ashita-ai/akashi/internal/model"
 	"github.com/ashita-ai/akashi/internal/storage"
 )
@@ -219,8 +217,7 @@ func (h *Handlers) HandleCreateHold(w http.ResponseWriter, r *http.Request) {
 func (h *Handlers) HandleReleaseHold(w http.ResponseWriter, r *http.Request) {
 	orgID := OrgIDFromContext(r.Context())
 
-	idStr := r.PathValue("id")
-	id, err := uuid.Parse(idStr)
+	id, err := parsePathUUID(r, "id")
 	if err != nil {
 		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "invalid hold id")
 		return


### PR DESCRIPTION
## Summary

Consolidated 14 manual `uuid.Parse(r.PathValue(...))` call sites across 6 handler files to use the existing `parsePathUUID` helper. Moved the helper from `handlers_conflicts.go` to `handlers.go` (shared section) and removed 3 unused uuid imports.

## Verification

- [x] All tests pass with race detector (`go test -race ./...`)
- [x] `golangci-lint` reports 0 issues
- [x] No API or behavior changes

## Risk

None—pure refactoring. No semantic changes.