### PR TITLE
fix: period selector now scopes all dashboard stat cards (#449)

### DIFF
--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1380,7 +1380,7 @@ func (s *Server) handleStats(ctx context.Context, _ mcplib.CallToolRequest) (*mc
 	orgID := ctxutil.OrgIDFromContext(ctx)
 
 	svc := tracehealth.New(s.db)
-	metrics, err := svc.Compute(ctx, orgID)
+	metrics, err := svc.Compute(ctx, orgID, nil, nil)
 	if err != nil {
 		return errorResult(fmt.Sprintf("failed to compute trace health: %v", err)), nil
 	}

--- a/internal/server/handlers_decisions.go
+++ b/internal/server/handlers_decisions.go
@@ -691,11 +691,32 @@ func (h *Handlers) HandleVerifyDecision(w http.ResponseWriter, r *http.Request) 
 
 // HandleTraceHealth handles GET /v1/trace-health.
 // Returns aggregate health metrics for the caller's organization.
+// Optional query params: from, to (RFC3339) scope metrics to a time window.
 func (h *Handlers) HandleTraceHealth(w http.ResponseWriter, r *http.Request) {
 	orgID := OrgIDFromContext(r.Context())
 
+	var from, to *time.Time
+	if v := r.URL.Query().Get("from"); v != "" {
+		parsed, err := time.Parse(time.RFC3339, v)
+		if err != nil {
+			writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "invalid 'from' timestamp")
+			return
+		}
+		t := parsed.UTC()
+		from = &t
+	}
+	if v := r.URL.Query().Get("to"); v != "" {
+		parsed, err := time.Parse(time.RFC3339, v)
+		if err != nil {
+			writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "invalid 'to' timestamp")
+			return
+		}
+		t := parsed.UTC()
+		to = &t
+	}
+
 	svc := tracehealth.New(h.db)
-	metrics, err := svc.Compute(r.Context(), orgID)
+	metrics, err := svc.Compute(r.Context(), orgID, from, to)
 	if err != nil {
 		h.writeInternalError(w, r, "failed to compute trace health", err)
 		return

--- a/internal/service/tracehealth/service.go
+++ b/internal/service/tracehealth/service.go
@@ -7,6 +7,7 @@ package tracehealth
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -68,8 +69,10 @@ func New(db storage.Store) *Service {
 }
 
 // Compute calculates all trace health metrics for an organization.
-func (s *Service) Compute(ctx context.Context, orgID uuid.UUID) (*Metrics, error) {
-	qs, err := s.db.GetDecisionQualityStats(ctx, orgID)
+// When from/to are non-nil they scope the decision and conflict windows.
+// Pass nil, nil to get all-time metrics (equivalent to the legacy behavior).
+func (s *Service) Compute(ctx context.Context, orgID uuid.UUID, from, to *time.Time) (*Metrics, error) {
+	qs, err := s.db.GetDecisionQualityStats(ctx, orgID, from, to)
 	if err != nil {
 		return nil, fmt.Errorf("tracehealth: quality stats: %w", err)
 	}
@@ -83,12 +86,12 @@ func (s *Service) Compute(ctx context.Context, orgID uuid.UUID) (*Metrics, error
 		}, nil
 	}
 
-	es, err := s.db.GetEvidenceCoverageStats(ctx, orgID)
+	es, err := s.db.GetEvidenceCoverageStats(ctx, orgID, from, to)
 	if err != nil {
 		return nil, fmt.Errorf("tracehealth: evidence stats: %w", err)
 	}
 
-	cc, err := s.db.GetConflictStatusCounts(ctx, orgID)
+	cc, err := s.db.GetConflictStatusCounts(ctx, orgID, from, to)
 	if err != nil {
 		return nil, fmt.Errorf("tracehealth: conflict status counts: %w", err)
 	}
@@ -142,7 +145,7 @@ func (s *Service) Compute(ctx context.Context, orgID uuid.UUID) (*Metrics, error
 	}
 
 	// Outcome signals: temporal, graph, and fate aggregate counts.
-	os, err := s.db.GetOutcomeSignalsSummary(ctx, orgID)
+	os, err := s.db.GetOutcomeSignalsSummary(ctx, orgID, from, to)
 	if err != nil {
 		return nil, fmt.Errorf("tracehealth: outcome signals: %w", err)
 	}

--- a/internal/service/tracehealth/service_test.go
+++ b/internal/service/tracehealth/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -32,19 +33,19 @@ type mockStore struct {
 	typeDistErr      error
 }
 
-func (m *mockStore) GetDecisionQualityStats(_ context.Context, _ uuid.UUID) (storage.DecisionQualityStats, error) {
+func (m *mockStore) GetDecisionQualityStats(_ context.Context, _ uuid.UUID, _, _ *time.Time) (storage.DecisionQualityStats, error) {
 	return m.qualityStats, m.qualityStatsErr
 }
 
-func (m *mockStore) GetEvidenceCoverageStats(_ context.Context, _ uuid.UUID) (storage.EvidenceCoverageStats, error) {
+func (m *mockStore) GetEvidenceCoverageStats(_ context.Context, _ uuid.UUID, _, _ *time.Time) (storage.EvidenceCoverageStats, error) {
 	return m.evidenceStats, m.evidenceStatsErr
 }
 
-func (m *mockStore) GetConflictStatusCounts(_ context.Context, _ uuid.UUID) (storage.ConflictStatusCounts, error) {
+func (m *mockStore) GetConflictStatusCounts(_ context.Context, _ uuid.UUID, _, _ *time.Time) (storage.ConflictStatusCounts, error) {
 	return m.conflictCounts, m.conflictErr
 }
 
-func (m *mockStore) GetOutcomeSignalsSummary(_ context.Context, _ uuid.UUID) (storage.OutcomeSignalsSummary, error) {
+func (m *mockStore) GetOutcomeSignalsSummary(_ context.Context, _ uuid.UUID, _, _ *time.Time) (storage.OutcomeSignalsSummary, error) {
 	return m.outcomeSignals, m.outcomeErr
 }
 
@@ -164,7 +165,7 @@ func TestCompute_InsufficientData(t *testing.T) {
 	}
 	svc := New(ms)
 
-	m, err := svc.Compute(context.Background(), uuid.New())
+	m, err := svc.Compute(context.Background(), uuid.New(), nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "insufficient_data", m.Status)
 	assert.NotNil(t, m.Completeness)
@@ -211,7 +212,7 @@ func TestCompute_HealthyOrg(t *testing.T) {
 	}
 	svc := New(ms)
 
-	m, err := svc.Compute(context.Background(), uuid.New())
+	m, err := svc.Compute(context.Background(), uuid.New(), nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "healthy", m.Status)
 
@@ -264,7 +265,7 @@ func TestCompute_NoConflictsOmitsConflictMetrics(t *testing.T) {
 	}
 	svc := New(ms)
 
-	m, err := svc.Compute(context.Background(), uuid.New())
+	m, err := svc.Compute(context.Background(), uuid.New(), nil, nil)
 	require.NoError(t, err)
 	assert.Nil(t, m.Conflicts, "conflicts should be nil when total == 0")
 }
@@ -275,7 +276,7 @@ func TestCompute_QualityStatsError(t *testing.T) {
 	}
 	svc := New(ms)
 
-	_, err := svc.Compute(context.Background(), uuid.New())
+	_, err := svc.Compute(context.Background(), uuid.New(), nil, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "quality stats")
 	assert.Contains(t, err.Error(), "db timeout")
@@ -288,7 +289,7 @@ func TestCompute_EvidenceStatsError(t *testing.T) {
 	}
 	svc := New(ms)
 
-	_, err := svc.Compute(context.Background(), uuid.New())
+	_, err := svc.Compute(context.Background(), uuid.New(), nil, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "evidence stats")
 }
@@ -301,7 +302,7 @@ func TestCompute_ConflictCountsError(t *testing.T) {
 	}
 	svc := New(ms)
 
-	_, err := svc.Compute(context.Background(), uuid.New())
+	_, err := svc.Compute(context.Background(), uuid.New(), nil, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "conflict status counts")
 }
@@ -315,7 +316,7 @@ func TestCompute_OutcomeSignalsError(t *testing.T) {
 	}
 	svc := New(ms)
 
-	_, err := svc.Compute(context.Background(), uuid.New())
+	_, err := svc.Compute(context.Background(), uuid.New(), nil, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "outcome signals")
 }
@@ -330,7 +331,7 @@ func TestCompute_ConfidenceDistributionError(t *testing.T) {
 	}
 	svc := New(ms)
 
-	_, err := svc.Compute(context.Background(), uuid.New())
+	_, err := svc.Compute(context.Background(), uuid.New(), nil, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "confidence distribution")
 }
@@ -345,7 +346,7 @@ func TestCompute_DecisionTypeDistributionError(t *testing.T) {
 	}
 	svc := New(ms)
 
-	_, err := svc.Compute(context.Background(), uuid.New())
+	_, err := svc.Compute(context.Background(), uuid.New(), nil, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "decision type distribution")
 }

--- a/internal/storage/conflicts.go
+++ b/internal/storage/conflicts.go
@@ -97,16 +97,27 @@ func (db *DB) CountConflicts(ctx context.Context, orgID uuid.UUID, filters Confl
 }
 
 // GetConflictStatusCounts returns the number of conflicts per resolution status for an org.
-func (db *DB) GetConflictStatusCounts(ctx context.Context, orgID uuid.UUID) (ConflictStatusCounts, error) {
+// When from/to are non-nil, only conflicts with detected_at in [from, to) are included.
+func (db *DB) GetConflictStatusCounts(ctx context.Context, orgID uuid.UUID, from, to *time.Time) (ConflictStatusCounts, error) {
 	var c ConflictStatusCounts
-	err := db.pool.QueryRow(ctx, `
+	q := `
 		SELECT count(*),
 		       count(*) FILTER (WHERE status = 'open'),
 		       count(*) FILTER (WHERE status = 'acknowledged'),
 		       count(*) FILTER (WHERE status = 'resolved'),
 		       count(*) FILTER (WHERE status = 'wont_fix')
 		FROM scored_conflicts
-		WHERE org_id = $1`, orgID).Scan(
+		WHERE org_id = $1`
+	args := []any{orgID}
+	if from != nil {
+		args = append(args, *from)
+		q += fmt.Sprintf(" AND detected_at >= $%d", len(args))
+	}
+	if to != nil {
+		args = append(args, *to)
+		q += fmt.Sprintf(" AND detected_at < $%d", len(args))
+	}
+	err := db.pool.QueryRow(ctx, q, args...).Scan(
 		&c.Total, &c.Open, &c.Acknowledged, &c.Resolved, &c.WontFix)
 	if err != nil {
 		return c, fmt.Errorf("storage: conflict status counts: %w", err)

--- a/internal/storage/decisions.go
+++ b/internal/storage/decisions.go
@@ -1796,9 +1796,10 @@ func (db *DB) CountUnvalidatedConflicts(ctx context.Context) (int, error) {
 }
 
 // GetDecisionQualityStats returns aggregate quality metrics for current decisions in an org.
-func (db *DB) GetDecisionQualityStats(ctx context.Context, orgID uuid.UUID) (DecisionQualityStats, error) {
+// When from/to are non-nil, only decisions with valid_from in [from, to) are included.
+func (db *DB) GetDecisionQualityStats(ctx context.Context, orgID uuid.UUID, from, to *time.Time) (DecisionQualityStats, error) {
 	var s DecisionQualityStats
-	err := db.pool.QueryRow(ctx, `
+	q := `
 		SELECT count(*),
 		       COALESCE(avg(completeness_score), 0),
 		       count(*) FILTER (WHERE completeness_score < 0.5),
@@ -1808,7 +1809,17 @@ func (db *DB) GetDecisionQualityStats(ctx context.Context, orgID uuid.UUID) (Dec
 		           SELECT 1 FROM alternatives a WHERE a.decision_id = decisions.id
 		       ))
 		FROM decisions
-		WHERE org_id = $1 AND valid_to IS NULL`, orgID).Scan(
+		WHERE org_id = $1 AND valid_to IS NULL`
+	args := []any{orgID}
+	if from != nil {
+		args = append(args, *from)
+		q += fmt.Sprintf(" AND valid_from >= $%d", len(args))
+	}
+	if to != nil {
+		args = append(args, *to)
+		q += fmt.Sprintf(" AND valid_from < $%d", len(args))
+	}
+	err := db.pool.QueryRow(ctx, q, args...).Scan(
 		&s.Total, &s.AvgCompleteness, &s.BelowHalf, &s.BelowThird, &s.WithReasoning, &s.WithAlternatives)
 	if err != nil {
 		return s, fmt.Errorf("storage: decision quality stats: %w", err)

--- a/internal/storage/evidence.go
+++ b/internal/storage/evidence.go
@@ -135,15 +135,26 @@ func (db *DB) GetEvidenceByDecision(ctx context.Context, decisionID uuid.UUID, o
 }
 
 // GetEvidenceCoverageStats returns how many current decisions have at least one evidence record.
-func (db *DB) GetEvidenceCoverageStats(ctx context.Context, orgID uuid.UUID) (EvidenceCoverageStats, error) {
+// When from/to are non-nil, only decisions with valid_from in [from, to) are included.
+func (db *DB) GetEvidenceCoverageStats(ctx context.Context, orgID uuid.UUID, from, to *time.Time) (EvidenceCoverageStats, error) {
 	var s EvidenceCoverageStats
-	err := db.pool.QueryRow(ctx, `
+	q := `
 		SELECT count(DISTINCT d.id) AS total,
 		       count(DISTINCT e.decision_id) AS with_evidence,
 		       count(e.id) AS total_records
 		FROM decisions d
 		LEFT JOIN evidence e ON d.id = e.decision_id AND e.org_id = d.org_id
-		WHERE d.org_id = $1 AND d.valid_to IS NULL`, orgID).Scan(
+		WHERE d.org_id = $1 AND d.valid_to IS NULL`
+	args := []any{orgID}
+	if from != nil {
+		args = append(args, *from)
+		q += fmt.Sprintf(" AND d.valid_from >= $%d", len(args))
+	}
+	if to != nil {
+		args = append(args, *to)
+		q += fmt.Sprintf(" AND d.valid_from < $%d", len(args))
+	}
+	err := db.pool.QueryRow(ctx, q, args...).Scan(
 		&s.TotalDecisions, &s.WithEvidence, &s.TotalRecords)
 	if err != nil {
 		return s, fmt.Errorf("storage: evidence coverage stats: %w", err)

--- a/internal/storage/sqlite/sqlite_test.go
+++ b/internal/storage/sqlite/sqlite_test.go
@@ -476,21 +476,21 @@ func TestTraceHealth(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("decision quality", func(t *testing.T) {
-		stats, err := db.GetDecisionQualityStats(ctx, orgID)
+		stats, err := db.GetDecisionQualityStats(ctx, orgID, nil, nil)
 		require.NoError(t, err)
 		assert.Equal(t, 1, stats.Total)
 		assert.Equal(t, 1, stats.WithReasoning)
 	})
 
 	t.Run("evidence coverage", func(t *testing.T) {
-		stats, err := db.GetEvidenceCoverageStats(ctx, orgID)
+		stats, err := db.GetEvidenceCoverageStats(ctx, orgID, nil, nil)
 		require.NoError(t, err)
 		assert.Equal(t, 1, stats.TotalDecisions)
 		assert.Equal(t, 0, stats.WithEvidence) // no evidence attached
 	})
 
 	t.Run("conflict status counts", func(t *testing.T) {
-		counts, err := db.GetConflictStatusCounts(ctx, orgID)
+		counts, err := db.GetConflictStatusCounts(ctx, orgID, nil, nil)
 		require.NoError(t, err)
 		assert.Equal(t, 0, counts.Total)
 	})
@@ -504,7 +504,7 @@ func TestTraceHealth(t *testing.T) {
 	})
 
 	t.Run("outcome signals summary", func(t *testing.T) {
-		summary, err := db.GetOutcomeSignalsSummary(ctx, orgID)
+		summary, err := db.GetOutcomeSignalsSummary(ctx, orgID, nil, nil)
 		require.NoError(t, err)
 		assert.Equal(t, 1, summary.DecisionsTotal)
 		assert.Equal(t, 1, summary.NeverSuperseded)
@@ -2743,14 +2743,14 @@ func TestTraceHealth_WithDecisions(t *testing.T) {
 	// Quality stats should reflect the decision. Note: completeness_score
 	// defaults to 0.0 because it's computed by the service layer (quality.Score),
 	// not by CreateTraceTx.
-	qs, err := db.GetDecisionQualityStats(ctx, orgID)
+	qs, err := db.GetDecisionQualityStats(ctx, orgID, nil, nil)
 	require.NoError(t, err)
 	assert.GreaterOrEqual(t, qs.Total, 1)
 	assert.GreaterOrEqual(t, qs.WithReasoning, 1)
 	assert.GreaterOrEqual(t, qs.WithAlternatives, 1)
 
 	// Evidence coverage should reflect the evidence.
-	ec, err := db.GetEvidenceCoverageStats(ctx, orgID)
+	ec, err := db.GetEvidenceCoverageStats(ctx, orgID, nil, nil)
 	require.NoError(t, err)
 	assert.GreaterOrEqual(t, ec.TotalDecisions, 1)
 	assert.GreaterOrEqual(t, ec.WithEvidence, 1)
@@ -2758,12 +2758,12 @@ func TestTraceHealth_WithDecisions(t *testing.T) {
 	assert.GreaterOrEqual(t, ec.TotalRecords, 1)
 
 	// Conflict status counts with no conflicts.
-	cc, err := db.GetConflictStatusCounts(ctx, orgID)
+	cc, err := db.GetConflictStatusCounts(ctx, orgID, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, 0, cc.Total)
 
 	// Outcome signals summary.
-	os, err := db.GetOutcomeSignalsSummary(ctx, orgID)
+	os, err := db.GetOutcomeSignalsSummary(ctx, orgID, nil, nil)
 	require.NoError(t, err)
 	assert.GreaterOrEqual(t, os.DecisionsTotal, 1)
 }
@@ -4441,7 +4441,7 @@ func TestGetOutcomeSignalsSummary_WithData(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	summary, err := db.GetOutcomeSignalsSummary(ctx, orgID)
+	summary, err := db.GetOutcomeSignalsSummary(ctx, orgID, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, 3, summary.DecisionsTotal)
 	assert.Equal(t, 3, summary.NeverSuperseded)
@@ -4533,7 +4533,7 @@ func TestGetConflictStatusCounts_WithData(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	counts, err := db.GetConflictStatusCounts(ctx, orgID)
+	counts, err := db.GetConflictStatusCounts(ctx, orgID, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, 2, counts.Total)
 	assert.Equal(t, 1, counts.Open)
@@ -4580,7 +4580,7 @@ func TestGetEvidenceCoverageStats_WithData(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	stats, err := db.GetEvidenceCoverageStats(ctx, orgID)
+	stats, err := db.GetEvidenceCoverageStats(ctx, orgID, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, 2, stats.TotalDecisions)
 	assert.Equal(t, 1, stats.WithEvidence)
@@ -4818,7 +4818,7 @@ func TestGetDecisionQualityStats_EmptyOrg(t *testing.T) {
 	require.NoError(t, db.EnsureDefaultOrg(ctx))
 	orgID := uuid.Nil
 
-	stats, err := db.GetDecisionQualityStats(ctx, orgID)
+	stats, err := db.GetDecisionQualityStats(ctx, orgID, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, 0, stats.Total)
 	assert.Equal(t, 0.0, stats.AvgCompleteness)
@@ -4868,7 +4868,7 @@ func TestGetDecisionQualityStats_WithData(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	stats, err := db.GetDecisionQualityStats(ctx, orgID)
+	stats, err := db.GetDecisionQualityStats(ctx, orgID, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, 2, stats.Total)
 	assert.Equal(t, 1, stats.WithReasoning, "only one decision has reasoning")
@@ -4885,7 +4885,7 @@ func TestGetOutcomeSignalsSummary_EmptyOrg(t *testing.T) {
 	require.NoError(t, db.EnsureDefaultOrg(ctx))
 	orgID := uuid.Nil
 
-	summary, err := db.GetOutcomeSignalsSummary(ctx, orgID)
+	summary, err := db.GetOutcomeSignalsSummary(ctx, orgID, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, 0, summary.DecisionsTotal)
 }
@@ -6384,7 +6384,7 @@ func TestGetEvidenceCoverageStats_EmptyOrg(t *testing.T) {
 	require.NoError(t, db.EnsureDefaultOrg(ctx))
 	orgID := uuid.Nil
 
-	stats, err := db.GetEvidenceCoverageStats(ctx, orgID)
+	stats, err := db.GetEvidenceCoverageStats(ctx, orgID, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, 0, stats.TotalDecisions)
 	assert.Equal(t, float64(0), stats.CoveragePercent)

--- a/internal/storage/sqlite/tracehealth.go
+++ b/internal/storage/sqlite/tracehealth.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -12,19 +13,28 @@ import (
 )
 
 // GetDecisionQualityStats returns aggregate quality metrics for an org's decisions.
-func (l *LiteDB) GetDecisionQualityStats(ctx context.Context, orgID uuid.UUID) (storage.DecisionQualityStats, error) {
+// When from/to are non-nil, only decisions with valid_from in [from, to) are included.
+func (l *LiteDB) GetDecisionQualityStats(ctx context.Context, orgID uuid.UUID, from, to *time.Time) (storage.DecisionQualityStats, error) {
 	var qs storage.DecisionQualityStats
-	err := l.db.QueryRowContext(ctx,
-		`SELECT
+	q := `SELECT
 		     COUNT(*),
 		     COALESCE(AVG(completeness_score), 0),
 		     COALESCE(SUM(CASE WHEN completeness_score < 0.5 THEN 1 ELSE 0 END), 0),
 		     COALESCE(SUM(CASE WHEN completeness_score < 0.33 THEN 1 ELSE 0 END), 0),
 		     COALESCE(SUM(CASE WHEN reasoning IS NOT NULL AND reasoning != '' THEN 1 ELSE 0 END), 0),
 		     COALESCE(SUM(CASE WHEN EXISTS (SELECT 1 FROM alternatives a WHERE a.decision_id = decisions.id) THEN 1 ELSE 0 END), 0)
-		 FROM decisions WHERE org_id = ? AND valid_to IS NULL`,
-		uuidStr(orgID),
-	).Scan(&qs.Total, &qs.AvgCompleteness, &qs.BelowHalf, &qs.BelowThird, &qs.WithReasoning, &qs.WithAlternatives)
+		 FROM decisions WHERE org_id = ? AND valid_to IS NULL`
+	args := []any{uuidStr(orgID)}
+	if from != nil {
+		q += " AND valid_from >= ?"
+		args = append(args, from.UTC().Format("2006-01-02T15:04:05.999999999Z"))
+	}
+	if to != nil {
+		q += " AND valid_from < ?"
+		args = append(args, to.UTC().Format("2006-01-02T15:04:05.999999999Z"))
+	}
+	err := l.db.QueryRowContext(ctx, q, args...).Scan(
+		&qs.Total, &qs.AvgCompleteness, &qs.BelowHalf, &qs.BelowThird, &qs.WithReasoning, &qs.WithAlternatives)
 	if err != nil {
 		return storage.DecisionQualityStats{}, fmt.Errorf("sqlite: quality stats: %w", err)
 	}
@@ -32,19 +42,27 @@ func (l *LiteDB) GetDecisionQualityStats(ctx context.Context, orgID uuid.UUID) (
 }
 
 // GetEvidenceCoverageStats returns evidence coverage metrics for an org.
-func (l *LiteDB) GetEvidenceCoverageStats(ctx context.Context, orgID uuid.UUID) (storage.EvidenceCoverageStats, error) {
+// When from/to are non-nil, only decisions with valid_from in [from, to) are included.
+func (l *LiteDB) GetEvidenceCoverageStats(ctx context.Context, orgID uuid.UUID, from, to *time.Time) (storage.EvidenceCoverageStats, error) {
 	var (
 		totalDecisions int
 		withEvidence   int
 		totalRecords   int
 	)
-	err := l.db.QueryRowContext(ctx,
-		`SELECT COUNT(DISTINCT d.id), COUNT(DISTINCT e.decision_id), COUNT(e.id)
+	q := `SELECT COUNT(DISTINCT d.id), COUNT(DISTINCT e.decision_id), COUNT(e.id)
 		 FROM decisions d
 		 LEFT JOIN evidence e ON d.id = e.decision_id AND e.org_id = d.org_id
-		 WHERE d.org_id = ? AND d.valid_to IS NULL`,
-		uuidStr(orgID),
-	).Scan(&totalDecisions, &withEvidence, &totalRecords)
+		 WHERE d.org_id = ? AND d.valid_to IS NULL`
+	args := []any{uuidStr(orgID)}
+	if from != nil {
+		q += " AND d.valid_from >= ?"
+		args = append(args, from.UTC().Format("2006-01-02T15:04:05.999999999Z"))
+	}
+	if to != nil {
+		q += " AND d.valid_from < ?"
+		args = append(args, to.UTC().Format("2006-01-02T15:04:05.999999999Z"))
+	}
+	err := l.db.QueryRowContext(ctx, q, args...).Scan(&totalDecisions, &withEvidence, &totalRecords)
 	if err != nil {
 		return storage.EvidenceCoverageStats{}, fmt.Errorf("sqlite: evidence coverage: %w", err)
 	}
@@ -68,18 +86,27 @@ func (l *LiteDB) GetEvidenceCoverageStats(ctx context.Context, orgID uuid.UUID) 
 }
 
 // GetConflictStatusCounts returns conflict status breakdown for an org.
-func (l *LiteDB) GetConflictStatusCounts(ctx context.Context, orgID uuid.UUID) (storage.ConflictStatusCounts, error) {
+// When from/to are non-nil, only conflicts with detected_at in [from, to) are included.
+func (l *LiteDB) GetConflictStatusCounts(ctx context.Context, orgID uuid.UUID, from, to *time.Time) (storage.ConflictStatusCounts, error) {
 	var cc storage.ConflictStatusCounts
-	err := l.db.QueryRowContext(ctx,
-		`SELECT
+	q := `SELECT
 		     COUNT(*),
 		     COALESCE(SUM(CASE WHEN status = 'open' THEN 1 ELSE 0 END), 0),
 		     COALESCE(SUM(CASE WHEN status = 'acknowledged' THEN 1 ELSE 0 END), 0),
 		     COALESCE(SUM(CASE WHEN status = 'resolved' THEN 1 ELSE 0 END), 0),
 		     COALESCE(SUM(CASE WHEN status = 'wont_fix' THEN 1 ELSE 0 END), 0)
-		 FROM scored_conflicts WHERE org_id = ?`,
-		uuidStr(orgID),
-	).Scan(&cc.Total, &cc.Open, &cc.Acknowledged, &cc.Resolved, &cc.WontFix)
+		 FROM scored_conflicts WHERE org_id = ?`
+	args := []any{uuidStr(orgID)}
+	if from != nil {
+		q += " AND detected_at >= ?"
+		args = append(args, from.UTC().Format("2006-01-02T15:04:05.999999999Z"))
+	}
+	if to != nil {
+		q += " AND detected_at < ?"
+		args = append(args, to.UTC().Format("2006-01-02T15:04:05.999999999Z"))
+	}
+	err := l.db.QueryRowContext(ctx, q, args...).Scan(
+		&cc.Total, &cc.Open, &cc.Acknowledged, &cc.Resolved, &cc.WontFix)
 	if err != nil {
 		return storage.ConflictStatusCounts{}, fmt.Errorf("sqlite: conflict status counts: %w", err)
 	}
@@ -111,10 +138,10 @@ func (l *LiteDB) GetWontFixRate(ctx context.Context, orgID uuid.UUID) (storage.W
 }
 
 // GetOutcomeSignalsSummary returns aggregate outcome signal metrics for an org.
-func (l *LiteDB) GetOutcomeSignalsSummary(ctx context.Context, orgID uuid.UUID) (storage.OutcomeSignalsSummary, error) {
+// When from/to are non-nil, only decisions with valid_from in [from, to) are included.
+func (l *LiteDB) GetOutcomeSignalsSummary(ctx context.Context, orgID uuid.UUID, from, to *time.Time) (storage.OutcomeSignalsSummary, error) {
 	var os storage.OutcomeSignalsSummary
-	err := l.db.QueryRowContext(ctx,
-		`SELECT
+	q := `SELECT
 		     COUNT(*),
 		     COALESCE(SUM(CASE WHEN NOT EXISTS (
 		         SELECT 1 FROM decisions sup WHERE sup.supersedes_id = d.id AND sup.org_id = d.org_id
@@ -147,9 +174,17 @@ func (l *LiteDB) GetOutcomeSignalsSummary(ctx context.Context, orgID uuid.UUID) 
 		         WHERE (sc.decision_a_id = d.id OR sc.decision_b_id = d.id)
 		           AND sc.status = 'resolved' AND sc.winning_decision_id IS NULL
 		     ) THEN 1 ELSE 0 END), 0)
-		 FROM decisions d WHERE d.org_id = ? AND d.valid_to IS NULL`,
-		uuidStr(orgID),
-	).Scan(
+		 FROM decisions d WHERE d.org_id = ? AND d.valid_to IS NULL`
+	args := []any{uuidStr(orgID)}
+	if from != nil {
+		q += " AND d.valid_from >= ?"
+		args = append(args, from.UTC().Format("2006-01-02T15:04:05.999999999Z"))
+	}
+	if to != nil {
+		q += " AND d.valid_from < ?"
+		args = append(args, to.UTC().Format("2006-01-02T15:04:05.999999999Z"))
+	}
+	err := l.db.QueryRowContext(ctx, q, args...).Scan(
 		&os.DecisionsTotal, &os.NeverSuperseded, &os.RevisedWithin48h,
 		&os.NeverCited, &os.CitedAtLeastOnce,
 		&os.ConflictsWon, &os.ConflictsLost, &os.ConflictsNoWinner,

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -3675,7 +3675,7 @@ func TestCountDecisionsByAPIKey(t *testing.T) {
 func TestGetDecisionQualityStats(t *testing.T) {
 	ctx := context.Background()
 
-	stats, err := testDB.GetDecisionQualityStats(ctx, uuid.Nil)
+	stats, err := testDB.GetDecisionQualityStats(ctx, uuid.Nil, nil, nil)
 	require.NoError(t, err)
 	assert.GreaterOrEqual(t, stats.Total, 0)
 	// From earlier tests, there should be at least some decisions with reasoning.
@@ -3685,7 +3685,7 @@ func TestGetDecisionQualityStats(t *testing.T) {
 func TestGetEvidenceCoverageStats(t *testing.T) {
 	ctx := context.Background()
 
-	stats, err := testDB.GetEvidenceCoverageStats(ctx, uuid.Nil)
+	stats, err := testDB.GetEvidenceCoverageStats(ctx, uuid.Nil, nil, nil)
 	require.NoError(t, err)
 	assert.GreaterOrEqual(t, stats.TotalDecisions, 0)
 	assert.GreaterOrEqual(t, stats.WithEvidence, 0)
@@ -3695,7 +3695,7 @@ func TestGetEvidenceCoverageStats(t *testing.T) {
 func TestGetConflictStatusCounts(t *testing.T) {
 	ctx := context.Background()
 
-	counts, err := testDB.GetConflictStatusCounts(ctx, uuid.Nil)
+	counts, err := testDB.GetConflictStatusCounts(ctx, uuid.Nil, nil, nil)
 	require.NoError(t, err)
 	assert.GreaterOrEqual(t, counts.Total, 0)
 	assert.Equal(t, counts.Total, counts.Open+counts.Acknowledged+counts.Resolved+counts.WontFix)
@@ -3704,7 +3704,7 @@ func TestGetConflictStatusCounts(t *testing.T) {
 func TestGetOutcomeSignalsSummary(t *testing.T) {
 	ctx := context.Background()
 
-	summary, err := testDB.GetOutcomeSignalsSummary(ctx, uuid.Nil)
+	summary, err := testDB.GetOutcomeSignalsSummary(ctx, uuid.Nil, nil, nil)
 	require.NoError(t, err)
 	assert.GreaterOrEqual(t, summary.DecisionsTotal, 0)
 	assert.GreaterOrEqual(t, summary.NeverSuperseded, 0)
@@ -7662,7 +7662,7 @@ func TestGetConflictAnalytics_StructureValidation(t *testing.T) {
 
 func TestGetOutcomeSignalsSummary_Populated(t *testing.T) {
 	ctx := context.Background()
-	summary, err := testDB.GetOutcomeSignalsSummary(ctx, uuid.Nil)
+	summary, err := testDB.GetOutcomeSignalsSummary(ctx, uuid.Nil, nil, nil)
 	require.NoError(t, err)
 	assert.GreaterOrEqual(t, summary.DecisionsTotal, 0)
 	assert.GreaterOrEqual(t, summary.NeverSuperseded, 0)
@@ -7677,7 +7677,7 @@ func TestGetOutcomeSignalsSummary_Populated(t *testing.T) {
 
 func TestGetDecisionQualityStats_Structure(t *testing.T) {
 	ctx := context.Background()
-	stats, err := testDB.GetDecisionQualityStats(ctx, uuid.Nil)
+	stats, err := testDB.GetDecisionQualityStats(ctx, uuid.Nil, nil, nil)
 	require.NoError(t, err)
 	assert.GreaterOrEqual(t, stats.Total, 0)
 }
@@ -9265,7 +9265,7 @@ func TestReserveSequenceNums_NegativeCount(t *testing.T) {
 
 func TestGetDecisionQualityStats_WithDecisions(t *testing.T) {
 	ctx := context.Background()
-	stats, err := testDB.GetDecisionQualityStats(ctx, uuid.Nil)
+	stats, err := testDB.GetDecisionQualityStats(ctx, uuid.Nil, nil, nil)
 	require.NoError(t, err)
 	// The default org will have decisions from other tests.
 	assert.GreaterOrEqual(t, stats.Total, 0)
@@ -9614,7 +9614,7 @@ func TestQueryDecisions_WithProjectFilter(t *testing.T) {
 
 func TestGetConflictStatusCounts_StructureVerification(t *testing.T) {
 	ctx := context.Background()
-	counts, err := testDB.GetConflictStatusCounts(ctx, uuid.Nil)
+	counts, err := testDB.GetConflictStatusCounts(ctx, uuid.Nil, nil, nil)
 	require.NoError(t, err)
 	assert.GreaterOrEqual(t, counts.Total, 0)
 	assert.GreaterOrEqual(t, counts.Open, 0)
@@ -9741,7 +9741,7 @@ func TestCountConflicts_WithDecisionTypeFilter(t *testing.T) {
 
 func TestGetEvidenceCoverageStats_Structure(t *testing.T) {
 	ctx := context.Background()
-	stats, err := testDB.GetEvidenceCoverageStats(ctx, uuid.Nil)
+	stats, err := testDB.GetEvidenceCoverageStats(ctx, uuid.Nil, nil, nil)
 	require.NoError(t, err)
 	assert.GreaterOrEqual(t, stats.TotalDecisions, 0)
 	assert.GreaterOrEqual(t, stats.TotalRecords, 0)

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -115,11 +115,16 @@ type Store interface {
 
 	// ---- Trace health ----
 
-	GetDecisionQualityStats(ctx context.Context, orgID uuid.UUID) (DecisionQualityStats, error)
-	GetEvidenceCoverageStats(ctx context.Context, orgID uuid.UUID) (EvidenceCoverageStats, error)
-	GetConflictStatusCounts(ctx context.Context, orgID uuid.UUID) (ConflictStatusCounts, error)
+	// GetDecisionQualityStats returns aggregate quality metrics. When from/to are non-nil
+	// only decisions with valid_from in [from, to) are included; nil means no bound.
+	GetDecisionQualityStats(ctx context.Context, orgID uuid.UUID, from, to *time.Time) (DecisionQualityStats, error)
+	// GetEvidenceCoverageStats returns evidence coverage metrics. from/to scope decisions by valid_from.
+	GetEvidenceCoverageStats(ctx context.Context, orgID uuid.UUID, from, to *time.Time) (EvidenceCoverageStats, error)
+	// GetConflictStatusCounts returns conflict status breakdown. from/to scope conflicts by detected_at.
+	GetConflictStatusCounts(ctx context.Context, orgID uuid.UUID, from, to *time.Time) (ConflictStatusCounts, error)
 	GetWontFixRate(ctx context.Context, orgID uuid.UUID) (WontFixRate, error)
-	GetOutcomeSignalsSummary(ctx context.Context, orgID uuid.UUID) (OutcomeSignalsSummary, error)
+	// GetOutcomeSignalsSummary returns outcome signals. from/to scope decisions by valid_from.
+	GetOutcomeSignalsSummary(ctx context.Context, orgID uuid.UUID, from, to *time.Time) (OutcomeSignalsSummary, error)
 	GetConfidenceDistribution(ctx context.Context, orgID uuid.UUID) (ConfidenceDistribution, error)
 	GetDecisionTypeDistribution(ctx context.Context, orgID uuid.UUID) ([]DecisionTypeCount, error)
 

--- a/internal/storage/tracehealth.go
+++ b/internal/storage/tracehealth.go
@@ -5,14 +5,28 @@ package storage
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 )
 
 // GetOutcomeSignalsSummary returns org-level aggregate outcome signal counts
 // for use in GET /v1/trace-health.
-func (db *DB) GetOutcomeSignalsSummary(ctx context.Context, orgID uuid.UUID) (OutcomeSignalsSummary, error) {
+// When from/to are non-nil, only decisions with valid_from in [from, to) are included.
+func (db *DB) GetOutcomeSignalsSummary(ctx context.Context, orgID uuid.UUID, from, to *time.Time) (OutcomeSignalsSummary, error) {
 	var s OutcomeSignalsSummary
+
+	// Build optional time-range clause for the anchor decision (d).
+	timeFilter := ""
+	args := []any{orgID}
+	if from != nil {
+		args = append(args, *from)
+		timeFilter += fmt.Sprintf(" AND d.valid_from >= $%d", len(args))
+	}
+	if to != nil {
+		args = append(args, *to)
+		timeFilter += fmt.Sprintf(" AND d.valid_from < $%d", len(args))
+	}
 
 	// Decision-level counts: total, never_superseded, revised_within_48h, citation coverage.
 	// Uses EXISTS subqueries to avoid joins that would multiply rows.
@@ -38,7 +52,7 @@ func (db *DB) GetOutcomeSignalsSummary(ctx context.Context, orgID uuid.UUID) (Ou
 		        WHERE cit.precedent_ref = d.id AND cit.org_id = d.org_id AND cit.valid_to IS NULL
 		    ))::int
 		FROM decisions d
-		WHERE d.org_id = $1 AND d.valid_to IS NULL`, orgID).Scan(
+		WHERE d.org_id = $1 AND d.valid_to IS NULL`+timeFilter, args...).Scan(
 		&s.DecisionsTotal,
 		&s.NeverSuperseded,
 		&s.RevisedWithin48h,

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -376,8 +376,15 @@ export async function adjudicateConflict(
 }
 
 // Trace health
-export async function getTraceHealth(): Promise<TraceHealth> {
-  return request<TraceHealth>("/v1/trace-health");
+export async function getTraceHealth(params?: {
+  from?: string;
+  to?: string;
+}): Promise<TraceHealth> {
+  const searchParams = new URLSearchParams();
+  if (params?.from) searchParams.set("from", params.from);
+  if (params?.to) searchParams.set("to", params.to);
+  const qs = searchParams.toString();
+  return request<TraceHealth>(`/v1/trace-health${qs ? `?${qs}` : ""}`);
 }
 
 // Conflict analytics

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -2,13 +2,10 @@ import { useQuery } from "@tanstack/react-query";
 import { useMemo, useState } from "react";
 import {
   getRecentDecisions,
-  listAgents,
   getTraceHealth,
   getConflictAnalytics,
   queryDecisions,
-  listAgentsWithStats,
 } from "@/lib/api";
-import type { AgentWithStats } from "@/lib/api";
 import type {
   Decision,
   ConflictTrendPoint,
@@ -331,11 +328,17 @@ function DecisionTypeChart({ data }: { data: DecisionTypeCount[] }) {
   );
 }
 
+type ScorecardAgent = {
+  agent_id: string;
+  decision_count: number;
+  last_decision_at: string | null;
+};
+
 /** Agent scorecard table. */
-function AgentScorecard({ agents }: { agents: AgentWithStats[] }) {
+function AgentScorecard({ agents }: { agents: ScorecardAgent[] }) {
   const active = [...agents]
-    .filter((a) => (a.decision_count ?? 0) > 0)
-    .sort((a, b) => (b.decision_count ?? 0) - (a.decision_count ?? 0));
+    .filter((a) => a.decision_count > 0)
+    .sort((a, b) => b.decision_count - a.decision_count);
   const sorted = active.slice(0, 5);
   const overflow = active.length - sorted.length;
 
@@ -394,13 +397,9 @@ export default function Dashboard() {
     queryKey: ["dashboard", "recent"],
     queryFn: () => getRecentDecisions({ limit: 5 }),
   });
-  const agents = useQuery({
-    queryKey: ["dashboard", "agents"],
-    queryFn: listAgents,
-  });
   const traceHealth = useQuery({
-    queryKey: ["dashboard", "trace-health"],
-    queryFn: getTraceHealth,
+    queryKey: ["dashboard", "trace-health", period],
+    queryFn: () => getTraceHealth(periodToTimeRange(period)),
     staleTime: 30_000,
   });
   const conflictAnalytics = useQuery({
@@ -421,11 +420,6 @@ export default function Dashboard() {
       }),
     staleTime: 60_000,
   });
-  const agentsWithStats = useQuery({
-    queryKey: ["dashboard", "agents-stats"],
-    queryFn: listAgentsWithStats,
-    staleTime: 60_000,
-  });
 
   const healthConfig = healthStatusConfig[traceHealth.data?.status ?? ""] ?? {
     label: "Unknown",
@@ -438,6 +432,29 @@ export default function Dashboard() {
   const analytics = conflictAnalytics.data;
   const decisionList = decisionsTrend.data?.decisions ?? [];
   const dailyStats = useMemo(() => buildDailyStats(decisionList), [decisionList]);
+
+  /** Period-scoped distinct active agents, derived from the already-fetched decisions list. */
+  const periodActiveAgentCount = useMemo(() => {
+    const ids = new Set(decisionList.map((d) => d.agent_id));
+    return ids.size;
+  }, [decisionList]);
+
+  /** Period-scoped agent scorecard, derived from the already-fetched decisions list. */
+  const periodAgentScorecard = useMemo((): ScorecardAgent[] => {
+    const byAgent: Record<string, { count: number; lastAt: string }> = {};
+    for (const d of decisionList) {
+      const prev = byAgent[d.agent_id];
+      byAgent[d.agent_id] = {
+        count: (prev?.count ?? 0) + 1,
+        lastAt: prev && prev.lastAt > d.created_at ? prev.lastAt : d.created_at,
+      };
+    }
+    return Object.entries(byAgent).map(([agent_id, stats]) => ({
+      agent_id,
+      decision_count: stats.count,
+      last_decision_at: stats.lastAt,
+    }));
+  }, [decisionList]);
 
   /** Decision type distribution derived from the period-filtered query. */
   const periodDecisionTypes: { decision_type: string; count: number }[] = useMemo(() => {
@@ -504,18 +521,14 @@ export default function Dashboard() {
             <FileText className="h-4 w-4 text-primary/50" />
           </CardHeader>
           <CardContent>
-            {recent.isPending ? (
+            {decisionsTrend.isPending ? (
               <Skeleton className="h-8 w-20" />
             ) : (
               <div className="text-3xl font-semibold tabular-nums tracking-tight">
-                {(recent.data?.total ?? 0).toLocaleString()}
+                {(decisionsTrend.data?.total ?? 0).toLocaleString()}
               </div>
             )}
-            {traceHealth.data && (
-              <p className="text-[11px] text-muted-foreground mt-1">
-                {traceHealth.data.completeness.total_decisions} total traced
-              </p>
-            )}
+            <p className="text-[11px] text-muted-foreground mt-1">in period</p>
           </CardContent>
         </Card>
 
@@ -525,14 +538,14 @@ export default function Dashboard() {
             <Users className="h-4 w-4 text-primary/50" />
           </CardHeader>
           <CardContent>
-            {agents.isPending ? (
+            {decisionsTrend.isPending ? (
               <Skeleton className="h-8 w-12" />
             ) : (
               <div className="text-3xl font-semibold tabular-nums tracking-tight">
-                {agents.data?.length ?? 0}
+                {periodActiveAgentCount}
               </div>
             )}
-            <p className="text-[11px] text-muted-foreground mt-1">registered</p>
+            <p className="text-[11px] text-muted-foreground mt-1">with decisions in period</p>
           </CardContent>
         </Card>
 
@@ -949,10 +962,10 @@ export default function Dashboard() {
             </CardTitle>
           </CardHeader>
           <CardContent>
-            {agentsWithStats.isPending ? (
+            {decisionsTrend.isPending ? (
               <Skeleton className="h-32 w-full" />
             ) : (
-              <AgentScorecard agents={agentsWithStats.data ?? []} />
+              <AgentScorecard agents={periodAgentScorecard} />
             )}
           </CardContent>
         </Card>


### PR DESCRIPTION
## Summary

Fixes #449. Every visible number on the dashboard now updates when the period selector changes.

**Backend (`GET /v1/trace-health`):**
- Accepts optional `from` / `to` query params (RFC3339). When present, metrics are scoped to that window.
- Four storage functions gained `from, to *time.Time` params on both the `Store` interface and the PostgreSQL + SQLite implementations:
  - `GetDecisionQualityStats` — scoped by `valid_from` (drives Trace Health completeness ring + status)
  - `GetEvidenceCoverageStats` — scoped by `valid_from`
  - `GetConflictStatusCounts` — scoped by `detected_at` (drives Open Conflicts count)
  - `GetOutcomeSignalsSummary` — scoped by `valid_from` (drives Stability % and Citation Rate %)
- `tracehealth.Service.Compute` gains `from, to *time.Time`; `nil, nil` preserves the existing all-time behavior used by the MCP `akashi_stats` tool.

**Frontend (`Dashboard.tsx`):**
- `traceHealth` query includes `period` in its cache key and passes `from`/`to`, so the completeness ring, Open Conflicts, Stability %, and Citation Rate % all re-fetch when the period changes.
- **Decisions count** uses `decisionsTrend.data.total` (already period-scoped) instead of the all-time `recent.data.total`.
- **Active Agents** is derived client-side as the count of distinct `agent_id` values in the period decisions list — no extra API call needed.
- **Agent Scorecard** is similarly derived client-side from the period decisions list, removing the `listAgentsWithStats` call and making it period-scoped without backend changes.

## What changed (before → after period switch)

| Card | Before | After |
|---|---|---|
| Decisions count | All-time total | Decisions in selected period |
| Active Agents | All registered agents | Distinct agents with decisions in period |
| Open Conflicts | All-time open conflicts | Conflicts detected in period that are open |
| Trace Health ring | All-time completeness | Avg completeness of period decisions |
| Stability % | All-time stability | Stability of period decisions |
| Citation Rate % | All-time citation rate | Citation rate of period decisions |
| Agent Scorecard | All-time decision counts | Decision counts in period |

## Test plan
- [x] `go test -race -count=1 ./...` — all pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] UI build — clean TypeScript, no errors
- [x] Switch 30d → 7d: all stat cards update
- [x] `nil, nil` call sites preserve existing all-time behavior for MCP stats tool

> The Force is patient. Luke didn't rush Yoda's training, and Yoda didn't skip the swamp.
> Backend changes only where the Force truly required them; client-side derivation for the rest.