### PR TITLE
feat: add /readyz readiness probe endpoint

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2391,6 +2391,30 @@ paths:
               schema:
                 $ref: "#/components/schemas/APIResponse_HealthResponse"
 
+  /readyz:
+    get:
+      operationId: readinessCheck
+      tags: [System]
+      summary: Readiness probe
+      description: |
+        Returns whether the server is ready to accept traffic. Checks database
+        connectivity and (if configured) Qdrant reachability. Intended for
+        Kubernetes readiness probes and load-balancer health checks.
+      security: []
+      responses:
+        "200":
+          description: All dependency checks passed — server is ready.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/APIResponse_ReadyzResponse"
+        "503":
+          description: One or more dependency checks failed — server is not ready.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/APIResponse_ReadyzResponse"
+
   # ── Org Settings ──────────────────────────────────────────────────
   /v1/org/settings:
     get:
@@ -4071,6 +4095,19 @@ components:
           type: integer
           format: int64
 
+    ReadyzResponse:
+      type: object
+      required: [status, checks]
+      properties:
+        status:
+          type: string
+          enum: [ready, not_ready]
+        checks:
+          type: object
+          additionalProperties:
+            type: string
+          description: Per-dependency status (e.g. postgres, qdrant).
+
     # ── Inline response wrappers ─────────────────────────────────────
     # These represent the `data` field contents in APIResponse envelopes.
 
@@ -4710,6 +4747,15 @@ components:
       properties:
         data:
           $ref: "#/components/schemas/HealthResponse"
+        meta:
+          $ref: "#/components/schemas/ResponseMeta"
+
+    APIResponse_ReadyzResponse:
+      type: object
+      required: [data, meta]
+      properties:
+        data:
+          $ref: "#/components/schemas/ReadyzResponse"
         meta:
           $ref: "#/components/schemas/ResponseMeta"
 

--- a/internal/model/api.go
+++ b/internal/model/api.go
@@ -387,6 +387,12 @@ type HealthResponse struct {
 	Uptime       int64  `json:"uptime_seconds"`
 }
 
+// ReadyzResponse is the response for GET /readyz.
+type ReadyzResponse struct {
+	Status string            `json:"status"` // "ready" or "not_ready"
+	Checks map[string]string `json:"checks"` // per-dependency status
+}
+
 // Organization represents a tenant in the multi-tenancy model.
 type Organization struct {
 	ID        uuid.UUID `json:"id"`

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -401,6 +401,43 @@ func (h *Handlers) HandleHealth(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, r, httpStatus, resp)
 }
 
+// HandleReadyz handles GET /readyz — a readiness probe for orchestrators.
+// Unlike /health (liveness), this returns 503 if any dependency required to
+// serve requests is unreachable, signalling that traffic should not be routed
+// to this instance.
+func (h *Handlers) HandleReadyz(w http.ResponseWriter, r *http.Request) {
+	checks := map[string]string{}
+	ready := true
+
+	if err := h.db.Ping(r.Context()); err != nil {
+		checks["postgres"] = "disconnected"
+		ready = false
+	} else {
+		checks["postgres"] = "connected"
+	}
+
+	if h.searcher != nil {
+		if err := h.searcher.Healthy(r.Context()); err != nil {
+			checks["qdrant"] = "disconnected"
+			ready = false
+		} else {
+			checks["qdrant"] = "connected"
+		}
+	}
+
+	status := "ready"
+	httpStatus := http.StatusOK
+	if !ready {
+		status = "not_ready"
+		httpStatus = http.StatusServiceUnavailable
+	}
+
+	writeJSON(w, r, httpStatus, model.ReadyzResponse{
+		Status: status,
+		Checks: checks,
+	})
+}
+
 // HandleMCPInfo handles GET /mcp/info (unauthenticated).
 // Returns static metadata about the MCP endpoint so clients can confirm
 // connectivity and discover supported auth schemes before adding credentials

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -275,8 +275,9 @@ func New(cfg ServerConfig) *Server {
 	// Config (no auth — feature flags for UI).
 	mux.HandleFunc("GET /config", h.HandleConfig)
 
-	// Health (no auth).
+	// Health & readiness (no auth).
 	mux.HandleFunc("GET /health", h.HandleHealth)
+	mux.HandleFunc("GET /readyz", h.HandleReadyz)
 
 	// MCP info (no auth) — lets clients confirm connectivity and discover auth schemes.
 	mux.HandleFunc("GET /mcp/info", h.HandleMCPInfo)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -275,6 +275,23 @@ func TestHealthEndpoint(t *testing.T) {
 	assert.Equal(t, "connected", result.Data.Postgres)
 }
 
+func TestReadyzEndpoint(t *testing.T) {
+	t.Run("ready when database is reachable", func(t *testing.T) {
+		resp, err := http.Get(testSrv.URL + "/readyz")
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var result struct {
+			Data model.ReadyzResponse `json:"data"`
+		}
+		data, _ := io.ReadAll(resp.Body)
+		require.NoError(t, json.Unmarshal(data, &result))
+		assert.Equal(t, "ready", result.Data.Status)
+		assert.Equal(t, "connected", result.Data.Checks["postgres"])
+	})
+}
+
 func TestSecurityHeaders(t *testing.T) {
 	resp, err := http.Get(testSrv.URL + "/health")
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

- Adds `GET /readyz` (no auth) that checks Postgres connectivity and Qdrant reachability
- Returns `200 {"status":"ready","checks":{...}}` when all dependencies are up
- Returns `503 {"status":"not_ready","checks":{...}}` with per-check detail when any dependency fails
- Includes OpenAPI spec and test coverage

## Design

Separate from `/health` (liveness) by intent: `/readyz` answers the binary gate question "can this instance serve requests?" while `/health` reports operational telemetry (buffer depth, uptime, version). Orchestrators use `/readyz` to stop routing traffic; they use `/health` to decide whether to restart.

## Test plan

- [x] `TestReadyzEndpoint` — verifies 200 with `ready` status and `postgres: connected` when DB is reachable
- [x] Full test suite passes with `-race -count=1`
- [x] `golangci-lint run` clean
- [ ] Manual: stop Postgres, confirm 503 with `postgres: disconnected`
- [ ] Manual: stop Qdrant, confirm 503 with `qdrant: disconnected`

Closes #412

> The transporter doesn't care if you're ready —
> it only asks if your pattern buffer is locked.
> Readiness is the ship's question, not the crew's.
> Scotty knew the difference; that's why he never beamed anyone into a wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)