### PR TITLE
fix: use ErrCodeServiceUnavailable for HTTP 503 responses

### DIFF
--- a/internal/model/api.go
+++ b/internal/model/api.go
@@ -217,14 +217,15 @@ type ErrorDetail struct {
 
 // ErrorCode constants for standard API error codes.
 const (
-	ErrCodeInvalidInput   = "INVALID_INPUT"
-	ErrCodeUnauthorized   = "UNAUTHORIZED"
-	ErrCodeForbidden      = "FORBIDDEN"
-	ErrCodeNotFound       = "NOT_FOUND"
-	ErrCodeConflict       = "CONFLICT"
-	ErrCodeInternalError  = "INTERNAL_ERROR"
-	ErrCodeRateLimited    = "RATE_LIMITED"
-	ErrCodeNotImplemented = "NOT_IMPLEMENTED"
+	ErrCodeInvalidInput       = "INVALID_INPUT"
+	ErrCodeUnauthorized       = "UNAUTHORIZED"
+	ErrCodeForbidden          = "FORBIDDEN"
+	ErrCodeNotFound           = "NOT_FOUND"
+	ErrCodeConflict           = "CONFLICT"
+	ErrCodeInternalError      = "INTERNAL_ERROR"
+	ErrCodeRateLimited        = "RATE_LIMITED"
+	ErrCodeNotImplemented     = "NOT_IMPLEMENTED"
+	ErrCodeServiceUnavailable = "SERVICE_UNAVAILABLE"
 )
 
 // CreateRunRequest is the request body for POST /v1/runs.

--- a/internal/server/handlers_runs.go
+++ b/internal/server/handlers_runs.go
@@ -189,9 +189,9 @@ func (h *Handlers) HandleAppendEvents(w http.ResponseWriter, r *http.Request) {
 		h.clearIdempotentWrite(r, orgID, idem)
 		switch {
 		case errors.Is(err, tracesvc.ErrBufferAtCapacity):
-			writeError(w, r, http.StatusServiceUnavailable, model.ErrCodeConflict, "event buffer is full, retry shortly")
+			writeError(w, r, http.StatusServiceUnavailable, model.ErrCodeServiceUnavailable, "event buffer is full, retry shortly")
 		case errors.Is(err, tracesvc.ErrBufferDraining):
-			writeError(w, r, http.StatusServiceUnavailable, model.ErrCodeConflict, "server is shutting down, retry on another instance")
+			writeError(w, r, http.StatusServiceUnavailable, model.ErrCodeServiceUnavailable, "server is shutting down, retry on another instance")
 		default:
 			h.writeInternalError(w, r, "failed to buffer events", err)
 		}


### PR DESCRIPTION
## Summary

- Adds `ErrCodeServiceUnavailable` (`"SERVICE_UNAVAILABLE"`) to the model error code constants
- Replaces incorrect `ErrCodeConflict` usage in the two HTTP 503 paths in `HandleTraceEvents` (buffer-full and server-draining)
- Wire-format fix: SDK consumers branching on the error code string will no longer misinterpret capacity/shutdown as a conflict

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `golangci-lint run ./...` passes (0 issues)
- [x] `atlas migrate validate` passes
- [x] `go test -race -count=1 ./internal/model/... ./internal/server/...` passes

Fixes #630

> The Sorting Hat never asks where you *want* to go —
> it reads what you already are and places you precisely.
> CONFLICT belonged in Slytherin all along; it just took
> SERVICE_UNAVAILABLE showing up to set the record straight.