### PR TITLE
feat(hooks): suggest task label from git branch in SessionStart (#473)

### DIFF
--- a/internal/server/handlers_hooks.go
+++ b/internal/server/handlers_hooks.go
@@ -190,7 +190,8 @@ func (h *Handlers) HandleHookSessionStart(w http.ResponseWriter, r *http.Request
 	}
 
 	project := inferProjectFromCWD(input.CWD)
-	recentContext := h.buildSessionContext(r.Context(), project)
+	taskLabel := suggestedTaskLabel(input.CWD)
+	recentContext := h.buildSessionContext(r.Context(), project, taskLabel)
 
 	writeHookJSON(w, hookResponse{
 		HookSpecificOutput: &hookSpecific{
@@ -459,7 +460,7 @@ func gitBranchTask(cwd string) string {
 // are left intact to preserve meaningful context in the audit trail.
 func stripBranchPrefix(branch string) string {
 	prefixes := []string{
-		"feature/", "fix/", "bugfix/", "hotfix/",
+		"feature/", "feat/", "fix/", "bugfix/", "hotfix/",
 		"chore/", "refactor/", "docs/", "test/",
 	}
 	for _, p := range prefixes {
@@ -470,9 +471,39 @@ func stripBranchPrefix(branch string) string {
 	return branch
 }
 
+// branchHashRe matches a bare commit-hash-shaped branch name (7–40 hex chars).
+// Such names carry no task-label meaning and should be suppressed from the
+// session-start suggestion.
+var branchHashRe = regexp.MustCompile(`^[0-9a-f]{7,40}$`)
+
+// suggestedTaskLabel returns a session-scoped task label derived from the
+// current git branch, or "" when no meaningful label can be produced.
+// Filters applied (in order):
+//   - empty cwd, non-git dir, or detached HEAD → "" (via gitBranchTask)
+//   - trunk branches (main / master / develop / trunk / HEAD) → ""
+//   - bare commit-hash-shaped names (7–40 hex chars) → ""
+//
+// Anything else — including personal prefixes like "evanvolgas/…" and
+// "release/v2.1" — is passed through so the agent sees the concrete label.
+func suggestedTaskLabel(cwd string) string {
+	label := gitBranchTask(cwd)
+	if label == "" {
+		return ""
+	}
+	switch strings.ToLower(label) {
+	case "main", "master", "develop", "trunk", "head":
+		return ""
+	}
+	if branchHashRe.MatchString(strings.ToLower(label)) {
+		return ""
+	}
+	return label
+}
+
 // buildSessionContext creates a compact text summary of recent decisions and conflicts
-// for injection into the IDE session context.
-func (h *Handlers) buildSessionContext(ctx context.Context, project string) string {
+// for injection into the IDE session context. When taskLabel is non-empty, a one-line
+// hint is appended so the agent can use it as the task field in akashi_trace calls.
+func (h *Handlers) buildSessionContext(ctx context.Context, project, taskLabel string) string {
 	// Use the default org (uuid.Nil) for unauthenticated hook queries.
 	orgID := uuid.Nil
 
@@ -555,6 +586,13 @@ func (h *Handlers) buildSessionContext(ctx context.Context, project string) stri
 			}
 			parts = append(parts, fmt.Sprintf("- [%s] %s vs %s%s", severity, g.AgentA, g.AgentB, explanation))
 		}
+	}
+
+	if taskLabel != "" {
+		parts = append(parts, fmt.Sprintf(
+			"\nSuggested task label for this session: %q (from current git branch).\nPass as the task field in akashi_trace calls to group related decisions.",
+			taskLabel,
+		))
 	}
 
 	parts = append(parts, "\nCall akashi_check before architecture/design decisions. Call akashi_trace after.")

--- a/internal/server/handlers_hooks_test.go
+++ b/internal/server/handlers_hooks_test.go
@@ -28,6 +28,18 @@ func makeTestGitRepo(t *testing.T) string {
 	return dir
 }
 
+// makeTestGitRepoOnBranch creates a temporary git repository whose current
+// branch is the given name. Uses `git symbolic-ref` on an unborn HEAD so it
+// works on any git version without needing an initial commit.
+func makeTestGitRepoOnBranch(t *testing.T, branch string) string {
+	t.Helper()
+	dir := makeTestGitRepo(t)
+	if out, err := exec.Command("git", "-C", dir, "symbolic-ref", "HEAD", "refs/heads/"+branch).CombinedOutput(); err != nil { //nolint:gosec
+		t.Skipf("git symbolic-ref failed: %s", out)
+	}
+	return dir
+}
+
 func TestHookCheckStore(t *testing.T) {
 	t.Run("empty store returns false", func(t *testing.T) {
 		s := newHookCheckStore()
@@ -830,6 +842,7 @@ func TestStripBranchPrefix(t *testing.T) {
 		want   string
 	}{
 		{"feature prefix", "feature/add-widget", "add-widget"},
+		{"feat prefix", "feat/add-widget", "add-widget"},
 		{"fix prefix", "fix/null-pointer", "null-pointer"},
 		{"bugfix prefix", "bugfix/crash-on-start", "crash-on-start"},
 		{"hotfix prefix", "hotfix/security-patch", "security-patch"},
@@ -897,6 +910,64 @@ func TestGitBranchTask_CurrentRepo(t *testing.T) {
 	// Running in a real git repo should return something non-empty
 	// (unless detached HEAD in CI). Just verify no panic.
 	_ = gitBranchTask(".")
+}
+
+func TestSuggestedTaskLabel(t *testing.T) {
+	t.Run("empty cwd", func(t *testing.T) {
+		assert.Empty(t, suggestedTaskLabel(""))
+	})
+
+	t.Run("non-git path", func(t *testing.T) {
+		assert.Empty(t, suggestedTaskLabel("/nonexistent/path/that/does/not/exist"))
+	})
+
+	t.Run("suppresses trunk branches", func(t *testing.T) {
+		for _, branch := range []string{"main", "master", "develop", "trunk"} {
+			t.Run(branch, func(t *testing.T) {
+				dir := makeTestGitRepoOnBranch(t, branch)
+				assert.Empty(t, suggestedTaskLabel(dir), "trunk branch %q must not surface as a task label", branch)
+			})
+		}
+	})
+
+	t.Run("suppresses trunk branches case-insensitively", func(t *testing.T) {
+		dir := makeTestGitRepoOnBranch(t, "MAIN")
+		assert.Empty(t, suggestedTaskLabel(dir))
+	})
+
+	t.Run("suppresses bare commit-hash names", func(t *testing.T) {
+		// 8 hex chars — shape of a short commit hash.
+		dir := makeTestGitRepoOnBranch(t, "deadbeef")
+		assert.Empty(t, suggestedTaskLabel(dir))
+	})
+
+	t.Run("suppresses full-length hash names", func(t *testing.T) {
+		dir := makeTestGitRepoOnBranch(t, "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0")
+		assert.Empty(t, suggestedTaskLabel(dir))
+	})
+
+	t.Run("strips known prefixes", func(t *testing.T) {
+		dir := makeTestGitRepoOnBranch(t, "feat/dashboard-period-selector")
+		assert.Equal(t, "dashboard-period-selector", suggestedTaskLabel(dir))
+	})
+
+	t.Run("passes through username prefixes", func(t *testing.T) {
+		dir := makeTestGitRepoOnBranch(t, "evanvolgas/gh-issue-fix")
+		assert.Equal(t, "evanvolgas/gh-issue-fix", suggestedTaskLabel(dir))
+	})
+
+	t.Run("passes through hyphenated task name without prefix", func(t *testing.T) {
+		// Not a trunk branch and not hash-shaped — should pass through.
+		dir := makeTestGitRepoOnBranch(t, "add-webhook-retries")
+		assert.Equal(t, "add-webhook-retries", suggestedTaskLabel(dir))
+	})
+
+	t.Run("name shorter than 7 hex chars is not a hash", func(t *testing.T) {
+		// "abc" is all-hex but too short to be a commit hash; treat as a
+		// legitimate label rather than stripping it.
+		dir := makeTestGitRepoOnBranch(t, "abc")
+		assert.Equal(t, "abc", suggestedTaskLabel(dir))
+	})
 }
 
 func TestInferProjectFromCWD_NonGitDir(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #473.

- `HandleHookSessionStart` now computes a suggested task label via a new `suggestedTaskLabel(cwd)` helper and passes it to `buildSessionContext`.
- `suggestedTaskLabel` wraps the existing `gitBranchTask`, then filters the cases the issue called out as not meaningful: trunk branches (`main` / `master` / `develop` / `trunk` / `HEAD`, case-insensitive) and bare commit-hash-shaped names (7–40 hex chars). Everything else flows through — personal prefixes (`evanvolgas/…`), `release/…`, plain hyphenated names — so the audit trail keeps useful context.
- `buildSessionContext` gets a new `taskLabel string` parameter and, when non-empty, appends a one-line hint before the existing call-to-action footer.
- `feat/` added to `stripBranchPrefix` — the issue spec listed it, the set already had `feature/` but not `feat/`.

Why this shape:
- The helper stays independent of `buildSessionContext` so it's unit-testable without standing up `h.db` (which is a concrete `*storage.DB`, not an interface).
- Tests drive branch name via `git symbolic-ref HEAD refs/heads/<name>` on an unborn HEAD, which works on any git version and needs no initial commit — avoids the `git init -b` path that requires git 2.28+.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go mod tidy` + `git diff --exit-code go.mod go.sum` (no diff)
- [x] `golangci-lint run ./...` — 0 issues
- [x] `atlas migrate validate --dir file://migrations`
- [x] `go test -race -count=1 ./...` — all packages pass
- [x] `TestSuggestedTaskLabel` exercises 12 subcases: empty cwd, non-git path, each trunk branch, case-insensitive trunk match, 8-char and 40-char hash shapes, stripped `feat/` prefix, `evanvolgas/…` pass-through, plain hyphenated pass-through, and a sub-7-char all-hex name (not a hash)
- [x] `TestStripBranchPrefix` extended with the new `feat/` case

> Sam wore the Ring for a handful of steps up the stairs of Cirith Ungol and handed it back. That's the whole job description for SessionStart context: carry the right label long enough to pass it on, then let go. Any agent that tries to hold onto task identity across sessions ends up in Mordor.