### PR TITLE
feat(mcp): accept cwd and repo_url for project inference

### DIFF
--- a/internal/mcp/roots.go
+++ b/internal/mcp/roots.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -12,6 +13,13 @@ import (
 	mcplib "github.com/mark3labs/mcp-go/mcp"
 	mcpserver "github.com/mark3labs/mcp-go/server"
 )
+
+// validRepoName constrains what parseRepoNameFromURL will accept as a repo
+// name. The result is written straight into decisions.project and the
+// project_links alias table, so anything that isn't clearly a repo-shaped
+// identifier must be rejected at the boundary. GitHub, GitLab, and Bitbucket
+// all reject names outside this shape, so no real remote URL is excluded.
+var validRepoName = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
 
 // rootsRequestTimeout bounds the synchronous round-trip to the client.
 // If the client doesn't respond in time, we skip roots gracefully.
@@ -233,26 +241,45 @@ func gitBranch(path string) string {
 }
 
 // parseRepoNameFromURL extracts the canonical repo name from a git remote URL.
-// Accepts SSH form (git@host:org/repo.git), HTTPS form (https://host/org/repo.git),
-// with or without the .git suffix. Returns "" for empty or obviously-malformed input.
+// Accepts scheme-bearing URLs (https://host/org/repo(.git)?, ssh://…, file://…)
+// and SSH shorthand (user@host:org/repo(.git)?). Query strings and fragments
+// are stripped. Bare filesystem paths and anything whose final segment isn't a
+// repo-shaped identifier return "".
 //
-// Uses the same normalization as gitRepoName: strip .git, then filepath.Base.
-// So git@github.com:ArdentAILabs/mono.git → "mono", matching the flat-namespace
-// canonical scheme used elsewhere. Callers that want the org prefix must not
-// rely on this function.
+// The returned name is flat — git@github.com:ArdentAILabs/mono.git → "mono",
+// matching the canonical scheme used elsewhere. Callers that need the org
+// prefix must not rely on this function.
 func parseRepoNameFromURL(repoURL string) string {
 	trimmed := strings.TrimSpace(repoURL)
 	if trimmed == "" {
 		return ""
 	}
-	// Reject anything without a repo separator — not a URL we can parse.
-	if !strings.ContainsAny(trimmed, ":/") {
+	var path string
+	switch {
+	case strings.Contains(trimmed, "://"):
+		// Scheme-bearing URL. net/url gives us the path without query/fragment
+		// and with any port on the host already removed.
+		u, err := url.Parse(trimmed)
+		if err != nil {
+			return ""
+		}
+		path = u.Path
+	case !strings.HasPrefix(trimmed, "/"):
+		// SSH shorthand: user@host:org/repo(.git)?. The first colon separates
+		// the host from the path. Reject empty-path and empty-host forms.
+		i := strings.Index(trimmed, ":")
+		if i <= 0 || i >= len(trimmed)-1 {
+			return ""
+		}
+		path = trimmed[i+1:]
+	default:
+		// Bare filesystem path (e.g. "/etc/passwd"). Not a git remote.
 		return ""
 	}
-	trimmed = strings.TrimSuffix(trimmed, "/")
-	trimmed = strings.TrimSuffix(trimmed, ".git")
-	base := filepath.Base(trimmed)
-	if base == "." || base == "/" || base == "" {
+	path = strings.TrimSuffix(path, "/")
+	path = strings.TrimSuffix(path, ".git")
+	base := filepath.Base(path)
+	if !validRepoName.MatchString(base) {
 		return ""
 	}
 	return base

--- a/internal/mcp/roots.go
+++ b/internal/mcp/roots.go
@@ -232,6 +232,32 @@ func gitBranch(path string) string {
 	return branch
 }
 
+// parseRepoNameFromURL extracts the canonical repo name from a git remote URL.
+// Accepts SSH form (git@host:org/repo.git), HTTPS form (https://host/org/repo.git),
+// with or without the .git suffix. Returns "" for empty or obviously-malformed input.
+//
+// Uses the same normalization as gitRepoName: strip .git, then filepath.Base.
+// So git@github.com:ArdentAILabs/mono.git → "mono", matching the flat-namespace
+// canonical scheme used elsewhere. Callers that want the org prefix must not
+// rely on this function.
+func parseRepoNameFromURL(repoURL string) string {
+	trimmed := strings.TrimSpace(repoURL)
+	if trimmed == "" {
+		return ""
+	}
+	// Reject anything without a repo separator — not a URL we can parse.
+	if !strings.ContainsAny(trimmed, ":/") {
+		return ""
+	}
+	trimmed = strings.TrimSuffix(trimmed, "/")
+	trimmed = strings.TrimSuffix(trimmed, ".git")
+	base := filepath.Base(trimmed)
+	if base == "." || base == "/" || base == "" {
+		return ""
+	}
+	return base
+}
+
 // rootURIs extracts the URI strings from a slice of roots.
 func rootURIs(roots []mcplib.Root) []string {
 	if len(roots) == 0 {

--- a/internal/mcp/roots_test.go
+++ b/internal/mcp/roots_test.go
@@ -135,17 +135,36 @@ func TestParseRepoNameFromURL(t *testing.T) {
 		repoURL string
 		want    string
 	}{
+		// Accepted inputs.
 		{"SSH with .git", "git@github.com:ArdentAILabs/mono.git", "mono"},
 		{"SSH without .git", "git@github.com:ArdentAILabs/mono", "mono"},
 		{"HTTPS with .git", "https://github.com/ArdentAILabs/mono.git", "mono"},
 		{"HTTPS without .git", "https://github.com/ArdentAILabs/mono", "mono"},
 		{"HTTPS with trailing slash", "https://github.com/org/repo/", "repo"},
+		{"HTTPS with port", "https://github.com:443/org/repo.git", "repo"},
+		{"ssh scheme URL", "ssh://git@github.com/org/repo.git", "repo"},
+		{"file scheme URL", "file:///srv/git/mirror/repo.git", "repo"},
 		{"nested GitLab path", "git@gitlab.com:team/subgroup/repo.git", "repo"},
 		{"whitespace trimmed", "  https://github.com/org/repo.git\n", "repo"},
+		// Query strings and fragments must be stripped, not pass through.
+		{"query string stripped", "https://github.com/org/repo.git?foo=bar", "repo"},
+		{"fragment stripped", "https://github.com/org/repo.git#readme", "repo"},
+		{"query without .git", "https://github.com/org/repo?utm=x", "repo"},
+		// Rejected inputs — each previously slipped through and became a
+		// garbage entry in decisions.project / project_links.
 		{"empty returns empty", "", ""},
 		{"whitespace only returns empty", "   ", ""},
 		{"no separator returns empty", "just-a-name", ""},
 		{"only separator returns empty", "/", ""},
+		{"bare filesystem path rejected", "/etc/passwd", ""},
+		{"scheme with no path rejected", "https://", ""},
+		{"lone colon rejected", "a:", ""},
+		{"leading colon rejected", ":b", ""},
+		{"double colon rejected", "::", ""},
+		{"SSH with empty path rejected", "git@host:", ""},
+		{"SSH pointing at .git only rejected", "git@host:.git", ""},
+		{"SSH pointing at dot rejected", "git@host:.", ""},
+		{"path traversal rejected", "foo/..", ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/mcp/roots_test.go
+++ b/internal/mcp/roots_test.go
@@ -129,6 +129,31 @@ func TestInferProjectFromRootsWithGit(t *testing.T) {
 	})
 }
 
+func TestParseRepoNameFromURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		repoURL string
+		want    string
+	}{
+		{"SSH with .git", "git@github.com:ArdentAILabs/mono.git", "mono"},
+		{"SSH without .git", "git@github.com:ArdentAILabs/mono", "mono"},
+		{"HTTPS with .git", "https://github.com/ArdentAILabs/mono.git", "mono"},
+		{"HTTPS without .git", "https://github.com/ArdentAILabs/mono", "mono"},
+		{"HTTPS with trailing slash", "https://github.com/org/repo/", "repo"},
+		{"nested GitLab path", "git@gitlab.com:team/subgroup/repo.git", "repo"},
+		{"whitespace trimmed", "  https://github.com/org/repo.git\n", "repo"},
+		{"empty returns empty", "", ""},
+		{"whitespace only returns empty", "   ", ""},
+		{"no separator returns empty", "just-a-name", ""},
+		{"only separator returns empty", "/", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, parseRepoNameFromURL(tt.repoURL))
+		})
+	}
+}
+
 func TestRootURIs(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -76,6 +76,12 @@ regardless of whether they were tagged "architecture" or "trade_off".`),
 			mcplib.WithString("project",
 				mcplib.Description("Optional: filter by project name (e.g. \"akashi\", \"my-langchain-app\"). Auto-detected from the working directory when omitted. Pass \"*\" to disable filtering and see decisions across all projects."),
 			),
+			mcplib.WithString("cwd",
+				mcplib.Description(`Absolute path to your current git working directory. Used as a fallback when MCP roots are unavailable — the server runs git there to determine the canonical project name.`),
+			),
+			mcplib.WithString("repo_url",
+				mcplib.Description(`Git remote URL (e.g. "git@github.com:org/repo.git"). Used as a fallback when cwd is also unavailable. Parsed server-side to extract the canonical project name.`),
+			),
 			mcplib.WithNumber("limit",
 				mcplib.Description("Maximum number of precedents to return"),
 				mcplib.Min(1),
@@ -179,7 +185,13 @@ SKIP: formatting, typo fixes, running tests, reading code, asking questions.`),
 				mcplib.Description(`What you're working on (e.g. "codebase review", "implement rate limiting"). Groups related decisions.`),
 			),
 			mcplib.WithString("project",
-				mcplib.Description(`The repository or project name (e.g. "akashi", "my-langchain-app"). Auto-detected from the git remote when omitted — prefer omitting unless you know the exact canonical name. Do NOT use workspace directory names.`),
+				mcplib.Description(`The repository or project name (e.g. "akashi", "my-langchain-app"). Auto-detected from the git remote when omitted — prefer omitting unless you know the exact canonical name. Do NOT use workspace directory names. If the server rejects your value with "unknown project", retry with cwd or repo_url instead of guessing again.`),
+			),
+			mcplib.WithString("cwd",
+				mcplib.Description(`Absolute path to your current git working directory. When provided, the server runs "git -C <cwd> remote get-url origin" to determine the canonical project name — more reliable than self-reporting the project string. Use this when MCP roots aren't configured, or when a trace has been rejected as "unknown project".`),
+			),
+			mcplib.WithString("repo_url",
+				mcplib.Description(`The git remote URL of the repository (e.g. "git@github.com:org/repo.git" or "https://github.com/org/repo"). The server parses this to extract the canonical project name. Useful when you know the remote URL but can't supply a local path (e.g. running outside a working copy).`),
 			),
 			mcplib.WithString("git_branch",
 				mcplib.Description(`The git branch you're working on (e.g. "main", "feature/add-caching"). Auto-detected from the working directory when omitted. Used for branch-aware conflict suppression — parallel operations on different branches won't generate spurious conflicts.`),
@@ -272,6 +284,12 @@ EXAMPLES:
 			mcplib.WithString("project",
 				mcplib.Description("Filter by project name (e.g. \"akashi\", \"my-langchain-app\"). Auto-detected from the working directory when omitted. Pass \"*\" to query across all projects. Applied in both modes."),
 			),
+			mcplib.WithString("cwd",
+				mcplib.Description(`Absolute path to your current git working directory. Used as a fallback when MCP roots are unavailable — the server runs git there to determine the canonical project name.`),
+			),
+			mcplib.WithString("repo_url",
+				mcplib.Description(`Git remote URL (e.g. "git@github.com:org/repo.git"). Used as a fallback when cwd is also unavailable. Parsed server-side to extract the canonical project name.`),
+			),
 			mcplib.WithNumber("limit",
 				mcplib.Description("Maximum results to return"),
 				mcplib.Min(1),
@@ -345,6 +363,12 @@ Defaults to groups with open conflicts; pass status="all" to see everything.`),
 			),
 			mcplib.WithString("project",
 				mcplib.Description("Filter by project name. Auto-detected from the working directory when omitted. Pass \"*\" to disable filtering and see conflicts across all projects."),
+			),
+			mcplib.WithString("cwd",
+				mcplib.Description(`Absolute path to your current git working directory. Used as a fallback when MCP roots are unavailable — the server runs git there to determine the canonical project name.`),
+			),
+			mcplib.WithString("repo_url",
+				mcplib.Description(`Git remote URL (e.g. "git@github.com:org/repo.git"). Used as a fallback when cwd is also unavailable. Parsed server-side to extract the canonical project name.`),
 			),
 			mcplib.WithNumber("limit",
 				mcplib.Description("Maximum results to return"),
@@ -469,9 +493,21 @@ func (s *Server) resolveProjectFilter(ctx context.Context, request mcplib.CallTo
 		}
 		return &explicit
 	}
-	// Auto-detect from MCP roots.
+	// Auto-detect: MCP roots first (server-initiated), then client-provided
+	// cwd (server runs git), then repo_url (server parses the URL). All three
+	// are server-verified — none trusts a raw project string from the agent.
 	if roots := s.requestRoots(ctx); len(roots) > 0 {
 		if project := inferProjectFromRootsWithGit(roots); project != "" {
+			return &project
+		}
+	}
+	if cwd := request.GetString("cwd", ""); cwd != "" {
+		if project := gitRepoName(cwd); project != "" {
+			return &project
+		}
+	}
+	if repoURL := request.GetString("repo_url", ""); repoURL != "" {
+		if project := parseRepoNameFromURL(repoURL); project != "" {
 			return &project
 		}
 	}
@@ -846,6 +882,30 @@ func (s *Server) handleTrace(ctx context.Context, request mcplib.CallToolRequest
 		}
 	}
 
+	// Fallback inference when MCP roots didn't yield a project: try the
+	// client-supplied cwd (server runs git) then repo_url (server parses).
+	// These are still server-verified — we run git ourselves — but don't
+	// require the MCP roots handshake, which many clients don't implement.
+	if _, hasProject := serverCtx["project"]; !hasProject {
+		if cwd := request.GetString("cwd", ""); cwd != "" {
+			if project := gitRepoName(cwd); project != "" {
+				serverCtx["project"] = project
+			}
+			if _, hasBranch := serverCtx["git_branch"]; !hasBranch {
+				if branch := gitBranch(cwd); branch != "" {
+					serverCtx["git_branch"] = branch
+				}
+			}
+		}
+	}
+	if _, hasProject := serverCtx["project"]; !hasProject {
+		if repoURL := request.GetString("repo_url", ""); repoURL != "" {
+			if project := parseRepoNameFromURL(repoURL); project != "" {
+				serverCtx["project"] = project
+			}
+		}
+	}
+
 	// Record the original agent_id when it was enriched from the tool name,
 	// so the audit trail preserves the mapping from JWT default to derived ID.
 	if agentIDEnriched {
@@ -973,8 +1033,10 @@ func (s *Server) handleTrace(ctx context.Context, request mcplib.CallToolRequest
 				if hasProjects {
 					return errorResult(fmt.Sprintf(
 						"unknown project %q: no server-side git verification available and no alias mapping exists. "+
-							"Ensure MCP roots are configured so the server can verify the project from git, "+
-							"or ask an admin to create a project alias",
+							"Retry this call with cwd set to your current git working directory "+
+							"(the server will run git there to find the canonical name), "+
+							"or with repo_url set to the repo's git remote URL. "+
+							"If neither is available, ensure MCP roots are configured or ask an admin to create a project alias.",
 						clientProject,
 					)), nil
 				}
@@ -1001,7 +1063,7 @@ func (s *Server) handleTrace(ctx context.Context, request mcplib.CallToolRequest
 		}
 		if hasProjects {
 			return errorResult(
-				"project is required: provide project in the trace call, set repo_url in context, " +
+				"project is required: pass project, cwd, or repo_url on the trace call, " +
 					"or configure MCP roots so the server can detect the project from git",
 			), nil
 		}

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -1341,6 +1341,64 @@ func TestResolveProjectFilter(t *testing.T) {
 		// so resolveProjectFilter should return nil.
 		assert.Nil(t, result)
 	})
+
+	t.Run("cwd fallback when no explicit project or roots", func(t *testing.T) {
+		ctx := adminCtx()
+		dir := makeGitRepo(t, "git@github.com:ArdentAILabs/mono.git")
+		req := mcplib.CallToolRequest{
+			Params: mcplib.CallToolParams{
+				Arguments: map[string]any{"cwd": dir},
+			},
+		}
+		result := testServer.resolveProjectFilter(ctx, req)
+		require.NotNil(t, result)
+		assert.Equal(t, "mono", *result)
+	})
+
+	t.Run("repo_url fallback when cwd also missing", func(t *testing.T) {
+		ctx := adminCtx()
+		req := mcplib.CallToolRequest{
+			Params: mcplib.CallToolParams{
+				Arguments: map[string]any{
+					"repo_url": "https://github.com/ArdentAILabs/mono.git",
+				},
+			},
+		}
+		result := testServer.resolveProjectFilter(ctx, req)
+		require.NotNil(t, result)
+		assert.Equal(t, "mono", *result)
+	})
+
+	t.Run("cwd takes precedence over repo_url", func(t *testing.T) {
+		ctx := adminCtx()
+		dir := makeGitRepo(t, "git@github.com:cwd-wins/cwd-repo.git")
+		req := mcplib.CallToolRequest{
+			Params: mcplib.CallToolParams{
+				Arguments: map[string]any{
+					"cwd":      dir,
+					"repo_url": "https://github.com/loser/url-repo.git",
+				},
+			},
+		}
+		result := testServer.resolveProjectFilter(ctx, req)
+		require.NotNil(t, result)
+		assert.Equal(t, "cwd-repo", *result, "cwd should beat repo_url when both are set")
+	})
+
+	t.Run("non-git cwd falls through to repo_url", func(t *testing.T) {
+		ctx := adminCtx()
+		req := mcplib.CallToolRequest{
+			Params: mcplib.CallToolParams{
+				Arguments: map[string]any{
+					"cwd":      t.TempDir(), // valid path, but not a git repo
+					"repo_url": "git@github.com:org/fallback-repo.git",
+				},
+			},
+		}
+		result := testServer.resolveProjectFilter(ctx, req)
+		require.NotNil(t, result)
+		assert.Equal(t, "fallback-repo", *result)
+	})
 }
 
 // ---------- handleCheck: full format ----------
@@ -3768,6 +3826,124 @@ func TestHandleTrace_AliasNormalizesProjectOnFallback(t *testing.T) {
 
 	require.NotNil(t, stored.Project, "decision should have a project")
 	assert.Equal(t, canonical, *stored.Project, "project should be normalized to canonical via alias")
+}
+
+func TestHandleTrace_CwdRescuesHallucinatedProject(t *testing.T) {
+	// Regression test for the mono incident: an agent self-reports a
+	// hallucinated project name but also passes cwd. The server should run
+	// git in cwd, discover the canonical name, normalize the decision to it,
+	// and auto-create an alias so future submissions of the same bad name
+	// land on the canonical.
+	ctx := adminCtx()
+	agentID := "cwd-rescue-" + uuid.New().String()[:8]
+	_, _ = testSvc.ResolveOrCreateAgent(ctx, uuid.Nil, agentID, model.RoleAdmin, nil)
+
+	canonical := "canonical-" + uuid.New().String()[:8]
+	hallucinated := "wrong-" + uuid.New().String()[:8]
+	dir := makeGitRepo(t, "git@github.com:ArdentAILabs/"+canonical+".git")
+
+	result, err := testServer.handleTrace(ctx, traceRequest(map[string]any{
+		"agent_id":      agentID,
+		"decision_type": "architecture",
+		"outcome":       "cwd rescue test decision",
+		"confidence":    0.6,
+		"project":       hallucinated,
+		"cwd":           dir,
+	}))
+	require.NoError(t, err)
+	require.False(t, result.IsError, "trace should succeed: %s", parseToolText(t, result))
+
+	var resp struct {
+		DecisionID string `json:"decision_id"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(parseToolText(t, result)), &resp))
+
+	decID, err := uuid.Parse(resp.DecisionID)
+	require.NoError(t, err)
+	stored, err := testDB.GetDecision(ctx, uuid.Nil, decID, storage.GetDecisionOpts{})
+	require.NoError(t, err)
+	require.NotNil(t, stored.Project)
+	assert.Equal(t, canonical, *stored.Project, "stored project should be the cwd-inferred canonical, not the hallucinated name")
+
+	// The auto-alias path should have fired so a future trace with the
+	// hallucinated name alone can be normalized without cwd.
+	resolved, err := testDB.ResolveProjectAlias(ctx, uuid.Nil, hallucinated)
+	require.NoError(t, err)
+	assert.Equal(t, canonical, resolved, "auto-alias should map hallucinated → canonical")
+}
+
+func TestHandleTrace_RepoURLInfersProject(t *testing.T) {
+	// When neither MCP roots nor cwd are available, repo_url should still
+	// allow the server to derive the canonical project name.
+	ctx := adminCtx()
+	agentID := "repo-url-" + uuid.New().String()[:8]
+	_, _ = testSvc.ResolveOrCreateAgent(ctx, uuid.Nil, agentID, model.RoleAdmin, nil)
+
+	canonical := "urlrepo-" + uuid.New().String()[:8]
+	result, err := testServer.handleTrace(ctx, traceRequest(map[string]any{
+		"agent_id":      agentID,
+		"decision_type": "architecture",
+		"outcome":       "repo_url inference test decision",
+		"confidence":    0.6,
+		"project":       "",
+		"repo_url":      "https://github.com/ArdentAILabs/" + canonical + ".git",
+	}))
+	require.NoError(t, err)
+	require.False(t, result.IsError, "trace should succeed: %s", parseToolText(t, result))
+
+	var resp struct {
+		DecisionID string `json:"decision_id"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(parseToolText(t, result)), &resp))
+
+	decID, err := uuid.Parse(resp.DecisionID)
+	require.NoError(t, err)
+	stored, err := testDB.GetDecision(ctx, uuid.Nil, decID, storage.GetDecisionOpts{})
+	require.NoError(t, err)
+	require.NotNil(t, stored.Project)
+	assert.Equal(t, canonical, *stored.Project, "stored project should be the repo_url-derived canonical")
+}
+
+func TestHandleTrace_UnknownProjectErrorSuggestsCwd(t *testing.T) {
+	// When the rejection fires, the error message should tell the agent how
+	// to recover: retry with cwd or repo_url. This is the behavioral gap that
+	// let the mono incident's sibling agent silently skip the trace.
+	ctx := adminCtx()
+	agentID := "unk-err-" + uuid.New().String()[:8]
+	_, _ = testSvc.ResolveOrCreateAgent(ctx, uuid.Nil, agentID, model.RoleAdmin, nil)
+
+	// Seed via cwd so the org has at least one known project regardless of
+	// test ordering. mustTrace would fail here because its default project
+	// "test-project" isn't guaranteed to exist as a canonical name yet.
+	seedDir := makeGitRepo(t, "git@github.com:seed-org/seedrepo.git")
+	seedResp, seedErr := testServer.handleTrace(ctx, mcplib.CallToolRequest{
+		Params: mcplib.CallToolParams{
+			Name: "akashi_trace",
+			Arguments: map[string]any{
+				"agent_id":      agentID,
+				"decision_type": "investigation",
+				"outcome":       "seed decision to establish a known project",
+				"confidence":    0.5,
+				"cwd":           seedDir,
+			},
+		},
+	})
+	require.NoError(t, seedErr)
+	require.False(t, seedResp.IsError, "seed trace should succeed: %s", parseToolText(t, seedResp))
+
+	result, err := testServer.handleTrace(ctx, traceRequest(map[string]any{
+		"agent_id":      agentID,
+		"decision_type": "architecture",
+		"outcome":       "should be rejected",
+		"confidence":    0.6,
+		"project":       "totally-hallucinated-" + uuid.New().String()[:8],
+	}))
+	require.NoError(t, err)
+	require.True(t, result.IsError, "expected rejection for unknown project")
+	text := parseToolText(t, result)
+	assert.Contains(t, text, "unknown project")
+	assert.Contains(t, text, "cwd", "error should suggest retrying with cwd")
+	assert.Contains(t, text, "repo_url", "error should suggest retrying with repo_url")
 }
 
 func TestResolveProjectFilter_ResolvesAlias(t *testing.T) {


### PR DESCRIPTION
## Summary

- Akashi runs as HTTP transport, so the server cannot read the client's filesystem and must rely on the MCP roots handshake to infer the project. When roots are unavailable (some clients do not expose them, handshake timeout), agents fall back to sending a hallucinated project name, the trace is rejected, and the decision is silently dropped.
- Plumbs `cwd` and `repo_url` through `akashi_trace`, `akashi_check`, `akashi_query`, and `akashi_conflicts`. The server resolves them via the existing git-remote helper (`parseRepoNameFromURL` + `gitRepoName`), auto-aliases hallucinated names to the canonical repo, and rewrites the rejection error to tell callers how to retry.

## Verification

- [x] I ran relevant tests locally (`go test -race ./...` + `-tags integration`).
- [ ] I updated docs/openapi for any API or behavior changes.
- [ ] If I changed config vars in `internal/config/config.go`, I also updated:
  - [ ] `docs/configuration.md`
  - [ ] `docs/runbook.md` (operational subset, if relevant)
  - [ ] `.env.example` (if baseline local/dev defaults changed)
- [x] `python3 scripts/check_doc_config_consistency.py` passes.

## Risk / Rollout Notes

- Additive only: two new optional string params per tool. Agents that already pass `project` keep working unchanged; agents that don't now have a second and third chance to be recognized before the trace is rejected.

> A palantír is bounded by line-of-sight and the will of the bearer — Denethor
> saw truly, but Sauron steered the frame. An HTTP-only server has the same
> affliction: it sees only what the client chooses to surface. Give it a second
> stone (cwd) and a third (repo_url), and one broken handshake no longer blinds it.