### PR TITLE
fix: add missing (org_id, created_at) index on decisions

### DIFF
--- a/migrations/090_decisions_org_created_index.sql
+++ b/migrations/090_decisions_org_created_index.sql
@@ -1,0 +1,4 @@
+-- 090: Add composite index on decisions(org_id, created_at) for integrity proof
+-- batch queries and any future retention queries that filter by physical write time.
+CREATE INDEX IF NOT EXISTS idx_decisions_org_created
+    ON decisions (org_id, created_at);

--- a/migrations/atlas.sum
+++ b/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:XC7kvDLB7rI8sYcE6tLKhk46x5WQVx7Wp+VJmxurryc=
+h1:4x5tjM1y9iC2s5ga4zbxOiCNC/4uRSBstm2Ah6PyyFQ=
 001_initial.sql h1:uhyGXto+QacAaGYb9ZTGjsBs5chlKi8O0eHz9aCQsrY=
 022_full_text_search.sql h1:9iwtA8MgCzAxDV9YkUBn0CLT9ePSmj3GcPoMGg8TXf0=
 023_fix_outbox_index.sql h1:OtMEFBcMRWej02+ghnBXlPr6BVq+LoA62Id9XUWfDNI=
@@ -68,3 +68,4 @@ h1:XC7kvDLB7rI8sYcE6tLKhk46x5WQVx7Wp+VJmxurryc=
 087_project_links_alias_index.sql h1:WytNkji711Eeko6Ijz9l1X0ZXOQh5RhidjDBSZf1UMY=
 088_unique_alias_per_project.sql h1:UY1u6IycabSjhWDRK9RDohqwSz/yDLgwQBwDWiRrSx8=
 089_fix_conflict_resolutions_trigger_and_proof_leaves_fk.sql h1:V4I0KLXGHcL24yvmbRd3Iei5yXDAYiL6xWYYKb5jMjA=
+090_decisions_org_created_index.sql h1:aCp2CB1qWHe7Jokn6EWlK8roQ9G6V2ck0XDTwNIuAeY=


### PR DESCRIPTION
## Summary

- Adds migration 090: composite index `idx_decisions_org_created` on `decisions(org_id, created_at)`
- Fixes sequential scans in the integrity proof batch query (`storage/integrity.go:159`) which filters by `org_id` and `created_at` but had no covering index — existing org indexes all use `valid_from`

## Test plan

- [x] All existing tests pass (`go test -race -count=1 ./...`)
- [x] Atlas migration validates cleanly
- [x] Pre-commit checks (build, vet, lint) all green

Closes #507

> Spock would note the logical inconsistency: you built an integrity proof system
> to detect tampering at scale, then neglected the index that lets it run at scale.
> "Fascinating," he'd say, one eyebrow raised — not at the oversight, but at how
> long it took a human to notice what any Vulcan would have caught in the first draft.