### PR TITLE
fix(sdk/python): make TraceEvidence.content conditionally required

### DIFF
--- a/sdk/python/src/akashi/types.py
+++ b/sdk/python/src/akashi/types.py
@@ -7,7 +7,7 @@ from enum import Enum
 from typing import Any
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 class ConflictFate(BaseModel):
@@ -259,6 +259,21 @@ class TraceEvidence(BaseModel):
     content: str = ""
     relevance_score: float | None = None
     metrics: dict[str, float] | None = None
+
+    @model_validator(mode="after")
+    def _validate_content_and_metrics(self) -> TraceEvidence:
+        if self.source_type == "metrics":
+            if not self.metrics:
+                raise ValueError("metrics field is required when source_type is 'metrics'")
+        else:
+            if not self.content:
+                raise ValueError(
+                    f"content is required when source_type is '{self.source_type}' "
+                    f"(only source_type='metrics' may omit content)"
+                )
+            if self.metrics:
+                raise ValueError("metrics field is only allowed when source_type is 'metrics'")
+        return self
 
 
 class TimeRange(BaseModel):

--- a/sdk/python/tests/test_types.py
+++ b/sdk/python/tests/test_types.py
@@ -1,0 +1,72 @@
+"""Tests for Pydantic model validation in akashi.types."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from akashi.types import TraceEvidence
+
+
+class TestTraceEvidenceValidation:
+    """TraceEvidence.content is conditionally required based on source_type."""
+
+    @pytest.mark.parametrize(
+        "source_type",
+        ["document", "api_response", "user_input", "search_result", "tool_output", "memory"],
+    )
+    def test_non_metrics_requires_content(self, source_type: str) -> None:
+        with pytest.raises(ValidationError, match="content is required"):
+            TraceEvidence(source_type=source_type)
+
+    @pytest.mark.parametrize(
+        "source_type",
+        ["document", "api_response", "user_input", "search_result", "tool_output", "memory"],
+    )
+    def test_non_metrics_rejects_empty_content(self, source_type: str) -> None:
+        with pytest.raises(ValidationError, match="content is required"):
+            TraceEvidence(source_type=source_type, content="")
+
+    @pytest.mark.parametrize(
+        "source_type",
+        ["document", "api_response", "user_input", "search_result", "tool_output", "memory"],
+    )
+    def test_non_metrics_accepts_content(self, source_type: str) -> None:
+        ev = TraceEvidence(source_type=source_type, content="some evidence text")
+        assert ev.content == "some evidence text"
+        assert ev.source_type == source_type
+
+    def test_non_metrics_rejects_metrics_field(self) -> None:
+        with pytest.raises(ValidationError, match="metrics field is only allowed"):
+            TraceEvidence(
+                source_type="document",
+                content="has content",
+                metrics={"latency_ms": 42.0},
+            )
+
+    def test_metrics_requires_metrics_field(self) -> None:
+        with pytest.raises(ValidationError, match="metrics field is required"):
+            TraceEvidence(source_type="metrics")
+
+    def test_metrics_rejects_empty_metrics(self) -> None:
+        with pytest.raises(ValidationError, match="metrics field is required"):
+            TraceEvidence(source_type="metrics", metrics={})
+
+    def test_metrics_allows_empty_content(self) -> None:
+        ev = TraceEvidence(source_type="metrics", metrics={"latency_ms": 42.0})
+        assert ev.content == ""
+        assert ev.metrics == {"latency_ms": 42.0}
+
+    def test_metrics_allows_content(self) -> None:
+        ev = TraceEvidence(
+            source_type="metrics",
+            content="optional description",
+            metrics={"latency_ms": 42.0},
+        )
+        assert ev.content == "optional description"
+
+    def test_optional_fields_default(self) -> None:
+        ev = TraceEvidence(source_type="document", content="text")
+        assert ev.source_uri is None
+        assert ev.relevance_score is None
+        assert ev.metrics is None


### PR DESCRIPTION
## Summary

- Adds a Pydantic `model_validator` to `TraceEvidence` that enforces `content` is non-empty for all `source_type` values except `"metrics"`
- For `source_type="metrics"`, validates that the `metrics` field is populated and `content` remains optional
- For non-metrics types, rejects the `metrics` field (mirrors Go server validation in `model/api.go`)
- Adds 24 parametrized tests covering all source types and edge cases

## Test plan

- [x] All 24 new tests in `test_types.py` pass
- [x] All 52 existing tests in `test_client.py` still pass
- [x] Go build/vet/migrations unaffected

Closes #499

> The Sorting Hat deliberated for seven minutes on Tom Riddle —
> longest haberdasher stall in recorded history — because even dark magic
> needs a proper type system, and Slytherin's was the only house
> with runtime validation on ambition.