### PR TITLE
refactor: replace map[string]any handler responses with typed structs

### DIFF
--- a/internal/model/responses.go
+++ b/internal/model/responses.go
@@ -1,0 +1,175 @@
+package model
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// TraceResponse is the response for POST /v1/trace.
+type TraceResponse struct {
+	RunID      uuid.UUID `json:"run_id"`
+	DecisionID uuid.UUID `json:"decision_id"`
+	EventCount int       `json:"event_count"`
+
+	EmbeddingSkipped   bool     `json:"embedding_skipped,omitempty"`
+	Warnings           []string `json:"warnings,omitempty"`
+	ConfidenceAdjusted bool     `json:"confidence_adjusted,omitempty"`
+	OriginalConfidence float32  `json:"original_confidence,omitempty"`
+	StoredConfidence   float32  `json:"stored_confidence,omitempty"`
+	ConfidenceReasons  []string `json:"confidence_reasons,omitempty"`
+}
+
+// TemporalQueryResponse is the response for POST /v1/query/temporal.
+type TemporalQueryResponse struct {
+	AsOf      time.Time  `json:"as_of"`
+	Decisions []Decision `json:"decisions"`
+}
+
+// DecisionRevisionsResponse is the response for GET /v1/decisions/{id}/revisions.
+type DecisionRevisionsResponse struct {
+	DecisionID uuid.UUID  `json:"decision_id"`
+	Revisions  []Decision `json:"revisions"`
+	Count      int        `json:"count"`
+}
+
+// VerifyDecisionResponse is the response for GET /v1/verify/{id}.
+type VerifyDecisionResponse struct {
+	DecisionID  uuid.UUID `json:"decision_id"`
+	Status      string    `json:"status"`
+	Verified    *bool     `json:"verified,omitempty"`
+	Valid       *bool     `json:"valid,omitempty"`
+	ContentHash string    `json:"content_hash,omitempty"`
+	Message     string    `json:"message,omitempty"`
+	RetractedAt string    `json:"retracted_at,omitempty"`
+
+	// Erasure-specific fields.
+	OriginalHash string     `json:"original_hash,omitempty"`
+	ErasedAt     *time.Time `json:"erased_at,omitempty"`
+	ErasedBy     string     `json:"erased_by,omitempty"`
+}
+
+// IntegrityViolationsResponse is the response for GET /v1/integrity/violations.
+type IntegrityViolationsResponse struct {
+	Violations any `json:"violations"`
+	Count      int `json:"count"`
+}
+
+// SessionViewSummary contains aggregate stats for a session.
+type SessionViewSummary struct {
+	StartedAt     time.Time      `json:"started_at"`
+	EndedAt       time.Time      `json:"ended_at"`
+	DurationSecs  float64        `json:"duration_secs"`
+	DecisionTypes map[string]int `json:"decision_types"`
+	AvgConfidence float64        `json:"avg_confidence"`
+}
+
+// SessionViewResponse is the response for GET /v1/sessions/{session_id}.
+type SessionViewResponse struct {
+	SessionID     uuid.UUID           `json:"session_id"`
+	Decisions     []Decision          `json:"decisions"`
+	DecisionCount int                 `json:"decision_count"`
+	Summary       *SessionViewSummary `json:"summary,omitempty"`
+}
+
+// EraseDecisionResponse is the response for POST /v1/decisions/{id}/erase.
+type EraseDecisionResponse struct {
+	DecisionID         uuid.UUID  `json:"decision_id"`
+	ErasedAt           *time.Time `json:"erased_at"`
+	OriginalHash       string     `json:"original_hash"`
+	ErasedHash         string     `json:"erased_hash"`
+	AlternativesErased int64      `json:"alternatives_erased"`
+	EvidenceErased     int64      `json:"evidence_erased"`
+	ClaimsErased       int64      `json:"claims_erased"`
+}
+
+// CreateAgentAPIKeyInfo is the nested api_key in the CreateAgentResponse.
+type CreateAgentAPIKeyInfo struct {
+	ID     uuid.UUID `json:"id"`
+	Prefix string    `json:"prefix"`
+}
+
+// CreateAgentResponse is the response for POST /v1/agents.
+type CreateAgentResponse struct {
+	Agent  Agent                 `json:"agent"`
+	APIKey CreateAgentAPIKeyInfo `json:"api_key"`
+	RawKey string                `json:"raw_key,omitempty"`
+}
+
+// AgentStatsResponse is the response for GET /v1/agents/{agent_id}/stats.
+type AgentStatsResponse struct {
+	AgentID string `json:"agent_id"`
+	Stats   any    `json:"stats"`
+}
+
+// DeleteAgentResponse is the response for DELETE /v1/agents/{agent_id}.
+type DeleteAgentResponse struct {
+	AgentID string `json:"agent_id"`
+	Deleted any    `json:"deleted"`
+}
+
+// UsageByKey is a single API key's usage in the usage response.
+type UsageByKey struct {
+	KeyID   *uuid.UUID `json:"key_id"`
+	Prefix  string     `json:"prefix"`
+	Label   string     `json:"label"`
+	AgentID string     `json:"agent_id"`
+	Count   int        `json:"decisions"`
+}
+
+// UsageByAgent is a single agent's usage in the usage response.
+type UsageByAgent struct {
+	AgentID   string `json:"agent_id"`
+	Decisions int    `json:"decisions"`
+}
+
+// GetUsageResponse is the response for GET /v1/usage.
+type GetUsageResponse struct {
+	OrgID          uuid.UUID      `json:"org_id"`
+	Period         string         `json:"period"`
+	TotalDecisions int            `json:"total_decisions"`
+	ByKey          []UsageByKey   `json:"by_key"`
+	ByAgent        []UsageByAgent `json:"by_agent"`
+}
+
+// RetentionPolicyResponse is the response for GET/PUT /v1/retention.
+type RetentionPolicyResponse struct {
+	RetentionDays         *int       `json:"retention_days"`
+	RetentionExcludeTypes []string   `json:"retention_exclude_types"`
+	LastRun               *time.Time `json:"last_run"`
+	LastRunDeleted        *int       `json:"last_run_deleted"`
+	NextRun               *time.Time `json:"next_run"`
+	Holds                 any        `json:"holds,omitempty"`
+}
+
+// PurgeResponse is the response for POST /v1/retention/purge.
+type PurgeResponse struct {
+	DryRun      bool `json:"dry_run"`
+	Deleted     any  `json:"deleted,omitempty"`
+	WouldDelete any  `json:"would_delete,omitempty"`
+}
+
+// DecisionProofResponse is the response for GET /v1/integrity/proof/{id}.
+type DecisionProofResponse struct {
+	DecisionID  uuid.UUID `json:"decision_id"`
+	ContentHash string    `json:"content_hash"`
+	ProofID     uuid.UUID `json:"proof_id"`
+	RootHash    string    `json:"root_hash"`
+	BatchStart  time.Time `json:"batch_start"`
+	BatchEnd    time.Time `json:"batch_end"`
+	ProofPath   any       `json:"proof_path"`
+	Verified    bool      `json:"verified"`
+}
+
+// AssessmentListResponse is the response for GET /v1/decisions/{id}/assessments.
+type AssessmentListResponse struct {
+	DecisionID  uuid.UUID            `json:"decision_id"`
+	Summary     AssessmentSummary    `json:"summary"`
+	Assessments []DecisionAssessment `json:"assessments"`
+	Count       int                  `json:"count"`
+}
+
+// GrantAllProjectLinksResponse is the response for POST /v1/project-links/grant-all.
+type GrantAllProjectLinksResponse struct {
+	LinksCreated int `json:"links_created"`
+}

--- a/internal/server/handlers_admin.go
+++ b/internal/server/handlers_admin.go
@@ -123,16 +123,15 @@ func (h *Handlers) HandleCreateAgent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp := map[string]any{
-		"agent": agent,
-		"api_key": map[string]any{
-			"id":     apiKey.ID,
-			"prefix": apiKey.Prefix,
+	resp := model.CreateAgentResponse{
+		Agent: agent,
+		APIKey: model.CreateAgentAPIKeyInfo{
+			ID:     apiKey.ID,
+			Prefix: apiKey.Prefix,
 		},
 	}
 	if showRawKey {
-		// Raw key is shown exactly once when server-generated.
-		resp["raw_key"] = rawKey
+		resp.RawKey = rawKey
 	}
 	writeJSON(w, r, http.StatusCreated, resp)
 }
@@ -433,9 +432,9 @@ func (h *Handlers) HandleAgentStats(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, r, http.StatusOK, map[string]any{
-		"agent_id": agentID,
-		"stats":    stats,
+	writeJSON(w, r, http.StatusOK, model.AgentStatsResponse{
+		AgentID: agentID,
+		Stats:   stats,
 	})
 }
 
@@ -503,9 +502,9 @@ func (h *Handlers) HandleDeleteAgent(w http.ResponseWriter, r *http.Request) {
 		_ = h.db.CompleteDeletionLog(r.Context(), orgID, logID, countMap)
 	}
 
-	writeJSON(w, r, http.StatusOK, map[string]any{
-		"agent_id": agentID,
-		"deleted":  result,
+	writeJSON(w, r, http.StatusOK, model.DeleteAgentResponse{
+		AgentID: agentID,
+		Deleted: result,
 	})
 }
 

--- a/internal/server/handlers_assessments.go
+++ b/internal/server/handlers_assessments.go
@@ -140,10 +140,10 @@ func (h *Handlers) HandleListAssessments(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	writeJSON(w, r, http.StatusOK, map[string]any{
-		"decision_id": decisionID,
-		"summary":     summary,
-		"assessments": assessments,
-		"count":       len(assessments),
+	writeJSON(w, r, http.StatusOK, model.AssessmentListResponse{
+		DecisionID:  decisionID,
+		Summary:     summary,
+		Assessments: assessments,
+		Count:       len(assessments),
 	})
 }

--- a/internal/server/handlers_decisions.go
+++ b/internal/server/handlers_decisions.go
@@ -186,26 +186,24 @@ func (h *Handlers) HandleTrace(w http.ResponseWriter, r *http.Request) {
 		}()
 	}
 
-	resp := map[string]any{
-		"run_id":      result.RunID,
-		"decision_id": result.DecisionID,
-		"event_count": result.EventCount,
-	}
-	if result.EmbeddingSkipped {
-		resp["embedding_skipped"] = true
+	resp := model.TraceResponse{
+		RunID:            result.RunID,
+		DecisionID:       result.DecisionID,
+		EventCount:       result.EventCount,
+		EmbeddingSkipped: result.EmbeddingSkipped,
 	}
 	if warnings := model.HighConfidenceWarnings(req.Decision.Confidence, len(req.Decision.Evidence), h.highConfidenceWarnThreshold); len(warnings) > 0 {
-		resp["warnings"] = warnings
+		resp.Warnings = warnings
 	}
 	reasoningLen := 0
 	if req.Decision.Reasoning != nil {
 		reasoningLen = len(strings.TrimSpace(*req.Decision.Reasoning))
 	}
 	if confAdj := quality.AdjustConfidence(req.Decision.Confidence, len(req.Decision.Evidence), len(req.Decision.Alternatives), reasoningLen); confAdj.WasAdjusted {
-		resp["confidence_adjusted"] = true
-		resp["original_confidence"] = confAdj.Original
-		resp["stored_confidence"] = confAdj.Adjusted
-		resp["confidence_reasons"] = confAdj.Reasons
+		resp.ConfidenceAdjusted = true
+		resp.OriginalConfidence = confAdj.Original
+		resp.StoredConfidence = confAdj.Adjusted
+		resp.ConfidenceReasons = confAdj.Reasons
 	}
 
 	h.completeIdempotentWriteBestEffort(r, orgID, idem, http.StatusCreated, resp)
@@ -476,9 +474,9 @@ func (h *Handlers) HandleTemporalQuery(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, r, http.StatusOK, map[string]any{
-		"as_of":     req.AsOf,
-		"decisions": decisions,
+	writeJSON(w, r, http.StatusOK, model.TemporalQueryResponse{
+		AsOf:      req.AsOf,
+		Decisions: decisions,
 	})
 }
 
@@ -707,10 +705,10 @@ func (h *Handlers) HandleDecisionRevisions(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	writeJSON(w, r, http.StatusOK, map[string]any{
-		"decision_id": id,
-		"revisions":   revisions,
-		"count":       len(revisions),
+	writeJSON(w, r, http.StatusOK, model.DecisionRevisionsResponse{
+		DecisionID: id,
+		Revisions:  revisions,
+		Count:      len(revisions),
 	})
 }
 
@@ -743,51 +741,47 @@ func (h *Handlers) HandleVerifyDecision(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	resp := map[string]any{"decision_id": id}
+	resp := model.VerifyDecisionResponse{DecisionID: id}
 
 	switch {
 	case d.ValidTo != nil:
-		// Decision was retracted — still verify hash integrity but report retracted status.
-		resp["status"] = "retracted"
-		resp["retracted_at"] = d.ValidTo.UTC().Format(time.RFC3339Nano)
+		resp.Status = "retracted"
+		resp.RetractedAt = d.ValidTo.UTC().Format(time.RFC3339Nano)
 		if d.ContentHash == "" {
-			resp["verified"] = false
-			resp["message"] = "this decision was created before content hashing was enabled"
+			verified := false
+			resp.Verified = &verified
+			resp.Message = "this decision was created before content hashing was enabled"
 		} else {
 			valid := integrity.VerifyContentHash(d.ContentHash, d.ID, d.DecisionType, d.Outcome, d.Confidence, d.Reasoning, d.ValidFrom)
-			resp["verified"] = valid
-			resp["content_hash"] = d.ContentHash
+			resp.Verified = &valid
+			resp.ContentHash = d.ContentHash
 		}
 	case d.ContentHash == "":
-		// Pre-migration decisions have no hash — don't report them as tampered.
-		resp["status"] = "no_hash"
-		resp["message"] = "this decision was created before content hashing was enabled"
+		resp.Status = "no_hash"
+		resp.Message = "this decision was created before content hashing was enabled"
 	default:
-		// Check for GDPR erasure before standard verification.
 		erasure, erasureErr := h.db.GetDecisionErasure(r.Context(), orgID, id)
 		switch {
 		case erasureErr == nil:
-			// Decision has been erased — verify the erased hash matches.
 			valid := integrity.VerifyContentHash(d.ContentHash, d.ID, d.DecisionType, d.Outcome, d.Confidence, d.Reasoning, d.ValidFrom)
-			resp["status"] = "erased"
-			resp["valid"] = valid
-			resp["content_hash"] = d.ContentHash
-			resp["original_hash"] = erasure.OriginalHash
-			resp["erased_at"] = erasure.ErasedAt
-			resp["erased_by"] = erasure.ErasedBy
+			resp.Status = "erased"
+			resp.Valid = &valid
+			resp.ContentHash = d.ContentHash
+			resp.OriginalHash = erasure.OriginalHash
+			resp.ErasedAt = &erasure.ErasedAt
+			resp.ErasedBy = erasure.ErasedBy
 		case !isNotFoundError(erasureErr):
 			h.writeInternalError(w, r, "failed to check erasure status", erasureErr)
 			return
 		default:
-			// No erasure — standard verification.
 			valid := integrity.VerifyContentHash(d.ContentHash, d.ID, d.DecisionType, d.Outcome, d.Confidence, d.Reasoning, d.ValidFrom)
-			resp["valid"] = valid
+			resp.Valid = &valid
 			if valid {
-				resp["status"] = "verified"
+				resp.Status = "verified"
 			} else {
-				resp["status"] = "tampered"
+				resp.Status = "tampered"
 			}
-			resp["content_hash"] = d.ContentHash
+			resp.ContentHash = d.ContentHash
 		}
 	}
 
@@ -818,9 +812,9 @@ func (h *Handlers) HandleListIntegrityViolations(w http.ResponseWriter, r *http.
 		return
 	}
 
-	writeJSON(w, r, http.StatusOK, map[string]any{
-		"violations": violations,
-		"count":      len(violations),
+	writeJSON(w, r, http.StatusOK, model.IntegrityViolationsResponse{
+		Violations: violations,
+		Count:      len(violations),
 	})
 }
 
@@ -876,10 +870,10 @@ func (h *Handlers) HandleSessionView(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if len(decs) == 0 {
-		writeJSON(w, r, http.StatusOK, map[string]any{
-			"session_id":     sid,
-			"decisions":      []any{},
-			"decision_count": 0,
+		writeJSON(w, r, http.StatusOK, model.SessionViewResponse{
+			SessionID:     sid,
+			Decisions:     []model.Decision{},
+			DecisionCount: 0,
 		})
 		return
 	}
@@ -909,16 +903,16 @@ func (h *Handlers) HandleSessionView(w http.ResponseWriter, r *http.Request) {
 	}
 	avgConfidence := totalConf / float64(len(decs))
 
-	writeJSON(w, r, http.StatusOK, map[string]any{
-		"session_id":     sid,
-		"decisions":      decs,
-		"decision_count": len(decs),
-		"summary": map[string]any{
-			"started_at":     startedAt,
-			"ended_at":       endedAt,
-			"duration_secs":  duration,
-			"decision_types": decisionTypes,
-			"avg_confidence": avgConfidence,
+	writeJSON(w, r, http.StatusOK, model.SessionViewResponse{
+		SessionID:     sid,
+		Decisions:     decs,
+		DecisionCount: len(decs),
+		Summary: &model.SessionViewSummary{
+			StartedAt:     startedAt,
+			EndedAt:       endedAt,
+			DurationSecs:  duration,
+			DecisionTypes: decisionTypes,
+			AvgConfidence: avgConfidence,
 		},
 	})
 }
@@ -1030,14 +1024,14 @@ func (h *Handlers) HandleEraseDecision(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, r, http.StatusOK, map[string]any{
-		"decision_id":         id,
-		"erased_at":           result.Erasure.ErasedAt,
-		"original_hash":       result.Erasure.OriginalHash,
-		"erased_hash":         result.Erasure.ErasedHash,
-		"alternatives_erased": result.AlternativesErased,
-		"evidence_erased":     result.EvidenceErased,
-		"claims_erased":       result.ClaimsErased,
+	writeJSON(w, r, http.StatusOK, model.EraseDecisionResponse{
+		DecisionID:         id,
+		ErasedAt:           &result.Erasure.ErasedAt,
+		OriginalHash:       result.Erasure.OriginalHash,
+		ErasedHash:         result.Erasure.ErasedHash,
+		AlternativesErased: result.AlternativesErased,
+		EvidenceErased:     result.EvidenceErased,
+		ClaimsErased:       result.ClaimsErased,
 	})
 }
 

--- a/internal/server/handlers_integrity.go
+++ b/internal/server/handlers_integrity.go
@@ -65,14 +65,14 @@ func (h *Handlers) HandleGetDecisionProof(w http.ResponseWriter, r *http.Request
 	}
 
 	// 4. Return the proof with a self-verification check.
-	writeJSON(w, r, http.StatusOK, map[string]any{
-		"decision_id":  decisionID,
-		"content_hash": contentHash,
-		"proof_id":     proof.ID,
-		"root_hash":    rootHash,
-		"batch_start":  proof.BatchStart,
-		"batch_end":    proof.BatchEnd,
-		"proof_path":   steps,
-		"verified":     rootHash == proof.RootHash,
+	writeJSON(w, r, http.StatusOK, model.DecisionProofResponse{
+		DecisionID:  decisionID,
+		ContentHash: contentHash,
+		ProofID:     proof.ID,
+		RootHash:    rootHash,
+		BatchStart:  proof.BatchStart,
+		BatchEnd:    proof.BatchEnd,
+		ProofPath:   steps,
+		Verified:    rootHash == proof.RootHash,
 	})
 }

--- a/internal/server/handlers_keys.go
+++ b/internal/server/handlers_keys.go
@@ -237,13 +237,6 @@ func (h *Handlers) HandleGetUsage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Enrich with key metadata using a single batch query to avoid N+1 round-trips.
-	type keyUsage struct {
-		KeyID   *uuid.UUID `json:"key_id"`
-		Prefix  string     `json:"prefix"`
-		Label   string     `json:"label"`
-		AgentID string     `json:"agent_id"`
-		Count   int        `json:"decisions"`
-	}
 
 	// Collect managed key IDs (skip uuid.Nil = legacy / unattributed).
 	var keyIDs []uuid.UUID
@@ -264,10 +257,10 @@ func (h *Handlers) HandleGetUsage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	var keyUsages []keyUsage
+	var keyUsages []model.UsageByKey
 	for keyID, count := range byKey {
 		if keyID == uuid.Nil {
-			keyUsages = append(keyUsages, keyUsage{
+			keyUsages = append(keyUsages, model.UsageByKey{
 				KeyID:   nil,
 				Prefix:  "",
 				Label:   "(legacy)",
@@ -278,7 +271,7 @@ func (h *Handlers) HandleGetUsage(w http.ResponseWriter, r *http.Request) {
 		}
 		kid := keyID
 		if k, ok := keysByID[keyID]; ok {
-			keyUsages = append(keyUsages, keyUsage{
+			keyUsages = append(keyUsages, model.UsageByKey{
 				KeyID:   &kid,
 				Prefix:  k.Prefix,
 				Label:   k.Label,
@@ -287,7 +280,7 @@ func (h *Handlers) HandleGetUsage(w http.ResponseWriter, r *http.Request) {
 			})
 		} else {
 			// Key was deleted — show ID only. Best-effort.
-			keyUsages = append(keyUsages, keyUsage{
+			keyUsages = append(keyUsages, model.UsageByKey{
 				KeyID: &kid,
 				Count: count,
 			})
@@ -301,20 +294,16 @@ func (h *Handlers) HandleGetUsage(w http.ResponseWriter, r *http.Request) {
 			agentCounts[ku.AgentID] += ku.Count
 		}
 	}
-	type agentUsage struct {
-		AgentID   string `json:"agent_id"`
-		Decisions int    `json:"decisions"`
-	}
-	var byAgent []agentUsage
+	var byAgent []model.UsageByAgent
 	for aid, cnt := range agentCounts {
-		byAgent = append(byAgent, agentUsage{AgentID: aid, Decisions: cnt})
+		byAgent = append(byAgent, model.UsageByAgent{AgentID: aid, Decisions: cnt})
 	}
 
-	writeJSON(w, r, http.StatusOK, map[string]any{
-		"org_id":          orgID,
-		"period":          periodStr,
-		"total_decisions": total,
-		"by_key":          keyUsages,
-		"by_agent":        byAgent,
+	writeJSON(w, r, http.StatusOK, model.GetUsageResponse{
+		OrgID:          orgID,
+		Period:         periodStr,
+		TotalDecisions: total,
+		ByKey:          keyUsages,
+		ByAgent:        byAgent,
 	})
 }

--- a/internal/server/handlers_project_links.go
+++ b/internal/server/handlers_project_links.go
@@ -123,7 +123,7 @@ func (h *Handlers) HandleGrantAllProjectLinks(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	writeJSON(w, r, http.StatusOK, map[string]any{
-		"links_created": created,
+	writeJSON(w, r, http.StatusOK, model.GrantAllProjectLinksResponse{
+		LinksCreated: created,
 	})
 }

--- a/internal/server/handlers_retention.go
+++ b/internal/server/handlers_retention.go
@@ -24,13 +24,13 @@ func (h *Handlers) HandleGetRetention(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, r, http.StatusOK, map[string]any{
-		"retention_days":          policy.RetentionDays,
-		"retention_exclude_types": policy.RetentionExcludeTypes,
-		"last_run":                policy.LastRunAt,
-		"last_run_deleted":        policy.LastRunDeleted,
-		"next_run":                policy.NextRunAt,
-		"holds":                   holds,
+	writeJSON(w, r, http.StatusOK, model.RetentionPolicyResponse{
+		RetentionDays:         policy.RetentionDays,
+		RetentionExcludeTypes: policy.RetentionExcludeTypes,
+		LastRun:               policy.LastRunAt,
+		LastRunDeleted:        policy.LastRunDeleted,
+		NextRun:               policy.NextRunAt,
+		Holds:                 holds,
 	})
 }
 
@@ -68,12 +68,12 @@ func (h *Handlers) HandleSetRetention(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, r, http.StatusOK, map[string]any{
-		"retention_days":          policy.RetentionDays,
-		"retention_exclude_types": policy.RetentionExcludeTypes,
-		"last_run":                policy.LastRunAt,
-		"last_run_deleted":        policy.LastRunDeleted,
-		"next_run":                policy.NextRunAt,
+	writeJSON(w, r, http.StatusOK, model.RetentionPolicyResponse{
+		RetentionDays:         policy.RetentionDays,
+		RetentionExcludeTypes: policy.RetentionExcludeTypes,
+		LastRun:               policy.LastRunAt,
+		LastRunDeleted:        policy.LastRunDeleted,
+		NextRun:               policy.NextRunAt,
 	})
 }
 
@@ -109,9 +109,9 @@ func (h *Handlers) HandlePurge(w http.ResponseWriter, r *http.Request) {
 			h.writeInternalError(w, r, "failed to count eligible decisions", err)
 			return
 		}
-		writeJSON(w, r, http.StatusOK, map[string]any{
-			"dry_run":      true,
-			"would_delete": counts,
+		writeJSON(w, r, http.StatusOK, model.PurgeResponse{
+			DryRun:      true,
+			WouldDelete: counts,
 		})
 		return
 	}
@@ -147,9 +147,9 @@ func (h *Handlers) HandlePurge(w http.ResponseWriter, r *http.Request) {
 	}
 	_ = h.db.CompleteDeletionLog(r.Context(), orgID, logID, countMap)
 
-	writeJSON(w, r, http.StatusOK, map[string]any{
-		"dry_run": false,
-		"deleted": countMap,
+	writeJSON(w, r, http.StatusOK, model.PurgeResponse{
+		DryRun:  false,
+		Deleted: countMap,
 	})
 }
 


### PR DESCRIPTION
## Summary
- Add `internal/model/responses.go` with 17 typed response structs covering all handlers that previously used ad-hoc `map[string]any` for response construction
- Update 7 handler files (`handlers_decisions.go`, `handlers_admin.go`, `handlers_keys.go`, `handlers_retention.go`, `handlers_integrity.go`, `handlers_assessments.go`, `handlers_project_links.go`) to use the new typed structs
- Wire format is unchanged — all 26 test packages pass with `-race -count=1`

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `golangci-lint run ./...` — 0 issues
- [x] `atlas migrate validate` passes
- [x] `go test -race -count=1 ./...` — all 26 packages pass
- [ ] Verify JSON responses in staging match pre-refactor shape (field names, omitempty behavior)

Closes #652

> The Sorting Hat never asks what house you *want* — it reads what you *are*.
> These handlers finally stopped pretending to be untyped maps and admitted
> they were structs all along. The Hat approves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)