### PR TITLE
fix: align golangci-lint version to v2.11.0 across all references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7
         with:
-          version: v2.11
+          version: v2.11.0
 
       - name: Vet
         run: go vet ./...

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Decision coordination layer for multi-agent AI systems ("version control for AI 
 - **UI:** React 19, TypeScript, Vite, Tailwind CSS (embedded via `go:embed` with `ui` build tag)
 - **SDKs:** Go, Python, TypeScript (in `sdk/`)
 - **Testing:** `testing` + testify assertions, testcontainers-go for integration tests
-- **Lint:** golangci-lint v2.9.0, Atlas migrate validate
+- **Lint:** golangci-lint v2.11.0, Atlas migrate validate
 
 ## First-time setup
 
@@ -46,7 +46,7 @@ make ci                                  # full local CI mirror
 
 **If go mod tidy changes go.mod/go.sum**, stage them in the commit.
 **If atlas validate fails**, run `atlas migrate hash --dir file://migrations` and stage `migrations/atlas.sum`.
-**golangci-lint location:** `~/go/bin/golangci-lint` (install: `go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0`).
+**golangci-lint location:** `~/go/bin/golangci-lint` (install: `go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.0`).
 
 ## Project structure
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ This guide covers local development setup, common workflows, and the architectur
 - **Go 1.26+** ([install](https://go.dev/dl/))
 - **Docker** (for testcontainers and the local stack)
 - **Atlas CLI** ([install](https://atlasgo.io/getting-started#installation)) — database migration tool
-- **golangci-lint v2.9.0** — `go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0`
+- **golangci-lint v2.11.0** — `go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.0`
 - **Node.js 20+** (only if working on the UI)
 
 ### Starting the test database

--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,8 @@ coverage: ## Run tests with coverage and enforce 50% threshold
 	$(GO) test $(GOFLAGS) -coverprofile=coverage.out ./...
 	bash scripts/check_coverage.sh coverage.out 50
 
-# NOTE: CI uses golangci-lint v2.8.0. Install locally with:
-#   go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.8.0
+# NOTE: CI uses golangci-lint v2.11.0. Install locally with:
+#   go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.0
 lint:
 	golangci-lint run ./...
 


### PR DESCRIPTION
## Summary

- Unified golangci-lint version from three conflicting values (v2.8.0 in Makefile, v2.9.0 in AGENTS.md/CONTRIBUTING.md, v2.11 in CI) to a single `v2.11.0` everywhere
- Updated: `Makefile`, `AGENTS.md` (symlinked as `CLAUDE.md`), `CONTRIBUTING.md`, `.github/workflows/ci.yml`

## Test plan

- [ ] Verify `golangci-lint run ./...` passes locally with v2.11.0 installed
- [ ] Confirm CI lint step uses v2.11.0 and passes

Fixes #633

> Warp core breach in Engineering — three decks running different
> dilithium configurations, each convinced theirs was the one Scotty
> signed off on. The fix was always the same: pick the version that's
> actually keeping the ship flying and flush the rest out the airlock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)