### PR TITLE
fix: add missing org_id filters to 5 storage queries

### DIFF
--- a/akashi.go
+++ b/akashi.go
@@ -999,7 +999,7 @@ func (a *App) verifyProofsForOrg(ctx context.Context, orgID uuid.UUID, proofs []
 		// Verify Merkle root.
 		// Prefer snapshotted proof_leaves (survives retention purge and GDPR erasure).
 		// Fall back to re-querying decisions for proofs created before migration 082.
-		hashes, err := a.db.GetProofLeaves(ctx, p.ID)
+		hashes, err := a.db.GetProofLeaves(ctx, orgID, p.ID)
 		if err != nil {
 			a.logger.Warn("integrity audit: failed to fetch proof leaves",
 				"org_id", orgID, "proof_id", p.ID, "error", err)
@@ -1304,7 +1304,7 @@ func (a *App) runRetention(ctx context.Context) {
 			"claims":       counts.Claims,
 			"events":       counts.Events,
 		}
-		if cerr := a.db.CompleteDeletionLog(opCtx, logID, countMap); cerr != nil {
+		if cerr := a.db.CompleteDeletionLog(opCtx, org.OrgID, logID, countMap); cerr != nil {
 			a.logger.Warn("retention: failed to complete deletion log", "org_id", org.OrgID, "error", cerr)
 		}
 

--- a/internal/server/handlers_admin.go
+++ b/internal/server/handlers_admin.go
@@ -503,7 +503,7 @@ func (h *Handlers) HandleDeleteAgent(w http.ResponseWriter, r *http.Request) {
 			"claims":       result.Claims,
 			"events":       result.Events,
 		}
-		_ = h.db.CompleteDeletionLog(r.Context(), logID, countMap)
+		_ = h.db.CompleteDeletionLog(r.Context(), orgID, logID, countMap)
 	}
 
 	writeJSON(w, r, http.StatusOK, map[string]any{

--- a/internal/server/handlers_retention.go
+++ b/internal/server/handlers_retention.go
@@ -148,7 +148,7 @@ func (h *Handlers) HandlePurge(w http.ResponseWriter, r *http.Request) {
 		"claims":       counts.Claims,
 		"events":       counts.Events,
 	}
-	_ = h.db.CompleteDeletionLog(r.Context(), logID, countMap)
+	_ = h.db.CompleteDeletionLog(r.Context(), orgID, logID, countMap)
 
 	writeJSON(w, r, http.StatusOK, map[string]any{
 		"dry_run": false,

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -61,7 +61,7 @@ func StartTouchLastSeenWorkers(db *storage.DB, n int) {
 					slog.Warn("failed to update agent last_seen", "agent_id", req.agentID, "error", err)
 				}
 				if req.apiKeyID != nil {
-					if err := db.TouchAPIKeyLastUsed(bgCtx, *req.apiKeyID); err != nil {
+					if err := db.TouchAPIKeyLastUsed(bgCtx, req.orgID, *req.apiKeyID); err != nil {
 						slog.Warn("failed to update api key last_used_at", "key_id", req.apiKeyID, "error", err)
 					}
 				}

--- a/internal/storage/api_keys.go
+++ b/internal/storage/api_keys.go
@@ -279,10 +279,10 @@ func (db *DB) RotateAPIKeyWithAudit(ctx context.Context, orgID uuid.UUID, oldKey
 // TouchAPIKeyLastUsed updates the last_used_at timestamp for an API key.
 // Called from the auth middleware on successful authentication via a managed key.
 // Uses a fire-and-forget pattern — callers should not block on the result.
-func (db *DB) TouchAPIKeyLastUsed(ctx context.Context, keyID uuid.UUID) error {
+func (db *DB) TouchAPIKeyLastUsed(ctx context.Context, orgID, keyID uuid.UUID) error {
 	_, err := db.pool.Exec(ctx,
-		`UPDATE api_keys SET last_used_at = now() WHERE id = $1`,
-		keyID,
+		`UPDATE api_keys SET last_used_at = now() WHERE id = $1 AND org_id = $2`,
+		keyID, orgID,
 	)
 	if err != nil {
 		return fmt.Errorf("storage: touch api key last_used: %w", err)

--- a/internal/storage/decisions.go
+++ b/internal/storage/decisions.go
@@ -392,8 +392,8 @@ func (db *DB) EraseDecision(
 		// Check idempotency: if already erased, return error.
 		var alreadyErased bool
 		err = tx.QueryRow(ctx,
-			`SELECT EXISTS(SELECT 1 FROM decision_erasures WHERE decision_id = $1)`,
-			decisionID,
+			`SELECT EXISTS(SELECT 1 FROM decision_erasures WHERE decision_id = $1 AND org_id = $2)`,
+			decisionID, orgID,
 		).Scan(&alreadyErased)
 		if err != nil {
 			return fmt.Errorf("storage: check existing erasure: %w", err)

--- a/internal/storage/integrity.go
+++ b/internal/storage/integrity.go
@@ -239,12 +239,12 @@ func (db *DB) CreateProofLeaves(ctx context.Context, proofID, orgID uuid.UUID, l
 // GetProofLeaves returns the leaf hashes for a proof, ordered lexicographically.
 // Falls back to GetDecisionHashesForBatch when no leaves are stored (proofs
 // created before migration 082).
-func (db *DB) GetProofLeaves(ctx context.Context, proofID uuid.UUID) ([]string, error) {
+func (db *DB) GetProofLeaves(ctx context.Context, orgID, proofID uuid.UUID) ([]string, error) {
 	rows, err := db.pool.Query(ctx,
 		`SELECT leaf_hash FROM proof_leaves
-		 WHERE proof_id = $1
+		 WHERE proof_id = $1 AND org_id = $2
 		 ORDER BY leaf_hash ASC`,
-		proofID,
+		proofID, orgID,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("storage: get proof leaves: %w", err)

--- a/internal/storage/retention.go
+++ b/internal/storage/retention.go
@@ -266,10 +266,10 @@ func (db *DB) StartDeletionLog(ctx context.Context, orgID uuid.UUID, trigger, in
 }
 
 // CompleteDeletionLog records the final counts and sets completed_at.
-func (db *DB) CompleteDeletionLog(ctx context.Context, logID uuid.UUID, counts map[string]any) error {
+func (db *DB) CompleteDeletionLog(ctx context.Context, orgID, logID uuid.UUID, counts map[string]any) error {
 	_, err := db.pool.Exec(ctx,
-		`UPDATE deletion_log SET deleted_counts = $2, completed_at = now() WHERE id = $1`,
-		logID, counts,
+		`UPDATE deletion_log SET deleted_counts = $2, completed_at = now() WHERE id = $1 AND org_id = $3`,
+		logID, counts, orgID,
 	)
 	if err != nil {
 		return fmt.Errorf("storage: complete deletion log: %w", err)

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -3504,7 +3504,7 @@ func TestAPIKeyLifecycle(t *testing.T) {
 	require.ErrorIs(t, err, storage.ErrNotFound)
 
 	// Touch last used.
-	err = testDB.TouchAPIKeyLastUsed(ctx, key.ID)
+	err = testDB.TouchAPIKeyLastUsed(ctx, uuid.Nil, key.ID)
 	require.NoError(t, err)
 
 	gotKey2, err := testDB.GetAPIKeyByID(ctx, uuid.Nil, key.ID)
@@ -3869,7 +3869,7 @@ func TestDeletionLogLifecycle(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEqual(t, uuid.Nil, logID)
 
-	err = testDB.CompleteDeletionLog(ctx, logID, map[string]any{"decisions": 5})
+	err = testDB.CompleteDeletionLog(ctx, uuid.Nil, logID, map[string]any{"decisions": 5})
 	require.NoError(t, err)
 }
 
@@ -7458,7 +7458,7 @@ func TestFindDecisionsMissingOutcomeEmbedding_DefaultLimit(t *testing.T) {
 func TestTouchAPIKeyLastUsed_NonExistent(t *testing.T) {
 	ctx := context.Background()
 	// Touching a nonexistent key should not error (fire-and-forget pattern).
-	err := testDB.TouchAPIKeyLastUsed(ctx, uuid.New())
+	err := testDB.TouchAPIKeyLastUsed(ctx, uuid.Nil, uuid.New())
 	require.NoError(t, err)
 }
 
@@ -10983,12 +10983,12 @@ func TestProofLeaves_CreateAndGet(t *testing.T) {
 	leaves := []string{"aaa_hash", "bbb_hash", "ccc_hash"}
 	require.NoError(t, testDB.CreateProofLeaves(ctx, proofID, orgID, leaves))
 
-	got, err := testDB.GetProofLeaves(ctx, proofID)
+	got, err := testDB.GetProofLeaves(ctx, orgID, proofID)
 	require.NoError(t, err)
 	assert.Equal(t, leaves, got, "leaves should round-trip in sorted order")
 
 	// No leaves for a random proof.
-	empty, err := testDB.GetProofLeaves(ctx, uuid.New())
+	empty, err := testDB.GetProofLeaves(ctx, orgID, uuid.New())
 	require.NoError(t, err)
 	assert.Empty(t, empty)
 }
@@ -11076,7 +11076,7 @@ func TestProofLeaves_SurvivesRetentionPurge(t *testing.T) {
 	assert.Empty(t, remaining, "decisions should be purged")
 
 	// But proof_leaves survive — verification still passes.
-	savedLeaves, err := testDB.GetProofLeaves(ctx, proofID)
+	savedLeaves, err := testDB.GetProofLeaves(ctx, orgID, proofID)
 	require.NoError(t, err)
 	require.Len(t, savedLeaves, count, "proof leaves should survive retention purge")
 
@@ -11161,7 +11161,7 @@ func TestProofLeaves_SurvivesGDPRErasure(t *testing.T) {
 	assert.False(t, ok, "verifying against mutated decisions table should fail")
 
 	// But proof_leaves preserve the original hashes — verification passes.
-	savedLeaves, err := testDB.GetProofLeaves(ctx, proofID)
+	savedLeaves, err := testDB.GetProofLeaves(ctx, orgID, proofID)
 	require.NoError(t, err)
 	require.Len(t, savedLeaves, 1)
 	assert.Equal(t, hashes[0], savedLeaves[0], "proof leaves should preserve original hash")

--- a/internal/storage/trace.go
+++ b/internal/storage/trace.go
@@ -278,8 +278,8 @@ func (db *DB) createTraceInTx(ctx context.Context, tx pgx.Tx, params CreateTrace
 
 	// 5. Complete run.
 	if _, err := tx.Exec(ctx,
-		`UPDATE agent_runs SET status = $1, completed_at = $2 WHERE id = $3`,
-		string(model.RunStatusCompleted), now, run.ID,
+		`UPDATE agent_runs SET status = $1, completed_at = $2 WHERE id = $3 AND org_id = $4`,
+		string(model.RunStatusCompleted), now, run.ID, params.OrgID,
 	); err != nil {
 		return model.AgentRun{}, model.Decision{}, fmt.Errorf("storage: complete run in trace tx: %w", err)
 	}


### PR DESCRIPTION
## Summary

- Adds `AND org_id = $N` to 5 storage queries that lacked the defense-in-depth tenant filter: `EraseDecision` (idempotency check), `GetProofLeaves`, `TouchAPIKeyLastUsed`, `CompleteDeletionLog`, and `createTraceInTx` (run completion)
- Threads `orgID` through function signatures where it was missing (`GetProofLeaves`, `TouchAPIKeyLastUsed`, `CompleteDeletionLog`) — all call sites already had the value available
- Updates all callers (handlers, middleware, background workers) and test call sites

## Test plan

- [ ] `go build ./...` passes
- [ ] `go vet ./...` clean
- [ ] `golangci-lint run ./...` — 0 issues
- [ ] `atlas migrate validate` passes
- [ ] `go test -race -count=1 ./...` passes (integration tests exercise all 5 paths)
- [ ] Verify `TestAPIKeyLifecycle` and `TestTouchAPIKeyLastUsed_NonExistent` still pass
- [ ] Verify `TestProofLeaves_CreateAndGet`, retention purge, and GDPR erasure proof leaf tests pass
- [ ] Verify `TestDeletionLogLifecycle` still passes

Closes #629

> Wands choose the wizard, but queries don't choose their tenant.
> Dumbledore would have added the org_id filter from the start —
> he understood that "contextually safe" is just "trusting Snape"
> with fewer steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)