### PR TITLE
fix: wire project filter to conflict queries in Check() and HTTP API

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1480,6 +1480,11 @@ paths:
             type: string
             enum: [factual, assessment, strategic, temporal]
           description: Filter by category.
+        - name: project
+          in: query
+          schema:
+            type: string
+          description: Filter by project name (matches project_a or project_b).
         - name: limit
           in: query
           schema:

--- a/internal/server/handlers_conflicts.go
+++ b/internal/server/handlers_conflicts.go
@@ -670,5 +670,8 @@ func parseConflictFilters(r *http.Request) storage.ConflictFilters {
 	if st := r.URL.Query().Get("status"); st != "" {
 		filters.Status = &st
 	}
+	if proj := r.URL.Query().Get("project"); proj != "" {
+		filters.Project = &proj
+	}
 	return filters
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -10771,9 +10771,16 @@ func TestHandleDecisionConflicts_Nonexistent(t *testing.T) {
 // Coverage push: HandleListConflicts — combined filters
 // ===========================================================================
 
+func TestHandleListConflicts_WithProjectFilter(t *testing.T) {
+	resp, err := authedRequest("GET", testSrv.URL+"/v1/conflicts?project=my-project", adminToken, nil)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
 func TestHandleListConflicts_CombinedFilters(t *testing.T) {
 	resp, err := authedRequest("GET",
-		testSrv.URL+"/v1/conflicts?status=open&severity=high&decision_type=implementation&agent_id=test-agent&limit=10&offset=0",
+		testSrv.URL+"/v1/conflicts?status=open&severity=high&decision_type=implementation&agent_id=test-agent&project=my-project&limit=10&offset=0",
 		adminToken, nil)
 	require.NoError(t, err)
 	defer func() { _ = resp.Body.Close() }()

--- a/internal/service/decisions/helpers_test.go
+++ b/internal/service/decisions/helpers_test.go
@@ -1657,6 +1657,7 @@ func (m *checkStore) ListConflicts(_ context.Context, _ uuid.UUID, filters stora
 	if m.conflictsErr != nil {
 		return nil, m.conflictsErr
 	}
+	result := m.conflicts
 	// Respect StatusIn filter to match production SQL behavior.
 	if len(filters.StatusIn) > 0 {
 		allowed := make(map[string]bool, len(filters.StatusIn))
@@ -1664,14 +1665,25 @@ func (m *checkStore) ListConflicts(_ context.Context, _ uuid.UUID, filters stora
 			allowed[s] = true
 		}
 		var filtered []model.DecisionConflict
-		for _, c := range m.conflicts {
+		for _, c := range result {
 			if allowed[c.Status] {
 				filtered = append(filtered, c)
 			}
 		}
-		return filtered, nil
+		result = filtered
 	}
-	return m.conflicts, nil
+	// Respect Project filter to match production SQL behavior.
+	if filters.Project != nil {
+		var filtered []model.DecisionConflict
+		for _, c := range result {
+			if (c.ProjectA != nil && *c.ProjectA == *filters.Project) ||
+				(c.ProjectB != nil && *c.ProjectB == *filters.Project) {
+				filtered = append(filtered, c)
+			}
+		}
+		result = filtered
+	}
+	return result, nil
 }
 
 func (m *checkStore) GetResolvedConflictsByType(_ context.Context, _ uuid.UUID, _ string, _ int) ([]model.ConflictResolution, error) {
@@ -1797,6 +1809,52 @@ func TestCheck_WithProjectAndAgentFilters(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.True(t, resp.HasPrecedent)
+}
+
+func TestCheck_ProjectFilterAppliesToConflicts(t *testing.T) {
+	t.Parallel()
+	myProject := "my-project"
+	otherProject := "other-project"
+	ms := &checkStore{
+		conflicts: []model.DecisionConflict{
+			{Status: "open", ProjectA: &myProject, ProjectB: &myProject},
+			{Status: "open", ProjectA: &otherProject, ProjectB: &otherProject},
+			{Status: "open", ProjectA: &myProject, ProjectB: &otherProject},
+		},
+	}
+	svc := New(ms, fakeEmbedder{dims: 3}, nil, testLogger(), nil)
+
+	resp, err := svc.Check(context.Background(), uuid.Nil, CheckInput{
+		DecisionType: "arch", Project: "my-project", Limit: 10,
+	})
+	require.NoError(t, err)
+	// Should only return conflicts where at least one side matches "my-project" (2 of 3).
+	assert.Len(t, resp.Conflicts, 2)
+	for _, c := range resp.Conflicts {
+		assert.True(t,
+			(c.ProjectA != nil && *c.ProjectA == "my-project") ||
+				(c.ProjectB != nil && *c.ProjectB == "my-project"),
+			"conflict should involve my-project")
+	}
+}
+
+func TestCheck_NoProjectFilterReturnsAllConflicts(t *testing.T) {
+	t.Parallel()
+	projA := "project-a"
+	projB := "project-b"
+	ms := &checkStore{
+		conflicts: []model.DecisionConflict{
+			{Status: "open", ProjectA: &projA, ProjectB: &projA},
+			{Status: "open", ProjectA: &projB, ProjectB: &projB},
+		},
+	}
+	svc := New(ms, fakeEmbedder{dims: 3}, nil, testLogger(), nil)
+
+	resp, err := svc.Check(context.Background(), uuid.Nil, CheckInput{
+		DecisionType: "arch", Limit: 10,
+	})
+	require.NoError(t, err)
+	assert.Len(t, resp.Conflicts, 2, "without project filter, all conflicts should be returned")
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/service/decisions/service.go
+++ b/internal/service/decisions/service.go
@@ -687,6 +687,10 @@ func (s *Service) Check(ctx context.Context, orgID uuid.UUID, input CheckInput) 
 			dt := input.DecisionType
 			conflictFilter.DecisionType = &dt
 		}
+		if input.Project != "" {
+			p := input.Project
+			conflictFilter.Project = &p
+		}
 		listed, err := s.db.ListConflicts(ctx, orgID, conflictFilter, input.Limit, 0)
 		if err != nil {
 			conflictErr = err


### PR DESCRIPTION
## Summary

- `Check()` service method and `GET /v1/conflicts` accepted a `project` parameter but never applied it when listing conflicts — all open conflicts across every project were returned. The storage layer already supported project filtering in SQL (`conflictWhere` generates `project_a = $N OR project_b = $N`); this commit wires `input.Project` through to `ConflictFilters.Project` in the service layer and adds `project` query param parsing to `parseConflictFilters()` for the HTTP endpoint.
- Updated OpenAPI spec to document the new `project` query parameter on `GET /v1/conflicts`.
- Added unit tests proving project filtering works for conflicts in `Check()`, plus integration tests for the HTTP endpoint.

## Verification

- [x] I ran relevant tests locally (`go test ./...` or targeted package tests).
- [x] I updated docs/openapi for any API or behavior changes.
- [ ] If I changed config vars in `internal/config/config.go`, I also updated:
  - [ ] `docs/configuration.md`
  - [ ] `docs/runbook.md` (operational subset, if relevant)
  - [ ] `.env.example` (if baseline local/dev defaults changed)
- [ ] `python3 scripts/check_doc_config_consistency.py` passes.

## Risk / Rollout Notes

- No migration or backward-compatibility risk. This is purely additive — callers that don't pass `project` get the same behavior as before (all conflicts returned). Callers that do pass `project` now get correctly filtered results instead of silently ignoring the filter.

> The Sorting Hat deliberated longer than expected — not between Gryffindor
> and Slytherin, but between "ship it now" and "ship it right." It chose
> the latter, because even magical hats know that a filter that accepts
> your input and quietly ignores it is the most Slytherin bug of all.