### PR TITLE
fix null cited_by crash on decision detail page

### DIFF
--- a/internal/storage/decisions.go
+++ b/internal/storage/decisions.go
@@ -2143,7 +2143,7 @@ func (db *DB) GetDecisionLineage(ctx context.Context, id, orgID uuid.UUID, limit
 		limit = 20
 	}
 
-	result := DecisionLineage{DecisionID: id}
+	result := DecisionLineage{DecisionID: id, CitedBy: []LineageEntry{}}
 
 	// Look up this decision's precedent_ref.
 	var precedentRef *uuid.UUID

--- a/ui/src/pages/DecisionDetail.tsx
+++ b/ui/src/pages/DecisionDetail.tsx
@@ -280,7 +280,7 @@ function DecisionLineage({ decisionId }: { decisionId: string }) {
   });
 
   if (isPending) return <Skeleton className="h-24 w-full" />;
-  if (!data || (!data.preceded_by && data.cited_by.length === 0)) return null;
+  if (!data || (!data.preceded_by && (!data.cited_by || data.cited_by.length === 0))) return null;
 
   return (
     <Card>
@@ -305,11 +305,11 @@ function DecisionLineage({ decisionId }: { decisionId: string }) {
         <div>
           <h4 className="text-xs font-medium text-muted-foreground mb-2">
             Cited by
-            {data.cited_by.length > 0 && (
+            {data.cited_by && data.cited_by.length > 0 && (
               <span className="ml-1 text-foreground">({data.cited_by.length}{data.cited_by_has_more ? "+" : ""})</span>
             )}
           </h4>
-          {data.cited_by.length > 0 ? (
+          {data.cited_by && data.cited_by.length > 0 ? (
             <div className="space-y-2">
               {data.cited_by.map((entry) => (
                 <LineageEntryRow key={entry.id} entry={entry} />


### PR DESCRIPTION
## Summary

- `GetDecisionLineage` returned a nil `CitedBy` slice, which `encoding/json` serializes as `null`. The React `DecisionLineage` component accessed `.length` on `null`, crashing the page for any decision without citations.
- Initialize `CitedBy` to `[]LineageEntry{}` in the storage layer so the API always returns `[]`, and add defensive null guards in the UI.

## Verification

- [x] I ran relevant tests locally (`go test ./...` or targeted package tests).
- [ ] I updated docs/openapi for any API or behavior changes.
- [ ] If I changed config vars in `internal/config/config.go`, I also updated:
  - [ ] `docs/configuration.md`
  - [ ] `docs/runbook.md` (operational subset, if relevant)
  - [ ] `.env.example` (if baseline local/dev defaults changed)
  - [ ] `docs/consistency-manifest.json` (only if policy/coverage rules changed)
- [ ] `python3 scripts/check_doc_config_consistency.py` passes.

## Risk / Rollout Notes

- Zero migration risk — no schema changes. The only behavioral change is the JSON serialization of an empty `cited_by` field going from `null` to `[]`, which is what the TypeScript type already expects.

> The Borg would never have this bug — their collective
> consciousness ensures every drone returns a proper empty array.
> But then again, they'd also assimilate your frontend framework
> before you could file the ticket.