### PR TITLE
fix: cap Go SDK response body reads at 10 MiB

### DIFF
--- a/sdk/go/akashi/client.go
+++ b/sdk/go/akashi/client.go
@@ -17,6 +17,10 @@ import (
 
 const userAgent = "akashi-go/0.2.0"
 
+// maxResponseBodySize caps how much data we read from the server to prevent
+// a misbehaving or compromised server from OOMing the client.
+const maxResponseBodySize = 10 << 20 // 10 MiB
+
 // Config holds the settings needed to construct a Client.
 type Config struct {
 	// BaseURL is the root URL of the Akashi server (e.g. "http://localhost:8080").
@@ -704,7 +708,7 @@ func (c *Client) doPostList(ctx context.Context, path string, body any, items an
 }
 
 func handleResponse(resp *http.Response, dest any) error {
-	bodyBytes, err := io.ReadAll(resp.Body)
+	bodyBytes, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBodySize))
 	if err != nil {
 		return fmt.Errorf("akashi: read response body: %w", err)
 	}
@@ -735,7 +739,7 @@ func handleResponse(resp *http.Response, dest any) error {
 // handleListResponse parses the list envelope from a response body.
 // items must be a pointer to a slice (e.g., *[]Decision).
 func handleListResponse(resp *http.Response, items any) (listEnvelope, error) {
-	bodyBytes, err := io.ReadAll(resp.Body)
+	bodyBytes, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBodySize))
 	if err != nil {
 		return listEnvelope{}, fmt.Errorf("akashi: read response body: %w", err)
 	}


### PR DESCRIPTION
## Summary

- Wraps `io.ReadAll(resp.Body)` with `io.LimitReader(resp.Body, 10<<20)` in both `handleResponse` and `handleListResponse` to prevent OOM from unbounded server responses.
- Adds a `maxResponseBodySize` constant (10 MiB) for the cap.

Closes #557

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test -race -count=1 ./...` passes
- [ ] Verify large-response behavior in integration environment (response > 10 MiB returns a truncated read, not a crash)

> The Sorting Hat never needed a size limit —
> it just read what it needed and stopped.
> But Hogwarts wasn't built on `io.ReadAll`,
> and even Dumbledore would cap his buffers
> if Voldemort controlled the server.