### PR TITLE
fix: reduce akashi_check call frequency and skip gate for empty projects

### DIFF
--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -22,9 +22,9 @@ import (
 // without requiring per-project configuration (CLAUDE.md, agents.md, etc.).
 const serverInstructions = `You have access to Akashi, a decision audit trail for AI agents.
 
-WORKFLOW — follow this for every non-trivial decision:
+WORKFLOW — follow this for architecture, design, and trade-off decisions:
 
-1. BEFORE deciding: call akashi_check to look for prior decisions and active conflicts.
+1. BEFORE making an architecture, design, trade-off, or security decision: call akashi_check to look for prior decisions and active conflicts.
    Pass a natural language query describing what you're about to decide. Use the results
    to avoid contradicting prior work and to cite relevant precedents.
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -29,11 +29,16 @@ func (s *Server) registerTools() {
 		mcplib.NewTool("akashi_check",
 			mcplib.WithDescription(`Check the black box for decision precedents before making a new one.
 
-WHEN TO USE: BEFORE making any decision. This is the most important tool —
-it prevents contradictions and lets you build on prior work.
+WHEN TO USE: Before architecture, design, trade-off, or security decisions —
+choices where contradicting a prior decision would cause real damage.
 
-Call this FIRST. Pass a natural language query describing what you're about
-to decide, and optionally narrow by decision_type. If the audit trail shows
+DO NOT CALL for mechanical changes (formatting, typo fixes, renaming,
+test updates), pure implementation of an already-decided approach, or
+reading/exploring code. The IDE hook gate handles edit permissions
+automatically — you do not need to call this tool just to unlock edits.
+
+Pass a natural language query describing what you're about to decide,
+and optionally narrow by decision_type. If the audit trail shows
 precedents, factor them into your reasoning. If conflicts exist, resolve them.
 
 WHAT YOU GET BACK:

--- a/internal/server/handlers_hooks.go
+++ b/internal/server/handlers_hooks.go
@@ -33,14 +33,18 @@ const hookMaxBodyBytes int64 = 256 << 10
 // supply an agent_id (e.g. legacy hook scripts), IsAnyRecent provides a
 // backwards-compatible fallback that behaves like the old global timestamp.
 type hookCheckStore struct {
-	mu     sync.RWMutex
-	checks map[string]time.Time // agent_id → last check time
+	mu            sync.RWMutex
+	checks        map[string]time.Time // agent_id → last check time
+	emptyProjects map[string]time.Time // project → marked-at time (0 decisions + 0 conflicts)
 }
 
 const hookCheckTTL = 10 * time.Minute
 
 func newHookCheckStore() *hookCheckStore {
-	return &hookCheckStore{checks: make(map[string]time.Time)}
+	return &hookCheckStore{
+		checks:        make(map[string]time.Time),
+		emptyProjects: make(map[string]time.Time),
+	}
 }
 
 // Record stores a check timestamp for the given agent.
@@ -76,7 +80,7 @@ func (s *hookCheckStore) IsAnyRecent() bool {
 	return false
 }
 
-// Cleanup evicts expired entries from the map.
+// Cleanup evicts expired entries from both maps.
 func (s *hookCheckStore) Cleanup() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -85,6 +89,46 @@ func (s *hookCheckStore) Cleanup() {
 			delete(s.checks, id)
 		}
 	}
+	for project, t := range s.emptyProjects {
+		if time.Since(t) >= hookCheckTTL {
+			delete(s.emptyProjects, project)
+		}
+	}
+}
+
+// MarkProjectEmpty records that a project has no decisions or conflicts.
+// Called during SessionStart when the project's audit trail is empty.
+func (s *hookCheckStore) MarkProjectEmpty(project string) {
+	if project == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.emptyProjects[project] = time.Now()
+}
+
+// IsProjectEmpty returns true if the project was marked as having no decisions
+// or conflicts within the TTL window. Empty projects skip the edit gate since
+// there is nothing to check against.
+func (s *hookCheckStore) IsProjectEmpty(project string) bool {
+	if project == "" {
+		return false
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	t, ok := s.emptyProjects[project]
+	return ok && time.Since(t) < hookCheckTTL
+}
+
+// ClearProjectEmpty removes the empty marker for a project. Called when a
+// decision is traced, so the edit gate re-engages for future checks.
+func (s *hookCheckStore) ClearProjectEmpty(project string) {
+	if project == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.emptyProjects, project)
 }
 
 // hookSessionStartInput is the JSON body sent by Claude Code / Cursor on SessionStart.
@@ -175,6 +219,7 @@ func (h *Handlers) HandleHookPreToolUse(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	// Fast path: in-memory check before shelling out to git.
 	allowed := false
 	if input.AgentID != "" {
 		allowed = h.hookChecks.IsRecent(input.AgentID)
@@ -184,6 +229,15 @@ func (h *Handlers) HandleHookPreToolUse(w http.ResponseWriter, r *http.Request) 
 		allowed = h.hookChecks.IsAnyRecent()
 	}
 	if allowed {
+		writeHookJSON(w, hookResponse{Continue: true, SuppressOutput: true})
+		return
+	}
+
+	// Short-circuit: if the project has no decision history, don't gate edits.
+	// The empty marker is set during SessionStart and cleared on first trace.
+	// This check comes after IsRecent because inferProjectFromCWD spawns a
+	// git subprocess, whereas IsRecent is a pure map lookup.
+	if project := inferProjectFromCWD(input.CWD); h.hookChecks.IsProjectEmpty(project) {
 		writeHookJSON(w, hookResponse{Continue: true, SuppressOutput: true})
 		return
 	}
@@ -209,6 +263,12 @@ func (h *Handlers) HandleHookPostToolUse(w http.ResponseWriter, r *http.Request)
 	switch {
 	case isAkashiTool(input.ToolName):
 		h.hookChecks.Record(input.AgentID)
+		// If a decision was just traced, the project is no longer empty.
+		if strings.Contains(input.ToolName, "trace") {
+			if project := inferProjectFromCWD(input.CWD); project != "" {
+				h.hookChecks.ClearProjectEmpty(project)
+			}
+		}
 		writeHookJSON(w, hookResponse{Continue: true, SuppressOutput: true})
 
 	case isBashTool(input.ToolName) && isGitCommit(input.ToolInput):
@@ -318,6 +378,8 @@ func (h *Handlers) autoTraceCommit(input hookPostToolUseInput, commitMsg string)
 
 	if _, err := h.decisionSvc.Trace(ctx, orgID, traceInput); err != nil {
 		h.logger.Warn("auto-trace failed", "error", err, "commit", truncateHook(commitMsg, 60))
+	} else {
+		h.hookChecks.ClearProjectEmpty(project)
 	}
 }
 
@@ -440,6 +502,16 @@ func (h *Handlers) buildSessionContext(ctx context.Context, project string) stri
 		conflicts = nil
 	}
 
+	// Track whether this project has any decision history.
+	// Empty projects get a relaxed edit gate in HandleHookPreToolUse.
+	if project != "" {
+		if len(recent) == 0 && len(conflicts) == 0 {
+			h.hookChecks.MarkProjectEmpty(project)
+		} else {
+			h.hookChecks.ClearProjectEmpty(project)
+		}
+	}
+
 	// Build header.
 	if project != "" {
 		parts = append(parts, fmt.Sprintf("[akashi] Project: %s | %d recent decisions | %d open conflicts",
@@ -477,7 +549,7 @@ func (h *Handlers) buildSessionContext(ctx context.Context, project string) stri
 		}
 	}
 
-	parts = append(parts, "\nCall akashi_check before decisions. Call akashi_trace after.")
+	parts = append(parts, "\nCall akashi_check before architecture/design decisions. Call akashi_trace after.")
 	return strings.Join(parts, "\n")
 }
 

--- a/internal/server/handlers_hooks_test.go
+++ b/internal/server/handlers_hooks_test.go
@@ -508,6 +508,112 @@ func TestHelpers(t *testing.T) {
 	})
 }
 
+func TestHookCheckStore_EmptyProjects(t *testing.T) {
+	t.Run("empty string project is ignored", func(t *testing.T) {
+		s := newHookCheckStore()
+		s.MarkProjectEmpty("")
+		assert.False(t, s.IsProjectEmpty(""))
+	})
+
+	t.Run("mark and check", func(t *testing.T) {
+		s := newHookCheckStore()
+		s.MarkProjectEmpty("myproject")
+		assert.True(t, s.IsProjectEmpty("myproject"))
+		assert.False(t, s.IsProjectEmpty("other"))
+	})
+
+	t.Run("clear removes marker", func(t *testing.T) {
+		s := newHookCheckStore()
+		s.MarkProjectEmpty("myproject")
+		s.ClearProjectEmpty("myproject")
+		assert.False(t, s.IsProjectEmpty("myproject"))
+	})
+
+	t.Run("clear on non-existent project is safe", func(t *testing.T) {
+		s := newHookCheckStore()
+		s.ClearProjectEmpty("never-marked") // must not panic
+		assert.False(t, s.IsProjectEmpty("never-marked"))
+	})
+
+	t.Run("clear empty string is safe", func(t *testing.T) {
+		s := newHookCheckStore()
+		s.ClearProjectEmpty("") // must not panic
+	})
+
+	t.Run("cleanup evicts expired empty-project entries", func(t *testing.T) {
+		s := newHookCheckStore()
+		s.mu.Lock()
+		s.emptyProjects["stale"] = time.Now().Add(-hookCheckTTL - time.Second)
+		s.emptyProjects["fresh"] = time.Now()
+		s.mu.Unlock()
+
+		s.Cleanup()
+
+		assert.False(t, s.IsProjectEmpty("stale"), "expired entry should be evicted")
+		assert.True(t, s.IsProjectEmpty("fresh"), "unexpired entry should survive")
+	})
+
+	t.Run("expired entry returns false from IsProjectEmpty", func(t *testing.T) {
+		s := newHookCheckStore()
+		s.mu.Lock()
+		s.emptyProjects["old"] = time.Now().Add(-hookCheckTTL - time.Second)
+		s.mu.Unlock()
+
+		assert.False(t, s.IsProjectEmpty("old"), "entry past TTL should not count as empty")
+	})
+}
+
+func TestHandleHookPreToolUse_EmptyProjectBypass(t *testing.T) {
+	t.Run("edit allowed for empty project without check", func(t *testing.T) {
+		h := &Handlers{hookChecks: newHookCheckStore()}
+		// Mark the project that /tmp resolves to as empty.
+		project := inferProjectFromCWD("/tmp")
+		h.hookChecks.MarkProjectEmpty(project)
+
+		body := `{"session_id":"sess-1","agent_id":"agent-a","tool_name":"Edit","tool_input":{},"cwd":"/tmp"}`
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("POST", "/hooks/pre-tool-use", strings.NewReader(body))
+		h.HandleHookPreToolUse(rec, req)
+
+		var resp hookResponse
+		require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+		assert.True(t, resp.Continue, "edit should be allowed for empty project")
+		assert.True(t, resp.SuppressOutput)
+	})
+
+	t.Run("edit still gated for non-empty project", func(t *testing.T) {
+		h := &Handlers{hookChecks: newHookCheckStore()}
+		// Do NOT mark the project as empty — gate should still apply.
+		body := `{"session_id":"sess-1","agent_id":"agent-a","tool_name":"Edit","tool_input":{},"cwd":"/tmp"}`
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("POST", "/hooks/pre-tool-use", strings.NewReader(body))
+		h.HandleHookPreToolUse(rec, req)
+
+		var resp hookResponse
+		require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+		require.NotNil(t, resp.HookSpecificOutput)
+		assert.Equal(t, "deny", resp.HookSpecificOutput.PermissionDecision)
+	})
+}
+
+func TestHandleHookPostToolUse_TraceClearsEmptyProject(t *testing.T) {
+	h := &Handlers{hookChecks: newHookCheckStore()}
+	project := inferProjectFromCWD("/tmp")
+	h.hookChecks.MarkProjectEmpty(project)
+	assert.True(t, h.hookChecks.IsProjectEmpty(project), "precondition: project should be empty")
+
+	body := `{"session_id":"sess-1","agent_id":"agent-a","tool_name":"mcp__akashi__akashi_trace","tool_input":{},"cwd":"/tmp"}`
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/hooks/post-tool-use", strings.NewReader(body))
+	h.HandleHookPostToolUse(rec, req)
+
+	assert.False(t, h.hookChecks.IsProjectEmpty(project), "project should no longer be empty after trace")
+
+	var resp hookResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.True(t, resp.Continue)
+}
+
 func TestHookMaxBytesReader(t *testing.T) {
 	// Verify that all three hook handlers reject bodies larger than hookMaxBodyBytes
 	// by returning Continue=true (graceful degradation, not an error page).


### PR DESCRIPTION
## Summary

- Narrows `akashi_check` tool guidance from "every non-trivial decision" to architecture, design, trade-off, and security decisions. Adds explicit "DO NOT CALL" guidance for mechanical changes.
- Adds an empty-project bypass to the edit gate: projects with no decision history (0 decisions, 0 conflicts) skip the `akashi_check` requirement entirely during `PreToolUse`.
- The empty-project marker is set during `SessionStart`, cleared on first `akashi_trace` or auto-trace, and expires via TTL (matching the existing `checks` map cleanup).

## Verification

- [x] I ran relevant tests locally (`go test ./...` or targeted package tests).
- [ ] I updated docs/openapi for any API or behavior changes.
- [ ] If I changed config vars in `internal/config/config.go`, I also updated:
  - [ ] `docs/configuration.md`
  - [ ] `docs/runbook.md` (operational subset, if relevant)
  - [ ] `.env.example` (if baseline local/dev defaults changed)
- [ ] `python3 scripts/check_doc_config_consistency.py` passes.

## Risk / Rollout Notes

- MCP tool definition changes affect all downstream agents connecting via MCP. Agents will call `akashi_check` less frequently — this is intentional to reduce noise for mechanical tasks, but means fewer audit trail lookups for borderline decisions.
- The empty-project bypass is in-memory only and TTL-bounded (10 min). No persistence risk. Worst case on stale marker: an edit goes through without a check prompt for up to 10 minutes after the project gains its first decision via an external path.

> The Sorting Hat never asks you to check precedent before putting you in Gryffindor.
> It just knows when the trail is empty, there's nothing to contradict — so it lets you through.
> Akashi could learn something from a hat that trusts its own silence.