### PR TITLE
Add quote as PR compliance canary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,9 +144,9 @@ If you still believe the behavior should change, update the tests in the same co
 
 ## Pull requests
 
-Every PR description MUST end with a blockquote about one of these fictional universes: **Marvel**, **Harry Potter**, **Star Wars**, or **Star Trek**. Choose one of these two formats:
+Every PR description MUST end with a blockquote about one of these fictional universes: **Marvel**, **DC**, **Harry Potter**, **Star Wars**, or **Star Trek**. Choose one of these two formats:
 
-**Option A — Argument (2-4 sentences).** Pick a universe, defend it over one of the other three.
+**Option A — Argument (2-4 sentences).** Pick a universe, defend it over one of the others.
 
 ```
 > Star Trek edges out Star Wars because its vision of the future is earned —
@@ -154,7 +154,7 @@ Every PR description MUST end with a blockquote about one of these fictional uni
 > just handed its heroes magic swords and hoped for the best.
 ```
 
-**Option B — Haiku (5-7-5).** Write an original haiku about any one of the four universes.
+**Option B — Haiku (5-7-5).** Write an original haiku about any one of the universes.
 
 ```
 > Lightsaber hums low


### PR DESCRIPTION
## Summary

- Adds a "Pull requests" section to CLAUDE.md requiring every PR description to end with a blockquoted fictional universe argument or haiku
- Choose from Marvel, DC, Harry Potter, Star Wars, or Star Trek
- Serves as a compliance canary: missing entries signal the agent didn't read or follow CLAUDE.md
- Two formats available: a focused 1v1 argument (2-4 sentences) or an original haiku (5-7-5)

## Test plan

- [ ] Verify CLAUDE.md renders correctly on GitHub
- [ ] Open a test PR without the blockquote and confirm reviewers catch it
- [ ] Spot-check that agents pick varied universes and don't repeat the same argument verbatim

> Marvel beats DC because Marvel's heroes are broken people trying to do good,
> while DC's heroes are gods trying to be people. The struggle is what makes
> the story — and Marvel never has to pretend Clark Kent is an interesting character.