### PR TITLE
perf: parallelize Qdrant queries in ConsensusScoresBatch

### DIFF
--- a/internal/service/decisions/helpers_test.go
+++ b/internal/service/decisions/helpers_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"math"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -513,7 +514,7 @@ type mockSearcher struct {
 	healthy       error
 	findResults   []search.Result
 	findErr       error
-	findCallCount int
+	findCallCount atomic.Int32
 }
 
 func (m *mockSearcher) Search(_ context.Context, _ uuid.UUID, _ []float32, _ model.QueryFilters, _ int) ([]search.Result, error) {
@@ -525,7 +526,7 @@ func (m *mockSearcher) Healthy(_ context.Context) error {
 }
 
 func (m *mockSearcher) FindSimilar(_ context.Context, _ uuid.UUID, _ []float32, _ uuid.UUID, _ []string, _ int) ([]search.Result, error) {
-	m.findCallCount++
+	m.findCallCount.Add(1)
 	return m.findResults, m.findErr
 }
 

--- a/internal/service/decisions/service.go
+++ b/internal/service/decisions/service.go
@@ -22,6 +22,8 @@ import (
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/ashita-ai/akashi/internal/conflicts"
 	"github.com/ashita-ai/akashi/internal/ctxutil"
 	"github.com/ashita-ai/akashi/internal/model"
@@ -818,20 +820,34 @@ func (s *Service) ConsensusScoresBatch(ctx context.Context, ids []uuid.UUID, org
 		return result, nil //nolint:nilerr
 	}
 
-	// Per-decision Qdrant queries. Collect all neighbor IDs for a single batch
-	// Postgres fetch, avoiding N+1 embedding lookups.
+	// Per-decision Qdrant queries, parallelized with bounded concurrency.
+	// Collect all neighbor IDs for a single batch Postgres fetch, avoiding
+	// N+1 embedding lookups.
 	neighborResultsByID := make(map[uuid.UUID][]search.Result, len(embMap))
 	allNeighborIDs := make(map[uuid.UUID]struct{})
+	var mu sync.Mutex
+
+	g, gCtx := errgroup.WithContext(ctx)
+	g.SetLimit(10) // bound concurrent Qdrant RPCs
+
 	for id, embs := range embMap {
-		results, qErr := cf.FindSimilar(ctx, orgID, embs[0].Slice(), id, nil, 50)
-		if qErr != nil {
-			s.logger.Warn("consensus batch: qdrant find similar failed", "decision_id", id, "error", qErr)
-			continue
-		}
-		neighborResultsByID[id] = results
-		for _, r := range results {
-			allNeighborIDs[r.DecisionID] = struct{}{}
-		}
+		g.Go(func() error {
+			results, qErr := cf.FindSimilar(gCtx, orgID, embs[0].Slice(), id, nil, 50)
+			if qErr != nil {
+				s.logger.Warn("consensus batch: qdrant find similar failed", "decision_id", id, "error", qErr)
+				return nil // non-fatal: skip this decision
+			}
+			mu.Lock()
+			neighborResultsByID[id] = results
+			for _, r := range results {
+				allNeighborIDs[r.DecisionID] = struct{}{}
+			}
+			mu.Unlock()
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return result, nil //nolint:nilerr // Qdrant errors are non-fatal for consensus
 	}
 
 	if len(allNeighborIDs) == 0 {


### PR DESCRIPTION
## Summary
- Replaces sequential `FindSimilar` Qdrant RPCs in `ConsensusScoresBatch` with `errgroup` bounded to 10 concurrent workers
- Reduces wall-clock latency from sum-of-all-queries to max-of-any-single-query (expected 5-15x improvement for typical batch sizes)
- Fixes test mock data race: `findCallCount` is now `atomic.Int32` to satisfy `-race`

## Test plan
- [x] `go test -race -count=1 ./internal/service/decisions/` — all pass
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] `atlas migrate validate` — clean

Fixes #553

> Warp 9, Mr. Sulu — because sending one hail at a time to Qdrant
> is the kind of sequential thinking that got the *Reliant* hijacked.
> Scotty would've parallelized those sensor sweeps from day one.