### PR TITLE
fix(conflicts): stop suppressing precedent-linked supersession pairs (#452)

### DIFF
--- a/internal/conflicts/scorer.go
+++ b/internal/conflicts/scorer.go
@@ -475,9 +475,10 @@ func (s *Scorer) scoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 
 		// Complementary workflow filter: suppress conflict creation when the
 		// pair matches a structural pattern (review→fix, same-agent refinement,
-		// precedent chain). Applied after scoring but before the confirmation
-		// gate to save LLM cost and eliminate false positives that embedding
-		// math cannot distinguish from genuine conflicts.
+		// or non-superseding precedent chain). Applied after scoring but before
+		// the confirmation gate to save LLM cost and eliminate false positives
+		// that embedding math cannot distinguish from genuine conflicts.
+		// Precedent-linked pairs with supersession keywords pass through (#452).
 		if isComplementaryWorkflowPair(d, sc.cand) {
 			s.metrics.workflowFiltered.Add(ctx, 1)
 			s.logger.Debug("conflict scorer: workflow filter suppressed pair",
@@ -586,6 +587,7 @@ func (s *Scorer) scoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 				FullOutcomeA:    d.Outcome,
 				FullOutcomeB:    cand.Outcome,
 				TopicSimilarity: sc.topicSim,
+				PrecedentLinked: isPrecedentLinked(d, cand),
 			})
 			s.metrics.llmCallDuration.Record(ctx, float64(time.Since(llmStart).Milliseconds()))
 			if err != nil {
@@ -991,15 +993,24 @@ func (s *Scorer) ClearAllConflicts(ctx context.Context) (int, error) {
 //     one ("implemented", "fixed", "resolved", "completed", "addressed").
 //
 //  3. Precedent chain: one decision cites the other via precedent_ref,
-//     meaning the agent explicitly linked them as cause-and-effect.
+//     meaning the agent explicitly linked them. However, precedent links can
+//     represent supersession (reversal) rather than refinement. When the later
+//     decision's outcome contains supersession keywords, the pair is passed
+//     through to LLM validation instead of being suppressed. See issue #452.
 func isComplementaryWorkflowPair(d, cand model.Decision) bool {
 	// Heuristic 3: Precedent chain. If either decision cites the other,
-	// they are linked by design — not conflicting.
-	if cand.PrecedentRef != nil && *cand.PrecedentRef == d.ID {
-		return true
-	}
-	if d.PrecedentRef != nil && *d.PrecedentRef == cand.ID {
-		return true
+	// they are linked by design. But linked decisions can still conflict
+	// (supersession). Check the later decision's outcome for reversal signals;
+	// if found, let the LLM decide instead of suppressing.
+	if isPrecedentLinked(d, cand) {
+		later := cand
+		if cand.ValidFrom.Before(d.ValidFrom) {
+			later = d
+		}
+		if containsSupersessionKeyword(later.Outcome) {
+			return false // probable supersession — let LLM validate
+		}
+		return true // probable refinement — suppress
 	}
 
 	// Determine temporal order: earlier and later decision.
@@ -1024,6 +1035,50 @@ func isComplementaryWorkflowPair(d, cand model.Decision) bool {
 		}
 	}
 
+	return false
+}
+
+// isPrecedentLinked returns true if either decision cites the other via
+// precedent_ref, meaning there is an explicit lineage link between them.
+func isPrecedentLinked(d, cand model.Decision) bool {
+	if cand.PrecedentRef != nil && *cand.PrecedentRef == d.ID {
+		return true
+	}
+	if d.PrecedentRef != nil && *d.PrecedentRef == cand.ID {
+		return true
+	}
+	return false
+}
+
+// supersessionKeywords are outcome substrings that indicate the decision
+// reverses or replaces a prior decision rather than refining it.
+var supersessionKeywords = []string{
+	"switched",
+	"superseding",
+	"superseded",
+	"replaced",
+	"replacing",
+	"reversed",
+	"reversing",
+	"reverted",
+	"reverting",
+	"migrated from",
+	"migrating from",
+	"instead of",
+	"no longer",
+	"abandoned",
+	"abandoning",
+}
+
+// containsSupersessionKeyword returns true if the outcome text contains any
+// keyword indicating the decision reverses or replaces a prior one.
+func containsSupersessionKeyword(outcome string) bool {
+	lower := strings.ToLower(outcome)
+	for _, kw := range supersessionKeywords {
+		if strings.Contains(lower, kw) {
+			return true
+		}
+	}
 	return false
 }
 

--- a/internal/conflicts/scorer_test.go
+++ b/internal/conflicts/scorer_test.go
@@ -2422,11 +2422,159 @@ func TestIsComplementaryWorkflowPair_PrecedentChain(t *testing.T) {
 			},
 			expected: false,
 		},
+		{
+			name: "precedent-linked with supersession keyword 'switched' → NOT filtered (#452)",
+			d: model.Decision{
+				ID: idA, DecisionType: "architecture", AgentID: "planner",
+				Outcome: "Chose Python for Mimir", ValidFrom: now,
+			},
+			cand: model.Decision{
+				ID: idB, DecisionType: "architecture", AgentID: "coder",
+				Outcome: "Switched to Go, superseding Python", ValidFrom: now.Add(time.Hour),
+				PrecedentRef: &idA,
+			},
+			expected: false,
+		},
+		{
+			name: "precedent-linked with supersession keyword 'replaced' → NOT filtered (#452)",
+			d: model.Decision{
+				ID: idA, DecisionType: "architecture", AgentID: "planner",
+				Outcome: "Use dual database approach", ValidFrom: now,
+			},
+			cand: model.Decision{
+				ID: idB, DecisionType: "architecture", AgentID: "coder",
+				Outcome: "Replaced dual DB with PostgreSQL only", ValidFrom: now.Add(time.Hour),
+				PrecedentRef: &idA,
+			},
+			expected: false,
+		},
+		{
+			name: "precedent-linked with 'instead of' → NOT filtered (#452)",
+			d: model.Decision{
+				ID: idA, DecisionType: "architecture", AgentID: "agent-a",
+				Outcome: "Use Redis for caching", ValidFrom: now,
+			},
+			cand: model.Decision{
+				ID: idB, DecisionType: "architecture", AgentID: "agent-a",
+				Outcome: "Use Memcached instead of Redis", ValidFrom: now.Add(time.Hour),
+				PrecedentRef: &idA,
+			},
+			expected: false,
+		},
+		{
+			name: "precedent-linked with 'no longer' → NOT filtered (#452)",
+			d: model.Decision{
+				ID: idA, DecisionType: "architecture", AgentID: "agent-a",
+				Outcome: "Use microservices architecture", ValidFrom: now,
+			},
+			cand: model.Decision{
+				ID: idB, DecisionType: "architecture", AgentID: "agent-a",
+				Outcome: "No longer using microservices, consolidating to monolith", ValidFrom: now.Add(time.Hour),
+				PrecedentRef: &idA,
+			},
+			expected: false,
+		},
+		{
+			name: "precedent-linked d cites cand with supersession keyword → NOT filtered (#452)",
+			d: model.Decision{
+				ID: idA, DecisionType: "architecture", AgentID: "coder",
+				Outcome: "Reverted to REST after gRPC proved problematic", ValidFrom: now.Add(time.Hour),
+				PrecedentRef: &idB,
+			},
+			cand: model.Decision{
+				ID: idB, DecisionType: "architecture", AgentID: "planner",
+				Outcome: "Use gRPC for all services", ValidFrom: now,
+			},
+			expected: false,
+		},
+		{
+			name: "precedent-linked refinement without supersession keywords → filtered",
+			d: model.Decision{
+				ID: idA, DecisionType: "architecture", AgentID: "planner",
+				Outcome: "Use PostgreSQL with connection pooling", ValidFrom: now,
+			},
+			cand: model.Decision{
+				ID: idB, DecisionType: "implementation", AgentID: "coder",
+				Outcome: "Implemented PostgreSQL connection pooling with pgbouncer", ValidFrom: now.Add(time.Hour),
+				PrecedentRef: &idA,
+			},
+			expected: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.expected, isComplementaryWorkflowPair(tt.d, tt.cand))
+		})
+	}
+}
+
+func TestContainsSupersessionKeyword(t *testing.T) {
+	tests := []struct {
+		outcome  string
+		expected bool
+	}{
+		{"Switched to Go, superseding Python", true},
+		{"Replaced dual DB with PostgreSQL only", true},
+		{"Reversed the earlier caching decision", true},
+		{"Reverted to the original approach", true},
+		{"Migrated from MySQL to PostgreSQL", true},
+		{"Use Memcached instead of Redis", true},
+		{"No longer using microservices", true},
+		{"Abandoned the event-sourcing approach", true},
+		{"Implemented the planned feature", false},
+		{"Fixed the bug identified in review", false},
+		{"Completed the migration to new schema", false},
+		{"Added connection pooling as planned", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.outcome, func(t *testing.T) {
+			assert.Equal(t, tt.expected, containsSupersessionKeyword(tt.outcome))
+		})
+	}
+}
+
+func TestIsPrecedentLinked(t *testing.T) {
+	idA := uuid.New()
+	idB := uuid.New()
+
+	tests := []struct {
+		name     string
+		d        model.Decision
+		cand     model.Decision
+		expected bool
+	}{
+		{
+			name:     "cand cites d",
+			d:        model.Decision{ID: idA},
+			cand:     model.Decision{ID: idB, PrecedentRef: &idA},
+			expected: true,
+		},
+		{
+			name:     "d cites cand",
+			d:        model.Decision{ID: idA, PrecedentRef: &idB},
+			cand:     model.Decision{ID: idB},
+			expected: true,
+		},
+		{
+			name:     "no link",
+			d:        model.Decision{ID: idA},
+			cand:     model.Decision{ID: idB},
+			expected: false,
+		},
+		{
+			name:     "cites unrelated",
+			d:        model.Decision{ID: idA},
+			cand:     model.Decision{ID: idB, PrecedentRef: ptr(uuid.New())},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isPrecedentLinked(tt.d, tt.cand))
 		})
 	}
 }

--- a/internal/conflicts/validator.go
+++ b/internal/conflicts/validator.go
@@ -34,6 +34,7 @@ type ValidateInput struct {
 	FullOutcomeA    string // full outcome when OutcomeA is a claim fragment
 	FullOutcomeB    string
 	TopicSimilarity float64 // decision-level embedding similarity (0–1); 0 means unavailable
+	PrecedentLinked bool    // true when one decision cites the other via precedent_ref
 }
 
 // ValidationResult holds the structured output from an LLM validation call.
@@ -145,6 +146,18 @@ func formatPrompt(input ValidateInput) string {
 	if input.TopicSimilarity >= 0.70 && input.AgentA != input.AgentB {
 		fmt.Fprintf(&b, "HIGH TOPIC OVERLAP: Embeddings show %.0f%% topic similarity, meaning both decisions address the same domain. Check whether the agents take OPPOSITE STANCES on the same specific question.\n",
 			input.TopicSimilarity*100)
+	}
+
+	// --- Precedent chain supersession hint (#452) ---
+	// When one decision explicitly cites the other via precedent_ref and
+	// contains supersession keywords, the heuristic filter passed it through
+	// for LLM validation. Hint the LLM that this is a linked pair where the
+	// later decision may reverse the earlier one.
+	if input.PrecedentLinked {
+		b.WriteString("PRECEDENT LINK: One decision explicitly cites the other as its precedent. " +
+			"The later decision may REFINE the earlier one (building on it) or SUPERSEDE it (reversing the choice). " +
+			"Pay close attention to whether the later decision's outcome contradicts or reverses the earlier decision's conclusion. " +
+			"If it does, classify as SUPERSESSION.\n")
 	}
 
 	// --- Decision type workflow hint ---

--- a/internal/conflicts/validator_test.go
+++ b/internal/conflicts/validator_test.go
@@ -643,6 +643,38 @@ func TestFormatPrompt_NonWorkflowPair(t *testing.T) {
 	assert.NotContains(t, prompt, "WORKFLOW PATTERN")
 }
 
+func TestFormatPrompt_PrecedentLinked(t *testing.T) {
+	now := time.Now()
+	prompt := formatPrompt(ValidateInput{
+		OutcomeA:        "Chose Python for Mimir",
+		OutcomeB:        "Switched to Go, superseding Python",
+		TypeA:           "architecture",
+		TypeB:           "architecture",
+		AgentA:          "planner",
+		AgentB:          "coder",
+		CreatedA:        now,
+		CreatedB:        now.Add(1 * time.Hour),
+		PrecedentLinked: true,
+	})
+	assert.Contains(t, prompt, "PRECEDENT LINK")
+	assert.Contains(t, prompt, "SUPERSEDE")
+}
+
+func TestFormatPrompt_NoPrecedentLink(t *testing.T) {
+	now := time.Now()
+	prompt := formatPrompt(ValidateInput{
+		OutcomeA: "Use PostgreSQL",
+		OutcomeB: "Use MySQL",
+		TypeA:    "architecture",
+		TypeB:    "architecture",
+		AgentA:   "planner-a",
+		AgentB:   "planner-b",
+		CreatedA: now,
+		CreatedB: now.Add(1 * time.Hour),
+	})
+	assert.NotContains(t, prompt, "PRECEDENT LINK")
+}
+
 func TestTruncateRunes(t *testing.T) {
 	// Below limit: unchanged.
 	assert.Equal(t, "hello", truncateRunes("hello", 10))


### PR DESCRIPTION
## Summary

- Heuristic 3 in `isComplementaryWorkflowPair` unconditionally suppressed all `precedent_ref`-linked pairs before LLM validation, causing false negatives for genuine supersession conflicts (e.g., Python→Go language reversal where the Go decision correctly cited the Python one).
- The fix checks the later decision's outcome for supersession keywords (`switched`, `replaced`, `reversed`, `instead of`, `no longer`, etc.). Pairs with these signals now pass through to LLM validation with a new `PRECEDENT LINK` prompt hint; pairs without them are still suppressed as refinements.
- Adds `PrecedentLinked` field to `ValidateInput` and propagates it from the scorer to the validator prompt.

## Verification

- [x] I ran relevant tests locally (`go test -race -count=1 ./...` — all 18 packages pass).
- [ ] I updated docs/openapi for any API or behavior changes.
- [ ] If I changed config vars in `internal/config/config.go`, I also updated:
  - [ ] `docs/configuration.md`
  - [ ] `docs/runbook.md` (operational subset, if relevant)
  - [ ] `.env.example` (if baseline local/dev defaults changed)
  - [ ] `docs/consistency-manifest.json` (only if policy/coverage rules changed)
- [ ] `python3 scripts/check_doc_config_consistency.py` passes.

## Risk / Rollout Notes

- No migration or schema changes. Pure Go logic change in the conflict scorer's pre-filter heuristic.
- Pairs that were previously silently suppressed will now reach LLM validation when they contain supersession language, which may slightly increase LLM call volume for orgs with heavy precedent_ref usage.
- No backward compatibility concerns — the change is additive (fewer false suppressions).

> Vader's "I am your father" only lands because Luke already chose
> to reject the dark side before he knew the lineage was real. The
> precedent existed all along — what changed was recognizing it could
> mean reversal, not just refinement. Akashi's scorer had the same
> blind spot: it saw the link and assumed continuity.