### PR TITLE
docs: update stale counts in README and CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,8 +66,8 @@ internal/
   ratelimit/         Pluggable token bucket rate limiter.
   telemetry/         OpenTelemetry setup (traces + metrics).
   testutil/          Shared test helpers (testcontainers, test DB, test logger).
-migrations/          Sequential SQL files (001..054). Atlas-managed checksums.
-adrs/                Technical architecture decision records (ADR-001 through ADR-008).
+migrations/          Sequential SQL files (001..085). Atlas-managed checksums.
+adrs/                Technical architecture decision records (ADR-001 through ADR-011).
 sdk/                 Go, Python, TypeScript client SDKs.
 ui/                  React 19 SPA (audit dashboard). Embedded via go:embed when built with -tags ui.
 docs/                Configuration reference, .env.example.
@@ -75,7 +75,7 @@ docs/                Configuration reference, .env.example.
 
 ## Architecture patterns
 
-**Multi-tenancy via org_id.** Every query MUST include `AND org_id = $N`. There are 84 org_id filters across the storage layer. Missing one is a data leak. When adding a new query, always scope by org_id.
+**Multi-tenancy via org_id.** Every query MUST include `AND org_id = $N`. There are 231 org_id filters across the storage layer. Missing one is a data leak. When adding a new query, always scope by org_id.
 
 **Bi-temporal model.** Decisions have `valid_from`/`valid_to` (business time) and `transaction_time` (system time). Active records have `valid_to IS NULL`. Always include this filter in queries that should return current state.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
-[![Go](https://img.shields.io/badge/Go-1.25-00ADD8.svg)](https://go.dev/)
+[![Go](https://img.shields.io/badge/Go-1.26-00ADD8.svg)](https://go.dev/)
 [![PostgreSQL](https://img.shields.io/badge/PostgreSQL-18-336791.svg)](https://www.postgresql.org/)
 
 **Version control for AI decisions.**


### PR DESCRIPTION
## Summary
- Fix Go version badge: 1.25 → 1.26 (matches `go.mod`)
- Update org_id filter count: 84 → 231 (counted non-test storage files with `rg`)
- Update migration range: 001..054 → 001..085
- Update ADR range: ADR-001..008 → ADR-001..011

Closes #567

## Test plan
- [x] Verified Go badge version matches `go.mod` (1.26.1)
- [x] Verified org_id count via `rg -c 'org_id\s*=\s*\$' internal/storage/ --glob '!*_test.go'` → 231
- [x] Verified last migration file is `085_conflict_resolutions.sql`
- [x] Verified 11 ADR files exist, last is `ADR-011-proof-leaves-retention-survival.md`

> Hermione kept a charmed calendar that updated class schedules on its own —
> if Hogwarts had one for README files, we wouldn't need this PR. Until then,
> we muggles count our org_id filters by hand.