### PR TITLE
fix(ui): cap dialog height and keep close button visible while scrolling

### DIFF
--- a/ui/src/components/ui/dialog.tsx
+++ b/ui/src/components/ui/dialog.tsx
@@ -33,12 +33,14 @@ const DialogContent = forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg max-h-[85vh] translate-x-[-50%] translate-y-[-50%] border bg-background shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className,
       )}
       {...props}
     >
-      {children}
+      <div className="overflow-y-auto p-6 gap-4 grid">
+        {children}
+      </div>
       <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>


### PR DESCRIPTION
## Summary

- Caps `DialogContent` height at 85vh and moves padding/gap/overflow into an inner scrollable div so that tall dialogs (e.g. adjudicate) scroll their content without the close button disappearing off-screen.

## Verification

- [x] I ran relevant tests locally (`go test ./...` or targeted package tests).
- [ ] I updated docs/openapi for any API or behavior changes.
  - N/A — UI-only change, no API or config changes.
- [ ] `python3 scripts/check_doc_config_consistency.py` passes.
  - N/A

## Risk / Rollout Notes

- Low risk. Only affects the shared `DialogContent` component — all dialogs now have a max height and scroll. No migration or backward compatibility concerns.

> The TARDIS is bigger on the inside, but even the Doctor
> would agree: a dialog that swallows the viewport whole
> is poor UX in any dimension. We capped it at 85vh —
> still roomy enough for a Time Lord's filing cabinet,
> compact enough that the close button doesn't vanish
> into the Void.