### PR TITLE
fix: align HandleListKeys with standard list envelope

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -5253,21 +5253,21 @@ components:
 
     APIResponse_KeyList:
       type: object
-      required: [data, meta]
+      required: [data, has_more, limit, offset, meta]
       properties:
         data:
-          type: object
-          properties:
-            keys:
-              type: array
-              items:
-                $ref: "#/components/schemas/APIKey"
-            total:
-              type: integer
-            limit:
-              type: integer
-            offset:
-              type: integer
+          type: array
+          items:
+            $ref: "#/components/schemas/APIKey"
+        total:
+          type: integer
+          nullable: true
+        has_more:
+          type: boolean
+        limit:
+          type: integer
+        offset:
+          type: integer
         meta:
           $ref: "#/components/schemas/ResponseMeta"
 

--- a/internal/model/api_key.go
+++ b/internal/model/api_key.go
@@ -40,15 +40,6 @@ type CreateKeyRequest struct {
 	ExpiresAt *string `json:"expires_at,omitempty"` // RFC3339
 }
 
-// APIKeyResponse is the list response for GET /v1/keys.
-type APIKeyResponse struct {
-	Keys    []APIKey `json:"keys"`
-	Total   int      `json:"total"`
-	Limit   int      `json:"limit"`
-	Offset  int      `json:"offset"`
-	HasMore bool     `json:"has_more"`
-}
-
 // RotateKeyResponse is the response for POST /v1/keys/{id}/rotate.
 type RotateKeyResponse struct {
 	NewKey       APIKeyWithRawKey `json:"new_key"`

--- a/internal/server/handlers_critical_test.go
+++ b/internal/server/handlers_critical_test.go
@@ -316,11 +316,9 @@ func TestHandlersCritical_RotateKeyOldKeyStopsWorking(t *testing.T) {
 	listResp, err := authedRequest("GET", testSrv.URL+"/v1/keys?limit=200", adminToken, nil)
 	require.NoError(t, err)
 	var keysResult struct {
-		Data struct {
-			Keys []struct {
-				ID      uuid.UUID `json:"id"`
-				AgentID string    `json:"agent_id"`
-			} `json:"keys"`
+		Data []struct {
+			ID      uuid.UUID `json:"id"`
+			AgentID string    `json:"agent_id"`
 		} `json:"data"`
 	}
 	listBody, _ := io.ReadAll(listResp.Body)
@@ -328,7 +326,7 @@ func TestHandlersCritical_RotateKeyOldKeyStopsWorking(t *testing.T) {
 	require.NoError(t, json.Unmarshal(listBody, &keysResult))
 
 	var keyID uuid.UUID
-	for _, k := range keysResult.Data.Keys {
+	for _, k := range keysResult.Data {
 		if k.AgentID == rotAgentID {
 			keyID = k.ID
 			break

--- a/internal/server/handlers_keys.go
+++ b/internal/server/handlers_keys.go
@@ -108,13 +108,8 @@ func (h *Handlers) HandleListKeys(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, r, http.StatusOK, model.APIKeyResponse{
-		Keys:    keys,
-		Total:   total,
-		Limit:   limit,
-		Offset:  offset,
-		HasMore: offset+len(keys) < total,
-	})
+	ptotal := total
+	writeListJSON(w, r, keys, &ptotal, offset+len(keys) < total, limit, offset)
 }
 
 // HandleRevokeKey handles DELETE /v1/keys/{id} (admin-only).

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -2122,12 +2122,12 @@ func TestHandleCreateAndListKeys(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp2.StatusCode)
 
 	var list struct {
-		Data model.APIKeyResponse `json:"data"`
+		Data []model.APIKey `json:"data"`
 	}
 	listData, _ := io.ReadAll(resp2.Body)
 	require.NoError(t, json.Unmarshal(listData, &list))
 	found := false
-	for _, k := range list.Data.Keys {
+	for _, k := range list.Data {
 		if k.ID == created.Data.ID {
 			found = true
 			break
@@ -9232,18 +9232,16 @@ func TestHandleListKeys_WithPagination(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 	var result struct {
-		Data struct {
-			Keys    []json.RawMessage `json:"keys"`
-			Total   int               `json:"total"`
-			Limit   int               `json:"limit"`
-			Offset  int               `json:"offset"`
-			HasMore bool              `json:"has_more"`
-		} `json:"data"`
+		Data    []json.RawMessage `json:"data"`
+		Total   *int              `json:"total"`
+		Limit   int               `json:"limit"`
+		Offset  int               `json:"offset"`
+		HasMore bool              `json:"has_more"`
 	}
 	body, _ := io.ReadAll(resp.Body)
 	require.NoError(t, json.Unmarshal(body, &result))
-	assert.Equal(t, 10, result.Data.Limit)
-	assert.Equal(t, 0, result.Data.Offset)
+	assert.Equal(t, 10, result.Limit)
+	assert.Equal(t, 0, result.Offset)
 }
 
 // ===========================================================================
@@ -9721,11 +9719,9 @@ func TestHandleRotateKey_Success(t *testing.T) {
 	resp, err := authedRequest("GET", testSrv.URL+"/v1/keys?limit=100", adminToken, nil)
 	require.NoError(t, err)
 	var keysResp struct {
-		Data struct {
-			Keys []struct {
-				ID      uuid.UUID `json:"id"`
-				AgentID string    `json:"agent_id"`
-			} `json:"keys"`
+		Data []struct {
+			ID      uuid.UUID `json:"id"`
+			AgentID string    `json:"agent_id"`
 		} `json:"data"`
 	}
 	body, _ := io.ReadAll(resp.Body)
@@ -9733,7 +9729,7 @@ func TestHandleRotateKey_Success(t *testing.T) {
 	require.NoError(t, json.Unmarshal(body, &keysResp))
 
 	var keyID uuid.UUID
-	for _, k := range keysResp.Data.Keys {
+	for _, k := range keysResp.Data {
 		if k.AgentID == "rotate-agent" {
 			keyID = k.ID
 			break


### PR DESCRIPTION
## Summary
- `HandleListKeys` was the only list endpoint using a nested `APIKeyResponse{Keys: [...]}` struct instead of the standard `writeListJSON` helper, producing `{"data": {"keys": [...]}}` instead of `{"data": [...]}`.
- All three SDKs (Go, Python, TypeScript) use list parsers that expect `data` to be a flat array — Python's `_handle_list_body` silently returned an empty list, Go/TS failed to unmarshal.
- Switched to `writeListJSON`, removed the dead `APIKeyResponse` type, updated OpenAPI spec to match the standard `ListResponse` shape.

## Test plan
- [x] All existing key handler tests updated and passing (`TestHandleCreateKey`, `TestHandleListKeys_WithPagination`, `TestHandleRotateKey_Success`, `TestHandlersCritical_RotateKeyOldKeyStopsWorking`)
- [x] `writeListJSON` unit tests continue to pass
- [x] Full test suite passes with `-race`
- [x] golangci-lint clean

Closes #651

> The Sorting Hat never tells you about the decisions it almost made —
> "nearly Slytherin" gets a throwaway line, but the reasoning chain
> behind seven years of house placements is lost forever. Akashi is
> what Hogwarts needed: an audit trail that remembers not just the
> outcome, but every alternative the hat considered and rejected.