### PR TITLE
fix: add missing argOffset++ in conflict filter builders

### DIFF
--- a/internal/storage/conflicts.go
+++ b/internal/storage/conflicts.go
@@ -882,6 +882,7 @@ func conflictGroupWhere(f ConflictGroupFilters, argOffset int) (string, []any) {
 	if f.ConflictKind != nil {
 		clause += fmt.Sprintf(" AND cg.conflict_kind = $%d", argOffset)
 		args = append(args, *f.ConflictKind)
+		argOffset++ //nolint:ineffassign
 	}
 	return clause, args
 }
@@ -1635,6 +1636,7 @@ func analyticsWhere(f ConflictAnalyticsFilters, argOffset int) (string, []any) {
 	if f.ConflictKind != nil {
 		clause += fmt.Sprintf(" AND sc.conflict_kind = $%d", argOffset)
 		args = append(args, *f.ConflictKind)
+		argOffset++ //nolint:ineffassign
 	}
 	return clause, args
 }


### PR DESCRIPTION
## Summary

- Adds the missing `argOffset++` after the `ConflictKind` filter block in both `conflictGroupWhere` and `analyticsWhere` (`internal/storage/conflicts.go`).
- `ConflictKind` is currently the last filter in both functions, so this is latent — but any filter added after it would silently bind to the wrong `$N` placeholder.
- Matches the established pattern used by every other filter block in these functions and in `conflictWhere`.

Closes #506

## Test plan

- [x] All existing tests pass (`go test -race -count=1 ./...`)
- [x] `go vet`, `golangci-lint`, `atlas migrate validate` all clean
- [ ] Verify CI green

> Wands choose the wizard, Mr. Potter — but SQL placeholders don't choose
> their own offsets. Miss one `argOffset++` and you've got a Confundus Charm
> on your WHERE clause: everything looks fine until the next filter shows up
> and binds to someone else's value. Constant vigilance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)