### PR TITLE
fix: surface conflict query errors in Check as ConflictsUnavailable

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -3647,6 +3647,12 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/DecisionConflict"
+        conflicts_unavailable:
+          type: boolean
+          description: >
+            True when the conflict list query failed due to a transient error.
+            The conflicts array may be empty or incomplete. Callers should
+            exercise extra caution before proceeding.
 
     # ── Health schemas ───────────────────────────────────────────────
     HealthResponse:

--- a/internal/compact/compact.go
+++ b/internal/compact/compact.go
@@ -423,6 +423,9 @@ func CheckResult(resp model.CheckResponse, canSuggestPrecedent bool) map[string]
 	}
 
 	summary := GenerateCheckSummary(resp.Decisions, resp.Conflicts)
+	if resp.ConflictsUnavailable {
+		summary += " ⚠ Conflict data unavailable due to a transient error — treat conflict list as incomplete."
+	}
 	if len(resp.PriorResolutions) > 0 {
 		summary += fmt.Sprintf(" %d prior conflict(s) for this decision type were formally resolved; winning approach(es) listed in prior_resolutions.", len(resp.PriorResolutions))
 	}
@@ -430,11 +433,15 @@ func CheckResult(resp model.CheckResponse, canSuggestPrecedent bool) map[string]
 	result := map[string]any{
 		"has_precedent":     resp.HasPrecedent,
 		"summary":           summary,
-		"action_needed":     ActionNeeded(resp.Conflicts),
+		"action_needed":     ActionNeeded(resp.Conflicts) || resp.ConflictsUnavailable,
 		"relevant_count":    len(resp.Decisions),
 		"decisions":         compactDecs,
 		"conflicts":         compactConfs,
 		"prior_resolutions": compactResolutions,
+	}
+
+	if resp.ConflictsUnavailable {
+		result["conflicts_unavailable"] = true
 	}
 
 	// precedent_ref_hint: the UUID of the best candidate for precedent_ref in the

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -566,6 +566,9 @@ func (s *Server) handleCheck(ctx context.Context, request mcplib.CallToolRequest
 	}
 
 	summary := generateCheckSummary(resp.Decisions, resp.Conflicts)
+	if resp.ConflictsUnavailable {
+		summary += " ⚠ Conflict data unavailable due to a transient error — treat conflict list as incomplete."
+	}
 	if len(resp.PriorResolutions) > 0 {
 		summary += fmt.Sprintf(" %d prior conflict(s) for this decision type were formally resolved; winning approach(es) listed in prior_resolutions.", len(resp.PriorResolutions))
 	}
@@ -573,11 +576,15 @@ func (s *Server) handleCheck(ctx context.Context, request mcplib.CallToolRequest
 	result := map[string]any{
 		"has_precedent":     resp.HasPrecedent,
 		"summary":           summary,
-		"action_needed":     actionNeeded(resp.Conflicts),
+		"action_needed":     actionNeeded(resp.Conflicts) || resp.ConflictsUnavailable,
 		"relevant_count":    len(resp.Decisions),
 		"decisions":         compactDecs,
 		"conflicts":         compactConfs,
 		"prior_resolutions": compactResolutions,
+	}
+
+	if resp.ConflictsUnavailable {
+		result["conflicts_unavailable"] = true
 	}
 
 	// precedent_ref_hint: the UUID of the best candidate for precedent_ref in the

--- a/internal/model/query.go
+++ b/internal/model/query.go
@@ -120,6 +120,10 @@ type CheckResponse struct {
 	HasPrecedent bool               `json:"has_precedent"`
 	Decisions    []Decision         `json:"decisions"`
 	Conflicts    []DecisionConflict `json:"conflicts,omitempty"`
+	// ConflictsUnavailable is true when the conflict list query failed due to
+	// a transient error. Callers should treat the conflicts slice as incomplete
+	// and exercise extra caution before proceeding.
+	ConflictsUnavailable bool `json:"conflicts_unavailable,omitempty"`
 	// PriorResolutions contains recently resolved conflicts for the requested
 	// decision type. Each entry shows which approach was formally chosen
 	// (winning_outcome / winning_agent) and which was rejected

--- a/internal/service/decisions/helpers_test.go
+++ b/internal/service/decisions/helpers_test.go
@@ -1692,6 +1692,7 @@ func TestCheck_ConflictListError(t *testing.T) {
 	require.NoError(t, err, "conflict list error should be non-fatal")
 	assert.True(t, resp.HasPrecedent)
 	assert.Empty(t, resp.Conflicts)
+	assert.True(t, resp.ConflictsUnavailable, "should signal that conflict data is degraded")
 }
 
 func TestCheck_FiltersResolvedConflicts(t *testing.T) {

--- a/internal/service/decisions/service.go
+++ b/internal/service/decisions/service.go
@@ -499,10 +499,6 @@ func (s *Service) Check(ctx context.Context, orgID uuid.UUID, input CheckInput) 
 		conflictErr error
 		resolutions []model.ConflictResolution
 	)
-	// Silence the linter — conflictErr is written in the goroutine and checked implicitly
-	// via the conflicts slice (nil on error). Keep the variable for future error propagation.
-	_ = conflictErr
-
 	var wg sync.WaitGroup
 
 	// 1. Search or structured query.
@@ -577,10 +573,11 @@ func (s *Service) Check(ctx context.Context, orgID uuid.UUID, input CheckInput) 
 	}
 
 	resp := model.CheckResponse{
-		HasPrecedent:     len(decisions) > 0,
-		Decisions:        decisions,
-		Conflicts:        conflicts,
-		PriorResolutions: resolutions,
+		HasPrecedent:         len(decisions) > 0,
+		Decisions:            decisions,
+		Conflicts:            conflicts,
+		ConflictsUnavailable: conflictErr != nil,
+		PriorResolutions:     resolutions,
 	}
 
 	return resp, nil

--- a/sdk/go/akashi/types.go
+++ b/sdk/go/akashi/types.go
@@ -167,9 +167,10 @@ type QueryOptions struct {
 
 // CheckResponse is the output of Client.Check.
 type CheckResponse struct {
-	HasPrecedent bool               `json:"has_precedent"`
-	Decisions    []Decision         `json:"decisions"`
-	Conflicts    []DecisionConflict `json:"conflicts,omitempty"`
+	HasPrecedent         bool               `json:"has_precedent"`
+	Decisions            []Decision         `json:"decisions"`
+	Conflicts            []DecisionConflict `json:"conflicts,omitempty"`
+	ConflictsUnavailable bool               `json:"conflicts_unavailable,omitempty"`
 }
 
 // TraceResponse is the output of Client.Trace.

--- a/sdk/python/src/akashi/types.py
+++ b/sdk/python/src/akashi/types.py
@@ -293,6 +293,7 @@ class CheckResponse(BaseModel):
     has_precedent: bool
     decisions: list[Decision]
     conflicts: list[DecisionConflict] = Field(default_factory=list)
+    conflicts_unavailable: bool = False
 
 
 class QueryResponse(BaseModel):

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -262,6 +262,7 @@ export interface CheckResponse {
   has_precedent: boolean;
   decisions: Decision[];
   conflicts?: DecisionConflict[];
+  conflicts_unavailable?: boolean;
 }
 
 export interface QueryResponse {


### PR DESCRIPTION
## Summary

- The `Check` endpoint previously silenced `conflictErr` (`_ = conflictErr`), returning an empty conflicts array when the conflict query failed transiently. Callers could not distinguish "no conflicts found" from "query failed."
- Adds a `ConflictsUnavailable bool` field to `CheckResponse`. When the conflict query errors, both the compact and MCP renderers append a degradation warning to the summary and force `action_needed=true`, preventing agents from silently proceeding with incomplete data.
- Updated across all surfaces: model, compact renderer, MCP handler, OpenAPI schema, Go/Python/TypeScript SDKs, and existing test coverage.

## Verification

- [x] I ran relevant tests locally (`go test ./...` or targeted package tests).
- [x] I updated docs/openapi for any API or behavior changes.
- [ ] If I changed config vars in `internal/config/config.go`, I also updated:
  - [ ] `docs/configuration.md`
  - [ ] `docs/runbook.md` (operational subset, if relevant)
  - [ ] `.env.example` (if baseline local/dev defaults changed)
  - [ ] `docs/consistency-manifest.json` (only if policy/coverage rules changed)
- N/A — no config changes.
- [ ] `python3 scripts/check_doc_config_consistency.py` passes.

## Risk / Rollout Notes

- Fully backward-compatible: the new field is `omitempty`, so existing consumers see no change when conflicts succeed. No migration required.

> Bones would have approved this patch. In sickbay, when the biobed
> sensors glitch, the display doesn't go blank — it flashes red and reads
> "SENSOR DEGRADED." Starfleet learned centuries ago that silence is the
> most dangerous failure mode. Now akashi_check knows it too.