### PR TITLE
fix: add jitter to SSE reconnection backoff

### DIFF
--- a/ui/src/lib/sse.ts
+++ b/ui/src/lib/sse.ts
@@ -73,8 +73,8 @@ export function useSSE(token: string | null, onAuthError?: () => void) {
     } finally {
       if (!controller.signal.aborted) {
         setStatus("disconnected");
-        // Reconnect with exponential backoff.
-        const delay = retryMs.current;
+        // Reconnect with exponential backoff + jitter to avoid thundering herd.
+        const delay = retryMs.current * (0.5 + Math.random());
         retryMs.current = Math.min(retryMs.current * 2, MAX_RETRY_MS);
         setTimeout(() => connect(), delay);
       }


### PR DESCRIPTION
## Summary

- Adds uniform random jitter (`0.5x–1.5x` base delay) to the SSE client's exponential backoff in `ui/src/lib/sse.ts`
- Prevents thundering herd when the server restarts and all dashboard clients reconnect at identical intervals

## Test plan

- [ ] Open multiple browser tabs with the dashboard connected via SSE
- [ ] Restart the server and observe reconnection timing in devtools — clients should reconnect at staggered intervals rather than in lockstep
- [ ] Verify reconnection still succeeds and events flow after reconnect

Fixes #563

> The Borg assimilate billions yet reconnect in perfect unison — a design flaw
> the Federation never had to patch. Starfleet vessels, scattered across sectors
> after a subspace blackout, check in at random intervals. Even in chaos,
> individuality scales better than the hive.