### PR TITLE
fix: skip gzip middleware for /mcp SSE stream

### DIFF
--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -121,10 +121,18 @@ func loggingMiddleware(logger *slog.Logger, next http.Handler) http.Handler {
 
 type statusWriter struct {
 	http.ResponseWriter
-	statusCode int
+	statusCode  int
+	wroteHeader bool
 }
 
 func (w *statusWriter) WriteHeader(code int) {
+	if w.wroteHeader {
+		// Subsequent calls (e.g. SSE handler error after 200 flush) are
+		// no-ops. We keep the first status code since that's what the
+		// client actually received.
+		return
+	}
+	w.wroteHeader = true
 	w.statusCode = code
 	w.ResponseWriter.WriteHeader(code)
 }
@@ -723,8 +731,9 @@ func localhostOnly(apiKey string, next http.Handler) http.Handler {
 // Uses BestSpeed to minimize CPU overhead on hot paths (check, trace).
 func gzipMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Skip SSE streams — they use chunked transfer encoding.
-		if r.URL.Path == "/v1/subscribe" {
+		// Skip SSE streams — they use chunked transfer encoding and
+		// require unbuffered writes for real-time delivery.
+		if r.URL.Path == "/v1/subscribe" || r.URL.Path == "/mcp" {
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -231,6 +231,18 @@ func TestStatusWriter(t *testing.T) {
 		assert.Equal(t, rec, sw.Unwrap())
 	})
 
+	t.Run("second WriteHeader is no-op", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		sw := &statusWriter{ResponseWriter: rec, statusCode: http.StatusOK}
+		sw.WriteHeader(http.StatusOK)
+		// Simulate an SSE handler that tries to write 500 after already
+		// having flushed 200 headers. The second call should be silently
+		// dropped so the logged status reflects what the client received.
+		sw.WriteHeader(http.StatusInternalServerError)
+		assert.Equal(t, http.StatusOK, sw.statusCode, "first status wins")
+		assert.Equal(t, http.StatusOK, rec.Code, "underlying writer keeps first status")
+	})
+
 	t.Run("Flush delegates to underlying Flusher", func(t *testing.T) {
 		rec := httptest.NewRecorder()
 		sw := &statusWriter{ResponseWriter: rec, statusCode: http.StatusOK}


### PR DESCRIPTION
## Summary
- The `gzipMiddleware` was wrapping the MCP StreamableHTTP (`/mcp`) response writer, corrupting SSE framing and preventing real-time streaming. MCP clients saw a broken GET stream and retried ~1/sec, producing ~17K error log entries over 17 hours while `POST /mcp` tool calls continued working fine.
- Added `/mcp` to the gzip skip list alongside the existing `/v1/subscribe` exemption.
- Made `statusWriter.WriteHeader` idempotent so duplicate status writes (e.g. SSE handler error after 200 flush) are silently dropped instead of logging "superfluous response.WriteHeader".

## Test plan
- [x] Existing `TestStatusWriter` subtests pass
- [x] New `"second WriteHeader is no-op"` test covers the idempotent guard
- [x] `go test -race ./internal/server/...` green
- [x] `golangci-lint run` clean
- [ ] After deploy: verify `GET /mcp` returns 200 with `Content-Type: text/event-stream` (no gzip wrapping)
- [ ] After deploy: confirm error log storm stops

> The Enterprise doesn't compress its subspace channels — you can't
> gzip a real-time data stream and expect Worf to parse Klingon threat
> assessments through a buffered pipe. Picard would never allow it.