### PR TITLE
docs: nudge agents toward creative PR quotes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,7 +162,9 @@ Every PR description MUST end with a blockquote about one of these fictional uni
 > Stars hold their breath still
 ```
 
-This is not optional. PRs missing the argument will be sent back.
+The more creative and non-obvious the connection, the better. Avoid the easy metaphors — don't reach for the Borg every time you touch audit trails, or the Prime Directive every time there's a policy constraint. Surprise us.
+
+This is not optional. PRs missing the blockquote will be sent back.
 
 ## Conventions
 


### PR DESCRIPTION
## Summary

- Added creativity guidance to the PR quote requirement in CLAUDE.md
- Explicitly calls out the overused patterns (Borg + audit trails, Prime Directive + policy) to discourage lazy metaphor-matching
- Soft nudge ("surprise us") rather than a hard rotation rule — lets agents be creative instead of mechanical

## Test plan

- [ ] Spot-check next 5 PRs for universe variety and metaphor originality

> Dumbledore's Army learned more in a hidden room than in years of
> Ministry-approved curriculum — proof that the best compliance canaries
> are the ones that make you think, not the ones that make you repeat
> the same approved answer. Umbridge would have loved seven straight
> Star Trek quotes.