### PR TITLE
fix: surface auth errors and accept Date in TS temporalQuery

### DIFF
--- a/sdk/python/src/akashi/auth.py
+++ b/sdk/python/src/akashi/auth.py
@@ -11,6 +11,23 @@ from datetime import datetime, timezone
 import httpx
 
 
+def _raise_auth_error(resp: httpx.Response) -> None:
+    """Raise on non-2xx auth responses, surfacing the server's error message."""
+    if resp.is_success:
+        return
+    detail = ""
+    try:
+        detail = resp.json().get("error", {}).get("message", "")
+    except Exception:
+        pass
+    msg = detail or resp.reason_phrase or str(resp.status_code)
+    raise httpx.HTTPStatusError(
+        f"Token refresh failed ({resp.status_code}): {msg}",
+        request=resp.request,
+        response=resp,
+    )
+
+
 @dataclass
 class TokenManager:
     """Manages JWT token lifecycle with automatic refresh.
@@ -71,7 +88,7 @@ class TokenManager:
             f"{self.base_url}/auth/token",
             json={"agent_id": self.agent_id, "api_key": self.api_key},
         )
-        resp.raise_for_status()
+        _raise_auth_error(resp)
         self._apply_token_response(resp.json()["data"])
 
     def _refresh_sync(self, client: httpx.Client) -> None:
@@ -79,5 +96,5 @@ class TokenManager:
             f"{self.base_url}/auth/token",
             json={"agent_id": self.agent_id, "api_key": self.api_key},
         )
-        resp.raise_for_status()
+        _raise_auth_error(resp)
         self._apply_token_response(resp.json()["data"])

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -910,6 +910,25 @@ class TestErrorMapping:
                 client.check("test")
 
 
+class TestAuthErrorExtraction:
+    @respx.mock
+    def test_auth_failure_surfaces_server_message(self) -> None:
+        respx.post(f"{BASE_URL}/auth/token").respond(
+            401,
+            json={"error": {"message": "invalid api key"}},
+        )
+        with _make_client() as client:
+            with pytest.raises(httpx.HTTPStatusError, match="invalid api key"):
+                client.check("test")
+
+    @respx.mock
+    def test_auth_failure_falls_back_without_message(self) -> None:
+        respx.post(f"{BASE_URL}/auth/token").respond(401, json={})
+        with _make_client() as client:
+            with pytest.raises(httpx.HTTPStatusError, match="401"):
+                client.check("test")
+
+
 class TestMiddleware:
     @respx.mock
     def test_sync_middleware_check_then_trace(self) -> None:

--- a/sdk/typescript/src/auth.ts
+++ b/sdk/typescript/src/auth.ts
@@ -58,7 +58,19 @@ export class TokenManager {
     });
 
     if (!resp.ok) {
-      throw new Error(`Token refresh failed: ${resp.status}`);
+      let detail = "";
+      try {
+        const errBody = (await resp.json()) as {
+          error?: { message?: string };
+        };
+        if (errBody.error?.message) {
+          detail = errBody.error.message;
+        }
+      } catch {
+        // Response may not be JSON; fall through to status-only message.
+      }
+      const suffix = detail || resp.statusText || String(resp.status);
+      throw new Error(`Token refresh failed (${resp.status}): ${suffix}`);
     }
 
     const body = (await resp.json()) as {

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -244,10 +244,12 @@ function buildCompleteRunBody(
 }
 
 function buildTemporalQueryBody(
-  asOf: string,
+  asOf: string | Date,
   filters?: QueryFilters,
 ): Record<string, unknown> {
-  const body: Record<string, unknown> = { as_of: asOf };
+  const body: Record<string, unknown> = {
+    as_of: asOf instanceof Date ? asOf.toISOString() : asOf,
+  };
   if (filters !== undefined) body.filters = filters;
   return body;
 }
@@ -652,7 +654,7 @@ export class AkashiClient {
 
   /** Query decisions as of a specific point in time. */
   async temporalQuery(
-    asOf: string,
+    asOf: string | Date,
     filters?: QueryFilters,
   ): Promise<Decision[]> {
     return this.post<Decision[]>(

--- a/sdk/typescript/tests/client.test.ts
+++ b/sdk/typescript/tests/client.test.ts
@@ -152,6 +152,48 @@ describe("AkashiClient", () => {
       );
       expect(tokenCalls).toHaveLength(1);
     });
+
+    it("surfaces server error message on auth failure", async () => {
+      // Reset the client so no cached token exists.
+      client = new AkashiClient({
+        baseUrl: "http://localhost:8080",
+        agentId: "test-agent",
+        apiKey: "test-key",
+      });
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        statusText: "Unauthorized",
+        headers: mockHeaders(),
+        json: () =>
+          Promise.resolve({ error: { message: "invalid api key" } }),
+      } as Response);
+
+      await expect(client.check("x")).rejects.toThrow(
+        "Token refresh failed (401): invalid api key",
+      );
+    });
+
+    it("falls back to statusText when auth error body has no message", async () => {
+      client = new AkashiClient({
+        baseUrl: "http://localhost:8080",
+        agentId: "test-agent",
+        apiKey: "test-key",
+      });
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        statusText: "Service Unavailable",
+        headers: mockHeaders(),
+        json: () => Promise.resolve({}),
+      } as Response);
+
+      await expect(client.check("x")).rejects.toThrow(
+        "Token refresh failed (503): Service Unavailable",
+      );
+    });
   });
 
   describe("check", () => {
@@ -972,6 +1014,17 @@ describe("AkashiClient", () => {
       const body = JSON.parse(lastCall[1].body);
       expect(body).toEqual({ as_of: "2024-06-01T00:00:00Z" });
       expect(body.filters).toBeUndefined();
+    });
+
+    it("accepts a Date object and converts to ISO string", async () => {
+      mockFetch.mockResolvedValueOnce(mockResponse(200, { data: [] }));
+
+      const date = new Date("2024-06-01T12:00:00.000Z");
+      await client.temporalQuery(date);
+
+      const lastCall = mockFetch.mock.calls[mockFetch.mock.calls.length - 1];
+      const body = JSON.parse(lastCall[1].body);
+      expect(body.as_of).toBe("2024-06-01T12:00:00.000Z");
     });
   });
 


### PR DESCRIPTION
## Summary

- TypeScript `temporalQuery` now accepts `string | Date`, matching Go (`time.Time`) and Python (`datetime`) for cross-SDK consistency
- Python and TypeScript auth token refresh now extracts the server's JSON error message instead of returning bare status codes (e.g. `"Token refresh failed (401): invalid api key"` instead of `"Token refresh failed: 401"`)
- Added tests for both fixes in TypeScript (vitest) and Python (pytest)

Closes #610

## Test plan

- [x] TypeScript SDK: 72/72 tests pass (`npx vitest run`)
- [x] Go SDK: tests pass (`go test ./...`)
- [ ] Python SDK: tests added but local Python 3.9 lacks `X | None` syntax for existing code — CI (Python 3.10+) will validate
- [ ] Verify auth error messages surface correctly in integration environment

> In the Mirror Dimension, Strange could fold space but never time —
> he needed the Eye of Agamotto for that. These SDKs had the same blind spot:
> TypeScript could query decisions but couldn't fold a `Date` into one.
> Now all three clients bend time the same way, no Infinity Stone required.