### PR TITLE
perf: eliminate double table scan on paginated decision queries

### DIFF
--- a/internal/storage/decisions.go
+++ b/internal/storage/decisions.go
@@ -564,13 +564,6 @@ func (db *DB) QueryDecisions(ctx context.Context, orgID uuid.UUID, req model.Que
 		where += fmt.Sprintf(" AND run_id IN (SELECT id FROM agent_runs WHERE trace_id = $%d AND org_id = $1)", len(args))
 	}
 
-	// Count total matching decisions.
-	countQuery := "SELECT COUNT(*) FROM decisions" + where
-	var total int
-	if err := db.pool.QueryRow(ctx, countQuery, args...).Scan(&total); err != nil {
-		return nil, 0, fmt.Errorf("storage: count decisions: %w", err)
-	}
-
 	// Build order clause.
 	orderBy := "valid_from"
 	if req.OrderBy != "" {
@@ -591,8 +584,10 @@ func (db *DB) QueryDecisions(ctx context.Context, orgID uuid.UUID, req model.Que
 
 	limit, offset := clampPagination(req.Limit, req.Offset, 50, 1000)
 
+	// Use COUNT(*) OVER() window function to get the total count alongside data
+	// rows in a single query, eliminating a separate COUNT(*) table scan.
 	selectQuery := fmt.Sprintf(
-		`SELECT %s FROM decisions%s ORDER BY %s %s LIMIT %d OFFSET %d`,
+		`SELECT %s, COUNT(*) OVER() FROM decisions%s ORDER BY %s %s LIMIT %d OFFSET %d`,
 		decisionCols, where, orderBy, orderDir, limit, offset,
 	)
 
@@ -602,7 +597,7 @@ func (db *DB) QueryDecisions(ctx context.Context, orgID uuid.UUID, req model.Que
 	}
 	defer rows.Close()
 
-	decisions, err := scanDecisions(rows)
+	decisions, total, err := scanDecisionsWithTotal(rows)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -843,13 +838,10 @@ func (db *DB) GetDecisionsByAgent(ctx context.Context, orgID uuid.UUID, agentID 
 
 	where, args := buildDecisionWhereClause(orgID, filters, 1, true)
 
-	var total int
-	if err := db.pool.QueryRow(ctx, "SELECT COUNT(*) FROM decisions"+where, args...).Scan(&total); err != nil {
-		return nil, 0, fmt.Errorf("storage: count agent decisions: %w", err)
-	}
-
+	// Use COUNT(*) OVER() window function to get the total count alongside data
+	// rows in a single query, eliminating a separate COUNT(*) table scan.
 	query := fmt.Sprintf(
-		`SELECT %s FROM decisions%s ORDER BY valid_from DESC LIMIT %d OFFSET %d`,
+		`SELECT %s, COUNT(*) OVER() FROM decisions%s ORDER BY valid_from DESC LIMIT %d OFFSET %d`,
 		decisionCols, where, limit, offset,
 	)
 
@@ -859,8 +851,7 @@ func (db *DB) GetDecisionsByAgent(ctx context.Context, orgID uuid.UUID, agentID 
 	}
 	defer rows.Close()
 
-	decisions, err := scanDecisions(rows)
-	return decisions, total, err
+	return scanDecisionsWithTotal(rows)
 }
 
 func buildDecisionWhereClause(orgID uuid.UUID, f model.QueryFilters, startArgIdx int, currentOnly bool) (string, []any) {
@@ -1224,6 +1215,33 @@ func scanDecisions(rows pgx.Rows) ([]model.Decision, error) {
 		decisions = append(decisions, d)
 	}
 	return decisions, rows.Err()
+}
+
+// scanDecisionsWithTotal scans rows that include a trailing COUNT(*) OVER()
+// column, returning the decisions and the total count in a single pass.
+// This avoids a separate COUNT query (double table scan) on paginated endpoints.
+func scanDecisionsWithTotal(rows pgx.Rows) ([]model.Decision, int, error) {
+	decisions := make([]model.Decision, 0)
+	var total int
+	for rows.Next() {
+		var d model.Decision
+		if err := rows.Scan(
+			&d.ID, &d.RunID, &d.AgentID, &d.OrgID, &d.DecisionType, &d.Outcome, &d.Confidence,
+			&d.Reasoning, &d.Metadata, &d.CompletenessScore, &d.OutcomeScore, &d.PrecedentRef,
+			&d.PrecedentReason, &d.SupersedesID, &d.ContentHash,
+			&d.ValidFrom, &d.ValidTo, &d.TransactionTime, &d.CreatedAt,
+			&d.SessionID, &d.AgentContext, &d.APIKeyID,
+			&d.Tool, &d.Model, &d.Project,
+			&total,
+		); err != nil {
+			return nil, 0, fmt.Errorf("storage: scan decision with total: %w", err)
+		}
+		decisions = append(decisions, d)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, err
+	}
+	return decisions, total, nil
 }
 
 // GetDecisionsByIDs returns active decisions for the given IDs within an org.

--- a/internal/storage/sqlite/decisions.go
+++ b/internal/storage/sqlite/decisions.go
@@ -264,16 +264,6 @@ const decisionCols = `id, run_id, agent_id, org_id, decision_type, outcome, conf
 func (l *LiteDB) QueryDecisions(ctx context.Context, orgID uuid.UUID, req model.QueryRequest) ([]model.Decision, int, error) {
 	where, args := buildDecisionWhere(orgID, req.Filters, req.TraceID)
 
-	// Count.
-	var total int
-	err := l.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM decisions "+where, args...).Scan(&total)
-	if err != nil {
-		return nil, 0, fmt.Errorf("sqlite: count decisions: %w", err)
-	}
-	if total == 0 {
-		return []model.Decision{}, 0, nil
-	}
-
 	// Order.
 	orderCol := "valid_from"
 	if req.OrderBy != "" {
@@ -293,7 +283,9 @@ func (l *LiteDB) QueryDecisions(ctx context.Context, orgID uuid.UUID, req model.
 		offset = 0
 	}
 
-	q := fmt.Sprintf("SELECT %s FROM decisions %s ORDER BY %s %s LIMIT ? OFFSET ?", //nolint:gosec // G201: interpolated values are sanitized constants
+	// Use COUNT(*) OVER() window function to get the total count alongside data
+	// rows in a single query, eliminating a separate COUNT(*) table scan.
+	q := fmt.Sprintf("SELECT %s, COUNT(*) OVER() FROM decisions %s ORDER BY %s %s LIMIT ? OFFSET ?", //nolint:gosec // G201: interpolated values are sanitized constants
 		decisionCols, where, orderCol, orderDir)
 	args = append(args, limit, offset)
 
@@ -303,7 +295,7 @@ func (l *LiteDB) QueryDecisions(ctx context.Context, orgID uuid.UUID, req model.
 	}
 	defer rows.Close() //nolint:errcheck
 
-	decisions, err := scanDecisionRows(rows)
+	decisions, total, err := scanDecisionRowsWithTotal(rows)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -799,6 +791,25 @@ func scanDecisionRows(rows *sql.Rows) ([]model.Decision, error) {
 	return decisions, nil
 }
 
+// scanDecisionRowsWithTotal scans rows that include a trailing COUNT(*) OVER()
+// column, returning the decisions and the total count in a single pass.
+func scanDecisionRowsWithTotal(rows *sql.Rows) ([]model.Decision, int, error) {
+	decisions := make([]model.Decision, 0)
+	var total int
+	for rows.Next() {
+		d, t, err := scanOneDecisionWithTotal(rows)
+		if err != nil {
+			return nil, 0, err
+		}
+		total = t
+		decisions = append(decisions, d)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("sqlite: decision rows: %w", err)
+	}
+	return decisions, total, nil
+}
+
 // rowScanner is satisfied by both *sql.Row and *sql.Rows.
 type rowScanner interface {
 	Scan(dest ...any) error
@@ -859,6 +870,66 @@ func scanOneDecision(row rowScanner) (model.Decision, error) {
 		d.Project = &project.String
 	}
 	return d, nil
+}
+
+// scanOneDecisionWithTotal scans the 25-column decisionCols plus a trailing
+// COUNT(*) OVER() total from a row.
+func scanOneDecisionWithTotal(row rowScanner) (model.Decision, int, error) {
+	var (
+		d            model.Decision
+		total        int
+		idStr        string
+		runIDStr     string
+		orgIDStr     string
+		metaJSON     sql.NullString
+		precedent    sql.NullString
+		supersedes   sql.NullString
+		validFromStr string
+		validToStr   sql.NullString
+		txTimeStr    string
+		createdStr   string
+		sessionStr   sql.NullString
+		ctxJSON      sql.NullString
+		apiKeyStr    sql.NullString
+		tool         sql.NullString
+		modelStr     sql.NullString
+		project      sql.NullString
+	)
+	err := row.Scan(&idStr, &runIDStr, &d.AgentID, &orgIDStr, &d.DecisionType,
+		&d.Outcome, &d.Confidence, &d.Reasoning, &metaJSON, &d.CompletenessScore,
+		&d.OutcomeScore, &precedent, &d.PrecedentReason, &supersedes, &d.ContentHash,
+		&validFromStr, &validToStr, &txTimeStr, &createdStr,
+		&sessionStr, &ctxJSON, &apiKeyStr, &tool, &modelStr, &project,
+		&total)
+	if err != nil {
+		return model.Decision{}, 0, fmt.Errorf("sqlite: scan decision with total: %w", err)
+	}
+
+	d.ID = parseUUID(idStr)
+	d.RunID = parseUUID(runIDStr)
+	d.OrgID = parseUUID(orgIDStr)
+	d.PrecedentRef = parseNullUUID(precedent)
+	d.SupersedesID = parseNullUUID(supersedes)
+	d.ValidFrom = parseTime(validFromStr)
+	d.ValidTo = parseNullTime(validToStr)
+	d.TransactionTime = parseTime(txTimeStr)
+	d.CreatedAt = parseTime(createdStr)
+	d.SessionID = parseNullUUID(sessionStr)
+	d.APIKeyID = parseNullUUID(apiKeyStr)
+	d.Metadata = map[string]any{}
+	_ = scanJSON(metaJSON, &d.Metadata)
+	d.AgentContext = map[string]any{}
+	_ = scanJSON(ctxJSON, &d.AgentContext)
+	if tool.Valid {
+		d.Tool = &tool.String
+	}
+	if modelStr.Valid {
+		d.Model = &modelStr.String
+	}
+	if project.Valid {
+		d.Project = &project.String
+	}
+	return d, total, nil
 }
 
 // ---- Batch loaders for alternatives and evidence ----


### PR DESCRIPTION
## Summary

- Replaces the separate `COUNT(*) + SELECT` two-query pattern with a single `COUNT(*) OVER()` window function in `QueryDecisions` and `GetDecisionsByAgent`
- Applied to both PostgreSQL and SQLite storage layers
- Adds `scanDecisionsWithTotal` scanner functions that handle the extra trailing column

Fixes #555

## Test plan

- [x] All existing SQLite `TestQueryDecisions*` and `TestGetDecisionsByAgent*` tests pass (50+ tests)
- [x] Full integration test suite passes with `-race`
- [x] `golangci-lint` clean, `go vet` clean

> The Enterprise-D's computer could answer any query in seconds,
> yet Starfleet still made Data run diagnostics twice — once to count
> the anomalies, once to describe them. Geordi would have filed this
> exact bug report.