### PR TITLE
fix: add org_id filter to outer UPDATE clauses in DeleteAgentData

### DIFF
--- a/internal/storage/delete.go
+++ b/internal/storage/delete.go
@@ -111,7 +111,7 @@ func (db *DB) DeleteAgentData(ctx context.Context, orgID uuid.UUID, agentID stri
 	// Also clear precedent_ref from OTHER agents that reference this agent's decisions.
 	_, err = tx.Exec(ctx,
 		`UPDATE decisions SET precedent_ref = NULL
-		 WHERE precedent_ref IN (SELECT id FROM decisions WHERE org_id = $1 AND agent_id = $2)`,
+		 WHERE org_id = $1 AND precedent_ref IN (SELECT id FROM decisions WHERE org_id = $1 AND agent_id = $2)`,
 		orgID, agentID)
 	if err != nil {
 		return DeleteAgentResult{}, fmt.Errorf("storage: clear external precedent refs: %w", err)
@@ -120,7 +120,7 @@ func (db *DB) DeleteAgentData(ctx context.Context, orgID uuid.UUID, agentID stri
 	// Also clear supersedes_id from OTHER agents that reference this agent's decisions.
 	_, err = tx.Exec(ctx,
 		`UPDATE decisions SET supersedes_id = NULL
-		 WHERE supersedes_id IN (SELECT id FROM decisions WHERE org_id = $1 AND agent_id = $2)`,
+		 WHERE org_id = $1 AND supersedes_id IN (SELECT id FROM decisions WHERE org_id = $1 AND agent_id = $2)`,
 		orgID, agentID)
 	if err != nil {
 		return DeleteAgentResult{}, fmt.Errorf("storage: clear external supersedes refs: %w", err)
@@ -248,7 +248,7 @@ func (db *DB) DeleteAgentData(ctx context.Context, orgID uuid.UUID, agentID stri
 	// Also clear parent_run_id from OTHER agents that reference this agent's runs.
 	_, err = tx.Exec(ctx,
 		`UPDATE agent_runs SET parent_run_id = NULL
-		 WHERE parent_run_id IN (SELECT id FROM agent_runs WHERE org_id = $1 AND agent_id = $2)`,
+		 WHERE org_id = $1 AND parent_run_id IN (SELECT id FROM agent_runs WHERE org_id = $1 AND agent_id = $2)`,
 		orgID, agentID)
 	if err != nil {
 		return DeleteAgentResult{}, fmt.Errorf("storage: clear external parent run refs: %w", err)


### PR DESCRIPTION
## Summary

- Adds `AND org_id = $1` to three outer `UPDATE` statements in `DeleteAgentData` that clear cross-agent references (`precedent_ref`, `supersedes_id`, `parent_run_id`) — the subqueries were scoped by `org_id` but the outer `WHERE` was not
- Issue #543 reported two (`decisions` table); a third identical pattern on `agent_runs` was fixed in the same pass

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] `atlas migrate validate` passes
- [x] `go test -race -count=1 ./...` — all green

Closes #543

> The Federation's General Order 1 is nice in theory, but Starfleet breaks it
> roughly once per season whenever the plot demands it. At least an `org_id`
> filter is a constraint the database will actually enforce.