### PR TITLE
feat(mcp): surface specific evidence gap tips in completeness feedback

### DIFF
--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -906,12 +906,14 @@ func computeMissingFields(decisionType, outcome string, confidence float32, reas
 		tips = append(tips, fmt.Sprintf("Add %d more rejected alternatives with rejection_reason >20 chars (+%d%%)", 3-substantive, (3-substantive)*5))
 	}
 
-	// Evidence (up to 0.15).
+	// Evidence (up to 0.15). Be specific about what counts as evidence so
+	// agents know what to attach — file paths, error messages, test output,
+	// benchmark numbers, or the constraint that drove the choice.
 	if len(evidence) < 2 {
 		if len(evidence) == 0 {
-			tips = append(tips, "Add 2+ evidence items (source_type + content) to support your decision (+15%)")
+			tips = append(tips, "Add evidence to make this trace verifiable: attach file paths, error messages, test output, benchmark numbers, or the constraint that drove the choice (source_type + content, 2+ items for +15%)")
 		} else {
-			tips = append(tips, "Add 1 more evidence item for full credit (+5%)")
+			tips = append(tips, "Add 1 more evidence item for full credit — e.g. a file path, error message, test result, or benchmark number (+5%)")
 		}
 	}
 

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -2852,4 +2853,84 @@ func TestHandleResolve_WinnerNotInConflict(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, result.IsError)
 	assert.Contains(t, parseToolText(t, result), "must be one of the two decisions")
+}
+
+func TestComputeMissingFields_EvidenceTips(t *testing.T) {
+	t.Parallel()
+
+	reasoning := "A long enough reasoning string that exceeds one hundred characters so it doesn't trigger the reasoning tip in the output"
+	reason := "solid reason for rejection"
+	fullAlts := []model.TraceAlternative{
+		{Label: "alt1", Selected: false, RejectionReason: &reason},
+		{Label: "alt2", Selected: false, RejectionReason: &reason},
+		{Label: "alt3", Selected: false, RejectionReason: &reason},
+	}
+
+	tests := []struct {
+		name     string
+		evidence []model.TraceEvidence
+		wantTip  string
+		noTip    bool
+	}{
+		{
+			name:     "no evidence — actionable tip with examples",
+			evidence: nil,
+			wantTip:  "Add evidence to make this trace verifiable: attach file paths, error messages, test output, benchmark numbers, or the constraint that drove the choice",
+		},
+		{
+			name:     "empty slice — same as nil",
+			evidence: []model.TraceEvidence{},
+			wantTip:  "Add evidence to make this trace verifiable",
+		},
+		{
+			name: "one evidence item — nudge for more",
+			evidence: []model.TraceEvidence{
+				{SourceType: "tool_output", Content: "test passed"},
+			},
+			wantTip: "Add 1 more evidence item for full credit",
+		},
+		{
+			name: "one evidence item tip includes examples",
+			evidence: []model.TraceEvidence{
+				{SourceType: "tool_output", Content: "test passed"},
+			},
+			wantTip: "file path, error message, test result, or benchmark number",
+		},
+		{
+			name: "two evidence items — no tip",
+			evidence: []model.TraceEvidence{
+				{SourceType: "document", Content: "evidence one"},
+				{SourceType: "api_response", Content: "evidence two"},
+			},
+			noTip: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tips := computeMissingFields("architecture", "chose X", 0.7, &reasoning, fullAlts, tc.evidence, true)
+
+			// Filter to only evidence-related tips.
+			var evidenceTips []string
+			for _, tip := range tips {
+				if containsEvidence(tip) {
+					evidenceTips = append(evidenceTips, tip)
+				}
+			}
+
+			if tc.noTip {
+				assert.Empty(t, evidenceTips, "expected no evidence tip with >=2 items")
+				return
+			}
+
+			require.Len(t, evidenceTips, 1, "expected exactly one evidence tip")
+			assert.Contains(t, evidenceTips[0], tc.wantTip)
+		})
+	}
+}
+
+// containsEvidence returns true if the tip string relates to evidence.
+func containsEvidence(tip string) bool {
+	return strings.Contains(tip, "evidence") || strings.Contains(tip, "verifiable")
 }


### PR DESCRIPTION
## Summary

- When `evidence` is absent, the completeness tip now enumerates concrete examples of what to attach (file paths, error messages, test output, benchmark numbers, constraints) instead of a generic "add evidence" message
- When `evidence` has only 1 item, the nudge likewise includes example types so agents know what to provide
- Added table-driven `TestComputeMissingFields_EvidenceTips` covering zero, one, and two+ evidence cases

## Test plan

- [x] `go test -race -count=1 -run TestComputeMissingFields_EvidenceTips ./internal/mcp/...` passes
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go build ./...` and `go vet ./...` clean
- [ ] Verify in a live MCP session that `akashi_trace` with no evidence returns the new actionable tip

Closes #458

> The Enterprise's computer could answer any question in seconds,
> yet Picard still asked "opinions?" around the conference table —
> because raw data without context is just noise. Evidence tips
> are the akashi equivalent of Picard's ready room briefings:
> they turn a bare decision into something the next crew can trust.