### PR TITLE
fix: align Go SDK types with server model

### DIFF
--- a/sdk/go/akashi/client_test.go
+++ b/sdk/go/akashi/client_test.go
@@ -1697,7 +1697,6 @@ func TestDecisionDeserializesAllFields(t *testing.T) {
 						"precedent_ref":      precedentRef,
 						"supersedes_id":      supersedesID,
 						"content_hash":       "sha256:abc123def456",
-						"tags":               []string{"backend", "infra"},
 						"valid_from":         now,
 						"transaction_time":   now,
 						"created_at":         now,
@@ -1738,9 +1737,6 @@ func TestDecisionDeserializesAllFields(t *testing.T) {
 	}
 	if d.ContentHash != "sha256:abc123def456" {
 		t.Errorf("expected content_hash 'sha256:abc123def456', got %q", d.ContentHash)
-	}
-	if len(d.Tags) != 2 || d.Tags[0] != "backend" || d.Tags[1] != "infra" {
-		t.Errorf("expected tags [backend, infra], got %v", d.Tags)
 	}
 }
 

--- a/sdk/go/akashi/types.go
+++ b/sdk/go/akashi/types.go
@@ -19,12 +19,11 @@ type Decision struct {
 	Confidence        float32        `json:"confidence"`
 	Reasoning         *string        `json:"reasoning,omitempty"`
 	Metadata          map[string]any `json:"metadata"`
-	CompletenessScore float64        `json:"completeness_score"`
-	OutcomeScore      *float64       `json:"outcome_score,omitempty"`
+	CompletenessScore float32        `json:"completeness_score"`
+	OutcomeScore      *float32       `json:"outcome_score,omitempty"`
 	PrecedentRef      *uuid.UUID     `json:"precedent_ref,omitempty"`
 	SupersedesID      *uuid.UUID     `json:"supersedes_id,omitempty"`
 	ContentHash       string         `json:"content_hash,omitempty"`
-	Tags              []string       `json:"tags,omitempty"`
 
 	// Composite agent identity: session and runtime context from the calling agent.
 	SessionID    *uuid.UUID     `json:"session_id,omitempty"`
@@ -132,10 +131,8 @@ type TraceRequest struct {
 
 // TraceAlternative is an alternative in a trace request.
 type TraceAlternative struct {
-	Label           string   `json:"label"`
-	Score           *float32 `json:"score,omitempty"`
-	Selected        bool     `json:"selected"`
-	RejectionReason *string  `json:"rejection_reason,omitempty"`
+	Label           string  `json:"label"`
+	RejectionReason *string `json:"rejection_reason,omitempty"`
 }
 
 // TraceEvidence is evidence in a trace request.
@@ -245,6 +242,9 @@ const (
 	EventReasoningStepCompleted EventType = "ReasoningStepCompleted"
 	EventDecisionMade           EventType = "DecisionMade"
 	EventDecisionRevised        EventType = "DecisionRevised"
+	EventDecisionSuperseded     EventType = "DecisionSuperseded"
+	EventDecisionRetracted      EventType = "DecisionRetracted"
+	EventDecisionErased         EventType = "DecisionErased"
 	EventToolCallStarted        EventType = "ToolCallStarted"
 	EventToolCallCompleted      EventType = "ToolCallCompleted"
 	EventAgentHandoff           EventType = "AgentHandoff"
@@ -261,8 +261,6 @@ type AgentEvent struct {
 	SequenceNum int64          `json:"sequence_num"`
 	OccurredAt  time.Time      `json:"occurred_at"`
 	AgentID     string         `json:"agent_id"`
-	TraceID     string         `json:"trace_id,omitempty"`
-	SpanID      string         `json:"span_id,omitempty"`
 	Payload     map[string]any `json:"payload"`
 	CreatedAt   time.Time      `json:"created_at"`
 }


### PR DESCRIPTION
## Summary

Fixes #631 — the Go SDK types had drifted from the server's internal model:

- **Float width**: `CompletenessScore` (`float64` → `float32`) and `OutcomeScore` (`*float64` → `*float32`) now match the server
- **Ghost fields removed**: `Decision.Tags`, `TraceAlternative.Score`/`.Selected`, `AgentEvent.TraceID`/`.SpanID` — all fields the server never serializes
- **Missing EventType constants added**: `EventDecisionSuperseded`, `EventDecisionRetracted`, `EventDecisionErased`

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] `atlas migrate validate` passes
- [x] SDK tests pass with race detector (`go test -race -count=1 ./...` in `sdk/go/akashi`)
- [ ] Verify Python and TypeScript SDKs don't have the same drift (out of scope for this PR)

> The Sorting Hat never placed anyone in Slytherin for wanting type safety —
> but it should have. Salazar knew: the real dark magic is a `float64` on the wire
> that silently truncates to `float32` in the database, losing nothing but your trust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)