### PR TITLE
fix: await background goroutines before closing DB pool on shutdown

### DIFF
--- a/akashi.go
+++ b/akashi.go
@@ -30,6 +30,7 @@ import (
 	"net/http"
 	"os"
 	"runtime/debug"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -80,6 +81,8 @@ type App struct {
 	logger          *slog.Logger
 	autoResolver    *autoresolve.Service
 	version         string
+
+	bgLoops sync.WaitGroup // tracks background goroutines for graceful shutdown
 
 	auditOrgCounter atomic.Uint64 // round-robin counter for integrity audit org selection
 
@@ -521,21 +524,34 @@ func (a *App) Run(ctx context.Context) error {
 		a.outbox.Start(ctx)
 	}
 	if a.broker != nil {
-		go a.broker.Start(ctx)
+		a.bgLoops.Add(1)
+		go func() {
+			defer a.bgLoops.Done()
+			a.broker.Start(ctx)
+		}()
 	}
 
-	// Background goroutines.
-	go a.conflictBackfillLoop(ctx)
-	go a.conflictRefreshLoop(ctx)
-	go a.integrityProofLoop(ctx)
-	go a.integrityAuditLoop(ctx)
-	go a.integrityFullAuditLoop(ctx)
-	go a.idempotencyCleanupLoop(ctx)
-	go a.hookCheckCleanupLoop(ctx)
-	go a.retentionLoop(ctx)
-	go a.claimEmbeddingRetryLoop(ctx)
-	go a.percentileRefreshLoop(ctx)
-	go a.autoResolveLoop(ctx)
+	// Background goroutines — all tracked by bgLoops so Shutdown can wait
+	// for them to exit before closing the database pool.
+	for _, fn := range []func(context.Context){
+		a.conflictBackfillLoop,
+		a.conflictRefreshLoop,
+		a.integrityProofLoop,
+		a.integrityAuditLoop,
+		a.integrityFullAuditLoop,
+		a.idempotencyCleanupLoop,
+		a.hookCheckCleanupLoop,
+		a.retentionLoop,
+		a.claimEmbeddingRetryLoop,
+		a.percentileRefreshLoop,
+		a.autoResolveLoop,
+	} {
+		a.bgLoops.Add(1)
+		go func() {
+			defer a.bgLoops.Done()
+			fn(ctx)
+		}()
+	}
 
 	// Start HTTP server.
 	errCh := make(chan error, 1)
@@ -606,6 +622,22 @@ func (a *App) Shutdown(ctx context.Context) error {
 		}
 		outboxCancel()
 	}
+
+	// Wait for background loops to exit. The Run() context was cancelled
+	// before Shutdown was called, so loops are draining. We bound the wait
+	// to avoid hanging on a stuck goroutine.
+	bgDone := make(chan struct{})
+	go func() { a.bgLoops.Wait(); close(bgDone) }()
+	loopCtx, loopCancel := contextWithOptionalTimeout(ctx, a.cfg.ShutdownLoopDrainTimeout)
+	select {
+	case <-bgDone:
+		a.logger.Info("all background loops exited")
+	case <-loopCtx.Done():
+		a.logger.Warn("background loops did not exit within timeout, proceeding with shutdown",
+			"configured_timeout", a.cfg.ShutdownLoopDrainTimeout,
+		)
+	}
+	loopCancel()
 
 	// Cleanup.
 	a.grantCache.Close()

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -193,6 +193,7 @@ Existing deployments that set `AKASHI_WAL_DIR` explicitly will continue to work 
 | `AKASHI_SHUTDOWN_ASYNC_DRAIN_TIMEOUT` | `30s` | Maximum time to drain in-flight post-trace async work (claim generation, conflict scoring) during shutdown. `0` = wait indefinitely |
 | `AKASHI_SHUTDOWN_BUFFER_DRAIN_TIMEOUT` | `30s` | Maximum time to flush in-memory events to Postgres during shutdown. `0` = wait indefinitely. The 30s default prevents process hang on unreachable database while giving the WAL time to recover unflushed events on restart. |
 | `AKASHI_SHUTDOWN_OUTBOX_DRAIN_TIMEOUT` | `0` | Outbox drain timeout (`0` = wait indefinitely) |
+| `AKASHI_SHUTDOWN_LOOP_DRAIN_TIMEOUT` | `10s` | Maximum time to wait for background loops (conflict backfill, retention, integrity audit, etc.) to exit during shutdown. `0` = wait indefinitely |
 | `AKASHI_PERCENTILE_REFRESH_INTERVAL` | `1h` | How often to refresh per-org signal percentile caches used for distribution-aware ReScore normalization. Set to `0` to disable |
 | `AKASHI_AUTO_RESOLVE_INTERVAL` | `1h` | How often the background auto-resolution worker runs to resolve eligible conflicts per org policy. Set to `0` to disable |
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -103,6 +103,7 @@ type Config struct {
 	ShutdownAsyncDrainTimeout     time.Duration // 0 disables timeout (wait indefinitely).
 	ShutdownBufferDrainTimeout    time.Duration // 0 disables timeout (wait indefinitely).
 	ShutdownOutboxDrainTimeout    time.Duration // 0 disables timeout (wait indefinitely).
+	ShutdownLoopDrainTimeout      time.Duration // 0 disables timeout (wait indefinitely).
 	IdempotencyCleanupInterval    time.Duration // Background cleanup cadence for idempotency keys.
 	IdempotencyCompletedTTL       time.Duration // Retention for completed idempotency records.
 	IdempotencyAbandonedTTL       time.Duration // Hard TTL for abandoned in-progress idempotency records.
@@ -251,6 +252,7 @@ func Load() (Config, error) {
 	cfg.ShutdownAsyncDrainTimeout, errs = collectDuration(errs, "AKASHI_SHUTDOWN_ASYNC_DRAIN_TIMEOUT", 30*time.Second)
 	cfg.ShutdownBufferDrainTimeout, errs = collectDuration(errs, "AKASHI_SHUTDOWN_BUFFER_DRAIN_TIMEOUT", 30*time.Second)
 	cfg.ShutdownOutboxDrainTimeout, errs = collectDuration(errs, "AKASHI_SHUTDOWN_OUTBOX_DRAIN_TIMEOUT", 0)
+	cfg.ShutdownLoopDrainTimeout, errs = collectDuration(errs, "AKASHI_SHUTDOWN_LOOP_DRAIN_TIMEOUT", 10*time.Second)
 	cfg.IdempotencyCleanupInterval, errs = collectDuration(errs, "AKASHI_IDEMPOTENCY_CLEANUP_INTERVAL", time.Hour)
 	cfg.IdempotencyCompletedTTL, errs = collectDuration(errs, "AKASHI_IDEMPOTENCY_COMPLETED_TTL", 7*24*time.Hour)
 	cfg.IdempotencyAbandonedTTL, errs = collectDuration(errs, "AKASHI_IDEMPOTENCY_ABANDONED_TTL", 24*time.Hour)
@@ -341,6 +343,9 @@ func (c Config) Validate() error {
 	}
 	if c.ShutdownOutboxDrainTimeout < 0 {
 		errs = append(errs, errors.New("config: AKASHI_SHUTDOWN_OUTBOX_DRAIN_TIMEOUT must be >= 0"))
+	}
+	if c.ShutdownLoopDrainTimeout < 0 {
+		errs = append(errs, errors.New("config: AKASHI_SHUTDOWN_LOOP_DRAIN_TIMEOUT must be >= 0"))
 	}
 	if c.IdempotencyCleanupInterval <= 0 {
 		errs = append(errs, errors.New("config: AKASHI_IDEMPOTENCY_CLEANUP_INTERVAL must be positive"))

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -571,6 +571,11 @@ func TestValidate_NegativeTimeouts(t *testing.T) {
 			setter: func(c *Config) { c.ShutdownOutboxDrainTimeout = -1 * time.Second },
 			errStr: "AKASHI_SHUTDOWN_OUTBOX_DRAIN_TIMEOUT",
 		},
+		{
+			name:   "negative shutdown loop drain timeout",
+			setter: func(c *Config) { c.ShutdownLoopDrainTimeout = -1 * time.Second },
+			errStr: "AKASHI_SHUTDOWN_LOOP_DRAIN_TIMEOUT",
+		},
 	}
 
 	for _, tt := range tests {
@@ -812,6 +817,7 @@ func validBaseConfig() Config {
 		ShutdownAsyncDrainTimeout:  30 * time.Second,
 		ShutdownBufferDrainTimeout: 30 * time.Second,
 		ShutdownOutboxDrainTimeout: 0,
+		ShutdownLoopDrainTimeout:   10 * time.Second,
 		OutboxPollInterval:         1 * time.Second,
 		ConflictRefreshInterval:    30 * time.Second,
 		IntegrityProofInterval:     5 * time.Minute,


### PR DESCRIPTION
## Summary

- Add `sync.WaitGroup` tracking for all 12 background goroutines (11 loops + SSE broker) started in `Run()`
- `Shutdown()` now waits for goroutines to exit before calling `db.Close()`, preventing connection-reset errors and incomplete operations when a goroutine is mid-query
- New `AKASHI_SHUTDOWN_LOOP_DRAIN_TIMEOUT` config (default 10s, `0` = wait indefinitely) bounds the wait so a stuck goroutine cannot hang shutdown
- Refactored loop launches into a table-driven pattern — adding a new background loop now requires adding one entry to the slice, making it impossible to forget the WaitGroup tracking

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] `atlas migrate validate` passes
- [x] Config validation tests pass (including new negative-timeout case)
- [ ] Full integration test suite (testcontainer failures on local machine are infra-related, not code-related)

Fixes #609

> The Borg assimilate civilizations in hours, but they never figured out
> graceful shutdown — just yank the vinculum and hope no drone is mid-query.
> Starfleet's `sync.WaitGroup` equivalent? "All hands, prepare for stand down."
> Picard waits for every department to report clear before powering down the warp core.
> That's the difference between collective efficiency and actual reliability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)