### PR TITLE
fix: repo accuracy audit — consensus_weight, spec sync, quality_score cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ internal/
   storage/sqlite/    SQLite storage backend for local/lite mode (build tag: lite).
   service/           Business logic. decisions/ (trace pipeline), embedding/, quality/, trace/ (event buffer, WAL),
                      autoassess/, autoresolve/, tracehealth/.
-  model/             Domain types. Decision, AgentEvent, Alternative, Evidence, Grant, etc.
+  model/             Domain types. Decision, AgentEvent, Alternative, Evidence, etc.
   config/            Env var loading and validation.
   auth/              JWT issuing/verification, API key hashing (Argon2id).
   authz/             RBAC enforcement, grant cache, access filtering.
@@ -71,7 +71,7 @@ internal/
   ratelimit/         Pluggable token bucket rate limiter.
   telemetry/         OpenTelemetry setup (traces + metrics).
   testutil/          Shared test helpers (testcontainers, test DB, test logger).
-migrations/          Sequential SQL files (001..097). Atlas-managed checksums.
+migrations/          Sequential SQL files (001..098). Atlas-managed checksums.
 adrs/                Technical architecture decision records (ADR-001 through ADR-015).
 sdk/                 Go, Python, TypeScript client SDKs.
 ui/                  React 19 SPA (audit dashboard). Embedded via go:embed when built with -tags ui.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -485,6 +485,8 @@ paths:
                 $ref: "#/components/schemas/APIResponse_GetRunResponse"
         "400":
           $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
 
@@ -513,10 +515,24 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/APIResponse_AppendEventsResponse"
+        "202":
+          description: Events buffered but flush failed; will retry.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/APIResponse_AppendEventsResponse"
         "400":
           $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+        "503":
+          description: Buffer at capacity or server shutting down.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
   /v1/runs/{run_id}/complete:
     post:
@@ -546,6 +562,8 @@ paths:
                 $ref: "#/components/schemas/APIResponse_AgentRun"
         "400":
           $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
 
@@ -664,7 +682,6 @@ paths:
                         sprint: "2026-Q1"
                         ticket: "ARCH-142"
                       completeness_score: 0.85
-                      quality_score: 0.85
                       valid_from: "2026-01-15T10:30:00Z"
                       transaction_time: "2026-01-15T10:30:00Z"
                       created_at: "2026-01-15T10:30:00Z"
@@ -770,6 +787,8 @@ paths:
                 $ref: "#/components/schemas/APIResponse_AgentHistoryResponse"
         "400":
           $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
 
   /v1/decisions/{id}:
     get:
@@ -1011,6 +1030,8 @@ paths:
                 $ref: "#/components/schemas/APIResponse_RevisionsResponse"
         "400":
           $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
 
@@ -1040,6 +1061,8 @@ paths:
                 $ref: "#/components/schemas/APIResponse_DecisionLineage"
         "400":
           $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
 
@@ -1188,6 +1211,8 @@ paths:
                     $ref: "#/components/schemas/ResponseMeta"
         "400":
           $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
 
@@ -1273,6 +1298,8 @@ paths:
                 $ref: "#/components/schemas/APIResponse_VerifyResponse"
         "400":
           $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
 
@@ -3411,7 +3438,6 @@ components:
         - confidence
         - metadata
         - completeness_score
-        - quality_score
         - valid_from
         - transaction_time
         - created_at
@@ -3457,13 +3483,6 @@ components:
             Computed as (correct + 0.5 * partially_correct) / total from the
             decision_assessments table. Null when no assessments exist. Updated
             on each new assessment via POST /v1/decisions/{id}/assess.
-        quality_score:
-          type: number
-          format: float
-          deprecated: true
-          description: >
-            Deprecated alias for completeness_score. Emitted alongside completeness_score for
-            one release cycle. Use completeness_score in new code.
         precedent_ref:
           type: string
           format: uuid
@@ -3574,10 +3593,12 @@ components:
           format: float
           minimum: 0.5
           maximum: 1
+          nullable: true
           description: |
             0.5 + 0.5 × (agreement_count / max(1, agreement_count + conflict_count)).
-            Range [0.5, 1.0]. Only present when at least one agreement or conflict exists.
-            Not stored — computed at response time.
+            Range [0.5, 1.0]. Null when no agreements or conflicts exist.
+            Not stored — computed at response time. Only populated on
+            GET /v1/decisions/{id} (detail view); omitted from list endpoints.
         alternatives:
           type: array
           items:
@@ -3640,6 +3661,15 @@ components:
         relevance_score:
           type: number
           format: float
+        metrics:
+          type: object
+          additionalProperties:
+            type: number
+            format: double
+          description: |
+            Numeric metrics associated with this evidence (e.g. accuracy, f1).
+            Only present when the evidence source_type is "metrics" or the
+            caller provided metric values.
         metadata:
           type: object
           additionalProperties: true

--- a/internal/compact/compact.go
+++ b/internal/compact/compact.go
@@ -59,10 +59,8 @@ func Decision(d model.Decision) map[string]any {
 	}
 
 	// Consensus weight: [0.5, 1.0]; only include when there's meaningful data.
-	total := d.AgreementCount + d.ConflictCount
-	if total > 0 {
-		cw := 0.5 + 0.5*float64(d.AgreementCount)/float64(max(1, total))
-		m["consensus_weight"] = math.Round(cw*1000) / 1000 // 3 decimal places
+	if cw := model.ComputeConsensusWeight(d.AgreementCount, d.ConflictCount); cw != nil {
+		m["consensus_weight"] = *cw
 	}
 
 	// Assessment summary: explicit correctness feedback from agents.

--- a/internal/model/decision.go
+++ b/internal/model/decision.go
@@ -1,11 +1,25 @@
 package model
 
 import (
+	"math"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/pgvector/pgvector-go"
 )
+
+// ComputeConsensusWeight returns the consensus weight for a decision given
+// its agreement and conflict counts. Returns nil when both are zero (no data).
+// Formula: 0.5 + 0.5 × (agreements / max(1, agreements + conflicts)), range [0.5, 1.0].
+func ComputeConsensusWeight(agreementCount, conflictCount int) *float64 {
+	total := agreementCount + conflictCount
+	if total == 0 {
+		return nil
+	}
+	cw := 0.5 + 0.5*float64(agreementCount)/float64(total)
+	cw = math.Round(cw*1000) / 1000 // 3 decimal places
+	return &cw
+}
 
 // Decision is a first-class decision entity with bi-temporal modeling.
 // Created from DecisionMade events and revised via DecisionRevised events.
@@ -71,6 +85,11 @@ type Decision struct {
 	// Returns 0 for decisions without embeddings.
 	AgreementCount int `json:"agreement_count"`
 	ConflictCount  int `json:"conflict_count"`
+
+	// ConsensusWeight (Spec 34): [0.5, 1.0], computed from agreement/conflict ratio.
+	// Only present on GET /v1/decisions/{id} (detail view), not list endpoints.
+	// nil when no agreements or conflicts exist.
+	ConsensusWeight *float64 `json:"consensus_weight,omitempty"`
 
 	// Outcome signals (Spec 35): temporal, graph, and fate signals computed at query time.
 	SupersessionVelocityHours *float64     `json:"supersession_velocity_hours"`

--- a/internal/server/handlers_decisions.go
+++ b/internal/server/handlers_decisions.go
@@ -393,6 +393,7 @@ func (h *Handlers) HandleGetDecision(w http.ResponseWriter, r *http.Request) {
 	if consensusErr == nil {
 		d.AgreementCount = agreementCount
 		d.ConflictCount = conflictCount
+		d.ConsensusWeight = model.ComputeConsensusWeight(agreementCount, conflictCount)
 	}
 	if signalsErr == nil {
 		d.SupersessionVelocityHours = signals.SupersessionVelocityHours

--- a/sdk/go/akashi/types.go
+++ b/sdk/go/akashi/types.go
@@ -50,8 +50,9 @@ type Decision struct {
 	Evidence     []Evidence    `json:"evidence,omitempty"`
 
 	// Consensus scoring: computed at query time from embedding similarity cluster.
-	AgreementCount int `json:"agreement_count"`
-	ConflictCount  int `json:"conflict_count"`
+	AgreementCount  int      `json:"agreement_count"`
+	ConflictCount   int      `json:"conflict_count"`
+	ConsensusWeight *float64 `json:"consensus_weight,omitempty"`
 
 	// Outcome signals: temporal, graph, and fate signals computed at query time.
 	SupersessionVelocityHours *float64     `json:"supersession_velocity_hours"`

--- a/sdk/python/src/akashi/types.py
+++ b/sdk/python/src/akashi/types.py
@@ -59,6 +59,7 @@ class Decision(BaseModel):
     evidence: list[Evidence] = Field(default_factory=list)
     agreement_count: int = 0
     conflict_count: int = 0
+    consensus_weight: float | None = None
     supersession_velocity_hours: float | None = None
     precedent_citation_count: int = 0
     conflict_fate: ConflictFate = Field(default_factory=lambda: ConflictFate())

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -47,6 +47,8 @@ export interface Decision {
   /** Consensus scoring: computed at query time. */
   agreement_count?: number;
   conflict_count?: number;
+  /** Consensus weight [0.5, 1.0]: only on detail view. */
+  consensus_weight?: number | null;
   /** Outcome signals: temporal, graph, and fate signals. */
   supersession_velocity_hours?: number | null;
   precedent_citation_count?: number;


### PR DESCRIPTION
## Summary

- Extract `ComputeConsensusWeight` into the model package as a shared function and expose `consensus_weight` as a computed `*float64` field on the decision detail endpoint (`GET /v1/decisions/{id}`).
- Remove the deprecated `quality_score` field from the OpenAPI spec (deprecated since Feb 2026; one release cycle elapsed).
- Add missing `403` responses to 7 endpoints, add `evidence.metrics` schema, and mark `consensus_weight` as `nullable` in the spec.
- Sync all three SDKs (Go, Python, TypeScript) with the new `consensus_weight` field.
- Correct AGENTS.md migration count (→098) and fix inaccurate `Grant` type name in the model description.

## Verification

- [x] I ran relevant tests locally (`go test ./...` or targeted package tests).
- [x] I updated docs/openapi for any API or behavior changes.
- [ ] If I changed config vars in `internal/config/config.go`, I also updated:
  - [ ] `docs/configuration.md`
  - [ ] `docs/runbook.md` (operational subset, if relevant)
  - [ ] `.env.example` (if baseline local/dev defaults changed)
- [ ] `python3 scripts/check_doc_config_consistency.py` passes.

## Risk / Rollout Notes

- `quality_score` removal is a breaking spec change for any consumer still referencing it. The field was deprecated for one full release cycle (Feb→Apr 2026) and was never present in the Go model — only in the spec. The `order_by=quality_score` query alias remains as a backward-compat shim in storage.
- `consensus_weight` is additive and nullable; existing clients that ignore unknown fields are unaffected.

> The Federation doesn't just patch hull breaches — they file the
> structural integrity report, update the ship's technical manual, and
> brief the next shift. Starfleet's real superpower was never the warp
> drive; it was the obsessive documentation culture that kept the
> Enterprise flying between refits.