### PR TITLE
fix(sdk/go): release mutex before network I/O in token refresh

### DIFF
--- a/sdk/go/akashi/auth.go
+++ b/sdk/go/akashi/auth.go
@@ -79,11 +79,12 @@ func (tm *tokenManager) doRefresh(f *tokenFuture) {
 	// Use a background context so that one caller's cancellation doesn't
 	// break the refresh for all waiters. Individual callers can still bail
 	// out via their own ctx in awaitFuture.
-	tok, err := tm.refresh(context.Background())
+	tok, expiresAt, err := tm.refresh(context.Background())
 
 	tm.mu.Lock()
 	if err == nil {
 		tm.token = tok
+		tm.expiresAt = expiresAt
 	}
 	f.tok = tok
 	f.err = err
@@ -116,33 +117,32 @@ type authResponseEnvelope struct {
 	} `json:"data"`
 }
 
-func (tm *tokenManager) refresh(ctx context.Context) (string, error) {
+func (tm *tokenManager) refresh(ctx context.Context) (string, time.Time, error) {
 	body, err := json.Marshal(authRequest{AgentID: tm.agentID, APIKey: tm.apiKey})
 	if err != nil {
-		return "", fmt.Errorf("akashi: marshal auth request: %w", err)
+		return "", time.Time{}, fmt.Errorf("akashi: marshal auth request: %w", err)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tm.baseURL+"/auth/token", bytes.NewReader(body))
 	if err != nil {
-		return "", fmt.Errorf("akashi: create auth request: %w", err)
+		return "", time.Time{}, fmt.Errorf("akashi: create auth request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := tm.client.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("akashi: auth request: %w", err)
+		return "", time.Time{}, fmt.Errorf("akashi: auth request: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("akashi: auth failed with status %d", resp.StatusCode)
+		return "", time.Time{}, fmt.Errorf("akashi: auth failed with status %d", resp.StatusCode)
 	}
 
 	var envelope authResponseEnvelope
 	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
-		return "", fmt.Errorf("akashi: decode auth response: %w", err)
+		return "", time.Time{}, fmt.Errorf("akashi: decode auth response: %w", err)
 	}
 
-	tm.expiresAt = envelope.Data.ExpiresAt
-	return envelope.Data.Token, nil
+	return envelope.Data.Token, envelope.Data.ExpiresAt, nil
 }

--- a/sdk/go/akashi/auth_test.go
+++ b/sdk/go/akashi/auth_test.go
@@ -3,13 +3,15 @@ package akashi
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // newTestServer returns an httptest.Server that responds to /auth/token with a
@@ -38,24 +40,14 @@ func TestGetToken_CachesValidToken(t *testing.T) {
 	ctx := context.Background()
 
 	tok1, err := tm.getToken(ctx)
-	if err != nil {
-		t.Fatalf("first getToken: %v", err)
-	}
-	if tok1 != "tok-valid" {
-		t.Fatalf("first token = %q, want %q", tok1, "tok-valid")
-	}
+	require.NoError(t, err, "first getToken")
+	assert.Equal(t, "tok-valid", tok1)
 
 	tok2, err := tm.getToken(ctx)
-	if err != nil {
-		t.Fatalf("second getToken: %v", err)
-	}
-	if tok2 != "tok-valid" {
-		t.Fatalf("second token = %q, want %q", tok2, "tok-valid")
-	}
+	require.NoError(t, err, "second getToken")
+	assert.Equal(t, "tok-valid", tok2)
 
-	if n := count.Load(); n != 1 {
-		t.Fatalf("server hit %d times, want 1 (token should be cached)", n)
-	}
+	assert.Equal(t, int64(1), count.Load(), "server should be hit exactly once (token should be cached)")
 }
 
 func TestGetToken_ConcurrentCallersShareOneRefresh(t *testing.T) {
@@ -81,22 +73,16 @@ func TestGetToken_ConcurrentCallersShareOneRefresh(t *testing.T) {
 	wg.Wait()
 
 	for i, err := range errs {
-		if err != nil {
-			t.Errorf("goroutine %d: %v", i, err)
-		}
-		if tokens[i] != "tok-valid" {
-			t.Errorf("goroutine %d: token = %q, want %q", i, tokens[i], "tok-valid")
-		}
+		assert.NoError(t, err, "goroutine %d", i)
+		assert.Equal(t, "tok-valid", tokens[i], "goroutine %d", i)
 	}
 
-	if n := count.Load(); n != 1 {
-		t.Fatalf("server hit %d times, want 1 (all concurrent callers should share one refresh)", n)
-	}
+	assert.Equal(t, int64(1), count.Load(), "all concurrent callers should share one refresh")
 }
 
 func TestGetToken_CallerContextCancellation(t *testing.T) {
 	var count atomic.Int64
-	// Very slow server — caller should be able to bail out.
+	// Very slow server -- caller should be able to bail out.
 	srv := newTestServer(t, &count, 5*time.Second)
 	defer srv.Close()
 
@@ -106,12 +92,8 @@ func TestGetToken_CallerContextCancellation(t *testing.T) {
 	defer cancel()
 
 	_, err := tm.getToken(ctx)
-	if err == nil {
-		t.Fatal("expected error from cancelled context, got nil")
-	}
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("expected DeadlineExceeded, got: %v", err)
-	}
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
 
 func TestGetToken_RefreshErrorDoesNotPoison(t *testing.T) {
@@ -135,19 +117,13 @@ func TestGetToken_RefreshErrorDoesNotPoison(t *testing.T) {
 
 	// First call fails.
 	_, err := tm.getToken(ctx)
-	if err == nil {
-		t.Fatal("expected error on first call, got nil")
-	}
+	require.Error(t, err)
 
-	// Second call should retry and succeed — the error must not leave the
+	// Second call should retry and succeed -- the error must not leave the
 	// tokenManager in a permanently broken state.
 	tok, err := tm.getToken(ctx)
-	if err != nil {
-		t.Fatalf("second getToken: %v", err)
-	}
-	if tok != "tok-retry" {
-		t.Fatalf("token = %q, want %q", tok, "tok-retry")
-	}
+	require.NoError(t, err, "second getToken")
+	assert.Equal(t, "tok-retry", tok)
 }
 
 func TestGetToken_ExpiredTokenTriggersRefresh(t *testing.T) {
@@ -159,12 +135,9 @@ func TestGetToken_ExpiredTokenTriggersRefresh(t *testing.T) {
 	ctx := context.Background()
 
 	// Prime the cache.
-	if _, err := tm.getToken(ctx); err != nil {
-		t.Fatalf("first getToken: %v", err)
-	}
-	if n := count.Load(); n != 1 {
-		t.Fatalf("server hit %d times after first call, want 1", n)
-	}
+	_, err := tm.getToken(ctx)
+	require.NoError(t, err, "first getToken")
+	require.Equal(t, int64(1), count.Load(), "server hit count after first call")
 
 	// Force expiration by backdating expiresAt.
 	tm.mu.Lock()
@@ -172,13 +145,7 @@ func TestGetToken_ExpiredTokenTriggersRefresh(t *testing.T) {
 	tm.mu.Unlock()
 
 	tok, err := tm.getToken(ctx)
-	if err != nil {
-		t.Fatalf("second getToken: %v", err)
-	}
-	if tok != "tok-valid" {
-		t.Fatalf("token = %q, want %q", tok, "tok-valid")
-	}
-	if n := count.Load(); n != 2 {
-		t.Fatalf("server hit %d times, want 2 (expired token should trigger second refresh)", n)
-	}
+	require.NoError(t, err, "second getToken")
+	assert.Equal(t, "tok-valid", tok)
+	assert.Equal(t, int64(2), count.Load(), "expired token should trigger second refresh")
 }

--- a/sdk/go/go.mod
+++ b/sdk/go/go.mod
@@ -3,3 +3,10 @@ module github.com/ashita-ai/akashi/sdk/go
 go 1.22
 
 require github.com/google/uuid v1.6.0
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.11.1
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/sdk/go/go.sum
+++ b/sdk/go/go.sum
@@ -1,2 +1,12 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
## Summary

- Replaces the lock-held-during-HTTP pattern in `tokenManager.getToken()` with a shared-future pattern: the first goroutine to see an expired token launches a background refresh, and all concurrent callers wait on the same channel
- Each caller's context is respected for cancellation/timeout without killing the shared refresh for other waiters
- Adds 5 tests covering caching, concurrent sharing (20 goroutines → 1 HTTP call), context cancellation, error non-poisoning, and expiry-triggered refresh — all pass with `-race`

## Test plan

- [x] `go test -race -count=1 ./akashi/...` passes (9.6s, all green)
- [x] `TestGetToken_ConcurrentCallersShareOneRefresh` — 20 goroutines, 100ms server delay, exactly 1 HTTP call
- [x] `TestGetToken_CallerContextCancellation` — caller bails out via context while background refresh continues
- [x] `TestGetToken_RefreshErrorDoesNotPoison` — failed refresh doesn't permanently break the manager
- [x] No race conditions detected under `-race`

Fixes #556

> The Borg assimilate everything into a single shared consciousness —
> which, come to think of it, is exactly what a shared-future pattern does
> to twenty goroutines all demanding the same token. Resistance to mutex
> contention is, apparently, not futile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)