### PR TITLE
test(model): add run state transition validation and tests

### DIFF
--- a/internal/model/run.go
+++ b/internal/model/run.go
@@ -6,6 +6,7 @@
 package model
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -19,6 +20,26 @@ const (
 	RunStatusCompleted RunStatus = "completed"
 	RunStatusFailed    RunStatus = "failed"
 )
+
+// IsTerminal reports whether the status represents an end state
+// from which no further transitions are allowed.
+func (s RunStatus) IsTerminal() bool {
+	return s == RunStatusCompleted || s == RunStatusFailed
+}
+
+// ValidateTransition checks whether moving from the current status to next
+// is a legal state transition. The valid state machine is:
+//
+//	running → completed
+//	running → failed
+//
+// Terminal states (completed, failed) reject all further transitions.
+func (s RunStatus) ValidateTransition(next RunStatus) error {
+	if s == RunStatusRunning && (next == RunStatusCompleted || next == RunStatusFailed) {
+		return nil
+	}
+	return fmt.Errorf("invalid run status transition: %q → %q", s, next)
+}
 
 // AgentRun is the top-level execution context for an agent.
 // Corresponds to an OTEL trace. Immutable once created.

--- a/internal/model/run_test.go
+++ b/internal/model/run_test.go
@@ -1,0 +1,110 @@
+package model
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunStatus_IsTerminal(t *testing.T) {
+	tests := []struct {
+		status   RunStatus
+		terminal bool
+	}{
+		{RunStatusRunning, false},
+		{RunStatusCompleted, true},
+		{RunStatusFailed, true},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.status), func(t *testing.T) {
+			assert.Equal(t, tt.terminal, tt.status.IsTerminal())
+		})
+	}
+}
+
+func TestRunStatus_ValidateTransition(t *testing.T) {
+	t.Run("valid transitions", func(t *testing.T) {
+		require.NoError(t, RunStatusRunning.ValidateTransition(RunStatusCompleted),
+			"running → completed should be allowed")
+		require.NoError(t, RunStatusRunning.ValidateTransition(RunStatusFailed),
+			"running → failed should be allowed")
+	})
+
+	t.Run("terminal states reject all transitions", func(t *testing.T) {
+		terminals := []RunStatus{RunStatusCompleted, RunStatusFailed}
+		targets := []RunStatus{RunStatusRunning, RunStatusCompleted, RunStatusFailed}
+
+		for _, from := range terminals {
+			for _, to := range targets {
+				err := from.ValidateTransition(to)
+				assert.Errorf(t, err, "%s → %s should be rejected (terminal state)", from, to)
+				assert.Contains(t, err.Error(), "invalid run status transition")
+			}
+		}
+	})
+
+	t.Run("running to running is invalid", func(t *testing.T) {
+		err := RunStatusRunning.ValidateTransition(RunStatusRunning)
+		assert.Error(t, err, "running → running is a no-op and should be rejected")
+	})
+
+	t.Run("unknown status values are rejected", func(t *testing.T) {
+		err := RunStatus("unknown").ValidateTransition(RunStatusCompleted)
+		assert.Error(t, err, "unknown source status should be rejected")
+
+		err = RunStatusRunning.ValidateTransition(RunStatus("cancelled"))
+		assert.Error(t, err, "unknown target status should be rejected")
+	})
+}
+
+func TestAgentRun_MetadataPreservedAcrossTransitions(t *testing.T) {
+	// Verifies that building a run, then simulating a transition,
+	// does not lose metadata. This tests the domain model's integrity
+	// rather than the storage layer.
+	meta := map[string]any{
+		"model":       "gpt-4",
+		"temperature": 0.7,
+		"tags":        []string{"prod", "v2"},
+	}
+
+	run := AgentRun{
+		ID:        uuid.New(),
+		AgentID:   "test-agent",
+		OrgID:     uuid.New(),
+		Status:    RunStatusRunning,
+		StartedAt: time.Now().UTC(),
+		Metadata:  meta,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	// Simulate completing the run (as the storage layer would).
+	require.NoError(t, run.Status.ValidateTransition(RunStatusCompleted))
+	now := time.Now().UTC()
+	run.Status = RunStatusCompleted
+	run.CompletedAt = &now
+
+	assert.Equal(t, RunStatusCompleted, run.Status)
+	assert.NotNil(t, run.CompletedAt)
+	assert.Equal(t, "gpt-4", run.Metadata["model"])
+	assert.Equal(t, 0.7, run.Metadata["temperature"])
+	assert.Equal(t, []string{"prod", "v2"}, run.Metadata["tags"])
+}
+
+func TestAgentRun_OptionalFieldsNilByDefault(t *testing.T) {
+	run := AgentRun{
+		ID:        uuid.New(),
+		AgentID:   "agent-1",
+		OrgID:     uuid.New(),
+		Status:    RunStatusRunning,
+		StartedAt: time.Now().UTC(),
+		CreatedAt: time.Now().UTC(),
+	}
+
+	assert.Nil(t, run.TraceID, "TraceID should be nil when not set")
+	assert.Nil(t, run.ParentRunID, "ParentRunID should be nil when not set")
+	assert.Nil(t, run.CompletedAt, "CompletedAt should be nil for a running run")
+	assert.Nil(t, run.Metadata, "Metadata should be nil when not set")
+}


### PR DESCRIPTION
## Summary

- Adds `ValidateTransition` and `IsTerminal` methods to `RunStatus` in `internal/model/run.go`, making the run lifecycle state machine (`running → completed | failed`) explicit at the model level
- Adds `internal/model/run_test.go` covering valid transitions, terminal state rejection, self-transition rejection, unknown status handling, metadata preservation, and optional field defaults

## Test plan

- [x] `go test -race -count=1 ./internal/model/...` passes
- [x] Full unit suite passes (`go test -race -count=1 ./...`)
- [x] All pre-commit checks pass (build, vet, golangci-lint, atlas validate)

Closes #407

> The transporter locks onto your pattern, disassembles you at the quantum level,
> and trusts that it reassembles you correctly on the other side. The real miracle
> isn't the technology — it's that Starfleet engineers wrote state machine validation
> tight enough that no one has ever materialized in a wall. McCoy's complaints were
> always about trust, not physics.