### PR TITLE
fix(mcp): accept group IDs in akashi_resolve

### DIFF
--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1497,6 +1497,16 @@ func (s *Server) resolveScoredConflict(
 		}
 	}
 
+	// Derive false_positive label for atomic insertion in the storage tx.
+	var fpLabel *string
+	if status == "false_positive" {
+		label := "unrelated_false_positive"
+		if fp := request.GetString("false_positive_label", ""); fp == "related_not_contradicting" {
+			label = fp
+		}
+		fpLabel = &label
+	}
+
 	audit := storage.MutationAuditEntry{
 		OrgID:        orgID,
 		ActorAgentID: resolvedBy,
@@ -1508,17 +1518,12 @@ func (s *Server) resolveScoredConflict(
 		Metadata:     map[string]any{"new_status": status, "resolved_by": resolvedBy},
 	}
 
-	oldStatus, err := s.db.UpdateConflictStatusWithAudit(ctx, conflictID, orgID, status, resolvedBy, resolutionNote, winningDecisionID, audit)
+	oldStatus, err := s.db.UpdateConflictStatusWithAudit(ctx, conflictID, orgID, status, resolvedBy, resolutionNote, winningDecisionID, fpLabel, audit)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
 			return errorResult("conflict not found"), nil
 		}
 		return errorResult(fmt.Sprintf("failed to update conflict: %v", err)), nil
-	}
-
-	// Auto-label false positives into ground truth for detector training.
-	if status == "false_positive" {
-		s.labelFalsePositive(ctx, request, conflictID, orgID, resolvedBy)
 	}
 
 	// Cascade resolution when resolving with a winner in a group.
@@ -1534,8 +1539,15 @@ func (s *Server) resolveScoredConflict(
 			ResourceID:   conflictID.String(),
 			Metadata:     map[string]any{"trigger_conflict_id": conflictID.String(), "winning_decision_id": winningDecisionID.String()},
 		}
-		cascaded, _ = s.db.CascadeResolveByOutcome(ctx, orgID, *conflict.GroupID, *winningDecisionID, conflictID, cascadeSimilarityThreshold, cascadeAudit)
-		if cascaded > 0 {
+		var cascadeErr error
+		cascaded, cascadeErr = s.db.CascadeResolveByOutcome(ctx, orgID, *conflict.GroupID, *winningDecisionID, conflictID, cascadeSimilarityThreshold, cascadeAudit)
+		if cascadeErr != nil {
+			s.logger.Warn("mcp: resolution cascade failed",
+				"trigger_conflict_id", conflictID,
+				"group_id", conflict.GroupID,
+				"error", cascadeErr,
+			)
+		} else if cascaded > 0 {
 			s.logger.Info("mcp: resolution cascade resolved conflicts",
 				"trigger_conflict_id", conflictID,
 				"group_id", conflict.GroupID,
@@ -1627,24 +1639,6 @@ func (s *Server) resolveConflictGroup(
 			mcplib.TextContent{Type: "text", Text: string(resultData)},
 		},
 	}, nil
-}
-
-// labelFalsePositive auto-labels a single scored_conflict as a false positive
-// for ground truth training.
-func (s *Server) labelFalsePositive(ctx context.Context, request mcplib.CallToolRequest, conflictID, orgID uuid.UUID, resolvedBy string) {
-	label := "unrelated_false_positive"
-	if fpLabel := request.GetString("false_positive_label", ""); fpLabel == "related_not_contradicting" {
-		label = fpLabel
-	}
-	if labelErr := s.db.UpsertConflictLabel(ctx, storage.ConflictLabel{
-		ScoredConflictID: conflictID,
-		OrgID:            orgID,
-		Label:            label,
-		LabeledBy:        resolvedBy,
-		LabeledAt:        time.Now(),
-	}); labelErr != nil {
-		s.logger.Warn("failed to auto-label false_positive conflict", "conflict_id", conflictID, "error", labelErr)
-	}
 }
 
 func (s *Server) handleStats(ctx context.Context, _ mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -2633,7 +2633,7 @@ func TestHandleCheck_WithPriorResolutions(t *testing.T) {
 	// Resolve the conflict with a winner to generate a prior resolution.
 	note := "alpha approach validated in production"
 	_, err = testDB.UpdateConflictStatusWithAudit(ctx, conflictID, uuid.Nil,
-		"resolved", testAdminID, &note, &decAID,
+		"resolved", testAdminID, &note, &decAID, nil,
 		storage.MutationAuditEntry{
 			OrgID:        uuid.Nil,
 			ActorAgentID: testAdminID,
@@ -2993,7 +2993,7 @@ func TestHandleResolve_GroupDoesNotRelabelPriorResolutions(t *testing.T) {
 
 	// First, resolve one conflict individually as "resolved" with no label.
 	_, err := testDB.UpdateConflictStatusWithAudit(ctx, conflictIDs[0], uuid.Nil,
-		"resolved", testAdminID, nil, nil,
+		"resolved", testAdminID, nil, nil, nil,
 		storage.MutationAuditEntry{
 			RequestID: uuid.New().String(), OrgID: uuid.Nil,
 			ActorAgentID: testAdminID, ActorRole: "admin",

--- a/internal/server/handlers_conflicts.go
+++ b/internal/server/handlers_conflicts.go
@@ -159,12 +159,22 @@ func (h *Handlers) HandlePatchConflict(w http.ResponseWriter, r *http.Request) {
 		resolvedBy = claims.Subject
 	}
 
+	// Derive false_positive label for atomic insertion in the storage tx.
+	var fpLabel *string
+	if req.Status == "false_positive" {
+		label := "unrelated_false_positive"
+		if req.FalsePositiveLabel != nil && *req.FalsePositiveLabel == "related_not_contradicting" {
+			label = *req.FalsePositiveLabel
+		}
+		fpLabel = &label
+	}
+
 	audit := h.buildAuditEntry(r, orgID,
 		"conflict_status_changed", "conflict", id.String(),
 		nil, nil,
 		map[string]any{"new_status": req.Status, "resolved_by": resolvedBy},
 	)
-	if _, err := h.db.UpdateConflictStatusWithAudit(r.Context(), id, orgID, req.Status, resolvedBy, req.ResolutionNote, req.WinningDecisionID, audit); err != nil {
+	if _, err := h.db.UpdateConflictStatusWithAudit(r.Context(), id, orgID, req.Status, resolvedBy, req.ResolutionNote, req.WinningDecisionID, fpLabel, audit); err != nil {
 		if isNotFoundError(err) {
 			writeError(w, r, http.StatusNotFound, model.ErrCodeNotFound, "conflict not found")
 			return
@@ -182,23 +192,6 @@ func (h *Handlers) HandlePatchConflict(w http.ResponseWriter, r *http.Request) {
 
 	if h.resolutionRecorder != nil {
 		h.resolutionRecorder.RecordResolution(r.Context(), req.Status, string(conflict.ConflictKind), 1)
-	}
-
-	// Auto-label false positives into ground truth for detector training.
-	if req.Status == "false_positive" {
-		label := "unrelated_false_positive"
-		if req.FalsePositiveLabel != nil && *req.FalsePositiveLabel == "related_not_contradicting" {
-			label = *req.FalsePositiveLabel
-		}
-		if labelErr := h.db.UpsertConflictLabel(r.Context(), storage.ConflictLabel{
-			ScoredConflictID: id,
-			OrgID:            orgID,
-			Label:            label,
-			LabeledBy:        resolvedBy,
-			LabeledAt:        time.Now(),
-		}); labelErr != nil {
-			h.logger.Warn("failed to auto-label false_positive conflict", "conflict_id", id, "error", labelErr)
-		}
 	}
 
 	// Resolution cascade: when a conflict is resolved with a winner and belongs

--- a/internal/service/autoresolve/service.go
+++ b/internal/service/autoresolve/service.go
@@ -89,7 +89,7 @@ func (s *Service) processOrg(ctx context.Context, org storage.OrgAutoResolveConf
 		}
 
 		_, err := s.db.UpdateConflictStatusWithAudit(ctx, c.ID, org.OrgID,
-			"resolved", "system:auto_resolve", &note, winner, audit)
+			"resolved", "system:auto_resolve", &note, winner, nil, audit)
 		if err != nil {
 			s.logger.Warn("autoresolve: resolve failed",
 				"conflict_id", c.ID, "org_id", org.OrgID, "error", err)

--- a/internal/storage/conflicts.go
+++ b/internal/storage/conflicts.go
@@ -303,7 +303,9 @@ func (db *DB) GetConflict(ctx context.Context, id, orgID uuid.UUID) (*model.Deci
 // UpdateConflictStatusWithAudit transitions a conflict to a new lifecycle
 // state and inserts a mutation audit entry, atomically in a single transaction.
 // winningDecisionID is optional; when provided it is written only for "resolved" transitions.
-func (db *DB) UpdateConflictStatusWithAudit(ctx context.Context, id, orgID uuid.UUID, status, resolvedBy string, resolutionNote *string, winningDecisionID *uuid.UUID, audit MutationAuditEntry) (oldStatus string, err error) {
+// fpLabel is optional; when non-nil and status is "false_positive", a ground-truth
+// label is inserted atomically within the same transaction.
+func (db *DB) UpdateConflictStatusWithAudit(ctx context.Context, id, orgID uuid.UUID, status, resolvedBy string, resolutionNote *string, winningDecisionID *uuid.UUID, fpLabel *string, audit MutationAuditEntry) (oldStatus string, err error) {
 	tx, err := db.pool.Begin(ctx)
 	if err != nil {
 		return "", fmt.Errorf("storage: begin conflict status tx: %w", err)
@@ -344,10 +346,31 @@ func (db *DB) UpdateConflictStatusWithAudit(ctx context.Context, id, orgID uuid.
 		return "", fmt.Errorf("storage: conflict: %w", ErrNotFound)
 	}
 
+	// Atomically label the conflict as a false positive for ground-truth
+	// training. Inserted in the same tx so a crash between status update
+	// and label insert can never leave an unlabeled false_positive.
+	if fpLabel != nil && status == "false_positive" {
+		_, err = tx.Exec(ctx,
+			`INSERT INTO conflict_labels (scored_conflict_id, org_id, label, labeled_by, labeled_at)
+			 VALUES ($1, $2, $3, $4, now())
+			 ON CONFLICT (scored_conflict_id) DO UPDATE SET
+			   label = excluded.label,
+			   labeled_by = excluded.labeled_by,
+			   labeled_at = excluded.labeled_at
+			 WHERE conflict_labels.org_id = excluded.org_id`,
+			id, orgID, *fpLabel, resolvedBy)
+		if err != nil {
+			return "", fmt.Errorf("storage: label false positive in conflict status tx: %w", err)
+		}
+	}
+
 	audit.BeforeData = map[string]any{"status": oldStatus}
 	afterData := map[string]any{"status": status, "resolved_by": resolvedBy}
 	if winningDecisionID != nil && status == "resolved" {
 		afterData["winning_decision_id"] = winningDecisionID.String()
+	}
+	if fpLabel != nil {
+		afterData["fp_label"] = *fpLabel
 	}
 	audit.AfterData = afterData
 	if err := InsertMutationAuditTx(ctx, tx, audit); err != nil {

--- a/internal/storage/sqlite/conflicts.go
+++ b/internal/storage/sqlite/conflicts.go
@@ -346,7 +346,9 @@ func (l *LiteDB) GetConflict(ctx context.Context, id, orgID uuid.UUID) (*model.D
 }
 
 // UpdateConflictStatusWithAudit transitions a conflict to a new lifecycle state.
-func (l *LiteDB) UpdateConflictStatusWithAudit(ctx context.Context, id, orgID uuid.UUID, status, resolvedBy string, resolutionNote *string, winningDecisionID *uuid.UUID, audit storage.MutationAuditEntry) (string, error) {
+// When fpLabel is non-nil and status is "false_positive", a ground-truth label
+// is inserted atomically within the same transaction.
+func (l *LiteDB) UpdateConflictStatusWithAudit(ctx context.Context, id, orgID uuid.UUID, status, resolvedBy string, resolutionNote *string, winningDecisionID *uuid.UUID, fpLabel *string, audit storage.MutationAuditEntry) (string, error) {
 	tx, err := l.db.BeginTx(ctx, nil)
 	if err != nil {
 		return "", fmt.Errorf("sqlite: begin conflict status tx: %w", err)
@@ -386,10 +388,30 @@ func (l *LiteDB) UpdateConflictStatusWithAudit(ctx context.Context, id, orgID uu
 		return "", fmt.Errorf("sqlite: update conflict status: %w", err)
 	}
 
+	// Atomically label the conflict as a false positive for ground-truth training.
+	if fpLabel != nil && status == "false_positive" {
+		_, err = tx.ExecContext(ctx,
+			`INSERT INTO conflict_labels (scored_conflict_id, org_id, label, labeled_by, labeled_at)
+			 VALUES (?, ?, ?, ?, datetime('now'))
+			 ON CONFLICT (scored_conflict_id) DO UPDATE SET
+			   label = excluded.label,
+			   labeled_by = excluded.labeled_by,
+			   labeled_at = excluded.labeled_at
+			 WHERE conflict_labels.org_id = excluded.org_id`,
+			uuidStr(id), uuidStr(orgID), *fpLabel, resolvedBy,
+		)
+		if err != nil {
+			return "", fmt.Errorf("sqlite: label false positive in conflict status tx: %w", err)
+		}
+	}
+
 	audit.BeforeData = map[string]any{"status": oldStatus}
 	afterData := map[string]any{"status": status, "resolved_by": resolvedBy}
 	if winningDecisionID != nil && status == "resolved" {
 		afterData["winning_decision_id"] = winningDecisionID.String()
+	}
+	if fpLabel != nil {
+		afterData["fp_label"] = *fpLabel
 	}
 	audit.AfterData = afterData
 	if err := insertAuditTx(ctx, tx, audit); err != nil {
@@ -405,7 +427,11 @@ func (l *LiteDB) UpdateConflictStatusWithAudit(ctx context.Context, id, orgID uu
 // ResolveConflictGroup batch-resolves all open conflicts in a conflict group.
 // When fpLabel is non-nil and status is "false_positive", ground truth labels
 // are inserted atomically within the same transaction.
-func (l *LiteDB) ResolveConflictGroup(ctx context.Context, groupID, orgID uuid.UUID, status, resolvedBy string, resolutionNote *string, _ *string, fpLabel *string, audit storage.MutationAuditEntry) (int, error) {
+func (l *LiteDB) ResolveConflictGroup(ctx context.Context, groupID, orgID uuid.UUID, status, resolvedBy string, resolutionNote *string, winningAgent *string, fpLabel *string, audit storage.MutationAuditEntry) (int, error) {
+	if winningAgent != nil {
+		return 0, fmt.Errorf("sqlite: ResolveConflictGroup with winningAgent is not supported (requires pgvector)")
+	}
+
 	tx, err := l.db.BeginTx(ctx, nil)
 	if err != nil {
 		return 0, fmt.Errorf("sqlite: begin resolve group tx: %w", err)

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -4094,8 +4094,9 @@ func TestUpdateConflictStatusWithAudit(t *testing.T) {
 
 	// Transition to false_positive (terminal status, sets resolved_by/resolved_at).
 	fpNote := "Not a real conflict."
+	fpLabel := "unrelated_false_positive"
 	oldStatus, err := testDB.UpdateConflictStatusWithAudit(ctx, conflictID, uuid.Nil,
-		"false_positive", "admin-agent", &fpNote, nil,
+		"false_positive", "admin-agent", &fpNote, nil, &fpLabel,
 		storage.MutationAuditEntry{
 			RequestID: "fp-" + suffix, OrgID: uuid.Nil,
 			ActorAgentID: "admin-agent", ActorRole: "admin",
@@ -4114,7 +4115,7 @@ func TestUpdateConflictStatusWithAudit(t *testing.T) {
 	// Transition to resolved with a winner (overriding false_positive).
 	resNote := "Right approach is better."
 	oldStatus2, err := testDB.UpdateConflictStatusWithAudit(ctx, conflictID, uuid.Nil,
-		"resolved", "admin-agent", &resNote, &dB.ID,
+		"resolved", "admin-agent", &resNote, &dB.ID, nil,
 		storage.MutationAuditEntry{
 			RequestID: "resolve-" + suffix, OrgID: uuid.Nil,
 			ActorAgentID: "admin-agent", ActorRole: "admin",
@@ -5472,7 +5473,7 @@ func TestGetResolvedConflictsByType(t *testing.T) {
 	// Resolve the conflict with dA as winner.
 	resNote := "alpha approach was better"
 	_, err = testDB.UpdateConflictStatusWithAudit(ctx, conflictID, uuid.Nil,
-		"resolved", "test-resolver", &resNote, &dA.ID, storage.MutationAuditEntry{
+		"resolved", "test-resolver", &resNote, &dA.ID, nil, storage.MutationAuditEntry{
 			RequestID:    uuid.New().String(),
 			OrgID:        uuid.Nil,
 			ActorAgentID: "test-resolver",
@@ -6299,7 +6300,7 @@ func TestGetDecisionOutcomeSignalsBatch_WithConflictFate(t *testing.T) {
 
 	resNote := "dA is better"
 	_, err = testDB.UpdateConflictStatusWithAudit(ctx, conflictID, uuid.Nil,
-		"resolved", "tester", &resNote, &dA.ID,
+		"resolved", "tester", &resNote, &dA.ID, nil,
 		storage.MutationAuditEntry{
 			RequestID: uuid.New().String(), OrgID: uuid.Nil,
 			ActorAgentID: "tester", ActorRole: "admin",
@@ -6641,7 +6642,7 @@ func TestGetAgentWinRates_WithResolvedConflicts(t *testing.T) {
 	// Resolve the conflict with agentA as winner.
 	resNote := "agentA wins"
 	_, err = testDB.UpdateConflictStatusWithAudit(ctx, conflictID, dA.OrgID,
-		"resolved", "test", &resNote, &dA.ID,
+		"resolved", "test", &resNote, &dA.ID, nil,
 		storage.MutationAuditEntry{
 			OrgID: dA.OrgID, ActorAgentID: "test", ActorRole: "admin",
 			Operation: "resolve_conflict", ResourceType: "conflict",
@@ -7259,7 +7260,7 @@ func TestGetDecisionOutcomeSignals_WithConflictFate(t *testing.T) {
 	// Resolve with dA as winner.
 	resNote := "agentA wins"
 	_, err = testDB.UpdateConflictStatusWithAudit(ctx, conflictID, dA.OrgID,
-		"resolved", "test", &resNote, &dA.ID,
+		"resolved", "test", &resNote, &dA.ID, nil,
 		storage.MutationAuditEntry{
 			OrgID: dA.OrgID, ActorAgentID: "test", ActorRole: "admin",
 			Operation: "resolve_conflict", ResourceType: "conflict",

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -68,7 +68,7 @@ type Store interface {
 	GetConflictCount(ctx context.Context, decisionID, orgID uuid.UUID) (int, error)
 	GetConflictCountsBatch(ctx context.Context, ids []uuid.UUID, orgID uuid.UUID) (map[uuid.UUID]int, error)
 	GetResolvedConflictsByType(ctx context.Context, orgID uuid.UUID, decisionType string, limit int) ([]model.ConflictResolution, error)
-	UpdateConflictStatusWithAudit(ctx context.Context, id, orgID uuid.UUID, status, resolvedBy string, resolutionNote *string, winningDecisionID *uuid.UUID, audit MutationAuditEntry) (oldStatus string, err error)
+	UpdateConflictStatusWithAudit(ctx context.Context, id, orgID uuid.UUID, status, resolvedBy string, resolutionNote *string, winningDecisionID *uuid.UUID, fpLabel *string, audit MutationAuditEntry) (oldStatus string, err error)
 	ResolveConflictGroup(ctx context.Context, groupID, orgID uuid.UUID, status, resolvedBy string, resolutionNote *string, winningAgent *string, fpLabel *string, audit MutationAuditEntry) (int, error)
 	CascadeResolveByOutcome(ctx context.Context, orgID, groupID, winningDecisionID, triggerID uuid.UUID, threshold float64, audit MutationAuditEntry) (int, error)
 	UpsertConflictLabel(ctx context.Context, cl ConflictLabel) error


### PR DESCRIPTION
## Summary

- `akashi_conflicts` returns conflict group IDs, but `akashi_resolve` only accepted scored_conflict IDs — making the entire conflict resolution workflow non-functional through MCP tools
- `handleResolve` now tries the ID as a scored_conflict first, then falls back to resolving all open conflicts in the matching conflict_group
- Group false_positive resolution labels all scored_conflicts individually for ground truth training
- `winning_decision_id` is rejected for group resolution (each scored_conflict in the group may have different decision pairs)
- Adds `ResolveConflictGroup` to the `Store` interface and SQLite implementation

Closes #519

## Test plan

- [ ] All existing tests pass (`go test -race -count=1 ./...` — verified locally)
- [ ] Pass a scored_conflict ID to `akashi_resolve` — behaves as before (backward compatible)
- [ ] Pass a conflict_group ID from `akashi_conflicts` to `akashi_resolve` with `status: "false_positive"` — resolves all open conflicts in the group and labels each for ground truth
- [ ] Pass a conflict_group ID with `winning_decision_id` set — returns a clear error message explaining why this is unsupported for groups
- [ ] Pass a UUID that matches neither table — returns "conflict not found"
- [ ] SQLite backend: `ResolveConflictGroup` resolves open conflicts and returns count

> The Borg assimilate without consent; Akashi at least asks you to resolve
> the conflict first. But until today it handed you an ID card printed in
> a language the bouncer didn't speak — group ID at the scored_conflict door.
> Even the Federation's universal translator would have caught that mismatch.