### PR TITLE
fix(ui): use flexbox in dialog to actually enable scrolling

### DIFF
--- a/ui/src/components/ui/dialog.tsx
+++ b/ui/src/components/ui/dialog.tsx
@@ -33,12 +33,12 @@ const DialogContent = forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg max-h-[85vh] translate-x-[-50%] translate-y-[-50%] border bg-background shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 flex flex-col w-full max-w-lg max-h-[85vh] translate-x-[-50%] translate-y-[-50%] border bg-background shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className,
       )}
       {...props}
     >
-      <div className="overflow-y-auto p-6 gap-4 grid">
+      <div className="overflow-y-auto flex-1 min-h-0 p-6 gap-4 flex flex-col">
         {children}
       </div>
       <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
@@ -66,7 +66,7 @@ function DialogFooter({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
   return (
     <div
       className={cn(
-        "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+        "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2 sticky bottom-0 bg-background pt-4 -mx-6 -mb-6 px-6 pb-6 border-t border-border",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary

- PR #512 added `max-h-[85vh]` and `overflow-y-auto` to DialogContent but kept CSS Grid layout. Grid items default to `min-height: auto`, preventing the inner wrapper from shrinking below its content size — so the scrollbar never activated and tall dialogs (like the Adjudicate Conflict dialog) were clipped at the viewport edge.
- Switches DialogContent from `grid` to `flex flex-col` and adds `min-h-0 flex-1` to the scrollable wrapper so it respects the parent's height constraint. Makes DialogFooter sticky so Save/Cancel buttons stay visible while scrolling.

## Verification

- [x] I ran relevant tests locally (`go test ./...` or targeted package tests).
- [ ] I updated docs/openapi for any API or behavior changes. *(N/A — UI-only CSS change)*
- [ ] If I changed config vars in `internal/config/config.go`, I also updated: *(N/A)*
- [ ] `python3 scripts/check_doc_config_consistency.py` passes. *(N/A)*

## Risk / Rollout Notes

- Pure CSS class change in the shared Dialog component. All dialogs using DialogContent get flex layout instead of grid — visually identical for short dialogs, scrollable for tall ones. DialogFooter now sticks to the bottom of the scroll viewport instead of scrolling away.

> The Sorting Hat considered placing this PR in Gryffindor for bravery,
> but `min-height: auto` is really more of a Slytherin trait — it looks
> harmless until it quietly undermines everything you built on top of it.
> At least Voldemort announced his intentions.