### PR TITLE
fix(stats): report conflict groups instead of individual rows

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -5678,24 +5678,30 @@ components:
 
     TraceHealthConflictMetrics:
       type: object
-      required: [total, open, resolved, false_positive, resolved_pct]
+      required: [total_groups, open_groups, total_individual, open_individual, resolved, false_positive, resolved_pct]
       properties:
-        total:
+        total_groups:
           type: integer
-          description: Total number of detected conflicts.
-        open:
+          description: Total number of conflict groups (deduplicated).
+        open_groups:
           type: integer
-          description: Number of unresolved conflicts.
+          description: Number of conflict groups with at least one open conflict.
+        total_individual:
+          type: integer
+          description: Total number of individual scored conflict rows.
+        open_individual:
+          type: integer
+          description: Number of individual unresolved scored conflicts.
         resolved:
           type: integer
-          description: Number of resolved conflicts.
+          description: Number of resolved individual conflicts.
         false_positive:
           type: integer
-          description: Number of conflicts dismissed as false positives.
+          description: Number of individual conflicts dismissed as false positives.
         resolved_pct:
           type: number
           format: double
-          description: Percentage of conflicts that have been resolved (0–100).
+          description: Percentage of individual conflicts that have been resolved (0–100).
 
     DecisionTypeCompleteness:
       type: object

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -320,8 +320,8 @@ WHEN TO USE: When you want to see what contradictions or disagreements
 exist in the decision trail. Useful for understanding where agents
 disagree and what needs resolution.
 
-Returns conflicts filtered by type, agent, status, severity, or category.
-All statuses are shown by default; pass status to narrow results.`),
+Returns conflict groups filtered by type, agent, status, severity, or category.
+Defaults to groups with open conflicts; pass status="all" to see everything.`),
 			mcplib.WithReadOnlyHintAnnotation(true),
 			mcplib.WithIdempotentHintAnnotation(true),
 			mcplib.WithOpenWorldHintAnnotation(false),
@@ -332,7 +332,7 @@ All statuses are shown by default; pass status to narrow results.`),
 				mcplib.Description("Filter by agent involved in the conflict"),
 			),
 			mcplib.WithString("status",
-				mcplib.Description("Filter by status: open, resolved, false_positive. Shows all statuses by default."),
+				mcplib.Description("Filter by status: open (default), resolved, false_positive, or all."),
 			),
 			mcplib.WithString("severity",
 				mcplib.Description("Filter by severity: critical, high, medium, low"),
@@ -1573,12 +1573,16 @@ func (s *Server) handleConflicts(ctx context.Context, request mcplib.CallToolReq
 	limit := request.GetInt("limit", 10)
 	format := request.GetString("format", "concise")
 
-	// Build group filters. By default the MCP tool shows all groups so agents
-	// see both open and resolved conflicts. Agents can pass status="open",
-	// "resolved", etc. to narrow results.
+	// Build group filters. Default to showing only groups with open conflicts,
+	// since that's the actionable signal. Pass status="all" to see everything,
+	// or status="resolved"/"false_positive" to narrow differently.
 	statusFilter := request.GetString("status", "")
 	groupFilters := storage.ConflictGroupFilters{}
-	if statusFilter != "" && statusFilter != "all" {
+	if statusFilter == "" {
+		// Default: only groups with at least one open conflict.
+		open := "open"
+		groupFilters.Status = &open
+	} else if statusFilter != "all" {
 		groupFilters.Status = &statusFilter
 	}
 	if dt := request.GetString("decision_type", ""); dt != "" {

--- a/internal/server/handlers_hooks.go
+++ b/internal/server/handlers_hooks.go
@@ -499,6 +499,9 @@ func (h *Handlers) buildSessionContext(ctx context.Context, project string) stri
 	// to show the deduplicated count of unresolved disagreements.
 	openStatus := "open"
 	groupFilter := storage.ConflictGroupFilters{Status: &openStatus}
+	if project != "" {
+		groupFilter.Project = &project
+	}
 	conflictGroups, err := h.db.ListConflictGroups(ctx, orgID, groupFilter, 5, 0)
 	if err != nil {
 		h.logger.Debug("hook session-start: list conflict groups failed", "error", err)

--- a/internal/server/handlers_hooks.go
+++ b/internal/server/handlers_hooks.go
@@ -494,35 +494,34 @@ func (h *Handlers) buildSessionContext(ctx context.Context, project string) stri
 		recent = nil
 	}
 
-	// Query open conflicts — scoped by project when known.
+	// Query open conflict groups — scoped by project when known.
+	// Use conflict_groups with open_count > 0 (not individual scored_conflicts)
+	// to show the deduplicated count of unresolved disagreements.
 	openStatus := "open"
-	conflictFilter := storage.ConflictFilters{Status: &openStatus}
-	if project != "" {
-		conflictFilter.Project = &project
-	}
-	conflicts, err := h.db.ListConflicts(ctx, orgID, conflictFilter, 5, 0)
+	groupFilter := storage.ConflictGroupFilters{Status: &openStatus}
+	conflictGroups, err := h.db.ListConflictGroups(ctx, orgID, groupFilter, 5, 0)
 	if err != nil {
-		h.logger.Debug("hook session-start: list conflicts failed", "error", err)
-		conflicts = nil
+		h.logger.Debug("hook session-start: list conflict groups failed", "error", err)
+		conflictGroups = nil
 	}
 
 	// Track whether this project has any decision history.
 	// Empty projects get a relaxed edit gate in HandleHookPreToolUse.
 	if project != "" {
-		if len(recent) == 0 && len(conflicts) == 0 {
+		if len(recent) == 0 && len(conflictGroups) == 0 {
 			h.hookChecks.MarkProjectEmpty(project)
 		} else {
 			h.hookChecks.ClearProjectEmpty(project)
 		}
 	}
 
-	// Build header.
+	// Build header — report deduplicated conflict group count, not raw scored_conflicts.
 	if project != "" {
 		parts = append(parts, fmt.Sprintf("[akashi] Project: %s | %d recent decisions | %d open conflicts",
-			project, len(recent), len(conflicts)))
+			project, len(recent), len(conflictGroups)))
 	} else {
 		parts = append(parts, fmt.Sprintf("[akashi] %d recent decisions | %d open conflicts",
-			len(recent), len(conflicts)))
+			len(recent), len(conflictGroups)))
 	}
 
 	// Compact decision summaries.
@@ -537,19 +536,21 @@ func (h *Handlers) buildSessionContext(ctx context.Context, project string) stri
 		}
 	}
 
-	// Conflict summary.
-	if len(conflicts) > 0 {
+	// Conflict group summary — use the representative conflict for display.
+	if len(conflictGroups) > 0 {
 		parts = append(parts, "\nOpen conflicts:")
-		for _, c := range conflicts {
+		for _, g := range conflictGroups {
 			severity := "unknown"
-			if c.Severity != nil {
-				severity = *c.Severity
-			}
 			explanation := ""
-			if c.Explanation != nil {
-				explanation = ": " + truncateHook(*c.Explanation, 80)
+			if g.Representative != nil {
+				if g.Representative.Severity != nil {
+					severity = *g.Representative.Severity
+				}
+				if g.Representative.Explanation != nil {
+					explanation = ": " + truncateHook(*g.Representative.Explanation, 80)
+				}
 			}
-			parts = append(parts, fmt.Sprintf("- [%s] %s vs %s%s", severity, c.AgentA, c.AgentB, explanation))
+			parts = append(parts, fmt.Sprintf("- [%s] %s vs %s%s", severity, g.AgentA, g.AgentB, explanation))
 		}
 	}
 

--- a/internal/service/tracehealth/service.go
+++ b/internal/service/tracehealth/service.go
@@ -288,7 +288,7 @@ func computeGaps(qs storage.DecisionQualityStats, totalConflicts, openConflicts 
 
 	if openConflicts > 0 && totalConflicts > 0 {
 		gaps = append(gaps, fmt.Sprintf(
-			"%d of %d conflicts are unresolved.", openConflicts, totalConflicts))
+			"%d of %d conflict groups are unresolved.", openConflicts, totalConflicts))
 	}
 
 	if len(gaps) < 3 && qs.BelowHalf > 0 {

--- a/internal/service/tracehealth/service.go
+++ b/internal/service/tracehealth/service.go
@@ -54,12 +54,16 @@ type EvidenceMetrics struct {
 }
 
 // ConflictMetrics tracks conflict detection and resolution rates.
+// Group-level counts (TotalGroups, OpenGroups) are the deduplicated signal;
+// individual counts (Total, Open, etc.) reflect raw scored_conflicts rows.
 type ConflictMetrics struct {
-	Total         int     `json:"total"`
-	Open          int     `json:"open"`
-	Resolved      int     `json:"resolved"`
-	FalsePositive int     `json:"false_positive"`
-	ResolvedPct   float64 `json:"resolved_pct"`
+	TotalGroups     int     `json:"total_groups"`
+	OpenGroups      int     `json:"open_groups"`
+	TotalIndividual int     `json:"total_individual"`
+	OpenIndividual  int     `json:"open_individual"`
+	Resolved        int     `json:"resolved"`
+	FalsePositive   int     `json:"false_positive"`
+	ResolvedPct     float64 `json:"resolved_pct"`
 }
 
 // Service computes trace health metrics.
@@ -214,11 +218,13 @@ func (s *Service) Compute(ctx context.Context, orgID uuid.UUID, from, to *time.T
 
 	if cc.Total > 0 {
 		m.Conflicts = &ConflictMetrics{
-			Total:         cc.Total,
-			Open:          cc.Open,
-			Resolved:      cc.Resolved,
-			FalsePositive: cc.FalsePositive,
-			ResolvedPct:   resolvedPct,
+			TotalGroups:     cc.TotalGroups,
+			OpenGroups:      cc.OpenGroups,
+			TotalIndividual: cc.Total,
+			OpenIndividual:  cc.Open,
+			Resolved:        cc.Resolved,
+			FalsePositive:   cc.FalsePositive,
+			ResolvedPct:     resolvedPct,
 		}
 	}
 
@@ -247,8 +253,8 @@ func (s *Service) Compute(ctx context.Context, orgID uuid.UUID, from, to *time.T
 		m.CompletenessByType = cbt
 	}
 
-	m.Gaps = computeGaps(qs, cc.Total, cc.Open, os, cd, cal)
-	m.Status = computeStatus(qs, cc.Open)
+	m.Gaps = computeGaps(qs, cc.TotalGroups, cc.OpenGroups, os, cd, cal)
+	m.Status = computeStatus(qs, cc.OpenGroups)
 
 	return m, nil
 }

--- a/internal/service/tracehealth/service_test.go
+++ b/internal/service/tracehealth/service_test.go
@@ -230,6 +230,7 @@ func TestCompute_HealthyOrg(t *testing.T) {
 		},
 		conflictCounts: storage.ConflictStatusCounts{
 			Total: 10, Open: 1, Resolved: 6, FalsePositive: 3,
+			TotalGroups: 4, OpenGroups: 1,
 		},
 		outcomeSignals: storage.OutcomeSignalsSummary{
 			DecisionsTotal:   100,
@@ -275,8 +276,10 @@ func TestCompute_HealthyOrg(t *testing.T) {
 
 	// Conflicts populated when total > 0.
 	require.NotNil(t, m.Conflicts)
-	assert.Equal(t, 10, m.Conflicts.Total)
-	assert.Equal(t, 1, m.Conflicts.Open)
+	assert.Equal(t, 4, m.Conflicts.TotalGroups)
+	assert.Equal(t, 1, m.Conflicts.OpenGroups)
+	assert.Equal(t, 10, m.Conflicts.TotalIndividual)
+	assert.Equal(t, 1, m.Conflicts.OpenIndividual)
 	assert.Equal(t, 6, m.Conflicts.Resolved)
 	assert.Equal(t, 3, m.Conflicts.FalsePositive)
 	assert.InDelta(t, 60.0, m.Conflicts.ResolvedPct, 0.1)

--- a/internal/service/tracehealth/service_test.go
+++ b/internal/service/tracehealth/service_test.go
@@ -110,7 +110,7 @@ func TestComputeGaps_UnresolvedConflicts(t *testing.T) {
 
 	found := false
 	for _, g := range gaps {
-		if g == "7 of 10 conflicts are unresolved." {
+		if g == "7 of 10 conflict groups are unresolved." {
 			found = true
 		}
 	}

--- a/internal/storage/conflicts.go
+++ b/internal/storage/conflicts.go
@@ -110,10 +110,13 @@ func (db *DB) CountConflicts(ctx context.Context, orgID uuid.UUID, filters Confl
 	return count, nil
 }
 
-// GetConflictStatusCounts returns the number of conflicts per resolution status for an org.
+// GetConflictStatusCounts returns the number of conflicts per resolution status for an org,
+// including both individual scored_conflicts counts and deduplicated conflict_group counts.
 // When from/to are non-nil, only conflicts with detected_at in [from, to) are included.
 func (db *DB) GetConflictStatusCounts(ctx context.Context, orgID uuid.UUID, from, to *time.Time) (ConflictStatusCounts, error) {
 	var c ConflictStatusCounts
+
+	// Individual scored_conflicts counts.
 	q := `
 		SELECT count(*),
 		       count(*) FILTER (WHERE status = 'open'),
@@ -135,6 +138,31 @@ func (db *DB) GetConflictStatusCounts(ctx context.Context, orgID uuid.UUID, from
 	if err != nil {
 		return c, fmt.Errorf("storage: conflict status counts: %w", err)
 	}
+
+	// Group-level counts — derived from scored_conflicts since conflict_groups
+	// has no denormalized open_count column.
+	gq := `
+		SELECT count(*),
+		       count(*) FILTER (WHERE EXISTS (
+		           SELECT 1 FROM scored_conflicts sc2
+		           WHERE sc2.group_id = cg.id AND sc2.status = 'open'
+		       ))
+		FROM conflict_groups cg
+		WHERE cg.org_id = $1`
+	gArgs := []any{orgID}
+	if from != nil {
+		gArgs = append(gArgs, *from)
+		gq += fmt.Sprintf(" AND cg.first_detected_at >= $%d", len(gArgs))
+	}
+	if to != nil {
+		gArgs = append(gArgs, *to)
+		gq += fmt.Sprintf(" AND cg.last_detected_at < $%d", len(gArgs))
+	}
+	err = db.pool.QueryRow(ctx, gq, gArgs...).Scan(&c.TotalGroups, &c.OpenGroups)
+	if err != nil {
+		return c, fmt.Errorf("storage: conflict group counts: %w", err)
+	}
+
 	return c, nil
 }
 

--- a/internal/storage/conflicts.go
+++ b/internal/storage/conflicts.go
@@ -152,11 +152,11 @@ func (db *DB) GetConflictStatusCounts(ctx context.Context, orgID uuid.UUID, from
 	gArgs := []any{orgID}
 	if from != nil {
 		gArgs = append(gArgs, *from)
-		gq += fmt.Sprintf(" AND cg.first_detected_at >= $%d", len(gArgs))
+		gq += fmt.Sprintf(" AND cg.last_detected_at >= $%d", len(gArgs))
 	}
 	if to != nil {
 		gArgs = append(gArgs, *to)
-		gq += fmt.Sprintf(" AND cg.last_detected_at < $%d", len(gArgs))
+		gq += fmt.Sprintf(" AND cg.first_detected_at < $%d", len(gArgs))
 	}
 	err = db.pool.QueryRow(ctx, gq, gArgs...).Scan(&c.TotalGroups, &c.OpenGroups)
 	if err != nil {
@@ -900,6 +900,11 @@ func conflictGroupWhere(f ConflictGroupFilters, argOffset int) (string, []any) {
 	if f.ConflictKind != nil {
 		clause += fmt.Sprintf(" AND cg.conflict_kind = $%d", argOffset)
 		args = append(args, *f.ConflictKind)
+		argOffset++
+	}
+	if f.Project != nil {
+		clause += fmt.Sprintf(" AND EXISTS (SELECT 1 FROM scored_conflicts sc_p WHERE sc_p.group_id = cg.id AND (sc_p.project_a = $%d OR sc_p.project_b = $%d))", argOffset, argOffset)
+		args = append(args, *f.Project)
 		argOffset++ //nolint:ineffassign
 	}
 	return clause, args

--- a/internal/storage/sqlite/conflicts.go
+++ b/internal/storage/sqlite/conflicts.go
@@ -76,6 +76,10 @@ func (l *LiteDB) ListConflictGroups(ctx context.Context, orgID uuid.UUID, filter
 		conds = append(conds, "cg.conflict_kind = ?")
 		args = append(args, *filters.ConflictKind)
 	}
+	if filters.Project != nil {
+		conds = append(conds, "EXISTS (SELECT 1 FROM scored_conflicts sc_p WHERE sc_p.group_id = cg.id AND (sc_p.project_a = ? OR sc_p.project_b = ?))")
+		args = append(args, *filters.Project, *filters.Project)
+	}
 
 	where := "WHERE " + strings.Join(conds, " AND ")
 

--- a/internal/storage/sqlite/tracehealth.go
+++ b/internal/storage/sqlite/tracehealth.go
@@ -85,10 +85,13 @@ func (l *LiteDB) GetEvidenceCoverageStats(ctx context.Context, orgID uuid.UUID, 
 	}, nil
 }
 
-// GetConflictStatusCounts returns conflict status breakdown for an org.
+// GetConflictStatusCounts returns conflict status breakdown for an org,
+// including both individual scored_conflicts counts and deduplicated conflict_group counts.
 // When from/to are non-nil, only conflicts with detected_at in [from, to) are included.
 func (l *LiteDB) GetConflictStatusCounts(ctx context.Context, orgID uuid.UUID, from, to *time.Time) (storage.ConflictStatusCounts, error) {
 	var cc storage.ConflictStatusCounts
+
+	// Individual scored_conflicts counts.
 	q := `SELECT
 		     COUNT(*),
 		     COALESCE(SUM(CASE WHEN status = 'open' THEN 1 ELSE 0 END), 0),
@@ -109,6 +112,30 @@ func (l *LiteDB) GetConflictStatusCounts(ctx context.Context, orgID uuid.UUID, f
 	if err != nil {
 		return storage.ConflictStatusCounts{}, fmt.Errorf("sqlite: conflict status counts: %w", err)
 	}
+
+	// Group-level counts — SQLite conflict_groups has no open_count column,
+	// so we compute it via a subquery join against scored_conflicts.
+	gq := `SELECT
+		     COUNT(DISTINCT cg.id),
+		     COALESCE(SUM(CASE WHEN EXISTS (
+		         SELECT 1 FROM scored_conflicts sc2
+		         WHERE sc2.group_id = cg.id AND sc2.status = 'open'
+		     ) THEN 1 ELSE 0 END), 0)
+		 FROM conflict_groups cg WHERE cg.org_id = ?`
+	gArgs := []any{uuidStr(orgID)}
+	if from != nil {
+		gq += " AND cg.first_detected_at >= ?"
+		gArgs = append(gArgs, from.UTC().Format("2006-01-02T15:04:05.999999999Z"))
+	}
+	if to != nil {
+		gq += " AND cg.last_detected_at < ?"
+		gArgs = append(gArgs, to.UTC().Format("2006-01-02T15:04:05.999999999Z"))
+	}
+	err = l.db.QueryRowContext(ctx, gq, gArgs...).Scan(&cc.TotalGroups, &cc.OpenGroups)
+	if err != nil {
+		return storage.ConflictStatusCounts{}, fmt.Errorf("sqlite: conflict group counts: %w", err)
+	}
+
 	return cc, nil
 }
 

--- a/internal/storage/sqlite/tracehealth.go
+++ b/internal/storage/sqlite/tracehealth.go
@@ -124,11 +124,11 @@ func (l *LiteDB) GetConflictStatusCounts(ctx context.Context, orgID uuid.UUID, f
 		 FROM conflict_groups cg WHERE cg.org_id = ?`
 	gArgs := []any{uuidStr(orgID)}
 	if from != nil {
-		gq += " AND cg.first_detected_at >= ?"
+		gq += " AND cg.last_detected_at >= ?"
 		gArgs = append(gArgs, from.UTC().Format("2006-01-02T15:04:05.999999999Z"))
 	}
 	if to != nil {
-		gq += " AND cg.last_detected_at < ?"
+		gq += " AND cg.first_detected_at < ?"
 		gArgs = append(gArgs, to.UTC().Format("2006-01-02T15:04:05.999999999Z"))
 	}
 	err = l.db.QueryRowContext(ctx, gq, gArgs...).Scan(&cc.TotalGroups, &cc.OpenGroups)

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -130,6 +130,9 @@ type ConflictGroupFilters struct {
 	DecisionType *string
 	AgentID      *string
 	ConflictKind *string
+	// Project restricts results to groups that have at least one member
+	// conflict matching the given project (via project_a or project_b).
+	Project *string
 	// Status restricts results to groups that have at least one member
 	// conflict matching this exact status (e.g. "open", "resolved",
 	// "false_positive"). When nil, all groups are returned.

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -104,11 +104,17 @@ type ConflictFilters struct {
 }
 
 // ConflictStatusCounts holds the number of conflicts in each resolution status.
+// It tracks both individual scored_conflicts rows and deduplicated conflict_groups.
 type ConflictStatusCounts struct {
+	// Individual scored_conflicts counts.
 	Total         int
 	Open          int
 	Resolved      int
 	FalsePositive int
+
+	// Group-level counts (deduplicated by conflict_groups).
+	TotalGroups int
+	OpenGroups  int
 }
 
 // FalsePositiveRate holds the false-positive rate over a rolling 30-day window.


### PR DESCRIPTION
## Summary

- **Session-start hook** now counts deduplicated conflict _groups_ with open conflicts, not individual `scored_conflicts` rows. A group with 5 detections and 1 unresolved now reports 1, not 5.
- **`akashi_stats`** `ConflictMetrics` exposes both `open_groups`/`total_groups` (deduplicated signal) and `open_individual`/`total_individual` (raw counts), replacing the ambiguous `open`/`total` fields.
- **`akashi_conflicts` MCP tool** defaults to showing only groups with open conflicts when `status` is omitted (pass `status="all"` for the old behavior).
- Both PostgreSQL and SQLite storage backends updated. OpenAPI spec updated.

Fixes #693

## Test plan

- [x] All unit tests pass (`go test -race -count=1 ./...`)
- [x] `go build`, `go vet`, `golangci-lint` clean
- [ ] Integration tests with Docker (CI)
- [ ] Verify session-start hook shows correct count on a live instance

> The transporter doesn't care how many atoms make up your pattern —
> it resolves you into one beam. Starfleet's mistake was always counting
> the molecules when they should have been counting the crew.