### PR TITLE
fix(ui): make precedent refs clickable

### DIFF
--- a/ui/src/pages/DecisionDetail.tsx
+++ b/ui/src/pages/DecisionDetail.tsx
@@ -1,6 +1,6 @@
 import { useParams, Link } from "react-router";
 import { useQuery } from "@tanstack/react-query";
-import { getRun, getDecisionRevisions, getDecisionConflicts, verifyDecisionIntegrity } from "@/lib/api";
+import { getRun, getDecision, getDecisionRevisions, getDecisionConflicts, verifyDecisionIntegrity } from "@/lib/api";
 import type { Decision, DecisionConflict } from "@/types/api";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge, decisionTypeBadgeVariant } from "@/components/ui/badge";
@@ -27,6 +27,35 @@ import {
   ShieldX,
   XCircle,
 } from "lucide-react";
+
+function PrecedentLink({ decisionId }: { decisionId: string }) {
+  const { data, isPending, error } = useQuery({
+    queryKey: ["precedent", decisionId],
+    queryFn: () => getDecision(decisionId),
+    staleTime: 60_000,
+    retry: false,
+  });
+
+  if (isPending) return <Skeleton className="h-4 w-32 inline-block" />;
+
+  if (error || !data) {
+    return (
+      <span className="font-mono text-xs text-muted-foreground" title="Referenced decision not found">
+        {decisionId.slice(0, 8)}… <span className="text-destructive">(not found)</span>
+      </span>
+    );
+  }
+
+  return (
+    <Link
+      to={`/decisions/${data.run_id}`}
+      className="font-mono text-xs text-primary hover:underline inline-flex items-center gap-1"
+    >
+      <GitBranch className="h-3 w-3" />
+      {decisionId.slice(0, 8)}…
+    </Link>
+  );
+}
 
 const evidenceSourceColors: Record<string, string> = {
   tool_output: "border-l-cyan-500/60",
@@ -440,7 +469,7 @@ export default function DecisionDetail() {
                   {decision.precedent_ref && (
                     <div className="col-span-2">
                       <dt className="text-xs text-muted-foreground">Precedent</dt>
-                      <dd className="font-mono text-xs truncate">{decision.precedent_ref}</dd>
+                      <dd><PrecedentLink decisionId={decision.precedent_ref} /></dd>
                     </div>
                   )}
                 </div>


### PR DESCRIPTION
## Summary

Adds a `PrecedentLink` component that transforms raw precedent decision IDs into interactive links. The component fetches the referenced decision to resolve its `run_id`, then links to the decision detail page. If the fetch fails or the decision doesn't exist, it gracefully degrades to showing the truncated ID with a "(not found)" indicator.

This improves UX by allowing users to navigate between related decisions in the audit trail.

## Verification

- [x] Change is UI-only, no backend/API changes required
- [x] Uses existing `getDecision` API function
- [x] Follows React Query patterns established in the same component
- [x] Includes error handling and loading states

## Risk / Rollout Notes

No risk. Purely additive UI enhancement with graceful fallback for missing/inaccessible decisions.

> In Star Trek, the Prime Directive is a precedent that shapes every decision the Federation makes.
> It's a principle so foundational that even Kirk wrestles with it. Here, precedent_ref does the same—
> making visible the lineage of decisions and letting agents see whose shoulders they stand on.