### PR TITLE
fix: validate conflict_kind query parameter against known values

### DIFF
--- a/internal/model/decision.go
+++ b/internal/model/decision.go
@@ -165,6 +165,17 @@ const (
 	ConflictKindSelfContradiction ConflictKind = "self_contradiction"
 )
 
+// ValidConflictKinds is the set of recognized conflict_kind values.
+var ValidConflictKinds = map[ConflictKind]bool{
+	ConflictKindCrossAgent:        true,
+	ConflictKindSelfContradiction: true,
+}
+
+// ValidConflictKind reports whether k is a recognized conflict kind.
+func ValidConflictKind(k string) bool {
+	return ValidConflictKinds[ConflictKind(k)]
+}
+
 // DecisionConflict represents a detected conflict between two decisions.
 type DecisionConflict struct {
 	ID                uuid.UUID    `json:"id"`

--- a/internal/server/handlers_conflicts.go
+++ b/internal/server/handlers_conflicts.go
@@ -20,7 +20,11 @@ func (h *Handlers) HandleListConflicts(w http.ResponseWriter, r *http.Request) {
 	claims := ClaimsFromContext(r.Context())
 	orgID := OrgIDFromContext(r.Context())
 
-	filters := parseConflictFilters(r)
+	filters, err := parseConflictFilters(r)
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, err.Error())
+		return
+	}
 	limit := queryLimit(r, 25)
 	offset := queryOffset(r)
 
@@ -63,6 +67,11 @@ func (h *Handlers) HandleListConflictGroups(w http.ResponseWriter, r *http.Reque
 		filters.AgentID = &aid
 	}
 	if ck := r.URL.Query().Get("conflict_kind"); ck != "" {
+		if !model.ValidConflictKind(ck) {
+			writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput,
+				errInvalidConflictKind(ck).Error())
+			return
+		}
 		filters.ConflictKind = &ck
 	}
 	if st := r.URL.Query().Get("status"); st != "" {
@@ -556,6 +565,11 @@ func (h *Handlers) HandleConflictAnalytics(w http.ResponseWriter, r *http.Reques
 		filters.DecisionType = &v
 	}
 	if v := r.URL.Query().Get("conflict_kind"); v != "" {
+		if !model.ValidConflictKind(v) {
+			writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput,
+				errInvalidConflictKind(v).Error())
+			return
+		}
 		filters.ConflictKind = &v
 	}
 
@@ -650,7 +664,8 @@ func (h *Handlers) executeCascadeResolution(r *http.Request, orgID uuid.UUID, co
 }
 
 // parseConflictFilters extracts conflict filter parameters from the request query string.
-func parseConflictFilters(r *http.Request) storage.ConflictFilters {
+// Returns an error if conflict_kind is present but not a recognized value.
+func parseConflictFilters(r *http.Request) (storage.ConflictFilters, error) {
 	filters := storage.ConflictFilters{}
 	if dt := r.URL.Query().Get("decision_type"); dt != "" {
 		filters.DecisionType = &dt
@@ -659,6 +674,9 @@ func parseConflictFilters(r *http.Request) storage.ConflictFilters {
 		filters.AgentID = &aid
 	}
 	if ck := r.URL.Query().Get("conflict_kind"); ck != "" {
+		if !model.ValidConflictKind(ck) {
+			return filters, errInvalidConflictKind(ck)
+		}
 		filters.ConflictKind = &ck
 	}
 	if sev := r.URL.Query().Get("severity"); sev != "" {
@@ -673,5 +691,10 @@ func parseConflictFilters(r *http.Request) storage.ConflictFilters {
 	if proj := r.URL.Query().Get("project"); proj != "" {
 		filters.Project = &proj
 	}
-	return filters
+	return filters, nil
+}
+
+// invalidConflictKindMsg builds a user-facing message listing valid conflict_kind values.
+func errInvalidConflictKind(got string) error {
+	return errors.New("invalid conflict_kind " + got + "; valid values are cross_agent, self_contradiction")
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -5945,6 +5945,13 @@ func TestHandleListConflicts_WithConflictKindFilter(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
+func TestHandleListConflicts_InvalidConflictKind(t *testing.T) {
+	resp, err := authedRequest("GET", testSrv.URL+"/v1/conflicts?conflict_kind=factaul", adminToken, nil)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
 func TestHandleListConflicts_WithDecisionTypeFilter(t *testing.T) {
 	resp, err := authedRequest("GET", testSrv.URL+"/v1/conflicts?decision_type=architecture", adminToken, nil)
 	require.NoError(t, err)
@@ -9825,10 +9832,17 @@ func TestHandleListConflictGroups_WithAgentFilter(t *testing.T) {
 }
 
 func TestHandleListConflictGroups_WithConflictKindFilter(t *testing.T) {
-	resp, err := authedRequest("GET", testSrv.URL+"/v1/conflict-groups?conflict_kind=direct", adminToken, nil)
+	resp, err := authedRequest("GET", testSrv.URL+"/v1/conflict-groups?conflict_kind=cross_agent", adminToken, nil)
 	require.NoError(t, err)
 	defer func() { _ = resp.Body.Close() }()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestHandleListConflictGroups_InvalidConflictKind(t *testing.T) {
+	resp, err := authedRequest("GET", testSrv.URL+"/v1/conflict-groups?conflict_kind=direct", adminToken, nil)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 }
 
 // ===========================================================================
@@ -9889,10 +9903,17 @@ func TestHandleConflictAnalytics_WithDecisionTypeFilter(t *testing.T) {
 }
 
 func TestHandleConflictAnalytics_WithConflictKindFilter(t *testing.T) {
-	resp, err := authedRequest("GET", testSrv.URL+"/v1/conflicts/analytics?conflict_kind=direct", adminToken, nil)
+	resp, err := authedRequest("GET", testSrv.URL+"/v1/conflicts/analytics?conflict_kind=self_contradiction", adminToken, nil)
 	require.NoError(t, err)
 	defer func() { _ = resp.Body.Close() }()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestHandleConflictAnalytics_InvalidConflictKind(t *testing.T) {
+	resp, err := authedRequest("GET", testSrv.URL+"/v1/conflicts/analytics?conflict_kind=direct", adminToken, nil)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 }
 
 func TestHandleGetUsage_ValidPastPeriod(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds `ValidConflictKind()` to `internal/model/decision.go` with the allowlist (`cross_agent`, `self_contradiction`)
- All three endpoints that accept `conflict_kind` — `GET /v1/conflicts`, `GET /v1/conflict-groups`, `GET /v1/conflicts/analytics` — now return HTTP 400 with a clear message listing valid values when given an unrecognized kind
- Previously, a typo like `conflict_kind=factaul` silently returned empty results with no indication the filter was wrong

## Test plan

- [x] New integration tests: `TestHandleListConflicts_InvalidConflictKind`, `TestHandleListConflictGroups_InvalidConflictKind`, `TestHandleConflictAnalytics_InvalidConflictKind` — all assert 400
- [x] Existing valid-kind tests updated and passing (`cross_agent`, `self_contradiction`)
- [x] Full pre-commit checks pass (build, vet, lint, atlas validate)
- [x] `go test -race` passes

Closes #402

> Spock would approve: the needs of the many (every developer who ever
> fat-fingered a query parameter and stared at empty results for twenty
> minutes) outweigh the needs of the few (the three lines of validation
> code that should have been here from the start). Live long and validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)