### PR TITLE
feat(mcp): auto-attach akashi_check result as evidence on trace

### DIFF
--- a/internal/mcp/check_cache.go
+++ b/internal/mcp/check_cache.go
@@ -1,0 +1,61 @@
+package mcp
+
+import (
+	"sync"
+	"time"
+)
+
+// checkCacheTTL is the maximum age of a cached check result before it is
+// discarded. If an agent takes longer than this between akashi_check and
+// akashi_trace, the check result is stale and won't be auto-attached.
+const checkCacheTTL = 5 * time.Minute
+
+// checkCacheEntry stores a serialized akashi_check response for a session.
+type checkCacheEntry struct {
+	content    string
+	capturedAt time.Time
+}
+
+// checkCache stores the most recent akashi_check response per MCP session,
+// so handleTrace can auto-inject it as evidence. Keyed by MCP session ID —
+// both handleCheck and handleTrace run on the same session, so this avoids
+// the session ID mismatch problem that plagued the PostToolUse approach
+// (Claude Code uses different session IDs for MCP vs built-in tools).
+type checkCache struct {
+	mu    sync.Mutex
+	cache map[string]checkCacheEntry
+}
+
+func newCheckCache() *checkCache {
+	return &checkCache{
+		cache: make(map[string]checkCacheEntry),
+	}
+}
+
+// Store saves a check result for the given session, replacing any previous entry.
+func (cc *checkCache) Store(sessionID, content string) {
+	cc.mu.Lock()
+	defer cc.mu.Unlock()
+	cc.cache[sessionID] = checkCacheEntry{
+		content:    content,
+		capturedAt: time.Now(),
+	}
+}
+
+// Drain returns and removes the cached check result for the given session.
+// Returns empty string if no entry exists or the entry has expired.
+func (cc *checkCache) Drain(sessionID string) string {
+	cc.mu.Lock()
+	defer cc.mu.Unlock()
+
+	entry, ok := cc.cache[sessionID]
+	if !ok {
+		return ""
+	}
+	delete(cc.cache, sessionID)
+
+	if time.Since(entry.capturedAt) > checkCacheTTL {
+		return ""
+	}
+	return entry.content
+}

--- a/internal/mcp/check_cache_test.go
+++ b/internal/mcp/check_cache_test.go
@@ -1,0 +1,104 @@
+package mcp
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckCache_StoreAndDrain(t *testing.T) {
+	cc := newCheckCache()
+
+	cc.Store("session-1", `{"has_precedent": true, "summary": "test"}`)
+
+	result := cc.Drain("session-1")
+	require.NotEmpty(t, result)
+	assert.Contains(t, result, "has_precedent")
+}
+
+func TestCheckCache_DrainClearsEntry(t *testing.T) {
+	cc := newCheckCache()
+
+	cc.Store("session-1", "check result")
+
+	first := cc.Drain("session-1")
+	require.Equal(t, "check result", first)
+
+	second := cc.Drain("session-1")
+	assert.Empty(t, second, "second drain should return empty after entry was consumed")
+}
+
+func TestCheckCache_DrainMissing(t *testing.T) {
+	cc := newCheckCache()
+	assert.Empty(t, cc.Drain("nonexistent"))
+}
+
+func TestCheckCache_SessionIsolation(t *testing.T) {
+	cc := newCheckCache()
+
+	cc.Store("session-1", "result-1")
+	cc.Store("session-2", "result-2")
+
+	assert.Equal(t, "result-1", cc.Drain("session-1"))
+	assert.Equal(t, "result-2", cc.Drain("session-2"))
+}
+
+func TestCheckCache_StoreOverwritesPrevious(t *testing.T) {
+	cc := newCheckCache()
+
+	cc.Store("session-1", "old check")
+	cc.Store("session-1", "new check")
+
+	result := cc.Drain("session-1")
+	assert.Equal(t, "new check", result, "latest store should overwrite previous")
+}
+
+func TestCheckCache_TTLExpiry(t *testing.T) {
+	cc := newCheckCache()
+
+	// Inject an expired entry directly.
+	cc.mu.Lock()
+	cc.cache["session-1"] = checkCacheEntry{
+		content:    "stale check",
+		capturedAt: time.Now().Add(-checkCacheTTL - time.Second),
+	}
+	cc.mu.Unlock()
+
+	result := cc.Drain("session-1")
+	assert.Empty(t, result, "expired entry should be discarded")
+
+	// Verify the entry was removed from the cache.
+	cc.mu.Lock()
+	_, exists := cc.cache["session-1"]
+	cc.mu.Unlock()
+	assert.False(t, exists, "expired entry should be deleted from cache")
+}
+
+func TestCheckCache_ConcurrentAccess(t *testing.T) {
+	cc := newCheckCache()
+	var wg sync.WaitGroup
+
+	// Concurrent stores.
+	for i := range 20 {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			cc.Store("session-1", "result")
+		}(i)
+	}
+
+	// Concurrent drains.
+	for range 10 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = cc.Drain("session-1")
+		}()
+	}
+
+	wg.Wait()
+	// No race detector failures = pass.
+}

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -59,6 +59,7 @@ type Server struct {
 	grantCache  *authz.GrantCache  // optional cache for LoadGrantedSet
 	logger      *slog.Logger
 	rootsCache  *rootsCache // caches MCP roots per session (one request per session)
+	checkCache  *checkCache // caches last akashi_check response per session for evidence auto-attach
 	onCheck     func()      // called when akashi_check is invoked; wires IDE hook gate
 }
 
@@ -77,6 +78,7 @@ func New(db storage.Store, decisionSvc *decisions.Service, grantCache *authz.Gra
 		grantCache:  grantCache,
 		logger:      logger,
 		rootsCache:  newRootsCache(),
+		checkCache:  newCheckCache(),
 	}
 
 	s.mcpServer = mcpserver.NewMCPServer(

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -571,6 +571,15 @@ func (s *Server) handleCheck(ctx context.Context, request mcplib.CallToolRequest
 	}
 
 	resultData, _ := json.MarshalIndent(result, "", "  ")
+
+	// Cache the compact check response so handleTrace can auto-inject it
+	// as evidence. Both handlers share the same MCP session.
+	if session := mcpserver.ClientSessionFromContext(ctx); session != nil {
+		if sid := session.SessionID(); sid != "" {
+			s.checkCache.Store(sid, string(resultData))
+		}
+	}
+
 	return &mcplib.CallToolResult{
 		Content: []mcplib.Content{
 			mcplib.TextContent{Type: "text", Text: string(resultData)},
@@ -826,6 +835,26 @@ func (s *Server) handleTrace(ctx context.Context, request mcplib.CallToolRequest
 	var apiKeyID *uuid.UUID
 	if claims != nil {
 		apiKeyID = claims.APIKeyID
+	}
+
+	// Auto-attach the preceding akashi_check response as evidence when the
+	// agent provided none. This injects the research step into the decision
+	// record automatically, rather than suggesting it after the fact.
+	if len(evidence) == 0 {
+		if session := mcpserver.ClientSessionFromContext(ctx); session != nil {
+			if sid := session.SessionID(); sid != "" {
+				if checkResult := s.checkCache.Drain(sid); checkResult != "" {
+					relevance := float32(0.6)
+					sourceURI := "akashi://check"
+					evidence = []model.TraceEvidence{{
+						SourceType:     "tool_output",
+						SourceURI:      &sourceURI,
+						Content:        checkResult,
+						RelevanceScore: &relevance,
+					}}
+				}
+			}
+		}
 	}
 
 	result, err := s.decisionSvc.Trace(ctx, orgID, decisions.TraceInput{

--- a/internal/server/handlers_decisions.go
+++ b/internal/server/handlers_decisions.go
@@ -157,6 +157,7 @@ func (h *Handlers) HandleTrace(w http.ResponseWriter, r *http.Request) {
 	if result.EmbeddingSkipped {
 		resp["embedding_skipped"] = true
 	}
+
 	h.completeIdempotentWriteBestEffort(r, orgID, idem, http.StatusCreated, resp)
 	writeJSON(w, r, http.StatusCreated, resp)
 }


### PR DESCRIPTION
## Summary

- When `akashi_trace` is called with zero evidence, the MCP server auto-injects the preceding `akashi_check` response as a `TraceEvidence` item (`source_type: tool_output`, `source_uri: akashi://check`, `relevance_score: 0.6`)
- Check results are cached per MCP session ID with a 5-minute TTL and consumed on first trace (one-shot drain)
- Evidence is injected *before* the `Trace()` call so it's embedded and stored atomically with the decision — no second trace needed
- Replaces the previous `EvidenceBuffer` approach which captured every tool response indiscriminately, surfaced suggestions after the trace was committed, and leaked across sessions via a machine-global buffer

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go test -race -count=1 ./internal/mcp/...` — 7 new check cache tests (store/drain, session isolation, TTL expiry, overwrite, concurrent access)
- [x] `go test -race -count=1 ./internal/server/...` — existing tests pass unchanged
- [ ] CI green

> The Half-Blood Prince's textbook worked because Snape didn't just
> hand Harry the answers — he annotated the margins with the reasoning
> that got him there. Evidence auto-attachment is the same idea: the
> research that informed the decision should travel with it, not sit
> in a buffer nobody reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)