### PR TITLE
fix: scrub decision_claims.claim_text during GDPR erasure

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -4439,7 +4439,7 @@ components:
 
     ErasureResponse:
       type: object
-      required: [decision_id, erased_at, original_hash, erased_hash, alternatives_erased, evidence_erased]
+      required: [decision_id, erased_at, original_hash, erased_hash, alternatives_erased, evidence_erased, claims_erased]
       properties:
         decision_id:
           type: string
@@ -4459,6 +4459,9 @@ components:
         evidence_erased:
           type: integer
           description: Number of evidence rows scrubbed.
+        claims_erased:
+          type: integer
+          description: Number of claim rows scrubbed.
 
     APIResponse_ErasureResponse:
       type: object

--- a/internal/server/handlers_decisions.go
+++ b/internal/server/handlers_decisions.go
@@ -991,6 +991,7 @@ func (h *Handlers) HandleEraseDecision(w http.ResponseWriter, r *http.Request) {
 		"erased_hash":         result.Erasure.ErasedHash,
 		"alternatives_erased": result.AlternativesErased,
 		"evidence_erased":     result.EvidenceErased,
+		"claims_erased":       result.ClaimsErased,
 	})
 }
 

--- a/internal/storage/decisions.go
+++ b/internal/storage/decisions.go
@@ -351,6 +351,7 @@ type DecisionErasureResult struct {
 	Erasure            model.DecisionErasure
 	AlternativesErased int64
 	EvidenceErased     int64
+	ClaimsErased       int64
 }
 
 // EraseDecision scrubs PII from a decision in-place (GDPR Art. 17 tombstone erasure).
@@ -358,10 +359,11 @@ type DecisionErasureResult struct {
 //  1. Activates the immutability trigger bypass via SET LOCAL
 //  2. Scrubs outcome/reasoning to "[erased]" and recomputes the content hash
 //  3. Scrubs alternatives (label, rejection_reason) and evidence (content, source_uri)
-//  4. Nulls out embeddings (contain semantic PII)
-//  5. Inserts a decision_erasures row with the original hash
-//  6. Records a DecisionErased event and mutation audit entry
-//  7. Queues a search index deletion
+//  4. Scrubs claims (claim_text derived from reasoning contains PII)
+//  5. Nulls out embeddings (contain semantic PII)
+//  6. Inserts a decision_erasures row with the original hash
+//  7. Records a DecisionErased event and mutation audit entry
+//  8. Queues a search index deletion
 //
 // Does NOT set valid_to — the decision remains "active" but scrubbed.
 func (db *DB) EraseDecision(
@@ -457,6 +459,17 @@ func (db *DB) EraseDecision(
 		return DecisionErasureResult{}, fmt.Errorf("storage: scrub evidence: %w", err)
 	}
 
+	// Scrub claims (claim_text is derived from reasoning and may contain PII).
+	claimTag, err := tx.Exec(ctx,
+		`UPDATE decision_claims
+		 SET claim_text = $1, embedding = NULL
+		 WHERE decision_id = $2 AND org_id = $3`,
+		ErasedSentinel, decisionID, orgID,
+	)
+	if err != nil {
+		return DecisionErasureResult{}, fmt.Errorf("storage: scrub claims: %w", err)
+	}
+
 	// Queue search index deletion.
 	if err := queueSearchOutbox(ctx, tx, decisionID, orgID, "delete"); err != nil {
 		return DecisionErasureResult{}, fmt.Errorf("storage: queue search outbox delete in erasure: %w", err)
@@ -530,6 +543,7 @@ func (db *DB) EraseDecision(
 		Erasure:            erasure,
 		AlternativesErased: altTag.RowsAffected(),
 		EvidenceErased:     evTag.RowsAffected(),
+		ClaimsErased:       claimTag.RowsAffected(),
 	}, nil
 }
 

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -4622,6 +4622,13 @@ func TestEraseDecision(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	// Add claims (derived from reasoning, may contain PII).
+	err = testDB.InsertClaims(ctx, []storage.Claim{
+		{DecisionID: d.ID, OrgID: uuid.Nil, ClaimIdx: 0, ClaimText: "sensitive claim one"},
+		{DecisionID: d.ID, OrgID: uuid.Nil, ClaimIdx: 1, ClaimText: "sensitive claim two"},
+	})
+	require.NoError(t, err)
+
 	result, err := testDB.EraseDecision(ctx, uuid.Nil, d.ID, "GDPR request", agentID, &storage.MutationAuditEntry{
 		RequestID: "erase-" + suffix, OrgID: uuid.Nil,
 		ActorAgentID: agentID, ActorRole: "admin",
@@ -4633,12 +4640,22 @@ func TestEraseDecision(t *testing.T) {
 	assert.Equal(t, "GDPR request", result.Erasure.Reason)
 	assert.Equal(t, int64(1), result.AlternativesErased)
 	assert.Equal(t, int64(1), result.EvidenceErased)
+	assert.Equal(t, int64(2), result.ClaimsErased)
 
 	// Verify decision outcome is scrubbed.
 	got, err := testDB.GetDecision(ctx, uuid.Nil, d.ID, storage.GetDecisionOpts{})
 	require.NoError(t, err)
 	assert.Equal(t, storage.ErasedSentinel, got.Outcome)
 	assert.Equal(t, storage.ErasedSentinel, *got.Reasoning)
+
+	// Verify claims are scrubbed (claim_text replaced, embedding nulled).
+	claims, err := testDB.FindClaimsByDecision(ctx, d.ID, uuid.Nil)
+	require.NoError(t, err)
+	require.Len(t, claims, 2, "claims should still exist after erasure")
+	for _, c := range claims {
+		assert.Equal(t, storage.ErasedSentinel, c.ClaimText, "claim_text must be scrubbed")
+		assert.Nil(t, c.Embedding, "claim embedding must be nulled")
+	}
 
 	// GetDecisionErasure should return the record.
 	erasure, err := testDB.GetDecisionErasure(ctx, uuid.Nil, d.ID)


### PR DESCRIPTION
## Summary

- The `EraseDecision` transaction scrubbed outcome, reasoning, alternatives, evidence, and embeddings but missed `decision_claims.claim_text`. Claims are LLM-extracted fragments of the original reasoning and contain the same PII.
- Adds a new step to the erasure transaction that sets `claim_text = '[erased]'` and `embedding = NULL` on all claims for the target decision, scoped by `org_id`.
- Surfaces the `claims_erased` count in the API response and updates the OpenAPI spec accordingly.
- Extends the existing `TestEraseDecision` to insert claims, assert the erased count, and verify both `claim_text` and `embedding` are scrubbed post-erasure.

## Verification

- [x] I ran relevant tests locally (`go test ./...` or targeted package tests).
- [x] I updated docs/openapi for any API or behavior changes.
- [ ] If I changed config vars in `internal/config/config.go`, I also updated:
  - [ ] `docs/configuration.md`
  - [ ] `docs/runbook.md` (operational subset, if relevant)
  - [ ] `.env.example` (if baseline local/dev defaults changed)
  - [ ] `docs/consistency-manifest.json` (only if policy/coverage rules changed)
- [x] `python3 scripts/check_doc_config_consistency.py` passes.

## Risk / Rollout Notes

- No migration required — the `decision_claims` table and its `org_id` column already exist. This is a pure application-layer change within the existing erasure transaction.
- The `claims_erased` field is now `required` in the OpenAPI `ErasureResponse` schema. SDK consumers that strictly validate response shapes will see the new field; since it's additive (integer, always present), this should not break existing integrations.

> Dumbledore's worst fear was never Voldemort — it was an audit trail
> he couldn't Obliviate. The Ministry scrubbed prophecy records for years
> and called it policy; Akashi at least has the decency to leave the
> tombstone standing and recompute the hash.