### PR TITLE
feat(trace): warn when confidence > 0.85 with no evidence

### DIFF
--- a/akashi.go
+++ b/akashi.go
@@ -358,7 +358,7 @@ func New(opts ...Option) (*App, error) {
 	grantCache := authz.NewGrantCache(30 * time.Second)
 
 	// MCP server.
-	mcpSrv := mcp.New(db, decisionSvc, grantCache, logger, version)
+	mcpSrv := mcp.New(db, decisionSvc, grantCache, logger, version, cfg.HighConfidenceWarnThreshold)
 
 	// SSE broker.
 	var broker *server.Broker
@@ -414,36 +414,37 @@ func New(opts ...Option) (*App, error) {
 
 	// Create HTTP server.
 	srv := server.New(server.ServerConfig{
-		DB:                      db,
-		JWTMgr:                  jwtMgr,
-		DecisionSvc:             decisionSvc,
-		Buffer:                  buf,
-		Broker:                  broker,
-		Searcher:                searcher,
-		GrantCache:              grantCache,
-		Logger:                  logger,
-		Port:                    cfg.Port,
-		ReadTimeout:             cfg.ReadTimeout,
-		WriteTimeout:            cfg.WriteTimeout,
-		MCPServer:               mcpSrv.MCPServer(),
-		Version:                 version,
-		MaxRequestBodyBytes:     cfg.MaxRequestBodyBytes,
-		RateLimiter:             limiter,
-		TrustProxy:              cfg.TrustProxy,
-		CORSAllowedOrigins:      cfg.CORSAllowedOrigins,
-		EnableDestructiveDelete: cfg.EnableDestructiveDelete,
-		RetentionInterval:       cfg.RetentionInterval,
-		UIFS:                    uiFS,
-		OpenAPISpec:             api.OpenAPISpec,
-		ExtraRoutes:             extraRoutes,
-		Middlewares:             middlewares,
-		DecisionHooks:           decisionHooks,
-		HooksEnabled:            cfg.HooksEnabled,
-		HooksAPIKey:             cfg.HooksAPIKey,
-		AutoTrace:               cfg.AutoTrace,
-		SignupEnabled:           cfg.SignupEnabled,
-		ResolutionRecorder:      conflictScorer,
-		ConflictValidator:       conflictValidator,
+		DB:                          db,
+		JWTMgr:                      jwtMgr,
+		DecisionSvc:                 decisionSvc,
+		Buffer:                      buf,
+		Broker:                      broker,
+		Searcher:                    searcher,
+		GrantCache:                  grantCache,
+		Logger:                      logger,
+		Port:                        cfg.Port,
+		ReadTimeout:                 cfg.ReadTimeout,
+		WriteTimeout:                cfg.WriteTimeout,
+		MCPServer:                   mcpSrv.MCPServer(),
+		Version:                     version,
+		MaxRequestBodyBytes:         cfg.MaxRequestBodyBytes,
+		RateLimiter:                 limiter,
+		TrustProxy:                  cfg.TrustProxy,
+		CORSAllowedOrigins:          cfg.CORSAllowedOrigins,
+		EnableDestructiveDelete:     cfg.EnableDestructiveDelete,
+		RetentionInterval:           cfg.RetentionInterval,
+		UIFS:                        uiFS,
+		OpenAPISpec:                 api.OpenAPISpec,
+		ExtraRoutes:                 extraRoutes,
+		Middlewares:                 middlewares,
+		DecisionHooks:               decisionHooks,
+		HooksEnabled:                cfg.HooksEnabled,
+		HooksAPIKey:                 cfg.HooksAPIKey,
+		AutoTrace:                   cfg.AutoTrace,
+		SignupEnabled:               cfg.SignupEnabled,
+		ResolutionRecorder:          conflictScorer,
+		ConflictValidator:           conflictValidator,
+		HighConfidenceWarnThreshold: cfg.HighConfidenceWarnThreshold,
 	})
 
 	// Wire akashi_check → IDE hook gate.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -3644,6 +3644,14 @@ components:
           format: uuid
         event_count:
           type: integer
+        embedding_skipped:
+          type: boolean
+          description: True when the embedding provider is unavailable or errored.
+        warnings:
+          type: array
+          items:
+            type: string
+          description: Quality warnings (e.g. high confidence without evidence). Present only when applicable.
 
     AppendEventsResponse:
       type: object

--- a/cmd/akashi-local/main.go
+++ b/cmd/akashi-local/main.go
@@ -86,7 +86,7 @@ func run() int {
 	decisionSvc := decisions.New(db, embedder, searcher, logger, conflictScorer)
 
 	// nil grantCache: no caching needed for single-user local mode.
-	mcpSrv := mcp.New(db, decisionSvc, nil, logger, version)
+	mcpSrv := mcp.New(db, decisionSvc, nil, logger, version, 0.85)
 
 	// Fixed local identity: platform_admin on the default org.
 	// This bypasses all RBAC checks and gives full access.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -237,6 +237,14 @@ Operational idempotency settings:
 
 Hook endpoints (`/hooks/session-start`, `/hooks/pre-tool-use`, `/hooks/post-tool-use`) are unauthenticated but restricted to localhost by default. They enable IDE agents to receive context injection, edit gating, and automatic decision tracing without shell-script marker files.
 
+## Trace quality warnings
+
+When a trace is recorded with high confidence but no supporting evidence, Akashi includes a `warnings` array in the response (both HTTP and MCP). The trace is still accepted (HTTP 201) — the warning is advisory, not blocking.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `AKASHI_HIGH_CONFIDENCE_WARNING_THRESHOLD` | `0.85` | Confidence above this value with zero evidence items triggers a warning in the trace response. Set higher to reduce warnings, or to `1.0` to disable. |
+
 ## Data retention
 
 Akashi supports per-org data retention policies that automatically delete decisions older than a configured threshold. Policies are set via `PUT /v1/retention` (admin-only). Legal holds (`POST /v1/retention/hold`) exempt matching decisions from both automated and GDPR deletion. All deletion operations are recorded in the `deletion_log` table.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -106,6 +106,9 @@ type Config struct {
 	PercentileRefreshInterval     time.Duration // How often to refresh signal percentile caches (default 1h).
 	AutoResolveInterval           time.Duration // How often the auto-resolution worker runs (default 1h, 0 disables).
 
+	// Trace quality warnings.
+	HighConfidenceWarnThreshold float64 // Confidence above this with zero evidence triggers a response warning (default: 0.85).
+
 	// Self-serve signup.
 	SignupEnabled bool // Enable POST /auth/signup for self-serve org creation (default: false).
 
@@ -192,6 +195,7 @@ func Load() (Config, error) {
 	cfg.ConflictDecisionTopicSimFloor, errs = collectFloat64(errs, "AKASHI_CONFLICT_DECISION_TOPIC_SIM_FLOOR", profileDefaults.decisionTopicSimFloor)
 	cfg.ConflictEarlyExitFloor, errs = collectFloat64(errs, "AKASHI_CONFLICT_EARLY_EXIT_FLOOR", profileDefaults.earlyExitFloor)
 	cfg.CrossEncoderThreshold, errs = collectFloat64(errs, "AKASHI_CONFLICT_CROSS_ENCODER_THRESHOLD", profileDefaults.crossEncoderThreshold)
+	cfg.HighConfidenceWarnThreshold, errs = collectFloat64(errs, "AKASHI_HIGH_CONFIDENCE_WARNING_THRESHOLD", 0.85)
 
 	// Boolean fields.
 	cfg.RateLimitEnabled, errs = collectBool(errs, "AKASHI_RATE_LIMIT_ENABLED", true)

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -53,13 +53,14 @@ Be honest about confidence — most decisions warrant 0.4-0.8, not 0.9+. Referen
 
 // Server wraps the MCP server with Akashi's service layer.
 type Server struct {
-	mcpServer   *mcpserver.MCPServer
-	db          storage.Store      // for resources (read-only queries)
-	decisionSvc *decisions.Service // for tools (shared business logic)
-	grantCache  *authz.GrantCache  // optional cache for LoadGrantedSet
-	logger      *slog.Logger
-	rootsCache  *rootsCache // caches MCP roots per session (one request per session)
-	onCheck     func()      // called when akashi_check is invoked; wires IDE hook gate
+	mcpServer                   *mcpserver.MCPServer
+	db                          storage.Store      // for resources (read-only queries)
+	decisionSvc                 *decisions.Service // for tools (shared business logic)
+	grantCache                  *authz.GrantCache  // optional cache for LoadGrantedSet
+	logger                      *slog.Logger
+	rootsCache                  *rootsCache // caches MCP roots per session (one request per session)
+	onCheck                     func()      // called when akashi_check is invoked; wires IDE hook gate
+	highConfidenceWarnThreshold float64     // confidence above this with zero evidence triggers a warning
 }
 
 // SetCheckNotify registers a callback that fires whenever akashi_check is called.
@@ -70,13 +71,14 @@ func (s *Server) SetCheckNotify(f func()) {
 }
 
 // New creates and configures a new MCP server with all resources, tools, and prompts.
-func New(db storage.Store, decisionSvc *decisions.Service, grantCache *authz.GrantCache, logger *slog.Logger, version string) *Server {
+func New(db storage.Store, decisionSvc *decisions.Service, grantCache *authz.GrantCache, logger *slog.Logger, version string, highConfidenceWarnThreshold float64) *Server {
 	s := &Server{
-		db:          db,
-		decisionSvc: decisionSvc,
-		grantCache:  grantCache,
-		logger:      logger,
-		rootsCache:  newRootsCache(),
+		db:                          db,
+		decisionSvc:                 decisionSvc,
+		grantCache:                  grantCache,
+		logger:                      logger,
+		rootsCache:                  newRootsCache(),
+		highConfidenceWarnThreshold: highConfidenceWarnThreshold,
 	}
 
 	s.mcpServer = mcpserver.NewMCPServer(

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -872,6 +872,9 @@ func (s *Server) handleTrace(ctx context.Context, request mcplib.CallToolRequest
 	if len(missing) > 0 {
 		responseMap["completeness_tips"] = missing
 	}
+	if warnings := model.HighConfidenceWarnings(confidence, len(evidence), s.highConfidenceWarnThreshold); len(warnings) > 0 {
+		responseMap["warnings"] = warnings
+	}
 
 	resultData, _ := json.Marshal(responseMap)
 

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -69,7 +69,7 @@ func setupAndRun(m *testing.M, tc *testutil.TestContainer) int {
 
 	embedder := embedding.NewNoopProvider(1024)
 	testSvc = decisions.New(testDB, embedder, nil, logger, nil)
-	testServer = New(testDB, testSvc, nil, logger, "test")
+	testServer = New(testDB, testSvc, nil, logger, "test", 0.85)
 
 	return m.Run()
 }
@@ -1433,7 +1433,7 @@ func TestMCPTraceHash_WithPrecedentRef(t *testing.T) {
 // ---------- New() constructor ----------
 
 func TestMCPServerNew(t *testing.T) {
-	s := New(testDB, testSvc, nil, testutil.TestLogger(), "test-version")
+	s := New(testDB, testSvc, nil, testutil.TestLogger(), "test-version", 0.85)
 	require.NotNil(t, s)
 	require.NotNil(t, s.MCPServer())
 	// Verify the server has the expected name by checking it's non-nil.
@@ -3077,4 +3077,57 @@ func TestHandleTrace_ExplicitModelSuppressesTip(t *testing.T) {
 // containsEvidence returns true if the tip string relates to evidence.
 func containsEvidence(tip string) bool {
 	return strings.Contains(tip, "evidence") || strings.Contains(tip, "verifiable")
+}
+
+// ---------- High confidence warning in MCP trace response ------------------
+
+func TestHandleTrace_HighConfidenceNoEvidenceWarning(t *testing.T) {
+	ctx := adminCtx()
+	agentID := "warn-mcp-" + uuid.New().String()[:8]
+	_, _ = testSvc.ResolveOrCreateAgent(ctx, uuid.Nil, agentID, model.RoleAdmin, nil)
+
+	result, err := testServer.handleTrace(ctx, traceRequest(map[string]any{
+		"agent_id":      agentID,
+		"decision_type": "architecture",
+		"outcome":       "chose approach without evidence",
+		"confidence":    0.9,
+	}))
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	text := parseToolText(t, result)
+	var resp struct {
+		Warnings []string `json:"warnings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(text), &resp))
+	require.Len(t, resp.Warnings, 1, "should include warning for high confidence without evidence")
+	assert.Contains(t, resp.Warnings[0], "high confidence claim")
+}
+
+func TestHandleTrace_HighConfidenceWithEvidenceNoWarning(t *testing.T) {
+	ctx := adminCtx()
+	agentID := "nowarn-mcp-" + uuid.New().String()[:8]
+	_, _ = testSvc.ResolveOrCreateAgent(ctx, uuid.Nil, agentID, model.RoleAdmin, nil)
+
+	evJSON, _ := json.Marshal([]model.TraceEvidence{
+		{SourceType: "document", Content: "supporting data"},
+		{SourceType: "test_output", Content: "all tests passed"},
+	})
+
+	result, err := testServer.handleTrace(ctx, traceRequest(map[string]any{
+		"agent_id":      agentID,
+		"decision_type": "architecture",
+		"outcome":       "chose approach with evidence",
+		"confidence":    0.9,
+		"evidence":      string(evJSON),
+	}))
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	text := parseToolText(t, result)
+	var resp struct {
+		Warnings []string `json:"warnings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(text), &resp))
+	assert.Empty(t, resp.Warnings, "should not warn when evidence is present")
 }

--- a/internal/model/api.go
+++ b/internal/model/api.go
@@ -277,6 +277,20 @@ type TraceEvidence struct {
 	RelevanceScore *float32 `json:"relevance_score,omitempty"`
 }
 
+// HighConfidenceWarnings returns warnings when confidence exceeds threshold
+// with zero evidence items. Returns nil when no warning applies.
+func HighConfidenceWarnings(confidence float32, evidenceCount int, threshold float64) []string {
+	if confidence > float32(threshold) && evidenceCount == 0 {
+		return []string{
+			fmt.Sprintf(
+				"high confidence claim (%.2g) without supporting evidence — consider adding evidence items to justify this confidence level",
+				confidence,
+			),
+		}
+	}
+	return nil
+}
+
 // AuthTokenRequest is the request body for POST /auth/token.
 type AuthTokenRequest struct {
 	AgentID string `json:"agent_id"`

--- a/internal/model/api_test.go
+++ b/internal/model/api_test.go
@@ -382,3 +382,42 @@ func TestValidateMetadataSize_OverMax(t *testing.T) {
 	assert.Contains(t, err.Error(), "metadata")
 	assert.Contains(t, err.Error(), "exceeds maximum size")
 }
+
+// ---- HighConfidenceWarnings ------------------------------------------------
+
+func TestHighConfidenceWarnings_HighConfidenceNoEvidence(t *testing.T) {
+	warnings := model.HighConfidenceWarnings(0.9, 0, 0.85)
+	require.Len(t, warnings, 1)
+	assert.Contains(t, warnings[0], "high confidence claim")
+	assert.Contains(t, warnings[0], "0.9")
+	assert.Contains(t, warnings[0], "without supporting evidence")
+}
+
+func TestHighConfidenceWarnings_HighConfidenceWithEvidence(t *testing.T) {
+	warnings := model.HighConfidenceWarnings(0.9, 2, 0.85)
+	assert.Nil(t, warnings, "should not warn when evidence is present")
+}
+
+func TestHighConfidenceWarnings_LowConfidenceNoEvidence(t *testing.T) {
+	warnings := model.HighConfidenceWarnings(0.5, 0, 0.85)
+	assert.Nil(t, warnings, "should not warn when confidence is below threshold")
+}
+
+func TestHighConfidenceWarnings_ExactlyAtThreshold(t *testing.T) {
+	warnings := model.HighConfidenceWarnings(0.85, 0, 0.85)
+	assert.Nil(t, warnings, "threshold is exclusive — 0.85 is not > 0.85")
+}
+
+func TestHighConfidenceWarnings_JustAboveThreshold(t *testing.T) {
+	warnings := model.HighConfidenceWarnings(0.86, 0, 0.85)
+	require.Len(t, warnings, 1)
+	assert.Contains(t, warnings[0], "0.86")
+}
+
+func TestHighConfidenceWarnings_CustomThreshold(t *testing.T) {
+	warnings := model.HighConfidenceWarnings(0.75, 0, 0.70)
+	require.Len(t, warnings, 1, "should fire with a lower custom threshold")
+
+	warnings = model.HighConfidenceWarnings(0.75, 0, 0.80)
+	assert.Nil(t, warnings, "should not fire when confidence is below custom threshold")
+}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -56,54 +56,59 @@ type Handlers struct {
 	// conflictValidator classifies relationships between decision pairs.
 	// Nil-safe: eval endpoint returns 501 when not configured.
 	conflictValidator conflicts.Validator
+	// highConfidenceWarnThreshold triggers a response warning when confidence
+	// exceeds this value and no evidence items are provided.
+	highConfidenceWarnThreshold float64
 }
 
 // HandlersDeps holds all dependencies for constructing Handlers.
 // Optional (nil-safe): Broker, Searcher, GrantCache, OpenAPISpec, DecisionHooks.
 type HandlersDeps struct {
-	DB                      *storage.DB
-	JWTMgr                  *auth.JWTManager
-	DecisionSvc             *decisions.Service
-	Buffer                  *trace.Buffer
-	Broker                  *Broker
-	Searcher                search.Searcher
-	GrantCache              *authz.GrantCache
-	Logger                  *slog.Logger
-	Version                 string
-	MaxRequestBodyBytes     int64
-	OpenAPISpec             []byte
-	EnableDestructiveDelete bool
-	RetentionInterval       time.Duration
-	DecisionHooks           []DecisionHook
-	AutoTrace               bool
-	TrustProxy              bool
-	ResolutionRecorder      conflicts.ResolutionRecorder
-	ConflictValidator       conflicts.Validator
+	DB                          *storage.DB
+	JWTMgr                      *auth.JWTManager
+	DecisionSvc                 *decisions.Service
+	Buffer                      *trace.Buffer
+	Broker                      *Broker
+	Searcher                    search.Searcher
+	GrantCache                  *authz.GrantCache
+	Logger                      *slog.Logger
+	Version                     string
+	MaxRequestBodyBytes         int64
+	OpenAPISpec                 []byte
+	EnableDestructiveDelete     bool
+	RetentionInterval           time.Duration
+	DecisionHooks               []DecisionHook
+	AutoTrace                   bool
+	TrustProxy                  bool
+	ResolutionRecorder          conflicts.ResolutionRecorder
+	ConflictValidator           conflicts.Validator
+	HighConfidenceWarnThreshold float64
 }
 
 // NewHandlers creates a new Handlers with all dependencies.
 func NewHandlers(d HandlersDeps) *Handlers {
 	return &Handlers{
-		db:                      d.DB,
-		jwtMgr:                  d.JWTMgr,
-		decisionSvc:             d.DecisionSvc,
-		buffer:                  d.Buffer,
-		broker:                  d.Broker,
-		searcher:                d.Searcher,
-		grantCache:              d.GrantCache,
-		logger:                  d.Logger,
-		startedAt:               time.Now(),
-		version:                 d.Version,
-		maxRequestBodyBytes:     d.MaxRequestBodyBytes,
-		openapiSpec:             d.OpenAPISpec,
-		enableDestructiveDelete: d.EnableDestructiveDelete,
-		retentionInterval:       d.RetentionInterval,
-		decisionHooks:           d.DecisionHooks,
-		hookChecks:              newHookCheckStore(),
-		autoTrace:               d.AutoTrace,
-		trustProxy:              d.TrustProxy,
-		resolutionRecorder:      d.ResolutionRecorder,
-		conflictValidator:       d.ConflictValidator,
+		db:                          d.DB,
+		jwtMgr:                      d.JWTMgr,
+		decisionSvc:                 d.DecisionSvc,
+		buffer:                      d.Buffer,
+		broker:                      d.Broker,
+		searcher:                    d.Searcher,
+		grantCache:                  d.GrantCache,
+		logger:                      d.Logger,
+		startedAt:                   time.Now(),
+		version:                     d.Version,
+		maxRequestBodyBytes:         d.MaxRequestBodyBytes,
+		openapiSpec:                 d.OpenAPISpec,
+		enableDestructiveDelete:     d.EnableDestructiveDelete,
+		retentionInterval:           d.RetentionInterval,
+		decisionHooks:               d.DecisionHooks,
+		hookChecks:                  newHookCheckStore(),
+		autoTrace:                   d.AutoTrace,
+		trustProxy:                  d.TrustProxy,
+		resolutionRecorder:          d.ResolutionRecorder,
+		conflictValidator:           d.ConflictValidator,
+		highConfidenceWarnThreshold: d.HighConfidenceWarnThreshold,
 	}
 }
 

--- a/internal/server/handlers_decisions.go
+++ b/internal/server/handlers_decisions.go
@@ -157,6 +157,9 @@ func (h *Handlers) HandleTrace(w http.ResponseWriter, r *http.Request) {
 	if result.EmbeddingSkipped {
 		resp["embedding_skipped"] = true
 	}
+	if warnings := model.HighConfidenceWarnings(req.Decision.Confidence, len(req.Decision.Evidence), h.highConfidenceWarnThreshold); len(warnings) > 0 {
+		resp["warnings"] = warnings
+	}
 	h.completeIdempotentWriteBestEffort(r, orgID, idem, http.StatusCreated, resp)
 	writeJSON(w, r, http.StatusCreated, resp)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -96,29 +96,33 @@ type ServerConfig struct {
 
 	// Conflict validator for the eval endpoint. Nil = eval returns 501.
 	ConflictValidator conflicts.Validator
+
+	// Trace quality warnings.
+	HighConfidenceWarnThreshold float64
 }
 
 // New creates a new HTTP server with all routes configured.
 func New(cfg ServerConfig) *Server {
 	h := NewHandlers(HandlersDeps{
-		DB:                      cfg.DB,
-		JWTMgr:                  cfg.JWTMgr,
-		DecisionSvc:             cfg.DecisionSvc,
-		Buffer:                  cfg.Buffer,
-		Broker:                  cfg.Broker,
-		Searcher:                cfg.Searcher,
-		GrantCache:              cfg.GrantCache,
-		Logger:                  cfg.Logger,
-		Version:                 cfg.Version,
-		MaxRequestBodyBytes:     cfg.MaxRequestBodyBytes,
-		OpenAPISpec:             cfg.OpenAPISpec,
-		EnableDestructiveDelete: cfg.EnableDestructiveDelete,
-		RetentionInterval:       cfg.RetentionInterval,
-		DecisionHooks:           cfg.DecisionHooks,
-		AutoTrace:               cfg.AutoTrace,
-		TrustProxy:              cfg.TrustProxy,
-		ResolutionRecorder:      cfg.ResolutionRecorder,
-		ConflictValidator:       cfg.ConflictValidator,
+		DB:                          cfg.DB,
+		JWTMgr:                      cfg.JWTMgr,
+		DecisionSvc:                 cfg.DecisionSvc,
+		Buffer:                      cfg.Buffer,
+		Broker:                      cfg.Broker,
+		Searcher:                    cfg.Searcher,
+		GrantCache:                  cfg.GrantCache,
+		Logger:                      cfg.Logger,
+		Version:                     cfg.Version,
+		MaxRequestBodyBytes:         cfg.MaxRequestBodyBytes,
+		OpenAPISpec:                 cfg.OpenAPISpec,
+		EnableDestructiveDelete:     cfg.EnableDestructiveDelete,
+		RetentionInterval:           cfg.RetentionInterval,
+		DecisionHooks:               cfg.DecisionHooks,
+		AutoTrace:                   cfg.AutoTrace,
+		TrustProxy:                  cfg.TrustProxy,
+		ResolutionRecorder:          cfg.ResolutionRecorder,
+		ConflictValidator:           cfg.ConflictValidator,
+		HighConfidenceWarnThreshold: cfg.HighConfidenceWarnThreshold,
 	})
 
 	mux := http.NewServeMux()

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -124,7 +124,7 @@ func TestMain(m *testing.M) {
 	buf.Start(ctx)
 	testBuf = buf
 
-	mcpSrv := mcp.New(db, decisionSvc, nil, logger, "test")
+	mcpSrv := mcp.New(db, decisionSvc, nil, logger, "test", 0.85)
 	srv := server.New(server.ServerConfig{
 		DB:                  db,
 		JWTMgr:              jwtMgr,
@@ -137,7 +137,8 @@ func TestMain(m *testing.M) {
 		Version:             "test",
 		MaxRequestBodyBytes: 1 * 1024 * 1024,
 		// Explicitly enabled for tests that exercise GDPR delete behavior.
-		EnableDestructiveDelete: true,
+		EnableDestructiveDelete:     true,
+		HighConfidenceWarnThreshold: 0.85,
 	})
 
 	// Seed admin.
@@ -10812,4 +10813,90 @@ func TestHandleTrace_ExplicitModelTakesPriorityOverXModelHeader(t *testing.T) {
 	require.NoError(t, json.Unmarshal(body, &result))
 	require.NotNil(t, result.Data.Model, "model should be populated")
 	assert.Equal(t, "gpt-4o", *result.Data.Model, "explicit model in body must take priority over X-Model header")
+}
+
+// ---- High confidence warning in trace response ----------------------------
+
+func TestHandleTrace_HighConfidenceNoEvidenceWarning(t *testing.T) {
+	agentID := "warn-agent-" + uuid.New().String()[:8]
+
+	resp, err := authedRequest("POST", testSrv.URL+"/v1/trace", adminToken,
+		model.TraceRequest{
+			AgentID: agentID,
+			Decision: model.TraceDecision{
+				DecisionType: "architecture",
+				Outcome:      "chose high confidence without evidence",
+				Confidence:   0.9,
+			},
+		})
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	var envelope struct {
+		Data struct {
+			DecisionID string   `json:"decision_id"`
+			Warnings   []string `json:"warnings"`
+		} `json:"data"`
+	}
+	body, _ := io.ReadAll(resp.Body)
+	require.NoError(t, json.Unmarshal(body, &envelope))
+	require.Len(t, envelope.Data.Warnings, 1, "should include one warning for high confidence without evidence")
+	assert.Contains(t, envelope.Data.Warnings[0], "high confidence claim")
+	assert.Contains(t, envelope.Data.Warnings[0], "without supporting evidence")
+}
+
+func TestHandleTrace_HighConfidenceWithEvidenceNoWarning(t *testing.T) {
+	agentID := "nowarn-agent-" + uuid.New().String()[:8]
+
+	resp, err := authedRequest("POST", testSrv.URL+"/v1/trace", adminToken,
+		model.TraceRequest{
+			AgentID: agentID,
+			Decision: model.TraceDecision{
+				DecisionType: "architecture",
+				Outcome:      "chose with evidence attached",
+				Confidence:   0.9,
+				Evidence: []model.TraceEvidence{
+					{SourceType: "document", Content: "supporting analysis"},
+				},
+			},
+		})
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	var envelope struct {
+		Data struct {
+			Warnings []string `json:"warnings"`
+		} `json:"data"`
+	}
+	body, _ := io.ReadAll(resp.Body)
+	require.NoError(t, json.Unmarshal(body, &envelope))
+	assert.Empty(t, envelope.Data.Warnings, "should not warn when evidence is present")
+}
+
+func TestHandleTrace_LowConfidenceNoWarning(t *testing.T) {
+	agentID := "low-conf-" + uuid.New().String()[:8]
+
+	resp, err := authedRequest("POST", testSrv.URL+"/v1/trace", adminToken,
+		model.TraceRequest{
+			AgentID: agentID,
+			Decision: model.TraceDecision{
+				DecisionType: "architecture",
+				Outcome:      "low confidence decision",
+				Confidence:   0.5,
+			},
+		})
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	var envelope struct {
+		Data struct {
+			Warnings []string `json:"warnings"`
+		} `json:"data"`
+	}
+	body, _ := io.ReadAll(resp.Body)
+	require.NoError(t, json.Unmarshal(body, &envelope))
+	assert.Empty(t, envelope.Data.Warnings, "should not warn for confidence below threshold")
 }


### PR DESCRIPTION
## Summary

- Adds a `warnings` array to the trace response (HTTP + MCP) when confidence exceeds a configurable threshold (default 0.85) with zero evidence items
- Warning is non-blocking — traces are still accepted with HTTP 201
- Threshold configurable via `AKASHI_HIGH_CONFIDENCE_WARNING_THRESHOLD` env var
- Shared `HighConfidenceWarnings()` in `model` package keeps logic DRY across both handlers

## Test plan

- [x] Unit tests for `HighConfidenceWarnings` — boundary values, custom thresholds, float32 precision at exact threshold
- [x] Integration tests for HTTP handler — warning present, warning absent with evidence, warning absent with low confidence
- [x] Integration tests for MCP handler — warning present, warning absent with evidence
- [x] All pre-commit checks pass (go build, go vet, golangci-lint, atlas validate)
- [x] Targeted test runs with `-race` pass

Closes #468

> In the Mirror Dimension, Strange bends reality to trap Kaecilius —
> but the warnings are always there, folded into the geometry itself.
> You just have to know where to look. That's what this PR does:
> folds a quality signal into the response so the next agent can't miss it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)