### PR TITLE
fix: add missing authorization check in HandleAssessDecision

### DIFF
--- a/internal/server/handlers_assessments.go
+++ b/internal/server/handlers_assessments.go
@@ -26,6 +26,26 @@ func (h *Handlers) HandleAssessDecision(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	// Verify the caller has access to the decision's agent before allowing assessment.
+	d, err := h.db.GetDecision(r.Context(), orgID, decisionID, storage.GetDecisionOpts{})
+	if err != nil {
+		if isNotFoundError(err) {
+			writeError(w, r, http.StatusNotFound, model.ErrCodeNotFound, "decision not found")
+			return
+		}
+		h.writeInternalError(w, r, "failed to get decision", err)
+		return
+	}
+	ok, err := canAccessAgent(r.Context(), h.db, claims, d.AgentID)
+	if err != nil {
+		h.writeInternalError(w, r, "authorization check failed", err)
+		return
+	}
+	if !ok {
+		writeError(w, r, http.StatusForbidden, model.ErrCodeForbidden, "no access to this decision")
+		return
+	}
+
 	var req model.AssessRequest
 	if err := decodeJSON(w, r, &req, h.maxRequestBodyBytes); err != nil {
 		handleDecodeError(w, r, err)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -5623,6 +5623,114 @@ func TestHandleAssessDecision_InvalidOutcome(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 }
 
+// ---- Coverage push: assess decision authorization ----
+
+func TestHandleAssessDecision_ForbiddenWithoutGrant(t *testing.T) {
+	// Create an agent that has no grants to admin's decisions.
+	agentID := fmt.Sprintf("assess-no-grant-%d", time.Now().UnixNano())
+	createAgent(testSrv.URL, adminToken, agentID, "Assess No Grant", "agent", agentID+"-key")
+	token := getToken(testSrv.URL, agentID, agentID+"-key")
+
+	// Create a decision as admin.
+	traceResp, err := authedRequest("POST", testSrv.URL+"/v1/trace", adminToken, model.TraceRequest{
+		AgentID: "admin",
+		Decision: model.TraceDecision{
+			DecisionType: "assess-authz-test",
+			Outcome:      "test outcome",
+			Confidence:   0.7,
+		},
+	})
+	require.NoError(t, err)
+	var traceResult struct {
+		Data struct {
+			DecisionID uuid.UUID `json:"decision_id"`
+		} `json:"data"`
+	}
+	b, _ := io.ReadAll(traceResp.Body)
+	_ = traceResp.Body.Close()
+	require.NoError(t, json.Unmarshal(b, &traceResult))
+
+	// Agent without grant tries to assess admin's decision — should be forbidden.
+	resp, err := authedRequest("POST", testSrv.URL+"/v1/decisions/"+traceResult.Data.DecisionID.String()+"/assess", token,
+		map[string]any{"outcome": "correct"})
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+}
+
+func TestHandleAssessDecision_OwnDecisionSucceeds(t *testing.T) {
+	// Agent traces a decision, then assesses it — should succeed.
+	traceResp, err := authedRequest("POST", testSrv.URL+"/v1/trace", agentToken, model.TraceRequest{
+		AgentID: "test-agent",
+		Decision: model.TraceDecision{
+			DecisionType: "assess-own-test",
+			Outcome:      "test outcome",
+			Confidence:   0.8,
+		},
+	})
+	require.NoError(t, err)
+	var traceResult struct {
+		Data struct {
+			DecisionID uuid.UUID `json:"decision_id"`
+		} `json:"data"`
+	}
+	b, _ := io.ReadAll(traceResp.Body)
+	_ = traceResp.Body.Close()
+	require.NoError(t, json.Unmarshal(b, &traceResult))
+
+	resp, err := authedRequest("POST", testSrv.URL+"/v1/decisions/"+traceResult.Data.DecisionID.String()+"/assess", agentToken,
+		map[string]any{"outcome": "correct"})
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestHandleAssessDecision_SucceedsWithGrant(t *testing.T) {
+	// Create a dedicated agent that will receive a grant.
+	granteeID := fmt.Sprintf("assess-grantee-%d", time.Now().UnixNano())
+	createAgent(testSrv.URL, adminToken, granteeID, "Assess Grantee", "agent", granteeID+"-key")
+	granteeToken := getToken(testSrv.URL, granteeID, granteeID+"-key")
+
+	// Create a decision as admin.
+	traceResp, err := authedRequest("POST", testSrv.URL+"/v1/trace", adminToken, model.TraceRequest{
+		AgentID: "admin",
+		Decision: model.TraceDecision{
+			DecisionType: "assess-grant-test",
+			Outcome:      "test outcome",
+			Confidence:   0.6,
+		},
+	})
+	require.NoError(t, err)
+	var traceResult struct {
+		Data struct {
+			DecisionID uuid.UUID `json:"decision_id"`
+		} `json:"data"`
+	}
+	b, _ := io.ReadAll(traceResp.Body)
+	_ = traceResp.Body.Close()
+	require.NoError(t, json.Unmarshal(b, &traceResult))
+
+	// Grant the agent access to admin's traces.
+	agentIDStr := "admin"
+	grantResp, err := authedRequest("POST", testSrv.URL+"/v1/grants", adminToken,
+		model.CreateGrantRequest{
+			GranteeAgentID: granteeID,
+			ResourceType:   "agent_traces",
+			ResourceID:     &agentIDStr,
+			Permission:     "read",
+		})
+	require.NoError(t, err)
+	defer func() { _ = grantResp.Body.Close() }()
+	require.Equal(t, http.StatusCreated, grantResp.StatusCode)
+
+	// Agent with grant assesses admin's decision — should succeed.
+	resp, err := authedRequest("POST", testSrv.URL+"/v1/decisions/"+traceResult.Data.DecisionID.String()+"/assess", granteeToken,
+		map[string]any{"outcome": "incorrect", "notes": "decision was wrong"})
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
 // ---- Coverage push: check endpoint ----
 
 func TestHandleCheck_MissingDecisionTypeField(t *testing.T) {


### PR DESCRIPTION
## Summary

- `HandleAssessDecision` (`POST /v1/decisions/{id}/assess`) enforced `writeRole` at the route level but never verified the caller has access to the decision's agent via `canAccessAgent`. Any agent with write permission could inject assessments for other agents' decisions, contaminating quality metrics.
- Added the same `canAccessAgent` authorization check already used by `HandleListAssessments`: fetch the decision, verify access to its agent, return 403 if denied.
- Added three test cases: agent assessing own decision (200), agent without grant assessing another's decision (403), agent with grant assessing another's decision (200).

Closes #607

## Test plan

- [x] `TestHandleAssessDecision_ForbiddenWithoutGrant` — agent without grant gets 403
- [x] `TestHandleAssessDecision_OwnDecisionSucceeds` — agent assessing own decision gets 200
- [x] `TestHandleAssessDecision_SucceedsWithGrant` — agent with grant gets 200
- [x] All existing assessment tests still pass
- [x] `go test -race -count=1 ./internal/server/` passes

> The Sorting Hat never had to deal with RBAC.
> It just *knew* — one look inside your head and you were placed.
> Meanwhile we're out here fetching decisions, checking grants,
> returning 403s, and wondering if Dumbledore ever ran `golangci-lint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)