### PR TITLE
fix: align SDK types across Go, Python, and TypeScript

### DIFF
--- a/sdk/go/akashi/auth.go
+++ b/sdk/go/akashi/auth.go
@@ -145,14 +145,20 @@ func (tm *tokenManager) refresh(ctx context.Context) (string, time.Time, error) 
 				Message string `json:"message"`
 			} `json:"error"`
 		}
+		var msg string
 		if json.Unmarshal(body, &errEnv) == nil && errEnv.Error.Message != "" {
-			return "", time.Time{}, fmt.Errorf("akashi: auth failed (%d): %s", resp.StatusCode, errEnv.Error.Message)
+			msg = errEnv.Error.Message
+		} else {
+			msg = string(body)
+			if msg == "" {
+				msg = http.StatusText(resp.StatusCode)
+			}
 		}
-		msg := string(body)
-		if msg == "" {
-			msg = http.StatusText(resp.StatusCode)
+		baseErr := fmt.Errorf("akashi: auth failed (%d): %s", resp.StatusCode, msg)
+		if resp.StatusCode == http.StatusUnauthorized {
+			return "", time.Time{}, &TokenExpiredError{Err: baseErr}
 		}
-		return "", time.Time{}, fmt.Errorf("akashi: auth failed (%d): %s", resp.StatusCode, msg)
+		return "", time.Time{}, baseErr
 	}
 
 	var envelope authResponseEnvelope

--- a/sdk/go/akashi/errors.go
+++ b/sdk/go/akashi/errors.go
@@ -71,3 +71,26 @@ func IsValidation(err error) bool {
 	}
 	return false
 }
+
+// TokenExpiredError indicates that the JWT token has expired and could not
+// be refreshed. It wraps an underlying error with additional context.
+type TokenExpiredError struct {
+	Err error
+}
+
+func (e *TokenExpiredError) Error() string {
+	if e.Err != nil {
+		return fmt.Sprintf("akashi: token expired: %v", e.Err)
+	}
+	return "akashi: token expired"
+}
+
+func (e *TokenExpiredError) Unwrap() error {
+	return e.Err
+}
+
+// IsTokenExpired returns true if the error indicates a token expiry.
+func IsTokenExpired(err error) bool {
+	var te *TokenExpiredError
+	return errors.As(err, &te)
+}

--- a/sdk/go/akashi/types.go
+++ b/sdk/go/akashi/types.go
@@ -122,8 +122,8 @@ type DecisionConflict struct {
 	RunA              uuid.UUID    `json:"run_a"`
 	RunB              uuid.UUID    `json:"run_b"`
 	DecisionType      string       `json:"decision_type"`
-	DecisionTypeA     string       `json:"decision_type_a"`
-	DecisionTypeB     string       `json:"decision_type_b"`
+	DecisionTypeA     *string      `json:"decision_type_a,omitempty"`
+	DecisionTypeB     *string      `json:"decision_type_b,omitempty"`
 	OutcomeA          string       `json:"outcome_a"`
 	OutcomeB          string       `json:"outcome_b"`
 	ConfidenceA       float32      `json:"confidence_a"`
@@ -592,8 +592,8 @@ type ConflictDetail struct {
 	RunA              uuid.UUID    `json:"run_a"`
 	RunB              uuid.UUID    `json:"run_b"`
 	DecisionType      string       `json:"decision_type"`
-	DecisionTypeA     string       `json:"decision_type_a"`
-	DecisionTypeB     string       `json:"decision_type_b"`
+	DecisionTypeA     *string      `json:"decision_type_a,omitempty"`
+	DecisionTypeB     *string      `json:"decision_type_b,omitempty"`
 	OutcomeA          string       `json:"outcome_a"`
 	OutcomeB          string       `json:"outcome_b"`
 	ConfidenceA       float32      `json:"confidence_a"`

--- a/sdk/typescript/src/auth.ts
+++ b/sdk/typescript/src/auth.ts
@@ -1,5 +1,7 @@
 /** Token management for Akashi API authentication. */
 
+import { TokenExpiredError } from "./errors.js";
+
 export class TokenManager {
   private token = "";
   private expiresAt = 0;
@@ -70,6 +72,11 @@ export class TokenManager {
         // Response may not be JSON; fall through to status-only message.
       }
       const suffix = detail || resp.statusText || String(resp.status);
+      if (resp.status === 401) {
+        throw new TokenExpiredError(
+          `Token refresh failed (${resp.status}): ${suffix}`,
+        );
+      }
       throw new Error(`Token refresh failed (${resp.status}): ${suffix}`);
     }
 

--- a/sdk/typescript/src/errors.ts
+++ b/sdk/typescript/src/errors.ts
@@ -17,6 +17,14 @@ export class AuthenticationError extends AkashiError {
   }
 }
 
+/** Raised when the JWT token has expired and could not be refreshed. */
+export class TokenExpiredError extends AuthenticationError {
+  constructor(message = "Token expired") {
+    super(message);
+    this.name = "TokenExpiredError";
+  }
+}
+
 /** Raised when the agent lacks permission (403). */
 export class AuthorizationError extends AkashiError {
   constructor(message = "Insufficient permissions") {

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -8,6 +8,7 @@ export {
   AuthenticationError,
   AuthorizationError,
   NotFoundError,
+  TokenExpiredError,
   ValidationError,
   ConflictError,
   RateLimitError,


### PR DESCRIPTION
Closes #662

## Summary

- **Go `DecisionConflict.DecisionTypeA/B`**: changed from bare `string` to `*string` with `omitempty`, matching Python (`str | None`) and TypeScript (`string?`). Bare string silently deserialized missing values as `""`, masking absent data.
- **Go SDK `TokenExpiredError`**: new error type with `Unwrap()` support and `IsTokenExpired()` helper. Auth token refresh now returns `*TokenExpiredError` on 401, letting consumers distinguish expiry from other auth failures via `errors.As`.
- **TypeScript SDK `TokenExpiredError`**: new class extending `AuthenticationError`. Auth refresh now throws `TokenExpiredError` on 401 instead of generic `Error`. Exported from package index.
- **Confidence float32**: deliberately kept as-is per prior decision that aligned SDK float types to the server model. No wire-level precision issue at 0.0–1.0 range.

## Test plan

- [x] `go test -race -count=1 ./...` — all 21 suites pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] `npx tsc --noEmit` in sdk/typescript — clean
- [x] `atlas migrate validate` — clean
- [ ] Verify `IsTokenExpired` works in a live integration test with an expired token

> The Borg assimilated thousands of species and still couldn't ship
> consistent type definitions across three SDKs. At least we only needed
> one commit.