### PR TITLE
fix: reduce hook overhead and fix commit message parsing

### DIFF
--- a/.claude/hooks/akashi-hook.sh
+++ b/.claude/hooks/akashi-hook.sh
@@ -139,7 +139,7 @@ case "$HOOK_EVENT" in
           else
             MARKER_AGE=$(( $(date +%s) - $(stat -c %Y "$MARKER") ))
           fi
-          if [ "$MARKER_AGE" -lt 3600 ]; then
+          if [ "$MARKER_AGE" -lt 600 ]; then
             echo '{"continue":true,"suppressOutput":true}'
             exit 0
           fi

--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -10,7 +10,7 @@
     "preToolUse": [
       {
         "command": ".cursor/hooks/akashi-hook.sh",
-        "matcher": "Edit|Write|MultiEdit|Bash",
+        "matcher": "Edit|Write|MultiEdit",
         "timeout": 10
       }
     ],

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -25,16 +25,16 @@ context appears in the IDE sidebar so the agent starts with awareness of prior w
 ### Edit gate
 
 Before any `Edit`, `Write`, or `MultiEdit` tool call, the hook checks whether
-`akashi_check` has been called in the current session (within the last 2 hours).
+`akashi_check` has been called in the current session (within the last 10 minutes).
 If not, the edit is **blocked** with a message asking the agent to call `akashi_check`
-first. Once checked, edits proceed normally until the 2-hour TTL expires.
+first. Once checked, edits proceed normally until the 10-minute TTL expires.
 
 ### Commit tracing
 
 After a `git commit`, the hook either:
 
 - **Auto-traces** the commit as a decision (`decision_type: "implementation"`,
-  `confidence: 0.7`) when `AKASHI_AUTO_TRACE=true` (the default), or
+  `confidence: 0.5`) when `AKASHI_AUTO_TRACE=true` (the default), or
 - **Suggests** running `akashi_trace` manually when auto-trace is disabled.
 
 ## Endpoints
@@ -131,8 +131,8 @@ so both IDEs use the same server endpoints.
 If the Akashi server is unreachable (curl timeout: 3 seconds):
 
 1. **Session start**: Prints a reminder to stderr, continues normally.
-2. **Edit gate**: Falls back to a marker file (`/tmp/akashi-checked-$(whoami)`) with the
-   same 2-hour TTL. Edits are still gated, just enforced locally.
+2. **Edit gate**: Falls back to an agent-scoped marker file (`/tmp/akashi-checked-{agent_id}`)
+   with the same 10-minute TTL. Edits are still gated, just enforced locally.
 3. **Commit trace**: Prints a reminder to call `akashi_trace` manually.
 
 When the server comes back, the in-memory session tracking takes over seamlessly.

--- a/internal/server/handlers_hooks.go
+++ b/internal/server/handlers_hooks.go
@@ -156,9 +156,13 @@ func (h *Handlers) HandleHookSessionStart(w http.ResponseWriter, r *http.Request
 	})
 }
 
-// HandleHookPreToolUse handles two cases:
-// 1. Edit/Write/MultiEdit gate: blocks until akashi_check has been called recently.
-// 2. Pre-commit reminder: suggests calling akashi_check before git commit.
+// HandleHookPreToolUse gates Edit/Write/MultiEdit until akashi_check has been
+// called recently. Non-edit tools pass through immediately.
+//
+// Note: Bash is intentionally excluded from the PreToolUse matcher to avoid
+// firing a network round-trip on every shell command. The pre-commit hint
+// (previously handled here) was not worth intercepting ~50 Bash calls per
+// session to catch ~2 git commits. Commit tracing is handled in PostToolUse.
 func (h *Handlers) HandleHookPreToolUse(w http.ResponseWriter, r *http.Request) {
 	var input hookPreToolUseInput
 	if err := decodeJSON(w, r, &input, hookMaxBodyBytes); err != nil {
@@ -166,40 +170,30 @@ func (h *Handlers) HandleHookPreToolUse(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	switch {
-	case isEditTool(input.ToolName):
-		allowed := false
-		if input.AgentID != "" {
-			allowed = h.hookChecks.IsRecent(input.AgentID)
-		} else {
-			// No agent_id in request — fall back to checking any agent.
-			// This preserves backwards compatibility with older hook scripts.
-			allowed = h.hookChecks.IsAnyRecent()
-		}
-		if allowed {
-			writeHookJSON(w, hookResponse{Continue: true, SuppressOutput: true})
-			return
-		}
-		writeHookJSON(w, hookResponse{
-			HookSpecificOutput: &hookSpecific{
-				HookEventName:            "PreToolUse",
-				PermissionDecision:       "deny",
-				PermissionDecisionReason: "Call akashi_check before making changes. This ensures you've checked for prior decisions and conflicts.",
-			},
-		})
-
-	case isGitCommit(input.ToolInput):
-		writeHookJSON(w, hookResponse{
-			Continue: true,
-			HookSpecificOutput: &hookSpecific{
-				HookEventName:     "PreToolUse",
-				AdditionalContext: "Consider calling akashi_check before committing to verify no conflicting decisions exist.",
-			},
-		})
-
-	default:
+	if !isEditTool(input.ToolName) {
 		writeHookJSON(w, hookResponse{Continue: true, SuppressOutput: true})
+		return
 	}
+
+	allowed := false
+	if input.AgentID != "" {
+		allowed = h.hookChecks.IsRecent(input.AgentID)
+	} else {
+		// No agent_id in request — fall back to checking any agent.
+		// This preserves backwards compatibility with older hook scripts.
+		allowed = h.hookChecks.IsAnyRecent()
+	}
+	if allowed {
+		writeHookJSON(w, hookResponse{Continue: true, SuppressOutput: true})
+		return
+	}
+	writeHookJSON(w, hookResponse{
+		HookSpecificOutput: &hookSpecific{
+			HookEventName:            "PreToolUse",
+			PermissionDecision:       "deny",
+			PermissionDecisionReason: "Call akashi_check before making changes. This ensures you've checked for prior decisions and conflicts.",
+		},
+	})
 }
 
 // HandleHookPostToolUse handles:
@@ -226,9 +220,17 @@ func (h *Handlers) HandleHookPostToolUse(w http.ResponseWriter, r *http.Request)
 }
 
 // handlePostCommit auto-traces a git commit and/or suggests manual tracing.
+//
+// The commit has already happened by the time PostToolUse fires, so we read
+// the subject from `git log -1 --format=%s` instead of parsing the command
+// string. This correctly handles HEREDOC commits, --amend, and editor-based
+// messages that the old regex-based parser could not.
 func (h *Handlers) handlePostCommit(w http.ResponseWriter, input hookPostToolUseInput) {
-	command := extractCommand(input.ToolInput)
-	commitMsg := extractCommitMessage(command)
+	commitMsg := gitCommitSubject(input.CWD)
+	if commitMsg == "" {
+		// Fallback: try parsing from the command string.
+		commitMsg = extractCommitMessage(extractCommand(input.ToolInput))
+	}
 	if commitMsg == "" {
 		commitMsg = "commit (message not parsed)"
 	}
@@ -328,6 +330,22 @@ func gitDiffNameOnly(cwd string) string {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	out, err := exec.CommandContext(ctx, "git", "-C", cwd, "diff", "--name-only", "HEAD~1").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// gitCommitSubject returns the subject line of the most recent commit,
+// or "" on error. This is preferred over regex-parsing the command string
+// because it handles HEREDOC commits, --amend, and editor-based messages.
+func gitCommitSubject(cwd string) string {
+	if cwd == "" {
+		return ""
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "git", "-C", cwd, "log", "-1", "--format=%s").Output()
 	if err != nil {
 		return ""
 	}
@@ -542,11 +560,15 @@ func formatAge(d time.Duration) string {
 	}
 }
 
-func truncateHook(s string, maxLen int) string {
-	if len(s) <= maxLen {
+// truncateHook truncates s to at most maxRunes runes, appending "..." if
+// truncated. Operates on runes, not bytes, to avoid splitting multi-byte
+// UTF-8 characters (e.g. CJK, emoji) mid-codepoint.
+func truncateHook(s string, maxRunes int) string {
+	runes := []rune(s)
+	if len(runes) <= maxRunes {
 		return s
 	}
-	return s[:maxLen] + "..."
+	return string(runes[:maxRunes]) + "..."
 }
 
 func writeHookJSON(w http.ResponseWriter, resp hookResponse) {

--- a/internal/server/handlers_hooks_test.go
+++ b/internal/server/handlers_hooks_test.go
@@ -227,7 +227,10 @@ func TestHandleHookPreToolUse_EditGate(t *testing.T) {
 	})
 }
 
-func TestHandleHookPreToolUse_GitCommitReminder(t *testing.T) {
+func TestHandleHookPreToolUse_BashPassesThrough(t *testing.T) {
+	// Bash is intentionally excluded from the PreToolUse matcher to avoid
+	// firing on every shell command. Even if Bash somehow reaches the handler,
+	// it should pass through since it's not an edit tool.
 	h := &Handlers{
 		hookChecks: newHookCheckStore(),
 	}
@@ -240,8 +243,7 @@ func TestHandleHookPreToolUse_GitCommitReminder(t *testing.T) {
 	var resp hookResponse
 	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
 	assert.True(t, resp.Continue)
-	require.NotNil(t, resp.HookSpecificOutput)
-	assert.Contains(t, resp.HookSpecificOutput.AdditionalContext, "akashi_check")
+	assert.True(t, resp.SuppressOutput)
 }
 
 func TestHandleHookPostToolUse_AkashiCheckMarker(t *testing.T) {
@@ -488,6 +490,15 @@ func TestHelpers(t *testing.T) {
 			{"empty string", "", 5, ""},
 			{"max zero truncates everything", "hello", 0, "..."},
 			{"single char limit", "hello", 1, "h..."},
+			// Rune-safe: CJK characters are 3 bytes each but 1 rune.
+			// "日本語テスト" = 6 runes. Truncating at 3 runes should give "日本語..."
+			{"CJK rune-safe", "日本語テスト", 3, "日本語..."},
+			// Emoji: 🎉 is 4 bytes but 1 rune.
+			{"emoji rune-safe", "🎉🎊🎈🎆", 2, "🎉🎊..."},
+			// Mixed ASCII and multi-byte.
+			{"mixed ascii and CJK", "hi日本", 3, "hi日..."},
+			// Under limit with multi-byte — should return original string.
+			{"multi-byte under limit", "日本", 5, "日本"},
 		}
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
@@ -723,6 +734,20 @@ func TestStripBranchPrefix(t *testing.T) {
 	}
 }
 
+func TestGitCommitSubject_EmptyCWD(t *testing.T) {
+	assert.Empty(t, gitCommitSubject(""))
+}
+
+func TestGitCommitSubject_InvalidPath(t *testing.T) {
+	assert.Empty(t, gitCommitSubject("/nonexistent/path/that/does/not/exist"))
+}
+
+func TestGitCommitSubject_CurrentRepo(t *testing.T) {
+	// Running in a real git repo should return the latest commit subject.
+	subject := gitCommitSubject(".")
+	assert.NotEmpty(t, subject, "current repo should have at least one commit")
+}
+
 func TestGitDiffNameOnly_EmptyCWD(t *testing.T) {
 	assert.Empty(t, gitDiffNameOnly(""))
 }
@@ -772,7 +797,9 @@ func TestWriteHookJSON_Success(t *testing.T) {
 	assert.True(t, resp.SuppressOutput)
 }
 
-func TestHandleHookPreToolUse_GitCommit(t *testing.T) {
+func TestHandleHookPreToolUse_BashGitCommitPassesThrough(t *testing.T) {
+	// Even git commit Bash commands should pass through PreToolUse — the
+	// pre-commit hint was removed to avoid intercepting every Bash call.
 	h := &Handlers{
 		hookChecks: newHookCheckStore(),
 	}
@@ -785,8 +812,7 @@ func TestHandleHookPreToolUse_GitCommit(t *testing.T) {
 	var resp hookResponse
 	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
 	assert.True(t, resp.Continue)
-	require.NotNil(t, resp.HookSpecificOutput)
-	assert.Contains(t, resp.HookSpecificOutput.AdditionalContext, "akashi_check")
+	assert.True(t, resp.SuppressOutput)
 }
 
 func TestHandleHookPreToolUse_EditAfterCheck(t *testing.T) {

--- a/scripts/install-ide-hooks.sh
+++ b/scripts/install-ide-hooks.sh
@@ -136,6 +136,15 @@ def has_command(hook_list, target_cmd):
                 return True
     return False
 
+def update_matcher(hook_list, target_cmd, old_matcher, new_matcher):
+    """Update the matcher for an existing hook registration."""
+    for entry in hook_list:
+        for h in entry.get("hooks", []):
+            if h.get("command") == target_cmd and entry.get("matcher") == old_matcher:
+                entry["matcher"] = new_matcher
+                return True
+    return False
+
 registered = []
 
 # SessionStart: context injection
@@ -144,11 +153,15 @@ if not has_command(session, cmd):
     session.append({"hooks": [{"type": "command", "command": cmd, "timeout": 5}]})
     registered.append("SessionStart")
 
-# PreToolUse: edit gate + pre-commit reminder
+# PreToolUse: edit gate (Bash intentionally excluded — see handlers_hooks.go)
 pre = hooks.setdefault("PreToolUse", [])
-if not has_command(pre, cmd):
-    pre.append({"matcher": "Bash|Edit|Write|MultiEdit", "hooks": [{"type": "command", "command": cmd, "timeout": 10}]})
-    registered.append("PreToolUse[Bash|Edit|Write|MultiEdit]")
+if has_command(pre, cmd):
+    # Migrate: remove Bash from PreToolUse matcher if present from older install.
+    if update_matcher(pre, cmd, "Bash|Edit|Write|MultiEdit", "Edit|Write|MultiEdit"):
+        registered.append("PreToolUse[Edit|Write|MultiEdit] (migrated: removed Bash)")
+else:
+    pre.append({"matcher": "Edit|Write|MultiEdit", "hooks": [{"type": "command", "command": cmd, "timeout": 10}]})
+    registered.append("PreToolUse[Edit|Write|MultiEdit]")
 
 # PostToolUse: check marker + auto-trace
 post = hooks.setdefault("PostToolUse", [])


### PR DESCRIPTION
## Summary

- Remove `Bash` from the PreToolUse hook matcher — ~95% of hook invocations were pass-through round-trips on non-commit shell commands (`go build`, `ls`, `go test`). Only `Edit|Write|MultiEdit` need the edit gate; PostToolUse still catches commits for auto-trace.
- Replace the fragile `-m "..."` commit message regex with `git log -1 --format=%s` in PostToolUse. The old regex broke on HEREDOC-style commits (stopped at the `'` in `<<'EOF'`), producing "commit (message not parsed)" for every auto-traced commit.
- Align the edit-gate TTL to 10 minutes across all three locations: server code (was 10m), shell fallback (was 1h), and docs (said 2h).
- Make `truncateHook` rune-safe so CJK characters and emoji don't get split mid-codepoint in hook responses and auto-traced decision outcomes.
- Add a migration path in the install script so `make install-hooks` updates existing `Bash|Edit|Write|MultiEdit` registrations to `Edit|Write|MultiEdit`.

## Verification

- [x] I ran relevant tests locally (`go test ./...` or targeted package tests).
- [x] I updated docs/openapi for any API or behavior changes.
- [ ] If I changed config vars in `internal/config/config.go`, I also updated:
  - N/A — no config var changes.
- [x] `go build`, `go vet`, `golangci-lint run`, `atlas migrate validate` all pass.

## Risk / Rollout Notes

- **Breaking change for PreToolUse matcher**: Existing `~/.claude/settings.json` installations still have `Bash` in the PreToolUse matcher. Running `make install-hooks` migrates it automatically. Without migration, the old matcher still works — it just fires unnecessarily on Bash calls (same behavior as before this PR).
- No migration needed. No database changes. No API changes.
- The `commitMsgRe` regex and `extractCommitMessage` function are kept as a fallback in case `git log` fails (e.g., CWD is empty), so existing tests still pass.

> The Borg would never tolerate a hook that fires on every `ls`. Efficiency is
> perfection — and 95% wasted cycles is the kind of imprecision that gets a
> drone disconnected from the Collective. Resistance to unnecessary round-trips
> is not futile; it is optimal.