### PR TITLE
fix: log errors and add onError callback in Vercel AI middleware

### DIFF
--- a/sdk/integrations/vercel-ai/src/middleware.ts
+++ b/sdk/integrations/vercel-ai/src/middleware.ts
@@ -6,8 +6,9 @@
  * - After each generation (streaming or not), `trace()` records the LLM output
  *   as a decision.
  *
- * All Akashi calls are fire-and-forget: errors are swallowed silently so they
- * never interrupt the model call.
+ * All Akashi calls are fire-and-forget: errors are logged via `console.warn`
+ * and never interrupt the model call. Supply an `onError` callback in options
+ * for custom error handling (e.g. structured logging, metrics).
  */
 
 import type { AkashiClient } from "akashi";
@@ -48,6 +49,15 @@ export interface AkashiMiddlewareOptions {
    * Defaults to `true`.
    */
   traceStreams?: boolean;
+
+  /**
+   * Called when an Akashi `check()` or `trace()` call fails. Receives the
+   * thrown error and the operation name (`"check"` or `"trace"`).
+   *
+   * Errors are always logged via `console.warn` regardless of whether this
+   * callback is provided.
+   */
+  onError?: (error: unknown, operation: "check" | "trace") => void;
 }
 
 /**
@@ -81,11 +91,13 @@ async function safeCheck(
   client: AkashiClient,
   decisionType: string,
   query: string | undefined,
+  onError?: (error: unknown, operation: "check" | "trace") => void,
 ): Promise<void> {
   try {
     await client.check(decisionType, query);
-  } catch {
-    // Never interrupt the model call.
+  } catch (err: unknown) {
+    console.warn("[akashi] check failed:", err);
+    try { onError?.(err, "check"); } catch { /* callback must not disrupt the model call */ }
   }
 }
 
@@ -94,6 +106,7 @@ async function safeTrace(
   decisionType: string,
   outcome: string,
   confidence: number,
+  onError?: (error: unknown, operation: "check" | "trace") => void,
   reasoning?: string,
 ): Promise<void> {
   try {
@@ -103,8 +116,9 @@ async function safeTrace(
       confidence,
       reasoning,
     });
-  } catch {
-    // Never interrupt the model call.
+  } catch (err: unknown) {
+    console.warn("[akashi] trace failed:", err);
+    try { onError?.(err, "trace"); } catch { /* callback must not disrupt the model call */ }
   }
 }
 
@@ -142,6 +156,7 @@ export function createAkashiMiddleware(
     checkBeforeGenerate = true,
     traceGenerations = true,
     traceStreams = true,
+    onError,
   } = options;
 
   return {
@@ -153,7 +168,7 @@ export function createAkashiMiddleware(
         const query = extractLastUserQuery(
           params.prompt as Array<{ role: string; content: unknown }>,
         );
-        await safeCheck(client, decisionType, query);
+        await safeCheck(client, decisionType, query, onError);
       }
 
       const result = await doGenerate();
@@ -166,7 +181,7 @@ export function createAkashiMiddleware(
             ?.map((c) => `tool:${c.toolName}(${JSON.stringify(c.args).slice(0, 100)})`)
             .join(", ") ??
           "";
-        await safeTrace(client, decisionType, text, confidence);
+        await safeTrace(client, decisionType, text, confidence, onError);
       }
 
       return result;
@@ -180,7 +195,7 @@ export function createAkashiMiddleware(
         const query = extractLastUserQuery(
           params.prompt as Array<{ role: string; content: unknown }>,
         );
-        await safeCheck(client, decisionType, query);
+        await safeCheck(client, decisionType, query, onError);
       }
 
       const result = await doStream();
@@ -205,7 +220,7 @@ export function createAkashiMiddleware(
         },
         async flush() {
           if (accumulated) {
-            await safeTrace(client, decisionType, accumulated, confidence);
+            await safeTrace(client, decisionType, accumulated, confidence, onError);
           }
         },
       });

--- a/sdk/integrations/vercel-ai/tests/middleware.test.ts
+++ b/sdk/integrations/vercel-ai/tests/middleware.test.ts
@@ -548,3 +548,100 @@ describe("all disabled", () => {
     expect(client.trace).not.toHaveBeenCalled();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Error reporting — console.warn + onError callback
+// ---------------------------------------------------------------------------
+
+describe("error reporting", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  it("logs check errors to console.warn", async () => {
+    const client = makeClient();
+    const err = new Error("check down");
+    vi.mocked(client.check).mockRejectedValue(err);
+    await runGenerate(client, "q", { text: "ok" });
+    expect(warnSpy).toHaveBeenCalledWith("[akashi] check failed:", err);
+  });
+
+  it("logs trace errors to console.warn", async () => {
+    const client = makeClient();
+    const err = new Error("trace down");
+    vi.mocked(client.trace).mockRejectedValue(err);
+    await runGenerate(client, "q", { text: "ok" });
+    expect(warnSpy).toHaveBeenCalledWith("[akashi] trace failed:", err);
+  });
+
+  it("calls onError with error and operation name on check failure", async () => {
+    const client = makeClient();
+    const err = new Error("check down");
+    vi.mocked(client.check).mockRejectedValue(err);
+    const onError = vi.fn();
+    await runGenerate(client, "q", { text: "ok" }, { onError });
+    expect(onError).toHaveBeenCalledWith(err, "check");
+  });
+
+  it("calls onError with error and operation name on trace failure", async () => {
+    const client = makeClient();
+    const err = new Error("trace down");
+    vi.mocked(client.trace).mockRejectedValue(err);
+    const onError = vi.fn();
+    await runGenerate(client, "q", { text: "ok" }, { onError });
+    expect(onError).toHaveBeenCalledWith(err, "trace");
+  });
+
+  it("calls onError on stream check failure", async () => {
+    const client = makeClient();
+    const err = new Error("check down");
+    vi.mocked(client.check).mockRejectedValue(err);
+    const onError = vi.fn();
+    const mw = createAkashiMiddleware(client, { onError });
+    const { stream } = await mw.wrapStream!({
+      doStream: vi.fn().mockResolvedValue(streamResult([
+        { type: "text-delta", textDelta: "text" },
+      ])),
+      doGenerate: vi.fn(),
+      params: callParams([]),
+      model: {} as never,
+    });
+    await drain(stream);
+    expect(onError).toHaveBeenCalledWith(err, "check");
+  });
+
+  it("calls onError on stream trace failure", async () => {
+    const client = makeClient();
+    const err = new Error("trace down");
+    vi.mocked(client.trace).mockRejectedValue(err);
+    const onError = vi.fn();
+    const mw = createAkashiMiddleware(client, { onError });
+    const { stream } = await mw.wrapStream!({
+      doStream: vi.fn().mockResolvedValue(streamResult([
+        { type: "text-delta", textDelta: "text" },
+      ])),
+      doGenerate: vi.fn(),
+      params: callParams([]),
+      model: {} as never,
+    });
+    await drain(stream);
+    expect(onError).toHaveBeenCalledWith(err, "trace");
+  });
+
+  it("does not call onError when no errors occur", async () => {
+    const client = makeClient();
+    const onError = vi.fn();
+    await runGenerate(client, "q", { text: "ok" }, { onError });
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("onError exception does not interrupt the model call", async () => {
+    const client = makeClient();
+    vi.mocked(client.check).mockRejectedValue(new Error("check down"));
+    const onError = vi.fn().mockImplementation(() => { throw new Error("callback blew up"); });
+    const result = await runGenerate(client, "q", { text: "still works" }, { onError });
+    expect(result.text).toBe("still works");
+  });
+});


### PR DESCRIPTION
## Summary

- Replace empty catch blocks in `safeCheck`/`safeTrace` with `console.warn("[akashi] ...")` so failures are always visible
- Add optional `onError(error, operation)` callback to `AkashiMiddlewareOptions` for custom error handling (structured logging, metrics, etc.)
- Wrap the `onError` callback in its own try/catch so a buggy callback never disrupts the model call

Closes #564

## Test plan

- [x] Existing 36 tests still pass (fire-and-forget behavior preserved)
- [x] 8 new tests covering:
  - `console.warn` called on check failure
  - `console.warn` called on trace failure
  - `onError` receives error + `"check"` operation name
  - `onError` receives error + `"trace"` operation name
  - `onError` fires on stream check failure
  - `onError` fires on stream trace failure
  - `onError` not called when no errors
  - Throwing `onError` callback doesn't interrupt the model call

> The Sorting Hat never tells you *why* it chose your house —
> it just moves on to the next kid. Turns out, silent classification
> without an audit trail is a liability even in the wizarding world.
> At least Akashi logs the catch now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)