### PR TITLE
fix: log swallowed DB error in HandleAuthToken

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -125,7 +125,11 @@ func (h *Handlers) HandleAuthToken(w http.ResponseWriter, r *http.Request) {
 	// Phase 1: check managed api_keys table.
 	var matched *model.Agent
 	var matchedKeyID *uuid.UUID
-	managedKeys, _ := h.db.GetActiveAPIKeysByAgentIDGlobal(r.Context(), req.AgentID)
+	managedKeys, err := h.db.GetActiveAPIKeysByAgentIDGlobal(r.Context(), req.AgentID)
+	if err != nil {
+		h.logger.Warn("managed key lookup failed, falling through to legacy",
+			"agent_id", req.AgentID, "error", err)
+	}
 	for _, k := range managedKeys {
 		valid, verr := auth.VerifyAPIKey(req.APIKey, k.KeyHash)
 		if verr != nil || !valid {


### PR DESCRIPTION
## Summary

- `HandleAuthToken` silently discarded the error from `GetActiveAPIKeysByAgentIDGlobal`, making DB outages manifest as auth failures with no server-side diagnostic trail
- Now logs at `Warn` level with `agent_id` and `error` context before continuing the fallback-to-legacy path
- Preserves the existing graceful degradation behavior — no change to the auth flow, just visibility

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test -race -count=1 -run TestHandleAuthToken ./internal/server/` passes

Closes #660

> The Sorting Hat never asks what house you *want* —
> it reads what you hide. Dumbledore's school runs on
> a classification model with zero explainability,
> no appeals process, and an 11-year-old's entire
> social graph as the training set. Still ships to prod
> every September.