### PR TITLE
fix: integrity_violations org_id FK CASCADE→RESTRICT

### DIFF
--- a/migrations/082_integrity_violations_org_fk_restrict.sql
+++ b/migrations/082_integrity_violations_org_fk_restrict.sql
@@ -1,0 +1,14 @@
+-- 082: change integrity_violations.org_id FK from CASCADE to RESTRICT.
+--
+-- Migration 079 corrected the proof_id FK from CASCADE to RESTRICT but
+-- missed org_id. With CASCADE, deleting an organization silently removes
+-- all its violation records — bypassing the immutability triggers added
+-- in 079. RESTRICT ensures violation records block org deletion, which
+-- is the correct behavior for an append-only tamper-evidence table.
+
+ALTER TABLE integrity_violations
+    DROP CONSTRAINT integrity_violations_org_id_fkey;
+
+ALTER TABLE integrity_violations
+    ADD CONSTRAINT integrity_violations_org_id_fkey
+    FOREIGN KEY (org_id) REFERENCES organizations(id) ON DELETE RESTRICT;

--- a/migrations/atlas.sum
+++ b/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:cmoRm+zw29uskEL32G9tclsuJivBCy+ba9f5nenPtBU=
+h1:ubxfXPTWbpNgSTz20km2mI+cczdJ5Ud9SbK+uMJmtME=
 001_initial.sql h1:uhyGXto+QacAaGYb9ZTGjsBs5chlKi8O0eHz9aCQsrY=
 022_full_text_search.sql h1:9iwtA8MgCzAxDV9YkUBn0CLT9ePSmj3GcPoMGg8TXf0=
 023_fix_outbox_index.sql h1:OtMEFBcMRWej02+ghnBXlPr6BVq+LoA62Id9XUWfDNI=
@@ -60,3 +60,4 @@ h1:cmoRm+zw29uskEL32G9tclsuJivBCy+ba9f5nenPtBU=
 079_integrity_violations_immutability.sql h1:8VfkR6KngSMST7JTAyIlqpPCVNd7c7cKrsRJgk3kYmE=
 080_integrity_audit_results_immutability.sql h1:L+Km8jnamz618YOYGRYGQB+tWg4bVvx+sBrrxGNh7Bk=
 081_conflict_project_columns.sql h1:9Qzd9zgObpFQUZrPLUWRBkBJcJIN2D4STzqEs2zvC6I=
+082_integrity_violations_org_fk_restrict.sql h1:jomhcRoBd8mwRQ9h7YLmx91rnSr8Wuy7FKL7kMZMF6M=


### PR DESCRIPTION
## Summary

- Changes `integrity_violations.org_id` FK from `ON DELETE CASCADE` to `ON DELETE RESTRICT`
- Migration 079 corrected `proof_id` but missed `org_id` — same class of bug
- Without this fix, deleting an org silently removes all its violation records, bypassing immutability triggers

## Test plan

- [x] `atlas migrate validate` passes
- [x] `go build ./...`, `go vet ./...`, `golangci-lint run ./...` clean
- [x] `go test -race -count=1 ./...` all green
- [ ] Integration: verify org deletion is blocked when violation records exist

Fixes #542

> The Sorting Hat never asks where you've been —
> only where you ought to go. CASCADE is Slytherin's
> answer to evidence management: convenient, quiet,
> and gone before anyone notices. RESTRICT is Dumbledore
> standing in the corridor at 2 AM, asking why you're
> trying to delete tamper evidence.