### PR TITLE
fix: correct HTTP status codes, org_id defense-in-depth, error consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ claude mcp add --transport http --scope user akashi http://localhost:8080/mcp \
 | [Subsystems](docs/subsystems.md) | Embeddings, rate limiting, Qdrant pipeline |
 | [Runbook](docs/runbook.md) | Health checks, monitoring, troubleshooting |
 | [Diagrams](docs/diagrams.md) | Write path, read path, auth flow, schema |
-| [ADRs](adrs/) | 10 architecture decision records |
+| [ADRs](adrs/) | 15 architecture decision records |
 | [OpenAPI](api/openapi.yaml) | Full API spec (also at `GET /openapi.yaml`) |
 
 ## License

--- a/internal/server/handlers_conflicts.go
+++ b/internal/server/handlers_conflicts.go
@@ -250,7 +250,7 @@ func (h *Handlers) HandleResolveConflictGroup(w http.ResponseWriter, r *http.Req
 			return
 		}
 		if errors.Is(err, storage.ErrRevisedDecisions) {
-			writeError(w, r, http.StatusConflict, model.ErrCodeInvalidInput,
+			writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput,
 				"some conflicts in the group reference revised decisions and cannot be resolved with a winner")
 			return
 		}

--- a/internal/server/handlers_labels.go
+++ b/internal/server/handlers_labels.go
@@ -1,12 +1,10 @@
 package server
 
 import (
-	"errors"
 	"net/http"
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5"
 
 	"github.com/ashita-ai/akashi/internal/model"
 	"github.com/ashita-ai/akashi/internal/storage"
@@ -74,8 +72,8 @@ func (h *Handlers) HandleUpsertConflictLabel(w http.ResponseWriter, r *http.Requ
 		Notes:            req.Notes,
 	}
 	if err := h.db.UpsertConflictLabel(r.Context(), cl); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			writeError(w, r, http.StatusConflict, model.ErrCodeConflict, "conflict belongs to a different organization")
+		if isNotFoundError(err) {
+			writeError(w, r, http.StatusNotFound, model.ErrCodeNotFound, "conflict not found")
 			return
 		}
 		h.writeInternalError(w, r, "failed to upsert conflict label", err)
@@ -97,7 +95,7 @@ func (h *Handlers) HandleGetConflictLabel(w http.ResponseWriter, r *http.Request
 
 	cl, err := h.db.GetConflictLabel(r.Context(), conflictID, orgID)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
+		if isNotFoundError(err) {
 			writeError(w, r, http.StatusNotFound, model.ErrCodeNotFound, "label not found")
 			return
 		}
@@ -119,7 +117,7 @@ func (h *Handlers) HandleDeleteConflictLabel(w http.ResponseWriter, r *http.Requ
 	}
 
 	if err := h.db.DeleteConflictLabel(r.Context(), conflictID, orgID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
+		if isNotFoundError(err) {
 			writeError(w, r, http.StatusNotFound, model.ErrCodeNotFound, "label not found")
 			return
 		}

--- a/internal/storage/retention.go
+++ b/internal/storage/retention.go
@@ -453,7 +453,10 @@ func (db *DB) deleteBatch(ctx context.Context, orgID uuid.UUID, ids []uuid.UUID)
 		); err != nil {
 			return fmt.Errorf("storage: archive alternatives batch: %w", err)
 		}
-		tag, err = tx.Exec(ctx, `DELETE FROM alternatives WHERE decision_id = ANY($1)`, ids)
+		tag, err = tx.Exec(ctx,
+			`DELETE FROM alternatives WHERE decision_id = ANY($1)
+		 AND decision_id IN (SELECT id FROM decisions WHERE org_id = $2)`,
+			ids, orgID)
 		if err != nil {
 			return fmt.Errorf("storage: delete alternatives batch: %w", err)
 		}


### PR DESCRIPTION
## Summary

- **HandleUpsertConflictLabel**: changed 409 → 404 for cross-org conflict lookup. The old 409 confirmed a resource exists in another org — information disclosure.
- **HandleResolveConflictGroup**: changed 409 → 400 for `ErrRevisedDecisions`. The request is invalid, not a state conflict.
- **retention.go `deleteBatch`**: added `org_id` filter to `DELETE FROM alternatives`. The upstream SELECT already scopes by org_id, but every other DELETE in the same function has an explicit check — this closes the defense-in-depth gap.
- **handlers_labels.go**: replaced 3 direct `pgx.ErrNoRows` checks with `isNotFoundError()`, matching the 23 other call sites in the handler layer. Removed unused `errors` and `pgx` imports.
- **README.md**: fixed ADR count from 10 → 15.

Also closed 7 resolved GitHub issues: #443, #312, #318, #444, #446, #401, #656.

## Verification

- [x] I ran relevant tests locally (`go test ./...` or targeted package tests).
- [ ] I updated docs/openapi for any API or behavior changes.
- [ ] If I changed config vars in `internal/config/config.go`, I also updated:
  - [ ] `docs/configuration.md`
  - [ ] `docs/runbook.md` (operational subset, if relevant)
  - [ ] `.env.example` (if baseline local/dev defaults changed)
- [ ] `python3 scripts/check_doc_config_consistency.py` passes.

## Risk / Rollout Notes

- The 409 → 404 and 409 → 400 status code changes are breaking for clients that match on those specific codes. In practice, 409 on these paths was semantically wrong and unlikely to be relied upon.
- The retention DELETE change adds a subquery but only fires during retention purge (background job, not latency-sensitive).

> Picard never had to file a pull request, but if he did, he'd insist
> on the same thing the Federation insists on at every first contact:
> identify yourself honestly. A 409 that should have been a 404 is just
> the Romulans cloaking a warbird — technically present, officially denied,
> and everyone's worse off for the ambiguity.