### PR TITLE
fix: log silently swallowed errors in storage layer

### DIFF
--- a/internal/storage/decisions.go
+++ b/internal/storage/decisions.go
@@ -698,6 +698,11 @@ func (db *DB) SearchDecisionsByText(ctx context.Context, orgID uuid.UUID, query 
 	// fall back to ILIKE instead of returning 500.
 	results, err := db.searchByFTS(ctx, orgID, query, filters, limit)
 	if err != nil {
+		db.logger.Warn("storage: FTS search failed, falling back to ILIKE",
+			"org_id", orgID,
+			"query", query,
+			"error", err,
+		)
 		return db.searchByILIKE(ctx, orgID, query, filters, limit)
 	}
 	if len(results) > 0 {

--- a/internal/storage/org_settings.go
+++ b/internal/storage/org_settings.go
@@ -115,7 +115,11 @@ func (db *DB) GetOrgsWithAutoResolution(ctx context.Context) ([]OrgAutoResolveCo
 		}
 		var data model.OrgSettingsData
 		if err := json.Unmarshal(raw, &data); err != nil {
-			continue // skip malformed rows
+			db.logger.Warn("storage: skipping malformed org settings row",
+				"org_id", c.OrgID,
+				"error", err,
+			)
+			continue
 		}
 		if data.ConflictResolution == nil {
 			continue


### PR DESCRIPTION
## Summary
- Add `slog.Warn` before the silent FTS→ILIKE fallback in `searchByFTS` (`internal/storage/decisions.go`), logging the org_id, query, and error
- Add `slog.Warn` when `GetOrgsWithAutoResolution` skips a malformed org settings row (`internal/storage/org_settings.go`), logging the org_id and unmarshal error

Closes #509

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test -race -count=1 ./internal/storage/...` passes
- [x] `atlas migrate validate` passes

> Spock would raise an eyebrow at a system that suppresses its own error
> signals — "Fascinating, Captain, the ship is on fire but the alarms have
> been… optimized away." Even the Enterprise logged its warp core warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)