### PR TITLE
fix: rename supersession_velocity JSON tag to include unit

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -3521,6 +3521,19 @@ components:
           description: |
             Number of open conflicts involving this decision.
             Computed at query time.
+        supersession_velocity_hours:
+          type: number
+          format: float
+          nullable: true
+          description: |
+            Hours between this decision's valid_from and the superseding
+            decision's valid_from. Null when the decision has not been
+            superseded. Computed at query time; not stored.
+        precedent_citation_count:
+          type: integer
+          description: |
+            Number of later decisions that reference this decision as a
+            precedent. Computed at query time.
         consensus_weight:
           type: number
           format: float

--- a/internal/model/decision.go
+++ b/internal/model/decision.go
@@ -73,7 +73,7 @@ type Decision struct {
 	ConflictCount  int `json:"conflict_count"`
 
 	// Outcome signals (Spec 35): temporal, graph, and fate signals computed at query time.
-	SupersessionVelocityHours *float64     `json:"supersession_velocity"`
+	SupersessionVelocityHours *float64     `json:"supersession_velocity_hours"`
 	PrecedentCitationCount    int          `json:"precedent_citation_count"`
 	ConflictFate              ConflictFate `json:"conflict_fate"`
 

--- a/ui/src/pages/DecisionDetail.tsx
+++ b/ui/src/pages/DecisionDetail.tsx
@@ -420,7 +420,7 @@ function OutcomeSignals({ decision }: { decision: Decision }) {
   const hasFate = decision.conflict_fate && (decision.conflict_fate.won > 0 || decision.conflict_fate.lost > 0 || decision.conflict_fate.resolved_no_winner > 0);
   const hasAssessment = decision.assessment_summary && decision.assessment_summary.total > 0;
   const hasCitations = (decision.precedent_citation_count ?? 0) > 0;
-  const hasSupersession = decision.supersession_velocity != null;
+  const hasSupersession = decision.supersession_velocity_hours != null;
   const hasConsensus = (decision.agreement_count ?? 0) > 0 || (decision.conflict_count ?? 0) > 0;
 
   if (!hasFate && !hasAssessment && !hasCitations && !hasSupersession && !hasConsensus) return null;
@@ -464,9 +464,9 @@ function OutcomeSignals({ decision }: { decision: Decision }) {
         {/* Supersession velocity */}
         {hasSupersession && (
           <div className="text-xs text-muted-foreground">
-            Superseded after {decision.supersession_velocity! < 1
-              ? `${Math.round(decision.supersession_velocity! * 60)}m`
-              : `${decision.supersession_velocity!.toFixed(1)}h`}
+            Superseded after {decision.supersession_velocity_hours! < 1
+              ? `${Math.round(decision.supersession_velocity_hours! * 60)}m`
+              : `${decision.supersession_velocity_hours!.toFixed(1)}h`}
           </div>
         )}
 

--- a/ui/src/types/api.ts
+++ b/ui/src/types/api.ts
@@ -84,7 +84,7 @@ export interface Decision {
   // Outcome signals
   agreement_count?: number;
   conflict_count?: number;
-  supersession_velocity?: number | null;
+  supersession_velocity_hours?: number | null;
   precedent_citation_count?: number;
   conflict_fate?: ConflictFate;
   // Assessment summary


### PR DESCRIPTION
## Summary

- Renamed the JSON tag on `Decision.SupersessionVelocityHours` from `supersession_velocity` to `supersession_velocity_hours` so the wire format communicates the unit to API consumers
- Updated the UI type (`api.ts`) and component (`DecisionDetail.tsx`) to use the new field name
- Added `supersession_velocity_hours` and `precedent_citation_count` to the OpenAPI spec where they were previously undocumented

Closes #639

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `golangci-lint run ./...` — 0 issues
- [x] `atlas migrate validate` passes
- [x] `go test -race` passes for `internal/storage`, `internal/search`, `internal/mcp`, `internal/service/decisions`
- [ ] Verify UI renders supersession velocity correctly on a decision detail page

> The Sorting Hat would never put this field in Slytherin —
> it lacks the ambition to hide what it truly is.
> "Supersession velocity," it whispers, but means hours all along;
> at least now the tag is as honest as a Hufflepuff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)