### PR TITLE
fix: tighten tamper-evidence FK constraints and add missing org_id FK

### DIFF
--- a/migrations/099_tamper_evidence_fk_tighten.sql
+++ b/migrations/099_tamper_evidence_fk_tighten.sql
@@ -1,0 +1,77 @@
+-- 099: Tighten FK constraints on tamper-evidence tables for consistency.
+--
+-- Three issues (GitHub #658):
+--
+-- 1. proof_leaves.proof_id uses ON DELETE CASCADE (migration 084). If integrity_proofs'
+--    immutability trigger were ever dropped (e.g. during a data migration), all leaf
+--    hashes would silently vanish — destroying the ability to verify Merkle proofs.
+--    Migrations 079/080 applied the same CASCADE→RESTRICT fix to integrity_violations
+--    and integrity_audit_results; proof_leaves was missed.
+--
+-- 2. proof_leaves.org_id uses the PostgreSQL default ON DELETE NO ACTION (implicit).
+--    Migration 082 explicitly switched integrity_violations.org_id to RESTRICT.
+--    Make the same choice explicit here: org deletion is blocked while proof leaves
+--    exist, which is correct for append-only tamper-evidence.
+--
+-- 3. proof_leaves has no immutability triggers despite being an append-only table
+--    that preserves cryptographic proof chains. Migrations 079/080 added triggers
+--    for integrity_violations and integrity_audit_results; proof_leaves was missed.
+--
+-- 4. decision_assessments.org_id (migration 051) has no FK constraint to organizations
+--    at all. Migration 086 already tightened decision_id to RESTRICT; org_id should
+--    have an FK too. Use RESTRICT to match the append-only audit semantics.
+
+-- ---------------------------------------------------------------------------
+-- Part 1: proof_leaves.proof_id — CASCADE → RESTRICT
+-- ---------------------------------------------------------------------------
+
+-- The inline FK from migration 084 uses the auto-generated name.
+ALTER TABLE proof_leaves
+    DROP CONSTRAINT proof_leaves_proof_id_fkey;
+
+ALTER TABLE proof_leaves
+    ADD CONSTRAINT proof_leaves_proof_id_fkey
+    FOREIGN KEY (proof_id) REFERENCES integrity_proofs(id) ON DELETE RESTRICT;
+
+-- ---------------------------------------------------------------------------
+-- Part 2: proof_leaves.org_id — NO ACTION (implicit) → RESTRICT (explicit)
+-- ---------------------------------------------------------------------------
+
+-- Migration 089 dropped the named fk_proof_leaves_org, leaving only the inline
+-- REFERENCES. PostgreSQL names inline FKs as <table>_<col>_fkey.
+ALTER TABLE proof_leaves
+    DROP CONSTRAINT proof_leaves_org_id_fkey;
+
+ALTER TABLE proof_leaves
+    ADD CONSTRAINT proof_leaves_org_id_fkey
+    FOREIGN KEY (org_id) REFERENCES organizations(id) ON DELETE RESTRICT;
+
+-- ---------------------------------------------------------------------------
+-- Part 3: proof_leaves immutability triggers
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION prevent_proof_leaves_modify()
+RETURNS TRIGGER AS $$ BEGIN
+  RAISE EXCEPTION 'proof_leaves is append-only';
+END; $$ LANGUAGE plpgsql;
+
+CREATE TRIGGER proof_leaves_immutable_update
+  BEFORE UPDATE ON proof_leaves
+  FOR EACH ROW EXECUTE FUNCTION prevent_proof_leaves_modify();
+
+CREATE TRIGGER proof_leaves_immutable_delete
+  BEFORE DELETE ON proof_leaves
+  FOR EACH ROW EXECUTE FUNCTION prevent_proof_leaves_modify();
+
+-- ---------------------------------------------------------------------------
+-- Part 4: decision_assessments.org_id — add missing FK with RESTRICT
+-- ---------------------------------------------------------------------------
+
+-- Use NOT VALID + VALIDATE to avoid holding ACCESS EXCLUSIVE on organizations
+-- for a full table scan (same pattern as migration 097 for project_links).
+ALTER TABLE decision_assessments
+    ADD CONSTRAINT fk_decision_assessments_org
+    FOREIGN KEY (org_id) REFERENCES organizations(id) ON DELETE RESTRICT
+    NOT VALID;
+
+ALTER TABLE decision_assessments VALIDATE CONSTRAINT fk_decision_assessments_org;

--- a/migrations/atlas.sum
+++ b/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:LP+JWU8mX2VjLSTLB3SXPCmNhq/SSfWOuthKR16YL2U=
+h1:OvG5/dhb2mcFHMEfXGg8UOun6234AqVO8gFlKM36FZ8=
 001_initial.sql h1:uhyGXto+QacAaGYb9ZTGjsBs5chlKi8O0eHz9aCQsrY=
 022_full_text_search.sql h1:9iwtA8MgCzAxDV9YkUBn0CLT9ePSmj3GcPoMGg8TXf0=
 023_fix_outbox_index.sql h1:OtMEFBcMRWej02+ghnBXlPr6BVq+LoA62Id9XUWfDNI=
@@ -77,3 +77,4 @@ h1:LP+JWU8mX2VjLSTLB3SXPCmNhq/SSfWOuthKR16YL2U=
 096_backfill_decision_types_with_trigger_bypass.sql h1:lTZh5HZ+i7Skiv4Vzi6iGdQ5HJQRIeEffakIpBK2rKo=
 097_project_links_org_fk.sql h1:bbU3dgYzxdKYepsbGYEIXHGA7TyufjxURXD6VqIFRkU=
 098_fix_remaining_project_assignments.sql h1:hh9aiqeQcFEjQI4qt5in6JnQflujJhQi8WYVq/yWAxQ=
+099_tamper_evidence_fk_tighten.sql h1:5gBoilnQtObLjOcitnfZ697TPLC2X8tP+0QIixpv+yE=


### PR DESCRIPTION
## Summary

- **proof_leaves.proof_id**: CASCADE → RESTRICT (matches integrity_violations/integrity_audit_results pattern from migrations 079/080)
- **proof_leaves.org_id**: implicit NO ACTION → explicit RESTRICT (matches migration 082)
- **proof_leaves**: adds immutability triggers (BEFORE UPDATE/DELETE) — the only tamper-evidence table that was missing them
- **decision_assessments.org_id**: adds missing FK to organizations with ON DELETE RESTRICT (uses NOT VALID + VALIDATE for zero-downtime)

## Context

Migrations 079/080/082 established the policy: append-only tamper-evidence tables use RESTRICT on all FKs and immutability triggers to prevent UPDATE/DELETE. proof_leaves (084) was created afterward and didn't follow the pattern. decision_assessments (051) simply omitted the org_id FK entirely.

## Test plan

- [x] `atlas migrate validate` passes
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test -race -count=1 ./...` — all pass
- [ ] Verify migration applies cleanly against a populated database

Closes #658

> The Sorting Hat never asks what house you *want* — it reads what you *are*
> and files you where you belong. RESTRICT is the Sorting Hat of foreign keys:
> it won't let you leave until every dependency is accounted for.