### PR TITLE
fix: consolidate duplicate ErrAgentNotFound and duplicate exec interfaces

### DIFF
--- a/internal/service/decisions/service.go
+++ b/internal/service/decisions/service.go
@@ -1056,8 +1056,9 @@ func (s *Service) SemanticSearchAvailable() bool {
 }
 
 // ErrAgentNotFound indicates the agent does not exist and the caller lacks
-// permission to auto-create it.
-var ErrAgentNotFound = errors.New("agent_id not found in this organization")
+// permission to auto-create it. It wraps storage.ErrAgentNotFound so callers
+// can match either the service-level or storage-level sentinel.
+var ErrAgentNotFound = fmt.Errorf("agent_id not found in this organization: %w", storage.ErrAgentNotFound)
 
 // ResolveOrCreateAgent looks up an agent by agent_id within an org. If the
 // agent does not exist and the caller has admin+ privileges, it auto-registers

--- a/internal/storage/decisions.go
+++ b/internal/storage/decisions.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/pgvector/pgvector-go"
 
 	"github.com/ashita-ai/akashi/internal/integrity"
@@ -48,14 +47,9 @@ func scanOneDecision(row pgxRowScanner) (model.Decision, error) {
 	return d, nil
 }
 
-// txExecer is satisfied by both pgx.Tx and *pgxpool.Pool.
-type txExecer interface {
-	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
-}
-
 // queueSearchOutbox inserts or resets a search outbox entry for a decision.
 // operation must be "upsert" or "delete".
-func queueSearchOutbox(ctx context.Context, exec txExecer, decisionID, orgID uuid.UUID, operation string) error {
+func queueSearchOutbox(ctx context.Context, exec pgxExecer, decisionID, orgID uuid.UUID, operation string) error {
 	_, err := exec.Exec(ctx,
 		`INSERT INTO search_outbox (decision_id, org_id, operation)
 		 VALUES ($1, $2, $3)


### PR DESCRIPTION
## Summary
- **`ErrAgentNotFound`**: `decisions.ErrAgentNotFound` now wraps `storage.ErrAgentNotFound` via `fmt.Errorf`, so `errors.Is` chains work from either the service or storage level. Previously these were two independent sentinels with different messages — callers had to know which package's error to match against.
- **Duplicate interfaces**: Removed `txExecer` from `decisions.go` (identical to `pgxExecer` in `audit.go`). `queueSearchOutbox` now uses `pgxExecer`.

## Test plan
- [x] All tests in `internal/service/decisions/`, `internal/storage/`, and `internal/server/` pass with `-race`
- [x] `go vet`, `golangci-lint`, and `atlas migrate validate` all clean
- [x] Verified `errors.Is(decisions.ErrAgentNotFound, storage.ErrAgentNotFound)` is true (wrapping chain)

Closes #636

> Wands choose the wizard, but errors choose nobody —
> they just float around the codebase until two of them
> claim the same name and some poor soul in Debugging class
> has to figure out which one their `errors.Is` caught.
> At least Ollivander only had one Elder Wand.