### PR TITLE
fix(migration): drop check constraint before status remap in 075

### DIFF
--- a/migrations/075_simplify_conflict_statuses.sql
+++ b/migrations/075_simplify_conflict_statuses.sql
@@ -8,9 +8,12 @@
 --   resolved would inflate ConflictsNoWinner since those rows have
 --   winning_decision_id IS NULL and would match the resolved-no-winner filter).
 
+-- Drop the old constraint first so the UPDATEs can write 'false_positive',
+-- which is not in the original CHECK list.
+ALTER TABLE scored_conflicts DROP CONSTRAINT scored_conflicts_status_check;
+
 UPDATE scored_conflicts SET status = 'open' WHERE status = 'acknowledged';
 UPDATE scored_conflicts SET status = 'false_positive' WHERE status = 'wont_fix';
 
-ALTER TABLE scored_conflicts DROP CONSTRAINT scored_conflicts_status_check;
 ALTER TABLE scored_conflicts ADD CONSTRAINT scored_conflicts_status_check
     CHECK (status IN ('open', 'resolved', 'false_positive'));

--- a/migrations/atlas.sum
+++ b/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:uDU2aTz6kSdqNIROqfJffCfQrHyUvanFvIa4prZa+vg=
+h1:I9gEggAEpnwiVepb/xKB8jKxaR1AYOTKvzvZRr2a3W0=
 001_initial.sql h1:uhyGXto+QacAaGYb9ZTGjsBs5chlKi8O0eHz9aCQsrY=
 022_full_text_search.sql h1:9iwtA8MgCzAxDV9YkUBn0CLT9ePSmj3GcPoMGg8TXf0=
 023_fix_outbox_index.sql h1:OtMEFBcMRWej02+ghnBXlPr6BVq+LoA62Id9XUWfDNI=
@@ -53,4 +53,4 @@ h1:uDU2aTz6kSdqNIROqfJffCfQrHyUvanFvIa4prZa+vg=
 072_evidence_metrics.sql h1:mWTFOEP45QQFbF8MRBlptTyMFE+pV0bQZAAo1gxkQ5c=
 073_precedent_reason.sql h1:78egqu3Q5HXZCN9C1IESOYg41HnGdRK5CWDQUnyEF7Y=
 074_agent_context_outbox_trigger.sql h1:y9b/Xlp3HphK55b2RFHJQcE4B94SlMKpKVVVJ1i4L0s=
-075_simplify_conflict_statuses.sql h1:bdvafiI9K7J3zWRwMKd6R5drW5MzZrBWEkVxRIYwDCs=
+075_simplify_conflict_statuses.sql h1:OFBOEJ7TKmAsxFtTJL3JxkADIjrhsst/vshdahnrjZc=


### PR DESCRIPTION
## Summary

- Migration 075 tried to `UPDATE scored_conflicts SET status = 'false_positive'` while the old check constraint (`status IN ('open', 'acknowledged', 'resolved', 'wont_fix')`) was still active. `false_positive` isn't in that list, so Postgres rejected the UPDATE with `SQLSTATE 23514`.
- Fix: move `DROP CONSTRAINT` before the UPDATE statements so the remap can write the new status values unconstrained, then add the tightened constraint afterward.

## Verification

- [x] I ran relevant tests locally (`go test ./...` or targeted package tests).
- [ ] I updated docs/openapi for any API or behavior changes.
- [ ] If I changed config vars in `internal/config/config.go`, I also updated:
  - [ ] `docs/configuration.md`
  - [ ] `docs/runbook.md` (operational subset, if relevant)
  - [ ] `.env.example` (if baseline local/dev defaults changed)
  - [ ] `docs/consistency-manifest.json` (only if policy/coverage rules changed)
- [ ] `python3 scripts/check_doc_config_consistency.py` passes.

## Risk / Rollout Notes

- If a dev database already attempted 075 and the transaction rolled back cleanly (expected behavior for `runMigrationTx`), restarting with this fix is sufficient. If the row was somehow recorded in `schema_migrations`, delete it first: `DELETE FROM schema_migrations WHERE version = '075_simplify_conflict_statuses.sql';`
- No behavioral change — same UPDATEs and final constraint, just reordered.

> The transporter doesn't care what order you disassemble the atoms —
> only that they reassemble correctly on the other end. Scotty would
> have caught this in code review: you cannae change the values before
> ye drop the constraint, Captain.