### PR TITLE
fix: consolidate truncation to prevent invalid UTF-8 in conflict data

### DIFF
--- a/internal/conflicts/lite_scorer.go
+++ b/internal/conflicts/lite_scorer.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/ashita-ai/akashi/internal/compact"
 	"github.com/ashita-ai/akashi/internal/storage"
 )
 
@@ -218,7 +219,7 @@ func (s *LiteScorer) insertConflict(ctx context.Context, orgID uuid.UUID, confli
 		a.id.String(), b.id.String(), orgID.String(),
 		a.agentID, b.agentID,
 		a.decisionType, b.decisionType,
-		truncate(a.outcome, 500), truncate(b.outcome, 500),
+		compact.Truncate(a.outcome, 500), compact.Truncate(b.outcome, 500),
 		topicSim, outcomeDivergence, significance,
 		"text_claims", explanation, now, severity, "open",
 		groupID.String(),
@@ -356,12 +357,4 @@ func jaccardSimilarity(a, b map[string]bool) float32 {
 		return 0
 	}
 	return float32(intersection) / float32(union)
-}
-
-// truncate limits a string to maxLen characters.
-func truncate(s string, maxLen int) string {
-	if len(s) <= maxLen {
-		return s
-	}
-	return s[:maxLen]
 }

--- a/internal/conflicts/lite_scorer_test.go
+++ b/internal/conflicts/lite_scorer_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ashita-ai/akashi/internal/compact"
+
 	_ "modernc.org/sqlite"
 )
 
@@ -289,9 +291,9 @@ func TestUniqueWords(t *testing.T) {
 }
 
 func TestTruncate(t *testing.T) {
-	assert.Equal(t, "abc", truncate("abcdef", 3))
-	assert.Equal(t, "ab", truncate("ab", 3))
-	assert.Equal(t, "", truncate("", 3))
+	assert.Equal(t, "abc...", compact.Truncate("abcdef", 3))
+	assert.Equal(t, "ab", compact.Truncate("ab", 3))
+	assert.Equal(t, "", compact.Truncate("", 3))
 }
 
 // TestScoreClaimOverlap_EmptyClaims verifies that empty claim slices return zeros.
@@ -388,12 +390,14 @@ func TestUniqueWords_EmptyString(t *testing.T) {
 	assert.Empty(t, words)
 }
 
-// TestTruncate_LiteScorer verifies the lite_scorer's truncate function.
+// TestTruncate_LiteScorer verifies rune-safe truncation via compact.Truncate.
 func TestTruncate_LiteScorer(t *testing.T) {
-	assert.Equal(t, "hello", truncate("hello", 10))
-	assert.Equal(t, "hel", truncate("hello", 3))
-	assert.Equal(t, "", truncate("", 5))
-	assert.Equal(t, "hello", truncate("hello", 5))
+	assert.Equal(t, "hello", compact.Truncate("hello", 10))
+	assert.Equal(t, "hel...", compact.Truncate("hello", 3))
+	assert.Equal(t, "", compact.Truncate("", 5))
+	assert.Equal(t, "hello", compact.Truncate("hello", 5))
+	// Multi-byte: rune-safe, no split mid-codepoint.
+	assert.Equal(t, "こん...", compact.Truncate("こんにちは", 2))
 }
 
 // TestLiteScorer_ProjectScoping verifies that the scorer scopes candidates

--- a/internal/conflicts/validator.go
+++ b/internal/conflicts/validator.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/ashita-ai/akashi/internal/compact"
 )
 
 // ValidateInput holds all context needed for relationship classification.
@@ -91,20 +93,20 @@ func formatPrompt(input ValidateInput) string {
 	fmt.Fprintf(&b, "Agent %q decision (%s, recorded %s):\n%s\n",
 		input.AgentA, input.TypeA, input.CreatedA.Format(time.RFC3339), input.OutcomeA)
 	if input.FullOutcomeA != "" && input.FullOutcomeA != input.OutcomeA {
-		fmt.Fprintf(&b, "[Full decision context: %s]\n", truncateRunes(input.FullOutcomeA, 500))
+		fmt.Fprintf(&b, "[Full decision context: %s]\n", compact.Truncate(input.FullOutcomeA, 500))
 	}
 	if input.ReasoningA != "" {
-		fmt.Fprintf(&b, "[Reasoning: %s]\n", truncateRunes(input.ReasoningA, 300))
+		fmt.Fprintf(&b, "[Reasoning: %s]\n", compact.Truncate(input.ReasoningA, 300))
 	}
 
 	// --- Decision by agent B ---
 	fmt.Fprintf(&b, "\nAgent %q decision (%s, recorded %s):\n%s\n",
 		input.AgentB, input.TypeB, input.CreatedB.Format(time.RFC3339), input.OutcomeB)
 	if input.FullOutcomeB != "" && input.FullOutcomeB != input.OutcomeB {
-		fmt.Fprintf(&b, "[Full decision context: %s]\n", truncateRunes(input.FullOutcomeB, 500))
+		fmt.Fprintf(&b, "[Full decision context: %s]\n", compact.Truncate(input.FullOutcomeB, 500))
 	}
 	if input.ReasoningB != "" {
-		fmt.Fprintf(&b, "[Reasoning: %s]\n", truncateRunes(input.ReasoningB, 300))
+		fmt.Fprintf(&b, "[Reasoning: %s]\n", compact.Truncate(input.ReasoningB, 300))
 	}
 
 	// --- Temporal and agent context ---
@@ -129,10 +131,10 @@ func formatPrompt(input ValidateInput) string {
 			"Only classify as CONTRADICTION if both decisions are clearly about the SAME system and make incompatible claims about it.\n")
 	}
 	if input.TaskA != "" {
-		fmt.Fprintf(&b, "Task (%s): %s\n", input.AgentA, truncateRunes(input.TaskA, 100))
+		fmt.Fprintf(&b, "Task (%s): %s\n", input.AgentA, compact.Truncate(input.TaskA, 100))
 	}
 	if input.TaskB != "" {
-		fmt.Fprintf(&b, "Task (%s): %s\n", input.AgentB, truncateRunes(input.TaskB, 100))
+		fmt.Fprintf(&b, "Task (%s): %s\n", input.AgentB, compact.Truncate(input.TaskB, 100))
 	}
 
 	// --- Session context (#170: temporal refinement) ---
@@ -257,16 +259,6 @@ func isWorkflowPair(typeA, typeB string) bool {
 		}
 	}
 	return false
-}
-
-// truncateRunes truncates a string to maxLen runes, appending "..." if truncated.
-// Rune-safe to avoid splitting multi-byte characters.
-func truncateRunes(s string, maxLen int) string {
-	runes := []rune(s)
-	if len(runes) <= maxLen {
-		return s
-	}
-	return string(runes[:maxLen]) + "..."
 }
 
 // formatDuration produces a human-readable duration string.

--- a/internal/conflicts/validator_test.go
+++ b/internal/conflicts/validator_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/ashita-ai/akashi/internal/compact"
 	"github.com/ashita-ai/akashi/internal/model"
 	"github.com/ashita-ai/akashi/internal/storage"
 )
@@ -677,15 +678,15 @@ func TestFormatPrompt_NoPrecedentLink(t *testing.T) {
 
 func TestTruncateRunes(t *testing.T) {
 	// Below limit: unchanged.
-	assert.Equal(t, "hello", truncateRunes("hello", 10))
+	assert.Equal(t, "hello", compact.Truncate("hello", 10))
 	// At limit: unchanged.
-	assert.Equal(t, "hello", truncateRunes("hello", 5))
+	assert.Equal(t, "hello", compact.Truncate("hello", 5))
 	// Above limit: truncated with "...".
-	assert.Equal(t, "hel...", truncateRunes("hello world", 3))
+	assert.Equal(t, "hel...", compact.Truncate("hello world", 3))
 	// Multi-byte characters.
-	assert.Equal(t, "こん...", truncateRunes("こんにちは", 2))
+	assert.Equal(t, "こん...", compact.Truncate("こんにちは", 2))
 	// Empty string.
-	assert.Equal(t, "", truncateRunes("", 10))
+	assert.Equal(t, "", compact.Truncate("", 10))
 }
 
 func TestFormatDuration(t *testing.T) {


### PR DESCRIPTION
## Summary

- **Bug**: `lite_scorer.truncate` operated on bytes, not runes — truncating at byte boundaries splits multi-byte UTF-8 characters (CJK, emoji, accented text), producing invalid UTF-8 in stored `outcome_a`/`outcome_b` conflict columns.
- **Fix**: Replaced the buggy `lite_scorer.truncate` and the duplicate `validator.truncateRunes` with calls to the already-exported `compact.Truncate`, which is rune-safe and appends `"..."` on truncation.
- **Net effect**: 3 implementations → 1 canonical implementation. 10 fewer lines of code. Tests updated with multi-byte coverage.

## Test plan

- [x] All existing tests pass (`go test -race -count=1 ./...`)
- [x] `TestTruncate_LiteScorer` now verifies rune-safety with CJK input (`こんにちは`)
- [x] `TestTruncateRunes` continues to verify multi-byte correctness via `compact.Truncate`
- [x] golangci-lint clean

Closes #550

> The transporter doesn't care about your character encoding —
> it disassembles you at the quantum level and reassembles you whole on the other side.
> If Starfleet can guarantee bit-perfect fidelity across a matter stream,
> the least we can do is not slice a rune in half.