### PR TITLE
fix: add structured error logging to 3 handler error paths

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -297,6 +298,11 @@ func (h *Handlers) HandleScopedToken(w http.ResponseWriter, r *http.Request) {
 // HandleSubscribe handles GET /v1/subscribe (SSE).
 func (h *Handlers) HandleSubscribe(w http.ResponseWriter, r *http.Request) {
 	if h.broker == nil {
+		h.logger.Error("SSE not available",
+			"error", "broker not initialized (LISTEN/NOTIFY not configured)",
+			"method", r.Method,
+			"path", r.URL.Path,
+			"request_id", RequestIDFromContext(r.Context()))
 		writeError(w, r, http.StatusServiceUnavailable, model.ErrCodeInternalError,
 			"SSE not available (LISTEN/NOTIFY not configured)")
 		return
@@ -304,7 +310,7 @@ func (h *Handlers) HandleSubscribe(w http.ResponseWriter, r *http.Request) {
 
 	flusher, ok := w.(http.Flusher)
 	if !ok {
-		writeError(w, r, http.StatusInternalServerError, model.ErrCodeInternalError, "streaming not supported")
+		h.writeInternalError(w, r, "streaming not supported", errors.New("http.Flusher not implemented"))
 		return
 	}
 

--- a/internal/server/handlers_export.go
+++ b/internal/server/handlers_export.go
@@ -59,11 +59,15 @@ func (h *Handlers) HandleExportDecisions(w http.ResponseWriter, r *http.Request)
 	for {
 		decisions, err := h.db.ExportDecisionsCursor(r.Context(), orgID, filters, cursor, pageSize)
 		if err != nil {
-			h.logger.Error("export failed", "error", err)
 			if cursor == nil {
 				// Headers not yet sent — we can still return a proper error response.
-				writeError(w, r, http.StatusInternalServerError, model.ErrCodeInternalError, "export failed")
+				h.writeInternalError(w, r, "export failed", err)
 			} else {
+				h.logger.Error("export failed mid-stream",
+					"error", err,
+					"method", r.Method,
+					"path", r.URL.Path,
+					"request_id", RequestIDFromContext(r.Context()))
 				// Headers already sent — write an error sentinel as the last NDJSON line
 				// so consumers can detect the truncation instead of silently accepting
 				// a partial export as complete.


### PR DESCRIPTION
## Summary

- Replace raw `writeError()` with `h.writeInternalError()` in `HandleSubscribe` (Flusher check) and `HandleExportDecisions` (cursor==nil failure) so these 500 paths produce structured server-side logs with method, path, and request_id.
- Add structured logging to the `HandleSubscribe` nil-broker path while preserving its 503 status code — SSE being unconfigured is service unavailability, not an internal error.
- Add structured logging with method/path/request_id to the `HandleExportDecisions` mid-stream failure path, replacing the minimal log that lacked request context.
- Hook responses (`writeHookJSON`) intentionally left without the standard `{data, meta}` envelope — they follow the Claude Code hooks protocol which expects `{continue, suppressOutput, ...}` at the top level.

Closes #637

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test -race -count=1 ./internal/server/` — all pass (59s)
- [x] `TestHandleSubscribe_NoBroker` still asserts 503
- [x] `TestHandleSubscribe_NilBroker` still asserts 503
- [x] `TestWriteHookJSON` still passes (no envelope change)

> Warp signatures ripple through subspace —
> the Enterprise drops out, sensors sweeping.
> "Anomalous readings in three call sites, Captain."
> Geordi's already re-routing the diagnostic logs through structured telemetry.
> "If we can't see what failed," Picard says, adjusting his tunic, "we can't fix it.
> Make it so." The viewscreen clears. Every error, accounted for.