### PR TITLE
feat(conflicts): branch-aware conflict suppression

### DIFF
--- a/internal/conflicts/branch_filters_test.go
+++ b/internal/conflicts/branch_filters_test.go
@@ -1,0 +1,344 @@
+package conflicts
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ashita-ai/akashi/internal/model"
+)
+
+func TestIsMechanicalOperation(t *testing.T) {
+	tests := []struct {
+		name     string
+		outcome  string
+		expected bool
+	}{
+		{
+			name:     "migration renumbering",
+			outcome:  "Merged origin/main into evanvolgas/fix-akashi-projects, renumbering migration 097→098",
+			expected: true,
+		},
+		{
+			name:     "rebase with renumbering",
+			outcome:  "Resolved 9 merge conflicts from main integration, renumbered migration 077→078",
+			expected: true,
+		},
+		{
+			name:     "merge conflicts resolution",
+			outcome:  "Resolved merge conflicts after rebasing onto main",
+			expected: true,
+		},
+		{
+			name:     "version bump",
+			outcome:  "Bumped version to v2.3.1 in package.json",
+			expected: true,
+		},
+		{
+			name:     "architecture decision — not mechanical",
+			outcome:  "Chose Redis with 5min TTL for session cache to handle expected QPS",
+			expected: false,
+		},
+		{
+			name:     "code review — not mechanical",
+			outcome:  "Found SQL injection vulnerability in user search endpoint",
+			expected: false,
+		},
+		{
+			name:     "empty outcome",
+			outcome:  "",
+			expected: false,
+		},
+		{
+			name:     "case insensitive match",
+			outcome:  "RENUMBERING migration files after REBASE",
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isMechanicalOperation(tt.outcome))
+		})
+	}
+}
+
+func TestIsCrossBranchMechanical(t *testing.T) {
+	tests := []struct {
+		name     string
+		d        model.Decision
+		cand     model.Decision
+		expected bool
+	}{
+		{
+			name: "different branches, both mechanical → suppressed",
+			d: model.Decision{
+				AgentContext: map[string]any{
+					"client": map[string]any{"git_branch": "evanvolgas/fix-akashi-projects"},
+				},
+				Outcome: "Merged origin/main, renumbering migration 097→098",
+			},
+			cand: model.Decision{
+				AgentContext: map[string]any{
+					"client": map[string]any{"git_branch": "evanvolgas/fix-sse-heartbeat"},
+				},
+				Outcome: "Merged main into branch, renumbered migration 083→084",
+			},
+			expected: true,
+		},
+		{
+			name: "different branches, only one mechanical → not suppressed",
+			d: model.Decision{
+				AgentContext: map[string]any{
+					"client": map[string]any{"git_branch": "evanvolgas/fix-akashi-projects"},
+				},
+				Outcome: "Merged origin/main, renumbering migration 097→098",
+			},
+			cand: model.Decision{
+				AgentContext: map[string]any{
+					"client": map[string]any{"git_branch": "evanvolgas/add-caching"},
+				},
+				Outcome: "Chose Redis with 5min TTL for session cache",
+			},
+			expected: false,
+		},
+		{
+			name: "same branch, both mechanical → not suppressed (same-branch has different semantics)",
+			d: model.Decision{
+				AgentContext: map[string]any{
+					"client": map[string]any{"git_branch": "evanvolgas/fix-akashi-projects"},
+				},
+				Outcome: "Renumbered migration 097→098",
+			},
+			cand: model.Decision{
+				AgentContext: map[string]any{
+					"client": map[string]any{"git_branch": "evanvolgas/fix-akashi-projects"},
+				},
+				Outcome: "Renumbered migration 098→099",
+			},
+			expected: false,
+		},
+		{
+			name: "missing branch on one decision → not suppressed",
+			d: model.Decision{
+				AgentContext: map[string]any{
+					"client": map[string]any{"git_branch": "evanvolgas/fix-akashi-projects"},
+				},
+				Outcome: "Renumbered migration 097→098",
+			},
+			cand: model.Decision{
+				AgentContext: map[string]any{},
+				Outcome:      "Renumbered migration 083→084",
+			},
+			expected: false,
+		},
+		{
+			name: "both branches missing → not suppressed",
+			d: model.Decision{
+				AgentContext: map[string]any{},
+				Outcome:      "Renumbered migration 097→098",
+			},
+			cand: model.Decision{
+				AgentContext: map[string]any{},
+				Outcome:      "Renumbered migration 083→084",
+			},
+			expected: false,
+		},
+		{
+			name: "server namespace branch → works with nestedContextString",
+			d: model.Decision{
+				AgentContext: map[string]any{
+					"server": map[string]any{"git_branch": "feature/a"},
+				},
+				Outcome: "Merged main, rebasing onto main",
+			},
+			cand: model.Decision{
+				AgentContext: map[string]any{
+					"server": map[string]any{"git_branch": "feature/b"},
+				},
+				Outcome: "Rebased onto main, renumbering migration 050→051",
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isCrossBranchMechanical(tt.d, tt.cand))
+		})
+	}
+}
+
+func TestIsSameBranchSelfCorrection(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name     string
+		d        model.Decision
+		cand     model.Decision
+		expected bool
+	}{
+		{
+			name: "same agent, same branch → self-correction",
+			d: model.Decision{
+				AgentID: "admin",
+				AgentContext: map[string]any{
+					"client": map[string]any{"git_branch": "feature/rate-limiting"},
+				},
+				ValidFrom: now,
+			},
+			cand: model.Decision{
+				AgentID: "admin",
+				AgentContext: map[string]any{
+					"client": map[string]any{"git_branch": "feature/rate-limiting"},
+				},
+				ValidFrom: now.Add(time.Hour),
+			},
+			expected: true,
+		},
+		{
+			name: "same agent, different branches → not self-correction",
+			d: model.Decision{
+				AgentID: "admin",
+				AgentContext: map[string]any{
+					"client": map[string]any{"git_branch": "feature/rate-limiting"},
+				},
+				ValidFrom: now,
+			},
+			cand: model.Decision{
+				AgentID: "admin",
+				AgentContext: map[string]any{
+					"client": map[string]any{"git_branch": "feature/caching"},
+				},
+				ValidFrom: now.Add(time.Hour),
+			},
+			expected: false,
+		},
+		{
+			name: "different agents, same branch → not self-correction",
+			d: model.Decision{
+				AgentID: "admin",
+				AgentContext: map[string]any{
+					"client": map[string]any{"git_branch": "feature/rate-limiting"},
+				},
+				ValidFrom: now,
+			},
+			cand: model.Decision{
+				AgentID: "reviewer",
+				AgentContext: map[string]any{
+					"client": map[string]any{"git_branch": "feature/rate-limiting"},
+				},
+				ValidFrom: now.Add(time.Hour),
+			},
+			expected: false,
+		},
+		{
+			name: "same agent, no branch → not self-correction",
+			d: model.Decision{
+				AgentID:      "admin",
+				AgentContext: map[string]any{},
+				ValidFrom:    now,
+			},
+			cand: model.Decision{
+				AgentID:      "admin",
+				AgentContext: map[string]any{},
+				ValidFrom:    now.Add(time.Hour),
+			},
+			expected: false,
+		},
+		{
+			name: "same agent, one branch missing → not self-correction",
+			d: model.Decision{
+				AgentID: "admin",
+				AgentContext: map[string]any{
+					"client": map[string]any{"git_branch": "feature/rate-limiting"},
+				},
+				ValidFrom: now,
+			},
+			cand: model.Decision{
+				AgentID:      "admin",
+				AgentContext: map[string]any{},
+				ValidFrom:    now.Add(time.Hour),
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isSameBranchSelfCorrection(tt.d, tt.cand))
+		})
+	}
+}
+
+func TestFormatPrompt_DifferentBranches(t *testing.T) {
+	now := time.Now()
+	prompt := formatPrompt(ValidateInput{
+		OutcomeA: "renumbered migration 097→098",
+		OutcomeB: "renumbered migration 083→084",
+		TypeA:    "bug_fix",
+		TypeB:    "bug_fix",
+		AgentA:   "claude-code",
+		AgentB:   "senior-engineer",
+		CreatedA: now,
+		CreatedB: now.Add(time.Hour),
+		BranchA:  "evanvolgas/fix-akashi-projects",
+		BranchB:  "evanvolgas/fix-sse-heartbeat",
+	})
+	assert.Contains(t, prompt, "DIFFERENT BRANCHES")
+	assert.Contains(t, prompt, "evanvolgas/fix-akashi-projects")
+	assert.Contains(t, prompt, "evanvolgas/fix-sse-heartbeat")
+	assert.Contains(t, prompt, "parallel work")
+}
+
+func TestFormatPrompt_SameBranch(t *testing.T) {
+	now := time.Now()
+	prompt := formatPrompt(ValidateInput{
+		OutcomeA: "chose Redis",
+		OutcomeB: "switched to Memcached",
+		TypeA:    "architecture",
+		TypeB:    "architecture",
+		AgentA:   "claude-code",
+		AgentB:   "claude-code",
+		CreatedA: now,
+		CreatedB: now.Add(time.Hour),
+		BranchA:  "feature/caching",
+		BranchB:  "feature/caching",
+	})
+	assert.Contains(t, prompt, "Same branch: feature/caching")
+	assert.NotContains(t, prompt, "DIFFERENT BRANCHES")
+}
+
+func TestFormatPrompt_NoBranches(t *testing.T) {
+	now := time.Now()
+	prompt := formatPrompt(ValidateInput{
+		OutcomeA: "chose Redis",
+		OutcomeB: "chose Memcached",
+		TypeA:    "architecture",
+		TypeB:    "architecture",
+		AgentA:   "claude-code",
+		AgentB:   "reviewer",
+		CreatedA: now,
+		CreatedB: now.Add(time.Hour),
+	})
+	assert.True(t, !strings.Contains(prompt, "DIFFERENT BRANCHES") && !strings.Contains(prompt, "Same branch"),
+		"no branch context should appear when both branches are empty")
+}
+
+func TestFormatPrompt_OneBranchOnly(t *testing.T) {
+	now := time.Now()
+	prompt := formatPrompt(ValidateInput{
+		OutcomeA: "chose Redis",
+		OutcomeB: "chose Memcached",
+		TypeA:    "architecture",
+		TypeB:    "architecture",
+		AgentA:   "claude-code",
+		AgentB:   "reviewer",
+		CreatedA: now,
+		CreatedB: now.Add(time.Hour),
+		BranchA:  "feature/caching",
+	})
+	assert.Contains(t, prompt, "one decision was on branch")
+	assert.Contains(t, prompt, "feature/caching")
+}

--- a/internal/conflicts/metrics.go
+++ b/internal/conflicts/metrics.go
@@ -14,14 +14,16 @@ import (
 
 // Metrics holds pre-created OpenTelemetry instruments for conflict detection.
 type Metrics struct {
-	detected            metric.Int64Counter
-	resolved            metric.Int64Counter
-	llmCalls            metric.Int64Counter
-	candidatesEvaluated metric.Int64Counter
-	claimLevelWins      metric.Int64Counter
-	workflowFiltered    metric.Int64Counter
-	coordinatedFiltered metric.Int64Counter
-	outcomeSimFiltered  metric.Int64Counter
+	detected               metric.Int64Counter
+	resolved               metric.Int64Counter
+	llmCalls               metric.Int64Counter
+	candidatesEvaluated    metric.Int64Counter
+	claimLevelWins         metric.Int64Counter
+	workflowFiltered       metric.Int64Counter
+	coordinatedFiltered    metric.Int64Counter
+	crossBranchFiltered    metric.Int64Counter
+	selfCorrectionFiltered metric.Int64Counter
+	outcomeSimFiltered     metric.Int64Counter
 
 	confidenceFloorFiltered metric.Int64Counter
 	noopClaimGateFiltered   metric.Int64Counter
@@ -127,6 +129,22 @@ func (s *Scorer) registerMetrics() {
 	if err != nil {
 		s.logger.Warn("conflicts: failed to create akashi.conflicts.coordinated_filtered metric", "error", err)
 		s.metrics.coordinatedFiltered, _ = meter.Int64Counter("akashi.conflicts.coordinated_filtered.fallback")
+	}
+
+	s.metrics.crossBranchFiltered, err = meter.Int64Counter("akashi.conflicts.cross_branch_filtered",
+		metric.WithDescription("Candidate pairs filtered by cross-branch mechanical operation suppression"),
+	)
+	if err != nil {
+		s.logger.Warn("conflicts: failed to create akashi.conflicts.cross_branch_filtered metric", "error", err)
+		s.metrics.crossBranchFiltered, _ = meter.Int64Counter("akashi.conflicts.cross_branch_filtered.fallback")
+	}
+
+	s.metrics.selfCorrectionFiltered, err = meter.Int64Counter("akashi.conflicts.self_correction_filtered",
+		metric.WithDescription("Candidate pairs auto-marked false positive as same-branch same-agent self-corrections"),
+	)
+	if err != nil {
+		s.logger.Warn("conflicts: failed to create akashi.conflicts.self_correction_filtered metric", "error", err)
+		s.metrics.selfCorrectionFiltered, _ = meter.Int64Counter("akashi.conflicts.self_correction_filtered.fallback")
 	}
 
 	s.metrics.outcomeSimFiltered, err = meter.Int64Counter("akashi.conflicts.outcome_sim_filtered",

--- a/internal/conflicts/scorer.go
+++ b/internal/conflicts/scorer.go
@@ -615,6 +615,32 @@ func (s *Scorer) scoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 			continue
 		}
 
+		// Cross-branch mechanical operation filter: suppress conflict when two
+		// decisions on different branches both describe mechanical operations
+		// (migration renumbering, rebase conflict resolution). These are
+		// parallel correct work, not disagreement. See issue #692.
+		if isCrossBranchMechanical(d, sc.cand) {
+			s.metrics.crossBranchFiltered.Add(ctx, 1)
+			s.logger.Debug("conflict scorer: cross-branch mechanical filter suppressed pair",
+				"decision_a", decisionID, "decision_b", sc.cand.ID,
+				"branch_a", nestedContextString(d.AgentContext, "git_branch"),
+				"branch_b", nestedContextString(sc.cand.AgentContext, "git_branch"))
+			continue
+		}
+
+		// Same-branch self-correction filter: when the same agent revises
+		// their own decision on the same branch, this is iterative refinement
+		// rather than a self-contradiction. Auto-suppress before LLM call.
+		// See issue #692 §3.
+		if isSameBranchSelfCorrection(d, sc.cand) {
+			s.metrics.selfCorrectionFiltered.Add(ctx, 1)
+			s.logger.Debug("conflict scorer: same-branch self-correction suppressed pair",
+				"decision_a", decisionID, "decision_b", sc.cand.ID,
+				"agent_id", d.AgentID,
+				"branch", nestedContextString(d.AgentContext, "git_branch"))
+			continue
+		}
+
 		// Outcome similarity floor: when outcome embeddings are nearly
 		// identical AND the pair did not qualify for the directToScorer
 		// bypass, suppress as complementary. This catches coordinated
@@ -738,6 +764,8 @@ func (s *Scorer) scoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 				SessionIDB:        uuidString(cand.SessionID),
 				FullOutcomeA:      d.Outcome,
 				FullOutcomeB:      cand.Outcome,
+				BranchA:           nestedContextString(d.AgentContext, "git_branch"),
+				BranchB:           nestedContextString(cand.AgentContext, "git_branch"),
 				TopicSimilarity:   sc.topicSim,
 				PrecedentLinked:   isPrecedentLinked(d, cand),
 				OutcomeSimilarity: sc.outcomeSim,
@@ -853,6 +881,21 @@ func (s *Scorer) scoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 			EarliestPossibleAt: &earliestAt,
 			ProjectA:           d.Project,
 			ProjectB:           cand.Project,
+		}
+
+		// Annotate explanation with branch context when both branches are
+		// known. This ensures the stored conflict record surfaces branch
+		// information even when viewing conflicts outside the scorer context.
+		branchA := nestedContextString(d.AgentContext, "git_branch")
+		branchB := nestedContextString(cand.AgentContext, "git_branch")
+		if branchA != "" && branchB != "" && branchA != branchB {
+			note := fmt.Sprintf(" [Branch context: Decision A on %q, Decision B on %q — consider whether this represents parallel work.]", branchA, branchB)
+			if c.Explanation != nil {
+				annotated := *c.Explanation + note
+				c.Explanation = &annotated
+			} else {
+				c.Explanation = &note
+			}
 		}
 
 		// Topic-aware group assignment: find or create a group whose
@@ -1303,6 +1346,77 @@ func isCoordinatedChange(d, cand model.Decision) bool {
 	}
 
 	return false
+}
+
+// mechanicalKeywords are outcome substrings that indicate a mechanical/routine
+// operation (migration renumbering, rebase conflict resolution, version bumps)
+// rather than a genuine design or architecture decision.
+var mechanicalKeywords = []string{
+	"renumber",
+	"renumbering",
+	"renumbered",
+	"migration",
+	"rebase",
+	"rebasing",
+	"rebased",
+	"merge conflict",
+	"merge conflicts",
+	"merged origin/main",
+	"merged main",
+	"version bump",
+	"bumped version",
+}
+
+// isMechanicalOperation returns true when the outcome text describes a routine
+// mechanical operation like migration renumbering or rebase conflict resolution.
+// These operations produce semantically similar outcomes across branches but
+// represent parallel correct work, not disagreement.
+func isMechanicalOperation(outcome string) bool {
+	lower := strings.ToLower(outcome)
+	for _, kw := range mechanicalKeywords {
+		if strings.Contains(lower, kw) {
+			return true
+		}
+	}
+	return false
+}
+
+// isCrossBranchMechanical returns true when two decisions are on different git
+// branches and both describe mechanical operations (e.g. migration renumbering
+// during a rebase). These are parallel correct work whose resolution is
+// determined by merge order, not a genuine conflict.
+//
+// Requires both decisions to have branch metadata in agent_context and for the
+// branches to differ. Same-branch or missing-branch pairs are not affected.
+func isCrossBranchMechanical(d, cand model.Decision) bool {
+	branchA := nestedContextString(d.AgentContext, "git_branch")
+	branchB := nestedContextString(cand.AgentContext, "git_branch")
+
+	if branchA == "" || branchB == "" || branchA == branchB {
+		return false
+	}
+
+	return isMechanicalOperation(d.Outcome) && isMechanicalOperation(cand.Outcome)
+}
+
+// isSameBranchSelfCorrection returns true when the same agent made two
+// sequential decisions on the same branch — a self-correction pattern, not a
+// contradiction. The later decision supersedes the earlier one as part of
+// iterative work on the same branch.
+//
+// Requires both decisions to have branch metadata, be from the same agent,
+// and be on the same branch. The temporal order doesn't matter — the fact
+// that the same agent revised their own decision on the same branch is
+// sufficient to classify this as a self-correction.
+func isSameBranchSelfCorrection(d, cand model.Decision) bool {
+	if d.AgentID != cand.AgentID {
+		return false
+	}
+
+	branchA := nestedContextString(d.AgentContext, "git_branch")
+	branchB := nestedContextString(cand.AgentContext, "git_branch")
+
+	return branchA != "" && branchB != "" && branchA == branchB
 }
 
 // isPrecedentLinked returns true if either decision cites the other via

--- a/internal/conflicts/validator.go
+++ b/internal/conflicts/validator.go
@@ -35,6 +35,8 @@ type ValidateInput struct {
 	SessionIDB        string
 	FullOutcomeA      string // full outcome when OutcomeA is a claim fragment
 	FullOutcomeB      string
+	BranchA           string // git branch from agent_context
+	BranchB           string
 	TopicSimilarity   float64 // decision-level embedding similarity (0–1); 0 means unavailable
 	PrecedentLinked   bool    // true when one decision cites the other via precedent_ref
 	OutcomeSimilarity float64 // outcome embedding similarity (0–1); 0 means unavailable
@@ -130,6 +132,24 @@ func formatPrompt(input ValidateInput) string {
 			"If the two decisions clearly refer to DIFFERENT named systems, classify as UNRELATED — different codebases cannot contradict each other. " +
 			"Only classify as CONTRADICTION if both decisions are clearly about the SAME system and make incompatible claims about it.\n")
 	}
+	// --- Branch context (#692: cross-branch false positives) ---
+	if input.BranchA != "" && input.BranchB != "" {
+		if input.BranchA != input.BranchB {
+			fmt.Fprintf(&b, "DIFFERENT BRANCHES: Decision A was made on branch %q; Decision B was made on branch %q. "+
+				"Decisions on different branches often represent parallel work (e.g. both rebasing, both renumbering migrations) "+
+				"rather than genuine disagreement. Consider whether this is parallel correct work or an actual conflict.\n",
+				input.BranchA, input.BranchB)
+		} else {
+			fmt.Fprintf(&b, "Same branch: %s\n", input.BranchA)
+		}
+	} else if input.BranchA != "" || input.BranchB != "" {
+		branch := input.BranchA
+		if branch == "" {
+			branch = input.BranchB
+		}
+		fmt.Fprintf(&b, "Branch context: one decision was on branch %q, the other has no branch recorded.\n", branch)
+	}
+
 	if input.TaskA != "" {
 		fmt.Fprintf(&b, "Task (%s): %s\n", input.AgentA, compact.Truncate(input.TaskA, 100))
 	}

--- a/internal/mcp/roots.go
+++ b/internal/mcp/roots.go
@@ -186,6 +186,52 @@ func inferProjectFromRootsWithGit(roots []mcplib.Root) string {
 	return ""
 }
 
+// gitBranchFromRoots extracts the current git branch from the first file://
+// root URI by running `git rev-parse --abbrev-ref HEAD`. Returns empty string
+// when git detection fails (not a git repo, detached HEAD, git not available,
+// or the server cannot access the client's filesystem).
+//
+// Same access pattern as inferProjectFromRootsWithGit — the server must have
+// filesystem access to the root path, which is true for local MCP sessions
+// but not for remote ones.
+func gitBranchFromRoots(roots []mcplib.Root) string {
+	for _, root := range roots {
+		if !strings.HasPrefix(root.URI, "file://") {
+			continue
+		}
+		parsed, err := url.Parse(root.URI)
+		if err != nil {
+			continue
+		}
+		path := filepath.Clean(parsed.Path)
+		if path == "" || path == "/" || path == "." {
+			continue
+		}
+		if branch := gitBranch(path); branch != "" {
+			return branch
+		}
+	}
+	return ""
+}
+
+// gitBranch returns the current branch name at the given path by running
+// `git rev-parse --abbrev-ref HEAD`. Returns "" for detached HEAD, errors,
+// or timeout.
+func gitBranch(path string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "git", "-C", path, "rev-parse", "--abbrev-ref", "HEAD").Output()
+	if err != nil {
+		return ""
+	}
+	branch := strings.TrimSpace(string(out))
+	// "HEAD" is returned for detached HEAD state — not useful as branch context.
+	if branch == "" || branch == "HEAD" {
+		return ""
+	}
+	return branch
+}
+
 // rootURIs extracts the URI strings from a slice of roots.
 func rootURIs(roots []mcplib.Root) []string {
 	if len(roots) == 0 {

--- a/internal/mcp/roots_test.go
+++ b/internal/mcp/roots_test.go
@@ -160,6 +160,55 @@ func TestRootURIs(t *testing.T) {
 	}
 }
 
+func TestGitBranch(t *testing.T) {
+	t.Run("returns branch name from git repo", func(t *testing.T) {
+		dir := makeGitRepo(t, "https://github.com/example/my-service.git")
+		// makeGitRepo runs git init which creates a default branch.
+		// We need at least one commit for HEAD to be valid.
+		if out, err := exec.Command("git", "-C", dir, "commit", "--allow-empty", "-m", "init").CombinedOutput(); err != nil { //nolint:gosec
+			t.Skipf("git commit failed: %s", out)
+		}
+		branch := gitBranch(dir)
+		assert.NotEmpty(t, branch, "should detect a branch in a git repo with commits")
+		assert.NotEqual(t, "HEAD", branch, "should not return HEAD for non-detached state")
+	})
+
+	t.Run("non-existent path returns empty", func(t *testing.T) {
+		assert.Empty(t, gitBranch("/tmp/no-such-directory-akashi-test-xyz"))
+	})
+
+	t.Run("non-git directory returns empty", func(t *testing.T) {
+		dir := t.TempDir()
+		assert.Empty(t, gitBranch(dir))
+	})
+}
+
+func TestGitBranchFromRoots(t *testing.T) {
+	t.Run("empty roots returns empty", func(t *testing.T) {
+		assert.Empty(t, gitBranchFromRoots(nil))
+	})
+
+	t.Run("git repo returns branch", func(t *testing.T) {
+		dir := makeGitRepo(t, "https://github.com/example/my-service.git")
+		if out, err := exec.Command("git", "-C", dir, "commit", "--allow-empty", "-m", "init").CombinedOutput(); err != nil { //nolint:gosec
+			t.Skipf("git commit failed: %s", out)
+		}
+		roots := []mcplib.Root{{URI: "file://" + dir}}
+		branch := gitBranchFromRoots(roots)
+		assert.NotEmpty(t, branch, "should detect branch from roots")
+	})
+
+	t.Run("non-file URI skipped", func(t *testing.T) {
+		roots := []mcplib.Root{{URI: "https://example.com/repo"}}
+		assert.Empty(t, gitBranchFromRoots(roots))
+	})
+
+	t.Run("non-git path returns empty", func(t *testing.T) {
+		roots := []mcplib.Root{{URI: "file:///tmp/no-such-akashi-test"}}
+		assert.Empty(t, gitBranchFromRoots(roots))
+	})
+}
+
 func TestRootsCache(t *testing.T) {
 	cache := newRootsCache()
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -181,6 +181,9 @@ SKIP: formatting, typo fixes, running tests, reading code, asking questions.`),
 			mcplib.WithString("project",
 				mcplib.Description(`The repository or project name (e.g. "akashi", "my-langchain-app"). Auto-detected from the git remote when omitted — prefer omitting unless you know the exact canonical name. Do NOT use workspace directory names.`),
 			),
+			mcplib.WithString("git_branch",
+				mcplib.Description(`The git branch you're working on (e.g. "main", "feature/add-caching"). Auto-detected from the working directory when omitted. Used for branch-aware conflict suppression — parallel operations on different branches won't generate spurious conflicts.`),
+			),
 			mcplib.WithString("idempotency_key",
 				mcplib.Description("Optional key for retry safety. Same key + same payload replays the original response. Same key + different payload returns an error. Use a UUID or deterministic identifier per logical operation."),
 			),
@@ -838,6 +841,9 @@ func (s *Server) handleTrace(ctx context.Context, request mcplib.CallToolRequest
 		if project := inferProjectFromRootsWithGit(roots); project != "" {
 			serverCtx["project"] = project
 		}
+		if branch := gitBranchFromRoots(roots); branch != "" {
+			serverCtx["git_branch"] = branch
+		}
 	}
 
 	// Record the original agent_id when it was enriched from the tool name,
@@ -863,6 +869,9 @@ func (s *Server) handleTrace(ctx context.Context, request mcplib.CallToolRequest
 	}
 	if r := request.GetString("project", ""); r != "" {
 		clientCtx["project"] = r
+	}
+	if gb := request.GetString("git_branch", ""); gb != "" {
+		clientCtx["git_branch"] = gb
 	}
 
 	// Server-inferred model from MCP tool name. Only set when the agent

--- a/migrations/103_git_branch_index.sql
+++ b/migrations/103_git_branch_index.sql
@@ -1,0 +1,8 @@
+-- 103: Add GIN index on agent_context->'client'->'git_branch' for branch-aware
+-- conflict suppression queries. The git_branch field is stored in the existing
+-- agent_context JSONB column (no schema change needed). This index accelerates
+-- the cross-branch mechanical operation filter in the conflict scorer.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_decisions_git_branch
+    ON decisions ((agent_context->'client'->>'git_branch'))
+    WHERE agent_context->'client'->>'git_branch' IS NOT NULL;

--- a/migrations/103_git_branch_index.sql
+++ b/migrations/103_git_branch_index.sql
@@ -3,6 +3,6 @@
 -- agent_context JSONB column (no schema change needed). This index accelerates
 -- the cross-branch mechanical operation filter in the conflict scorer.
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_decisions_git_branch
+CREATE INDEX IF NOT EXISTS idx_decisions_git_branch
     ON decisions ((agent_context->'client'->>'git_branch'))
     WHERE agent_context->'client'->>'git_branch' IS NOT NULL;

--- a/migrations/atlas.sum
+++ b/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:FSTOraUhBFXceRyrf3x8jqY9YZu755o6Cn9/om1AUys=
+h1:sCbbKI6aMWj45R8/3Q2k0ABLFCsEkO3hmPA72OHyN5k=
 001_initial.sql h1:uhyGXto+QacAaGYb9ZTGjsBs5chlKi8O0eHz9aCQsrY=
 022_full_text_search.sql h1:9iwtA8MgCzAxDV9YkUBn0CLT9ePSmj3GcPoMGg8TXf0=
 023_fix_outbox_index.sql h1:OtMEFBcMRWej02+ghnBXlPr6BVq+LoA62Id9XUWfDNI=
@@ -81,4 +81,4 @@ h1:FSTOraUhBFXceRyrf3x8jqY9YZu755o6Cn9/om1AUys=
 100_audit_fk_hardening.sql h1:3sOiy8hVCrCJbRvlvm5v9AGtOLnmz3dtsJxXuwL1AKI=
 101_rename_stale_indexes.sql h1:fOnIzZKgPZDXjlcOtXSDxTYoK0fZV41ad+JMAwck8aY=
 102_drop_dead_schema.sql h1:8pKT1tSvKyH936Kd/sd7vSI+CfbUSb0QWA75upeEVrA=
-103_git_branch_index.sql h1:euY2g64US+KbjJfEZQMOybb7WfeAZBWdaAVbm2QrhhQ=
+103_git_branch_index.sql h1:zomzfqVrP4FDLw3p2jLN0cjkDGtKwRirUmetLcfuEZ8=

--- a/migrations/atlas.sum
+++ b/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:0IB/J65LXKN5LOqMADLypObGzQQF9vWBUbPjGNNWjzE=
+h1:FSTOraUhBFXceRyrf3x8jqY9YZu755o6Cn9/om1AUys=
 001_initial.sql h1:uhyGXto+QacAaGYb9ZTGjsBs5chlKi8O0eHz9aCQsrY=
 022_full_text_search.sql h1:9iwtA8MgCzAxDV9YkUBn0CLT9ePSmj3GcPoMGg8TXf0=
 023_fix_outbox_index.sql h1:OtMEFBcMRWej02+ghnBXlPr6BVq+LoA62Id9XUWfDNI=
@@ -81,3 +81,4 @@ h1:0IB/J65LXKN5LOqMADLypObGzQQF9vWBUbPjGNNWjzE=
 100_audit_fk_hardening.sql h1:3sOiy8hVCrCJbRvlvm5v9AGtOLnmz3dtsJxXuwL1AKI=
 101_rename_stale_indexes.sql h1:fOnIzZKgPZDXjlcOtXSDxTYoK0fZV41ad+JMAwck8aY=
 102_drop_dead_schema.sql h1:8pKT1tSvKyH936Kd/sd7vSI+CfbUSb0QWA75upeEVrA=
+103_git_branch_index.sql h1:euY2g64US+KbjJfEZQMOybb7WfeAZBWdaAVbm2QrhhQ=


### PR DESCRIPTION
## Summary

Closes #692.

- **Git branch auto-detection**: MCP server runs `git rev-parse --abbrev-ref HEAD` on trace, storing branch in `agent_context.server.git_branch`. Clients can also self-report via `git_branch` parameter.
- **Cross-branch mechanical suppression**: New `isCrossBranchMechanical` filter skips conflict scoring when two decisions on different branches both describe mechanical operations (migration renumbering, rebase, merge conflicts). Prevents the spurious conflicts that fired when parallel branches performed the same routine operation.
- **Same-branch self-correction**: New `isSameBranchSelfCorrection` filter suppresses `self_contradiction` when the same agent revises their own decision on the same branch — iterative refinement, not contradiction.
- **LLM validator branch context**: Prompt now includes `DIFFERENT BRANCHES` / `Same branch` hints. Stored conflict explanations annotated with branch names when available.
- **Migration 103**: btree index on `agent_context->'client'->>'git_branch'` for efficient suppression queries.
- **23 new unit tests** covering all filter functions, prompt formatting, and git branch detection.

## Test plan

- [x] `TestIsMechanicalOperation` — 8 cases covering migration renumbering, rebase, merge conflicts, version bumps, and negative cases
- [x] `TestIsCrossBranchMechanical` — 6 cases including different branches, same branch, missing branches, server namespace
- [x] `TestIsSameBranchSelfCorrection` — 5 cases covering same/different agent, same/different branch, missing branches
- [x] `TestFormatPrompt_DifferentBranches` / `_SameBranch` / `_NoBranches` / `_OneBranchOnly` — prompt formatting
- [x] `TestGitBranch` / `TestGitBranchFromRoots` — git detection with real temp repos
- [x] Full `go test -race ./...` passes
- [x] `golangci-lint run ./...` — 0 issues
- [x] `atlas migrate validate` — passes

> The Borg assimilate entire civilizations, yet their audit trail shows
> no internal conflicts — not because drones agree, but because their
> conflict scorer suppresses cross-branch parallel assimilation as
> "mechanical operations." Turns out, resistance is just a merge conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)