### PR TITLE
fix: use git-aware project inference for traces

### DIFF
--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -719,7 +719,7 @@ func (s *Server) handleTrace(ctx context.Context, request mcplib.CallToolRequest
 		if uris := rootURIs(roots); len(uris) > 0 {
 			serverCtx["roots"] = uris
 		}
-		if project := inferProjectFromRoots(roots); project != "" {
+		if project := inferProjectFromRootsWithGit(roots); project != "" {
 			serverCtx["project"] = project
 		}
 	}


### PR DESCRIPTION
## Summary

- Fixed project name inference mismatch between trace writes and query reads. The trace handler used directory basename (e.g., "washington") instead of git remote name (e.g., "akashi"), causing decisions to be stored with incorrect project names and potentially missed by project-scoped queries.

## Verification

- [x] Ran `go test -race -count=1 ./internal/mcp/...` — all project/roots inference tests pass.
- [x] Ran `go build ./...`, `go vet ./...`, `golangci-lint run ./...` — no errors.

## Risk / Rollout Notes

- Existing decisions with incorrect project names (stored while bug existed) retain their names; the generated column value is immutable after insertion.
- New traces will correctly infer project from git remote, allowing project-scoped queries to find them.
- No API/config/migration changes required.