### PR TITLE
fix: add WAL fail-safe validation and crash recovery test

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -397,6 +397,13 @@ func (c Config) Validate() error {
 		errs = append(errs, errors.New("config: AKASHI_CONFLICT_OUTCOME_SIM_FLOOR must be between 0.0 and 1.0 (0 disables)"))
 	}
 
+	// WAL fail-safe: refuse to start without WAL unless explicitly disabled.
+	// The envStr helper prevents AKASHI_WAL_DIR="" from clearing the default,
+	// but this catches programmatic Config construction or future refactors.
+	if c.WALDir == "" && !c.WALDisable {
+		errs = append(errs, errors.New("config: WAL is required for crash durability; set AKASHI_WAL_DIR or set AKASHI_WAL_DISABLE=true to explicitly accept data loss risk"))
+	}
+
 	// JWT keys must be both set or both empty (ephemeral mode). Mismatched config
 	// would cause token validation to fail for all clients.
 	privSet := c.JWTPrivateKeyPath != ""

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -173,6 +173,43 @@ func TestLoad_WALDisableOverridesExplicitDir(t *testing.T) {
 	}
 }
 
+func TestValidate_EmptyWALDirWithoutDisable(t *testing.T) {
+	// A Config with WALDir="" and WALDisable=false should fail validation.
+	// Through Load(), envStr prevents this — this tests the belt-and-suspenders
+	// guard in Validate that catches programmatic Config construction.
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() for baseline config failed: %v", err)
+	}
+
+	// Simulate the unsafe state: WAL dir cleared without the disable flag.
+	cfg.WALDir = ""
+	cfg.WALDisable = false
+
+	err = cfg.Validate()
+	if err == nil {
+		t.Fatal("expected Validate() to fail when WALDir is empty and WALDisable is false")
+	}
+	if !contains(err.Error(), "WAL is required") {
+		t.Fatalf("error should mention WAL requirement, got: %s", err.Error())
+	}
+}
+
+func TestValidate_EmptyWALDirWithDisable(t *testing.T) {
+	// WALDir="" + WALDisable=true is the legitimate opt-out path.
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() for baseline config failed: %v", err)
+	}
+
+	cfg.WALDir = ""
+	cfg.WALDisable = true
+
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected Validate() to succeed when WAL is explicitly disabled, got: %v", err)
+	}
+}
+
 func floatClose(a, b, eps float64) bool {
 	return math.Abs(a-b) < eps
 }
@@ -788,6 +825,7 @@ func validBaseConfig() Config {
 		RateLimitEnabled:           true,
 		RateLimitRPS:               100,
 		RateLimitBurst:             200,
+		WALDir:                     "./data/wal",
 	}
 }
 

--- a/internal/service/trace/buffer_test.go
+++ b/internal/service/trace/buffer_test.go
@@ -576,6 +576,79 @@ func TestBuffer_StartWithWALRecovery(t *testing.T) {
 	require.NoError(t, buf2.Drain(drainCtx))
 }
 
+func TestBuffer_StartWithWALRecovery_MidFlushCrash(t *testing.T) {
+	// Simulates a crash between COPY-to-Postgres and WAL checkpoint advance.
+	// Events are in BOTH Postgres and WAL. Recovery must deduplicate via the
+	// idempotent insert path without errors or duplicate rows.
+	run := createTestRun(t)
+
+	cfg := WALConfig{
+		Dir:            t.TempDir(),
+		SyncMode:       "none",
+		MaxSegmentSize: minSegmentSize,
+		MaxSegmentRecs: minSegmentRecords,
+	}
+
+	// Phase 1: Write events via buffer, flush to Postgres, then simulate crash
+	// before WAL checkpoint advances.
+	wal1, err := NewWAL(testLogger(), cfg)
+	require.NoError(t, err)
+
+	buf1 := NewBuffer(testDB, testLogger(), 1000, 10*time.Minute, wal1)
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	buf1.Start(ctx1)
+
+	_, err = buf1.Append(context.Background(), run.ID, run.AgentID, run.OrgID, makeEventInputs(5))
+	require.NoError(t, err)
+
+	// Force flush so events are in Postgres.
+	flushCtx, flushCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer flushCancel()
+	require.NoError(t, buf1.FlushNow(flushCtx))
+
+	// Verify events are in Postgres.
+	got, err := testDB.GetEventsByRun(context.Background(), run.OrgID, run.ID, 0)
+	require.NoError(t, err)
+	require.Len(t, got, 5, "events should be in DB after flush")
+
+	// Crash: close WAL without drain. The flush above advanced the checkpoint,
+	// so we need to re-write the events to WAL to simulate the mid-flush case
+	// (events reached Postgres but checkpoint didn't advance).
+	cancel1()
+	<-buf1.done
+	require.NoError(t, wal1.Close())
+
+	// Recreate WAL and write the same events back (simulating checkpoint not
+	// having advanced — events still in WAL segments).
+	wal2, err := NewWAL(testLogger(), cfg)
+	require.NoError(t, err)
+
+	// Write the same events that are already in Postgres back into the WAL.
+	// This simulates the state after a mid-flush crash: events in both places.
+	_, err = wal2.Write(got)
+	require.NoError(t, err)
+	require.NoError(t, wal2.Close())
+
+	// Phase 2: Recovery should handle duplicates gracefully.
+	wal3, err := NewWAL(testLogger(), cfg)
+	require.NoError(t, err)
+
+	buf2 := NewBuffer(testDB, testLogger(), 1000, 100*time.Millisecond, wal3)
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	defer cancel2()
+	buf2.Start(ctx2) // triggers recovery with idempotent dedup
+
+	// Verify no duplicates: still exactly 5 events.
+	require.Eventually(t, func() bool {
+		events, err := testDB.GetEventsByRun(context.Background(), run.OrgID, run.ID, 0)
+		return err == nil && len(events) == 5
+	}, 5*time.Second, 100*time.Millisecond, "should have exactly 5 events after dedup recovery, no duplicates")
+
+	drainCtx, drainCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer drainCancel()
+	require.NoError(t, buf2.Drain(drainCtx))
+}
+
 func TestBuffer_FlushOnceWithWALCheckpoint(t *testing.T) {
 	run := createTestRun(t)
 


### PR DESCRIPTION
## Summary

- Add `Validate()` check that refuses to start when `WALDir=""` and `WALDisable=false`, closing the last gap where a programmatically constructed Config could silently disable crash durability
- Add integration test for mid-flush crash recovery: events present in both Postgres (via COPY) and WAL (checkpoint not advanced) are properly deduplicated through the idempotent insert path
- Fix `validBaseConfig()` test helper to include `WALDir` so existing validation tests pass with the new check

Closes #526

## Test plan

- [x] `TestValidate_EmptyWALDirWithoutDisable` — config with empty WALDir and WALDisable=false is rejected
- [x] `TestValidate_EmptyWALDirWithDisable` — config with empty WALDir and WALDisable=true passes
- [x] `TestBuffer_StartWithWALRecovery_MidFlushCrash` — events in both Postgres and WAL are deduplicated on recovery, no duplicates
- [x] Full suite: `go test -race -count=1 ./...` passes, `golangci-lint` clean

> Warp fields don't prevent data loss — they just move the problem
> to a reference frame where you can't observe it. The WAL is more
> honest: it writes the event to disk, syncs, and only then tells
> you it's safe. No temporal tricks, no subspace buffers, just the
> unglamorous physics of sequential I/O.

🤖 Generated with [Claude Code](https://claude.com/claude-code)