### PR TITLE
fix: rename stale indexes, drop redundant org index

### DIFF
--- a/migrations/101_rename_stale_indexes.sql
+++ b/migrations/101_rename_stale_indexes.sql
@@ -1,0 +1,7 @@
+-- 101: Rename indexes left over from quality_score → completeness_score rename
+-- (migration 050), and drop redundant idx_scored_conflicts_org which is
+-- subsumed by every other org-prefixed index on scored_conflicts.
+
+ALTER INDEX idx_decisions_quality RENAME TO idx_decisions_completeness;
+ALTER INDEX idx_decisions_type_quality RENAME TO idx_decisions_type_completeness;
+DROP INDEX idx_scored_conflicts_org;

--- a/migrations/atlas.sum
+++ b/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:yhDmKsnNfmQRGJfYGiW5wfWWuR0oyCUhr1/z+OmAmnw=
+h1:M2/Ug13HxqaevLbajbSFrey2yNd+ZcADrMvDI7i7c6c=
 001_initial.sql h1:uhyGXto+QacAaGYb9ZTGjsBs5chlKi8O0eHz9aCQsrY=
 022_full_text_search.sql h1:9iwtA8MgCzAxDV9YkUBn0CLT9ePSmj3GcPoMGg8TXf0=
 023_fix_outbox_index.sql h1:OtMEFBcMRWej02+ghnBXlPr6BVq+LoA62Id9XUWfDNI=
@@ -79,3 +79,4 @@ h1:yhDmKsnNfmQRGJfYGiW5wfWWuR0oyCUhr1/z+OmAmnw=
 098_fix_remaining_project_assignments.sql h1:hh9aiqeQcFEjQI4qt5in6JnQflujJhQi8WYVq/yWAxQ=
 099_tamper_evidence_fk_tighten.sql h1:5gBoilnQtObLjOcitnfZ697TPLC2X8tP+0QIixpv+yE=
 100_audit_fk_hardening.sql h1:3sOiy8hVCrCJbRvlvm5v9AGtOLnmz3dtsJxXuwL1AKI=
+101_rename_stale_indexes.sql h1:fOnIzZKgPZDXjlcOtXSDxTYoK0fZV41ad+JMAwck8aY=


### PR DESCRIPTION
## Summary

- Renames `idx_decisions_quality` → `idx_decisions_completeness` and `idx_decisions_type_quality` → `idx_decisions_type_completeness` to match the column rename from migration 050 (`quality_score` → `completeness_score`)
- Drops `idx_scored_conflicts_org(org_id)` which is redundant — subsumed by `idx_scored_conflicts_org_sig`, `idx_scored_conflicts_detected`, `idx_scored_conflicts_org_kind`, `idx_scored_conflicts_org_detected_status`, and `idx_scored_conflicts_org_resolved`

Closes #661

## Test plan

- [ ] `atlas migrate validate` passes
- [ ] All existing tests pass (`go test -race -count=1 ./...`)
- [ ] Verify on a staging database that the three `ALTER INDEX`/`DROP INDEX` statements apply cleanly

> The transporter doesn't care what you named the pattern buffer —
> it reassembles you from the same atoms either way. But Starfleet
> Engineering renamed theirs after Wolf 359, because when you're
> debugging at 3 AM, `annular_confinement_beam` beats `acb_legacy_v2`
> every single time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)