### PR TITLE
fix: add platform_admin and org_owner to UI AgentRole type

### DIFF
--- a/ui/src/pages/Agents.tsx
+++ b/ui/src/pages/Agents.tsx
@@ -78,6 +78,8 @@ function compareAgents(a: AgentWithStats, b: AgentWithStats, field: SortField, d
 }
 
 const roleColors: Record<AgentRole, "default" | "secondary" | "destructive" | "success" | "warning" | "outline"> = {
+  platform_admin: "destructive",
+  org_owner: "warning",
   admin: "default",
   agent: "secondary",
   reader: "outline",
@@ -214,6 +216,8 @@ export default function Agents() {
                       <SelectItem value="reader">Reader</SelectItem>
                       <SelectItem value="agent">Agent</SelectItem>
                       <SelectItem value="admin">Admin</SelectItem>
+                      <SelectItem value="org_owner">Org Owner</SelectItem>
+                      <SelectItem value="platform_admin">Platform Admin</SelectItem>
                     </SelectContent>
                   </Select>
                   <input type="hidden" name="role" value={selectedRole} />

--- a/ui/src/types/api.ts
+++ b/ui/src/types/api.ts
@@ -32,6 +32,8 @@ export interface AuthTokenResponse {
 
 // Agent
 export type AgentRole =
+  | "platform_admin"
+  | "org_owner"
   | "admin"
   | "agent"
   | "reader";


### PR DESCRIPTION
## Summary

- The Go RBAC model defines 5 roles (`platform_admin > org_owner > admin > agent > reader`) but the UI TypeScript `AgentRole` type only included 3 (`admin`, `agent`, `reader`). This caused the `Record<AgentRole, ...>` roleColors map to be incomplete and prevented creating agents with the higher-privilege roles from the UI.
- Adds both missing roles to the type union, the badge color map (destructive for platform_admin, warning for org_owner), and the create-agent form dropdown.

## Verification

- [x] I ran relevant tests locally (`go test ./...` or targeted package tests).
- [ ] I updated docs/openapi for any API or behavior changes.
- [ ] If I changed config vars in `internal/config/config.go`, I also updated:
  - [ ] `docs/configuration.md`
  - [ ] `docs/runbook.md` (operational subset, if relevant)
  - [ ] `.env.example` (if baseline local/dev defaults changed)
  - [ ] `docs/consistency-manifest.json` (only if policy/coverage rules changed)
- [ ] `python3 scripts/check_doc_config_consistency.py` passes.

## Risk / Rollout Notes

- No migration or backward-compatibility risk. This is a UI-only change; server-side RBAC enforcement is unchanged. The server already rejects privilege escalation attempts via `RoleRank` checks, so exposing these roles in the dropdown does not widen access.

> Spock would raise an eyebrow at a type system that forgot two-fifths
> of its own enumeration. "Fascinating — the compiler had the logic,
> yet chose not to enforce it." Somewhere in the bowels of the Enterprise,
> a junior engineer quietly adds the missing variants before anyone notices.