### PR TITLE
dx: add make new-migration helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: all build build-local build-ui build-with-ui test test-unit test-integration lint fmt vet clean docker-up docker-down ci security tidy \
-       dev-ui migrate-apply migrate-lint migrate-hash migrate-diff migrate-status migrate-validate \
+       dev-ui migrate-apply migrate-lint migrate-hash migrate-diff migrate-status migrate-validate new-migration \
        check-doc-consistency verify-restore reconcile-qdrant reconcile-qdrant-repair \
        archive-events-dry-run archive-events verify-exit-criteria install-hooks clean-hooks coverage
 
@@ -107,6 +107,16 @@ migrate-status: ## Show migration status
 
 migrate-validate: ## Validate migration file integrity (checksums + SQL)
 	$(ATLAS) migrate validate --dir file://migrations
+
+new-migration: ## Create a new migration file (usage: make new-migration name=add_foo_index)
+	@test -n "$(name)" || (echo "usage: make new-migration name=<migration_name>" && exit 1)
+	@LAST=$$(ls migrations/*.sql 2>/dev/null | sed 's|.*/||' | sort -n | tail -1 | grep -o '^[0-9]*'); \
+	NEXT=$$(printf "%03d" $$(( $${LAST:-0} + 1 ))); \
+	FILE="migrations/$${NEXT}_$(name).sql"; \
+	DESC=$$(echo "$(name)" | tr '_' ' '); \
+	echo "-- $${NEXT}: $${DESC}." > "$$FILE"; \
+	$(ATLAS) migrate hash --dir file://migrations; \
+	echo "Created $$FILE"
 
 verify-restore: ## Run post-restore DB verification checks (requires DATABASE_URL)
 	bash scripts/verify_restore.sh


### PR DESCRIPTION
## Summary

- Adds a `new-migration` Makefile target that automates migration file scaffolding
- Scans `migrations/*.sql` to determine the next sequential number, creates the file with the standard `-- NNN: description.` comment header, and runs `atlas migrate hash`
- Errors clearly when `name` is not provided

## Usage

```sh
make new-migration name=add_foo_index
# → Created migrations/103_add_foo_index.sql
```

Closes #415

## Test plan

- [x] Verified `make new-migration name=test_migration_helper` creates `103_test_migration_helper.sql` with correct header
- [x] Verified `make new-migration` (no name) errors with usage message
- [x] Verified `atlas migrate validate` passes after creation and cleanup
- [x] `go build`, `go vet`, `golangci-lint` all pass

> The sorting hat doesn't deliberate over migration numbers —
> it just *knows*. "103, GRYFFINDOR!" it shouts, and the file
> appears in the migrations folder before you've finished saying
> "make new-migration." Dumbledore nods approvingly from behind
> his half-moon spectacles; he always said the best magic was
> the kind that saved you from counting things manually.