### PR TITLE
feat(ui): decision lineage view for precedent attribution chains

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -907,6 +907,35 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
+  /v1/decisions/{id}/lineage:
+    get:
+      operationId: getDecisionLineage
+      tags: [Query]
+      summary: Get decision precedent lineage
+      description: |
+        Returns the precedent chain for a decision: the decision it cites
+        as a precedent (`preceded_by`) and decisions that cite it (`cited_by`).
+        Requires `reader` role or higher.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: The decision ID to get lineage for.
+      responses:
+        "200":
+          description: Lineage chain for the decision.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/APIResponse_DecisionLineage"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
   /v1/decisions/{id}/conflicts:
     get:
       operationId: getDecisionConflicts
@@ -4147,6 +4176,65 @@ components:
           $ref: "#/components/schemas/RevisionsResponse"
         meta:
           $ref: "#/components/schemas/ResponseMeta"
+
+    APIResponse_DecisionLineage:
+      type: object
+      required: [data, meta]
+      properties:
+        data:
+          $ref: "#/components/schemas/DecisionLineage"
+        meta:
+          $ref: "#/components/schemas/ResponseMeta"
+
+    DecisionLineage:
+      type: object
+      required: [decision_id, preceded_by, cited_by, cited_by_has_more]
+      properties:
+        decision_id:
+          type: string
+          format: uuid
+        preceded_by:
+          nullable: true
+          $ref: "#/components/schemas/LineageEntry"
+        cited_by:
+          type: array
+          items:
+            $ref: "#/components/schemas/LineageEntry"
+        cited_by_has_more:
+          type: boolean
+
+    LineageEntry:
+      type: object
+      required: [id, run_id, agent_id, decision_type, outcome, confidence, created_at, valid_from]
+      properties:
+        id:
+          type: string
+          format: uuid
+        run_id:
+          type: string
+          format: uuid
+        agent_id:
+          type: string
+        decision_type:
+          type: string
+        outcome:
+          type: string
+        confidence:
+          type: number
+          format: float
+        project:
+          type: string
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        valid_from:
+          type: string
+          format: date-time
+        valid_to:
+          type: string
+          format: date-time
+          nullable: true
 
     VerifyResponse:
       type: object

--- a/internal/server/handlers_decisions.go
+++ b/internal/server/handlers_decisions.go
@@ -1049,3 +1049,27 @@ func (h *Handlers) HandleDecisionFacets(w http.ResponseWriter, r *http.Request) 
 		Projects: projects,
 	})
 }
+
+// HandleGetDecisionLineage handles GET /v1/decisions/{id}/lineage (reader+).
+// Returns the precedent chain: the decision this one cites and decisions that cite it.
+func (h *Handlers) HandleGetDecisionLineage(w http.ResponseWriter, r *http.Request) {
+	orgID := OrgIDFromContext(r.Context())
+
+	id, err := parsePathUUID(r, "id")
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "invalid decision ID")
+		return
+	}
+
+	lineage, err := h.db.GetDecisionLineage(r.Context(), id, orgID, 20)
+	if err != nil {
+		if isNotFoundError(err) {
+			writeError(w, r, http.StatusNotFound, model.ErrCodeNotFound, "decision not found")
+			return
+		}
+		h.writeInternalError(w, r, "failed to get decision lineage", err)
+		return
+	}
+
+	writeJSON(w, r, http.StatusOK, lineage)
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -199,6 +199,9 @@ func New(cfg ServerConfig) *Server {
 	// Decision conflicts (reader+).
 	mux.Handle("GET /v1/decisions/{id}/conflicts", readRole(http.HandlerFunc(h.HandleDecisionConflicts)))
 
+	// Decision lineage: precedent chain visualization (reader+).
+	mux.Handle("GET /v1/decisions/{id}/lineage", readRole(http.HandlerFunc(h.HandleGetDecisionLineage)))
+
 	// Decision assessments: explicit outcome feedback (spec 29 / ADR-020 Tier 2).
 	mux.Handle("POST /v1/decisions/{id}/assess", writeRole(http.HandlerFunc(h.HandleAssessDecision)))
 	mux.Handle("GET /v1/decisions/{id}/assessments", readRole(http.HandlerFunc(h.HandleListAssessments)))

--- a/internal/storage/decisions.go
+++ b/internal/storage/decisions.go
@@ -2055,3 +2055,105 @@ func (db *DB) GetCitationPercentilesForOrg(ctx context.Context, orgID uuid.UUID)
 	}
 	return breakpoints, nil
 }
+
+// LineageEntry is a compact summary of a decision in a lineage chain.
+type LineageEntry struct {
+	ID           uuid.UUID  `json:"id"`
+	RunID        uuid.UUID  `json:"run_id"`
+	AgentID      string     `json:"agent_id"`
+	DecisionType string     `json:"decision_type"`
+	Outcome      string     `json:"outcome"`
+	Confidence   float32    `json:"confidence"`
+	Project      *string    `json:"project,omitempty"`
+	CreatedAt    time.Time  `json:"created_at"`
+	ValidFrom    time.Time  `json:"valid_from"`
+	ValidTo      *time.Time `json:"valid_to,omitempty"`
+}
+
+// DecisionLineage holds the upstream precedent and downstream citations for a decision.
+type DecisionLineage struct {
+	DecisionID  uuid.UUID      `json:"decision_id"`
+	PrecededBy  *LineageEntry  `json:"preceded_by"`
+	CitedBy     []LineageEntry `json:"cited_by"`
+	CitedByMore bool           `json:"cited_by_has_more"`
+}
+
+const lineageCols = `id, run_id, agent_id, decision_type, outcome, confidence, project, created_at, valid_from, valid_to`
+
+func scanLineageEntry(row pgxRowScanner) (LineageEntry, error) {
+	var e LineageEntry
+	if err := row.Scan(
+		&e.ID, &e.RunID, &e.AgentID, &e.DecisionType, &e.Outcome,
+		&e.Confidence, &e.Project, &e.CreatedAt, &e.ValidFrom, &e.ValidTo,
+	); err != nil {
+		return LineageEntry{}, fmt.Errorf("storage: scan lineage entry: %w", err)
+	}
+	return e, nil
+}
+
+// GetDecisionLineage returns the precedent chain for a decision: the decision it
+// cites (preceded_by) and decisions that cite it (cited_by), scoped by org_id.
+// cited_by is capped at limit+1 rows so the caller can detect has_more.
+func (db *DB) GetDecisionLineage(ctx context.Context, id, orgID uuid.UUID, limit int) (DecisionLineage, error) {
+	if limit <= 0 {
+		limit = 20
+	}
+
+	result := DecisionLineage{DecisionID: id}
+
+	// Look up this decision's precedent_ref.
+	var precedentRef *uuid.UUID
+	if err := db.pool.QueryRow(ctx,
+		`SELECT precedent_ref FROM decisions WHERE id = $1 AND org_id = $2`,
+		id, orgID).Scan(&precedentRef); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return result, fmt.Errorf("storage: decision %s not found: %w", id, err)
+		}
+		return result, fmt.Errorf("storage: lineage lookup: %w", err)
+	}
+
+	// Fetch the precedent decision summary if one exists.
+	if precedentRef != nil {
+		row := db.pool.QueryRow(ctx,
+			`SELECT `+lineageCols+` FROM decisions WHERE id = $1 AND org_id = $2`,
+			*precedentRef, orgID)
+		entry, err := scanLineageEntry(row)
+		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+			return result, fmt.Errorf("storage: precedent fetch: %w", err)
+		}
+		if err == nil {
+			result.PrecededBy = &entry
+		}
+	}
+
+	// Fetch decisions that cite this one as their precedent, most recent first.
+	rows, err := db.pool.Query(ctx,
+		`SELECT `+lineageCols+` FROM decisions
+		 WHERE precedent_ref = $1 AND org_id = $2 AND valid_to IS NULL
+		 ORDER BY created_at DESC
+		 LIMIT $3`,
+		id, orgID, limit+1)
+	if err != nil {
+		return result, fmt.Errorf("storage: cited_by query: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		entry, err := scanLineageEntry(rows)
+		if err != nil {
+			return result, err
+		}
+		result.CitedBy = append(result.CitedBy, entry)
+	}
+	if err := rows.Err(); err != nil {
+		return result, fmt.Errorf("storage: cited_by rows: %w", err)
+	}
+
+	// Trim to limit and set has_more flag.
+	if len(result.CitedBy) > limit {
+		result.CitedBy = result.CitedBy[:limit]
+		result.CitedByMore = true
+	}
+
+	return result, nil
+}

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -14,6 +14,7 @@ import type {
   Decision,
   DecisionConflict,
   DecisionFacets,
+  DecisionLineage,
   ConflictGroup,
   Grant,
   GrantsList,
@@ -338,6 +339,13 @@ export async function verifyDecisionIntegrity(
   id: string,
 ): Promise<{ decision_id: string; status: string; valid?: boolean; content_hash?: string; message?: string }> {
   return request(`/v1/verify/${id}`);
+}
+
+// Decision lineage
+export async function getDecisionLineage(
+  id: string,
+): Promise<DecisionLineage> {
+  return request<DecisionLineage>(`/v1/decisions/${id}/lineage`);
 }
 
 // Decision conflicts

--- a/ui/src/pages/DecisionDetail.tsx
+++ b/ui/src/pages/DecisionDetail.tsx
@@ -1,7 +1,7 @@
 import { useParams, Link } from "react-router";
 import { useQuery } from "@tanstack/react-query";
-import { getRun, getDecision, getDecisionRevisions, getDecisionConflicts, verifyDecisionIntegrity } from "@/lib/api";
-import type { Decision, DecisionConflict } from "@/types/api";
+import { getRun, getDecision, getDecisionLineage, getDecisionRevisions, getDecisionConflicts, verifyDecisionIntegrity } from "@/lib/api";
+import type { Decision, DecisionConflict, LineageEntry } from "@/types/api";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge, decisionTypeBadgeVariant } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
@@ -233,6 +233,98 @@ function DecisionConflicts({ decisionId }: { decisionId: string }) {
               </div>
             );
           })}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function LineageEntryRow({ entry }: { entry: LineageEntry }) {
+  return (
+    <Link
+      to={`/decisions/${entry.run_id}`}
+      className="flex items-start gap-3 rounded-md border p-3 text-sm hover:bg-accent/50 transition-colors"
+    >
+      <GitBranch className="h-4 w-4 mt-0.5 shrink-0 text-muted-foreground" />
+      <div className="min-w-0 flex-1 space-y-1">
+        <div className="flex items-center gap-2 flex-wrap">
+          <Badge variant={decisionTypeBadgeVariant(entry.decision_type)} className="text-xs">
+            {entry.decision_type}
+          </Badge>
+          <Badge variant="secondary" className="text-xs">
+            {(entry.confidence * 100).toFixed(0)}%
+          </Badge>
+          <span className="font-mono text-xs text-muted-foreground">
+            {entry.agent_id}
+          </span>
+          {entry.project && (
+            <span className="font-mono text-xs text-muted-foreground">
+              {entry.project}
+            </span>
+          )}
+          <span className="text-xs text-muted-foreground ml-auto shrink-0">
+            {formatRelativeTime(entry.created_at)}
+          </span>
+        </div>
+        <p className="text-xs text-muted-foreground leading-relaxed">
+          {truncate(entry.outcome, 200)}
+        </p>
+      </div>
+    </Link>
+  );
+}
+
+function DecisionLineage({ decisionId }: { decisionId: string }) {
+  const { data, isPending } = useQuery({
+    queryKey: ["lineage", decisionId],
+    queryFn: () => getDecisionLineage(decisionId),
+    staleTime: 60_000,
+  });
+
+  if (isPending) return <Skeleton className="h-24 w-full" />;
+  if (!data || (!data.preceded_by && data.cited_by.length === 0)) return null;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-sm font-medium">
+          <GitBranch className="h-4 w-4" />
+          Lineage
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* Preceded by */}
+        <div>
+          <h4 className="text-xs font-medium text-muted-foreground mb-2">Preceded by</h4>
+          {data.preceded_by ? (
+            <LineageEntryRow entry={data.preceded_by} />
+          ) : (
+            <p className="text-xs text-muted-foreground italic">No precedents recorded</p>
+          )}
+        </div>
+
+        {/* Cited by */}
+        <div>
+          <h4 className="text-xs font-medium text-muted-foreground mb-2">
+            Cited by
+            {data.cited_by.length > 0 && (
+              <span className="ml-1 text-foreground">({data.cited_by.length}{data.cited_by_has_more ? "+" : ""})</span>
+            )}
+          </h4>
+          {data.cited_by.length > 0 ? (
+            <div className="space-y-2">
+              {data.cited_by.map((entry) => (
+                <LineageEntryRow key={entry.id} entry={entry} />
+              ))}
+              {data.cited_by_has_more && (
+                <p className="text-xs text-muted-foreground italic text-center pt-1">
+                  More citations exist
+                </p>
+              )}
+            </div>
+          ) : (
+            <p className="text-xs text-muted-foreground italic">Not yet cited</p>
+          )}
         </div>
       </CardContent>
     </Card>
@@ -577,6 +669,9 @@ export default function DecisionDetail() {
 
                 {/* Revision chain */}
                 <RevisionChain decisionId={decision.id} />
+
+                {/* Lineage: precedent chain */}
+                <DecisionLineage decisionId={decision.id} />
 
                 {/* Related conflicts */}
                 <DecisionConflicts decisionId={decision.id} />

--- a/ui/src/types/api.ts
+++ b/ui/src/types/api.ts
@@ -434,6 +434,27 @@ export interface ConflictTrendPoint {
   resolved: number;
 }
 
+// Lineage
+export interface LineageEntry {
+  id: string;
+  run_id: string;
+  agent_id: string;
+  decision_type: string;
+  outcome: string;
+  confidence: number;
+  project?: string | null;
+  created_at: string;
+  valid_from: string;
+  valid_to?: string | null;
+}
+
+export interface DecisionLineage {
+  decision_id: string;
+  preceded_by: LineageEntry | null;
+  cited_by: LineageEntry[];
+  cited_by_has_more: boolean;
+}
+
 // Health
 export interface HealthResponse {
   status: string;


### PR DESCRIPTION
## Summary

- Adds `GET /v1/decisions/{id}/lineage` endpoint returning the upstream precedent (`preceded_by`) and downstream citations (`cited_by`) as compact `LineageEntry` summaries
- Renders a **Lineage** card on the decision detail page with clickable links to both directions of the chain
- Handles empty states gracefully ("No precedents recorded" / "Not yet cited") and supports `has_more` pagination for high-citation decisions

## Details

No migration needed — the queries use the existing `precedent_ref` column with proper `org_id` scoping and `valid_to IS NULL` filtering for active-only citations. The `cited_by` list is capped at 20 entries with a `has_more` flag.

**Files changed:**
- `internal/storage/decisions.go` — `GetDecisionLineage` query + `LineageEntry`/`DecisionLineage` types
- `internal/server/handlers_decisions.go` — `HandleGetDecisionLineage` handler
- `internal/server/server.go` — route registration
- `api/openapi.yaml` — endpoint + schema definitions
- `ui/src/types/api.ts` — TypeScript types
- `ui/src/lib/api.ts` — `getDecisionLineage` API function
- `ui/src/pages/DecisionDetail.tsx` — `DecisionLineage` + `LineageEntryRow` components

## Test plan

- [ ] Verify `GET /v1/decisions/{id}/lineage` returns correct `preceded_by` when decision has a `precedent_ref`
- [ ] Verify `cited_by` lists all active decisions referencing this one as their precedent
- [ ] Verify empty states render correctly for decisions with no lineage
- [ ] Verify links in the Lineage card navigate to the correct decision detail pages
- [ ] Verify org_id scoping prevents cross-tenant data leakage

Closes #457

> The Borg assimilate without attribution — every species absorbed, no
> precedent recorded, no lineage traced. If they'd had an audit trail,
> Picard might have negotiated instead of fighting Wolf 359.

🤖 Generated with [Claude Code](https://claude.com/claude-code)