### PR TITLE
fix: use decision timestamps for conflict group first_detected_at

### DIFF
--- a/internal/conflicts/lite_scorer.go
+++ b/internal/conflicts/lite_scorer.go
@@ -113,23 +113,25 @@ func (s *LiteScorer) ScoreForDecision(ctx context.Context, decisionID, orgID uui
 }
 
 type liteDecision struct {
-	id           uuid.UUID
-	agentID      string
-	decisionType string
-	outcome      string
-	project      *string
+	id              uuid.UUID
+	agentID         string
+	decisionType    string
+	outcome         string
+	project         *string
+	transactionTime time.Time
 }
 
 func (s *LiteScorer) loadDecision(ctx context.Context, id, orgID uuid.UUID) (liteDecision, error) {
 	var d liteDecision
 	var idStr string
 	var project sql.NullString
+	var txTime string
 
 	err := s.db.QueryRowContext(ctx,
-		`SELECT id, agent_id, decision_type, outcome, project
+		`SELECT id, agent_id, decision_type, outcome, project, transaction_time
 		 FROM decisions WHERE id = ? AND org_id = ? AND valid_to IS NULL`,
 		id.String(), orgID.String(),
-	).Scan(&idStr, &d.agentID, &d.decisionType, &d.outcome, &project)
+	).Scan(&idStr, &d.agentID, &d.decisionType, &d.outcome, &project, &txTime)
 	if err != nil {
 		return liteDecision{}, fmt.Errorf("load decision: %w", err)
 	}
@@ -137,13 +139,14 @@ func (s *LiteScorer) loadDecision(ctx context.Context, id, orgID uuid.UUID) (lit
 	if project.Valid {
 		d.project = &project.String
 	}
+	d.transactionTime, _ = time.Parse(time.RFC3339Nano, txTime)
 	return d, nil
 }
 
 func (s *LiteScorer) loadCandidates(ctx context.Context, orgID uuid.UUID, src liteDecision) ([]liteDecision, error) {
 	// Load recent same-type decisions (last 50) from any agent.
 	// Excludes the source decision and superseded decisions.
-	q := `SELECT id, agent_id, decision_type, outcome, project
+	q := `SELECT id, agent_id, decision_type, outcome, project, transaction_time
 	      FROM decisions
 	      WHERE org_id = ? AND decision_type = ? AND id != ?
 	        AND valid_to IS NULL`
@@ -168,13 +171,15 @@ func (s *LiteScorer) loadCandidates(ctx context.Context, orgID uuid.UUID, src li
 		var d liteDecision
 		var idStr string
 		var project sql.NullString
-		if err := rows.Scan(&idStr, &d.agentID, &d.decisionType, &d.outcome, &project); err != nil {
+		var txTime string
+		if err := rows.Scan(&idStr, &d.agentID, &d.decisionType, &d.outcome, &project, &txTime); err != nil {
 			return nil, err
 		}
 		d.id, _ = uuid.Parse(idStr)
 		if project.Valid {
 			d.project = &project.String
 		}
+		d.transactionTime, _ = time.Parse(time.RFC3339Nano, txTime)
 		out = append(out, d)
 	}
 	return out, rows.Err()
@@ -250,14 +255,23 @@ func (s *LiteScorer) findOrCreateGroup(ctx context.Context, orgID uuid.UUID, a, 
 		return uuid.Nil, err
 	}
 
-	// Create new group.
+	// Create new group. Use the later decision's transaction_time as
+	// first_detected_at — a conflict can't exist before both decisions exist.
 	groupID := uuid.New()
 	now := time.Now().UTC().Format(time.RFC3339Nano)
+	firstDetected := now
+	if !a.transactionTime.IsZero() && !b.transactionTime.IsZero() {
+		earliest := a.transactionTime
+		if b.transactionTime.After(earliest) {
+			earliest = b.transactionTime
+		}
+		firstDetected = earliest.Format(time.RFC3339Nano)
+	}
 	topicLabel := storage.TruncateOutcome(a.outcome, 120)
 	_, err = s.db.ExecContext(ctx,
 		`INSERT INTO conflict_groups (id, org_id, agent_a, agent_b, conflict_kind, decision_type, group_topic, first_detected_at, last_detected_at)
 		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		groupID.String(), orgID.String(), agentA, agentB, conflictKind, a.decisionType, topicLabel, now, now,
+		groupID.String(), orgID.String(), agentA, agentB, conflictKind, a.decisionType, topicLabel, firstDetected, now,
 	)
 	if err != nil {
 		return uuid.Nil, err

--- a/internal/conflicts/lite_scorer_test.go
+++ b/internal/conflicts/lite_scorer_test.go
@@ -34,7 +34,8 @@ func openTestDB(t *testing.T) *sql.DB {
 			embedding BLOB,
 			valid_from TEXT NOT NULL,
 			valid_to TEXT,
-			project TEXT
+			project TEXT,
+			transaction_time TEXT NOT NULL DEFAULT (datetime('now'))
 		);
 		CREATE TABLE scored_conflicts (
 			id TEXT PRIMARY KEY,

--- a/internal/conflicts/scorer.go
+++ b/internal/conflicts/scorer.go
@@ -631,30 +631,39 @@ func (s *Scorer) scoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 		// Always store full outcomes on the conflict record, even when the
 		// claim method won (claim fragments are used as OutcomeA/B in the
 		// ValidateInput for LLM comparison only).
+		// A conflict cannot exist before both decisions exist. Use the later
+		// decision's transaction_time as the earliest possible detection time
+		// for group creation (instead of now()).
+		earliestAt := d.TransactionTime
+		if cand.TransactionTime.After(earliestAt) {
+			earliestAt = cand.TransactionTime
+		}
+
 		c := model.DecisionConflict{
-			ConflictKind:      kind,
-			DecisionAID:       decisionID,
-			DecisionBID:       cand.ID,
-			OrgID:             orgID,
-			AgentA:            d.AgentID,
-			AgentB:            cand.AgentID,
-			DecisionTypeA:     d.DecisionType,
-			DecisionTypeB:     cand.DecisionType,
-			OutcomeA:          d.Outcome,
-			OutcomeB:          cand.Outcome,
-			TopicSimilarity:   ptr(sc.topicSim),
-			OutcomeDivergence: ptr(sc.bestDiv),
-			Significance:      ptr(sc.bestSig),
-			ScoringMethod:     bestMethod,
-			Explanation:       explanation,
-			Category:          category,
-			Severity:          severity,
-			Relationship:      relationship,
-			ConfidenceWeight:  ptr(sc.confWeight),
-			TemporalDecay:     ptr(sc.decay),
-			Status:            "open",
-			ClaimTextA:        sc.claimFragA,
-			ClaimTextB:        sc.claimFragB,
+			ConflictKind:       kind,
+			DecisionAID:        decisionID,
+			DecisionBID:        cand.ID,
+			OrgID:              orgID,
+			AgentA:             d.AgentID,
+			AgentB:             cand.AgentID,
+			DecisionTypeA:      d.DecisionType,
+			DecisionTypeB:      cand.DecisionType,
+			OutcomeA:           d.Outcome,
+			OutcomeB:           cand.Outcome,
+			TopicSimilarity:    ptr(sc.topicSim),
+			OutcomeDivergence:  ptr(sc.bestDiv),
+			Significance:       ptr(sc.bestSig),
+			ScoringMethod:      bestMethod,
+			Explanation:        explanation,
+			Category:           category,
+			Severity:           severity,
+			Relationship:       relationship,
+			ConfidenceWeight:   ptr(sc.confWeight),
+			TemporalDecay:      ptr(sc.decay),
+			Status:             "open",
+			ClaimTextA:         sc.claimFragA,
+			ClaimTextB:         sc.claimFragB,
+			EarliestPossibleAt: &earliestAt,
 		}
 
 		// Topic-aware group assignment: find or create a group whose
@@ -664,6 +673,7 @@ func (s *Scorer) scoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 			groupID, grpErr := s.db.FindOrCreateTopicGroup(ctx,
 				orgID, d.AgentID, cand.AgentID, kind,
 				d.DecisionType, *d.OutcomeEmbedding, topicLabel,
+				c.EarliestPossibleAt,
 			)
 			if grpErr != nil {
 				s.logger.Warn("conflict scorer: topic group lookup failed, falling back",

--- a/internal/model/decision.go
+++ b/internal/model/decision.go
@@ -207,6 +207,12 @@ type DecisionConflict struct {
 	// whose winning side this new conflict contradicts. When set, the conflict
 	// was auto-escalated to critical severity.
 	ReopensResolutionID *uuid.UUID `json:"reopens_resolution_id,omitempty"`
+
+	// EarliestPossibleAt is max(decision_a.transaction_time, decision_b.transaction_time).
+	// A conflict cannot exist before both decisions exist. Used as first_detected_at
+	// when creating a new conflict group, instead of now().
+	// Not persisted — computed by the scorer and passed through to storage.
+	EarliestPossibleAt *time.Time `json:"-"`
 }
 
 // ConflictGroup is a canonical conflict cluster scoped to a semantic topic

--- a/internal/storage/conflicts.go
+++ b/internal/storage/conflicts.go
@@ -406,11 +406,17 @@ func (db *DB) InsertScoredConflict(ctx context.Context, c model.DecisionConflict
 	}
 	topicLabel := TruncateOutcome(outcomeA, 120)
 
+	// Use earliest possible detection time for new group creation instead of now().
+	firstDetected := time.Now()
+	if c.EarliestPossibleAt != nil && !c.EarliestPossibleAt.IsZero() {
+		firstDetected = *c.EarliestPossibleAt
+	}
+
 	var id uuid.UUID
 	err := db.pool.QueryRow(ctx,
 		// CTE step 1: try to find an existing group for this agent pair + type.
 		// CTE step 2: update last_detected_at when reusing an existing group.
-		// CTE step 3: if none exists, create a new one.
+		// CTE step 3: if none exists, create a new one with decision-derived timestamp.
 		// CTE step 4: pick whichever returned a row (existing preferred).
 		`WITH existing AS (
 		     SELECT id FROM conflict_groups
@@ -423,8 +429,8 @@ func (db *DB) InsertScoredConflict(ctx context.Context, c model.DecisionConflict
 		     WHERE id = (SELECT id FROM existing) AND org_id = $3
 		 ), new_grp AS (
 		     INSERT INTO conflict_groups
-		         (org_id, agent_a, agent_b, conflict_kind, decision_type, group_topic)
-		     SELECT $3, $5, $6, $4, $8, $23
+		         (org_id, agent_a, agent_b, conflict_kind, decision_type, group_topic, first_detected_at)
+		     SELECT $3, $5, $6, $4, $8, $23, $25
 		     WHERE NOT EXISTS (SELECT 1 FROM existing)
 		     RETURNING id
 		 ), grp AS (
@@ -472,7 +478,7 @@ func (db *DB) InsertScoredConflict(ctx context.Context, c model.DecisionConflict
 		grpAgentA, grpAgentB, typeA, typeB, outcomeA, outcomeB,
 		topicSim, outcomeDiv, sig, method, c.Explanation,
 		c.Category, c.Severity, c.Relationship, c.ConfidenceWeight, c.TemporalDecay,
-		claimTextA, claimTextB, topicLabel, c.ReopensResolutionID,
+		claimTextA, claimTextB, topicLabel, c.ReopensResolutionID, firstDetected,
 	).Scan(&id)
 	if err != nil {
 		return uuid.Nil, err
@@ -581,6 +587,7 @@ func (db *DB) FindOrCreateTopicGroup(
 	decisionType string,
 	outcomeEmbedding pgvector.Vector,
 	topicLabel string,
+	earliestPossibleAt *time.Time,
 ) (uuid.UUID, error) {
 	// Normalize agent pair ordering.
 	if agentA > agentB {
@@ -642,13 +649,19 @@ func (db *DB) FindOrCreateTopicGroup(
 		return uuid.Nil, fmt.Errorf("storage: find topic group: %w", err)
 	}
 
-	// No matching group — create a new one.
+	// No matching group — create a new one. Use the earliest possible detection
+	// time (max of both decisions' transaction_time) instead of now() for
+	// first_detected_at so that backfills produce historically accurate timestamps.
+	firstDetected := time.Now()
+	if earliestPossibleAt != nil && !earliestPossibleAt.IsZero() {
+		firstDetected = *earliestPossibleAt
+	}
 	err = tx.QueryRow(ctx,
 		`INSERT INTO conflict_groups
-		     (org_id, agent_a, agent_b, conflict_kind, decision_type, group_topic)
-		 VALUES ($1, $2, $3, $4, $5, $6)
+		     (org_id, agent_a, agent_b, conflict_kind, decision_type, group_topic, first_detected_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7)
 		 RETURNING id`,
-		orgID, agentA, agentB, string(conflictKind), decisionType, topicLabel,
+		orgID, agentA, agentB, string(conflictKind), decisionType, topicLabel, firstDetected,
 	).Scan(&groupID)
 	if err != nil {
 		return uuid.Nil, fmt.Errorf("storage: create topic group: %w", err)

--- a/internal/storage/decisions.go
+++ b/internal/storage/decisions.go
@@ -1852,12 +1852,12 @@ func (db *DB) GetDecisionForScoring(ctx context.Context, id, orgID uuid.UUID) (m
 	var d model.Decision
 	err := db.pool.QueryRow(ctx,
 		`SELECT id, run_id, agent_id, org_id, decision_type, outcome, confidence, reasoning,
-		 valid_from, embedding, outcome_embedding, session_id, agent_context, project
+		 valid_from, embedding, outcome_embedding, session_id, agent_context, project, transaction_time
 		 FROM decisions WHERE id = $1 AND org_id = $2 AND valid_to IS NULL`,
 		id, orgID,
 	).Scan(
 		&d.ID, &d.RunID, &d.AgentID, &d.OrgID, &d.DecisionType, &d.Outcome, &d.Confidence, &d.Reasoning,
-		&d.ValidFrom, &d.Embedding, &d.OutcomeEmbedding, &d.SessionID, &d.AgentContext, &d.Project,
+		&d.ValidFrom, &d.Embedding, &d.OutcomeEmbedding, &d.SessionID, &d.AgentContext, &d.Project, &d.TransactionTime,
 	)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {

--- a/internal/storage/sqlite/decisions.go
+++ b/internal/storage/sqlite/decisions.go
@@ -410,7 +410,7 @@ func (l *LiteDB) GetDecisionsByAgent(ctx context.Context, orgID uuid.UUID, agent
 func (l *LiteDB) GetDecisionForScoring(ctx context.Context, id, orgID uuid.UUID) (model.Decision, error) {
 	row := l.db.QueryRowContext(ctx,
 		`SELECT id, run_id, agent_id, org_id, decision_type, outcome, confidence, reasoning,
-		        valid_from, embedding, outcome_embedding, session_id, agent_context, project
+		        valid_from, embedding, outcome_embedding, session_id, agent_context, project, transaction_time
 		 FROM decisions WHERE id = ? AND org_id = ? AND valid_to IS NULL`,
 		uuidStr(id), uuidStr(orgID),
 	)
@@ -426,11 +426,12 @@ func (l *LiteDB) GetDecisionForScoring(ctx context.Context, id, orgID uuid.UUID)
 		sessionIDStr sql.NullString
 		agentCtxJSON sql.NullString
 		project      sql.NullString
+		txTimeStr    string
 	)
 	err := row.Scan(&idStr, &runIDStr, &d.AgentID, &orgIDStr, &d.DecisionType,
 		&d.Outcome, &d.Confidence, &d.Reasoning,
 		&validFromStr, &embBlob, &outEmbBlob,
-		&sessionIDStr, &agentCtxJSON, &project)
+		&sessionIDStr, &agentCtxJSON, &project, &txTimeStr)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return model.Decision{}, storage.ErrNotFound
@@ -442,6 +443,7 @@ func (l *LiteDB) GetDecisionForScoring(ctx context.Context, id, orgID uuid.UUID)
 	d.RunID = parseUUID(runIDStr)
 	d.OrgID = parseUUID(orgIDStr)
 	d.ValidFrom = parseTime(validFromStr)
+	d.TransactionTime = parseTime(txTimeStr)
 	d.Embedding = blobToVector(embBlob)
 	d.OutcomeEmbedding = blobToVector(outEmbBlob)
 	d.SessionID = parseNullUUID(sessionIDStr)

--- a/migrations/069_fix_conflict_group_timestamps.sql
+++ b/migrations/069_fix_conflict_group_timestamps.sql
@@ -1,0 +1,24 @@
+-- 069: Fix conflict_groups.first_detected_at to reflect when conflicts could
+-- have first existed, not when the scorer happened to run.
+--
+-- Problem: first_detected_at defaults to now() at group creation time, which
+-- means backfills and rescores stamp every group with the current date. This
+-- makes it impossible to trend false positive rates over time.
+--
+-- Fix: set first_detected_at = max(decision_a.transaction_time, decision_b.transaction_time)
+-- for each group. A conflict cannot exist before both participating decisions exist,
+-- so the later decision's creation time is the earliest possible detection time.
+
+UPDATE conflict_groups cg
+SET first_detected_at = sub.earliest_possible
+FROM (
+    SELECT sc.group_id,
+           MIN(GREATEST(da.transaction_time, db.transaction_time)) AS earliest_possible
+    FROM scored_conflicts sc
+    JOIN decisions da ON da.id = sc.decision_a_id
+    JOIN decisions db ON db.id = sc.decision_b_id
+    WHERE sc.group_id IS NOT NULL
+    GROUP BY sc.group_id
+) sub
+WHERE cg.id = sub.group_id
+  AND sub.earliest_possible < cg.first_detected_at;

--- a/migrations/atlas.sum
+++ b/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:vykKuQ3ofwghJxH8RedMrcHogz9mkUwKO7iDyPlJSj4=
+h1:vqWCc5HsQ3b0fq12AeSZL7lyOoJiNhgcU8Qz3RE0wwc=
 001_initial.sql h1:uhyGXto+QacAaGYb9ZTGjsBs5chlKi8O0eHz9aCQsrY=
 022_full_text_search.sql h1:9iwtA8MgCzAxDV9YkUBn0CLT9ePSmj3GcPoMGg8TXf0=
 023_fix_outbox_index.sql h1:OtMEFBcMRWej02+ghnBXlPr6BVq+LoA62Id9XUWfDNI=
@@ -47,3 +47,4 @@ h1:vykKuQ3ofwghJxH8RedMrcHogz9mkUwKO7iDyPlJSj4=
 066_performance_indexes.sql h1:wvBV0q6JgrtlPubDCyla9J35URbeDq+NKD6ptaT3+S8=
 067_precedent_escalation.sql h1:b20zVZLpiLH2lmYfJAt9WWTOY6yxHeBiBGE4TI0If4c=
 068_cascade_delete_alternatives_evidence.sql h1:XSxpNbHG1wV4KtULVA7wda0M+biDDIcChMrdTm95nDs=
+069_fix_conflict_group_timestamps.sql h1:EWuaO1TtKMr+43D9lLlLNZq4TV8JkRtFQM6nPU1cEA4=


### PR DESCRIPTION
## Summary

- `conflict_groups.first_detected_at` was set to `now()` at group creation time, so backfills and rescores stamped every group with the current date — making it impossible to trend false positive rates over time.
- Threads `transaction_time` through the scoring pipeline (both PostgreSQL `Scorer` and SQLite `LiteScorer`) and uses `max(decision_a.transaction_time, decision_b.transaction_time)` as `first_detected_at` for new conflict groups, with safe fallback to `time.Now()` when timestamps are unavailable.
- Adds migration 069 to correct existing groups by computing the earliest possible detection time from their scored conflicts.

## Verification

- [x] I ran relevant tests locally (`go test ./...` or targeted package tests).
- [ ] I updated docs/openapi for any API or behavior changes.
- [ ] If I changed config vars in `internal/config/config.go`, I also updated:
  - [ ] `docs/configuration.md`
  - [ ] `docs/runbook.md` (operational subset, if relevant)
  - [ ] `.env.example` (if baseline local/dev defaults changed)
  - [ ] `docs/consistency-manifest.json` (only if policy/coverage rules changed)
- [ ] `python3 scripts/check_doc_config_consistency.py` passes.

## Risk / Rollout Notes

- Migration 069 is a data-only UPDATE (no schema change). It only corrects timestamps that are too late, never pushes them forward (guarded by `earliest_possible < first_detected_at`). Safe to run on live data with no downtime.
- No API or config changes — purely internal scoring pipeline plumbing.

> The temporal prime directive is Star Trek's most underrated insight:
> you don't get to rewrite history just because you have the technology.
> Sometimes the hardest engineering is making timestamps tell the truth
> about when things actually happened, not when you noticed them.