### PR TITLE
trace rejection UX: fuzzy suggestions + post-commit warning

### DIFF
--- a/akashi.go
+++ b/akashi.go
@@ -490,6 +490,12 @@ func New(opts ...Option) (*App, error) {
 	// PreToolUse hook knows a check was performed and allows edits.
 	mcpSrv.SetCheckNotify(srv.Handlers().NotifyCheckCalled)
 
+	// Wire akashi_trace outcomes → IDE hook gate. On rejection, the
+	// post-commit hook surfaces a warning so the agent can't silently
+	// commit after a failed trace; on success, any prior rejection
+	// marker is cleared.
+	mcpSrv.SetTraceCompleteNotify(srv.Handlers().NotifyTraceComplete)
+
 	// Seed admin agent.
 	if err := srv.Handlers().SeedAdmin(context.Background(), cfg.AdminAPIKey.Value()); err != nil {
 		db.Close(context.Background())

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -55,16 +55,18 @@ Be honest about confidence — most decisions warrant 0.4-0.8, not 0.9+. Referen
 
 // Server wraps the MCP server with Akashi's service layer.
 type Server struct {
-	mcpServer                   *mcpserver.MCPServer
-	db                          storage.Store      // for resources (read-only queries)
-	decisionSvc                 *decisions.Service // for tools (shared business logic)
-	grantCache                  *authz.GrantCache  // optional cache for LoadGrantedSet
-	logger                      *slog.Logger
-	rootsCache                  *rootsCache          // caches MCP roots per session (one request per session)
-	checkCache                  *checkCache          // tracks whether akashi_check returned results per session for precedent nudge
-	onCheck                     func(agentID string) // called when akashi_check is invoked; wires IDE hook gate
-	highConfidenceWarnThreshold float32              // confidence above this with no evidence triggers a warning
-	standardTypes               map[string]bool      // configurable set of standard decision types for tips
+	mcpServer       *mcpserver.MCPServer
+	db              storage.Store      // for resources (read-only queries)
+	decisionSvc     *decisions.Service // for tools (shared business logic)
+	grantCache      *authz.GrantCache  // optional cache for LoadGrantedSet
+	logger          *slog.Logger
+	rootsCache      *rootsCache // caches MCP roots per session (one request per session)
+	checkCache      *checkCache // tracks whether akashi_check returned results per session for precedent nudge
+	onCheck         func(agentID string)
+	onTraceComplete func(agentID string, isError bool, errMsg string)
+
+	highConfidenceWarnThreshold float32
+	standardTypes               map[string]bool
 	autoAssessor                *autoassess.Assessor // optional auto-assessor for conflict resolution signals
 }
 
@@ -73,6 +75,15 @@ type Server struct {
 // checks per-agent rather than per-machine.
 func (s *Server) SetCheckNotify(f func(agentID string)) {
 	s.onCheck = f
+}
+
+// SetTraceCompleteNotify registers a callback that fires after every
+// akashi_trace tool call, with isError reflecting whether the call returned
+// an error result. The hook layer uses this to surface a warning at git
+// commit time when the agent's last trace was rejected — closing the
+// "agent burns attempts then silently commits" failure mode.
+func (s *Server) SetTraceCompleteNotify(f func(agentID string, isError bool, errMsg string)) {
+	s.onTraceComplete = f
 }
 
 // SetAutoAssessor registers the auto-assessor for conflict resolution signals.
@@ -127,4 +138,20 @@ func errorResult(msg string) *mcplib.CallToolResult {
 		},
 		IsError: true,
 	}
+}
+
+// firstTextContent returns the text of the first TextContent block in a
+// tool result, or "" if none is present. Used to surface a concise summary
+// of why a tool call errored when notifying downstream consumers (e.g. the
+// IDE hook gate's last-trace-error tracker).
+func firstTextContent(result *mcplib.CallToolResult) string {
+	if result == nil {
+		return ""
+	}
+	for _, c := range result.Content {
+		if tc, ok := c.(mcplib.TextContent); ok {
+			return tc.Text
+		}
+	}
+	return ""
 }

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -679,13 +679,29 @@ func (s *Server) handleCheck(ctx context.Context, request mcplib.CallToolRequest
 	}, nil
 }
 
-func (s *Server) handleTrace(ctx context.Context, request mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+func (s *Server) handleTrace(ctx context.Context, request mcplib.CallToolRequest) (toolResult *mcplib.CallToolResult, err error) {
 	orgID := ctxutil.OrgIDFromContext(ctx)
 	claims := ctxutil.ClaimsFromContext(ctx)
 
 	if claims == nil {
 		return errorResult("authentication required"), nil
 	}
+
+	// Notify the IDE hook gate of every trace outcome — success clears any
+	// "last trace failed" marker, failure sets it. The post-commit hook
+	// reads this to warn when an agent committed after a rejected trace.
+	// Use the JWT-claimed identity (pre-enrichment) to match how the IDE
+	// hook script scopes its own per-agent state.
+	defer func() {
+		if s.onTraceComplete == nil || claims == nil || claims.AgentID == "" {
+			return
+		}
+		if toolResult != nil && toolResult.IsError {
+			s.onTraceComplete(claims.AgentID, true, firstTextContent(toolResult))
+		} else if toolResult != nil {
+			s.onTraceComplete(claims.AgentID, false, "")
+		}
+	}()
 
 	agentID := request.GetString("agent_id", "")
 	// Normalize decision_type for validation and hash computation. The service

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ashita-ai/akashi/internal/authz"
 	"github.com/ashita-ai/akashi/internal/ctxutil"
 	"github.com/ashita-ai/akashi/internal/model"
+	"github.com/ashita-ai/akashi/internal/projectsuggest"
 	"github.com/ashita-ai/akashi/internal/service/decisions"
 	"github.com/ashita-ai/akashi/internal/service/quality"
 	"github.com/ashita-ai/akashi/internal/service/tracehealth"
@@ -1031,13 +1032,19 @@ func (s *Server) handleTrace(ctx context.Context, request mcplib.CallToolRequest
 					)), nil
 				}
 				if hasProjects {
+					var suffix string
+					if known, kerr := s.db.DistinctProjects(ctx, orgID); kerr == nil {
+						suffix = projectsuggest.FormatRejectionSuffix(clientProject, known)
+					} else {
+						s.logger.Warn("distinct projects lookup failed (suggestions suppressed)", "error", kerr)
+					}
 					return errorResult(fmt.Sprintf(
 						"unknown project %q: no server-side git verification available and no alias mapping exists. "+
 							"Retry this call with cwd set to your current git working directory "+
 							"(the server will run git there to find the canonical name), "+
 							"or with repo_url set to the repo's git remote URL. "+
-							"If neither is available, ensure MCP roots are configured or ask an admin to create a project alias.",
-						clientProject,
+							"If neither is available, ensure MCP roots are configured or ask an admin to create a project alias.%s",
+						clientProject, suffix,
 					)), nil
 				}
 				// First-ever project in this org — accept it to bootstrap.

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -3944,6 +3944,51 @@ func TestHandleTrace_UnknownProjectErrorSuggestsCwd(t *testing.T) {
 	assert.Contains(t, text, "unknown project")
 	assert.Contains(t, text, "cwd", "error should suggest retrying with cwd")
 	assert.Contains(t, text, "repo_url", "error should suggest retrying with repo_url")
+	assert.Contains(t, text, "Known projects",
+		"rejection should enumerate known projects so the agent can pick one without guessing")
+}
+
+func TestHandleTrace_UnknownProjectErrorSuggestsCanonical(t *testing.T) {
+	// The mono-incident pattern: an org-prefixed name like "ardent-mono"
+	// when the canonical is "mono". The rejection error must point the
+	// agent at the canonical via "Did you mean" so it can recover on the
+	// next attempt rather than burn more tries on hallucinated names.
+	ctx := adminCtx()
+	agentID := "unk-sug-" + uuid.New().String()[:8]
+	_, _ = testSvc.ResolveOrCreateAgent(ctx, uuid.Nil, agentID, model.RoleAdmin, nil)
+
+	// Seed a canonical project named exactly "mono" (the basename the
+	// suggester should derive from "ardent-mono"). We fake-create the
+	// repo so the cwd path establishes "mono" as a known project.
+	seedDir := makeGitRepo(t, "git@github.com:seed-org/mono.git")
+	seedResp, seedErr := testServer.handleTrace(ctx, mcplib.CallToolRequest{
+		Params: mcplib.CallToolParams{
+			Name: "akashi_trace",
+			Arguments: map[string]any{
+				"agent_id":      agentID,
+				"decision_type": "investigation",
+				"outcome":       "seed mono as a known project for suggestion test",
+				"confidence":    0.5,
+				"cwd":           seedDir,
+			},
+		},
+	})
+	require.NoError(t, seedErr)
+	require.False(t, seedResp.IsError, "seed trace should succeed: %s", parseToolText(t, seedResp))
+
+	result, err := testServer.handleTrace(ctx, traceRequest(map[string]any{
+		"agent_id":      agentID,
+		"decision_type": "architecture",
+		"outcome":       "should be rejected with a 'did you mean mono' hint",
+		"confidence":    0.6,
+		"project":       "ardent-mono",
+	}))
+	require.NoError(t, err)
+	require.True(t, result.IsError, "expected rejection for org-prefixed unknown project")
+	text := parseToolText(t, result)
+	assert.Contains(t, text, "Did you mean")
+	assert.Contains(t, text, `"mono"`,
+		"rejection should suggest the canonical 'mono' from the org-prefixed submission")
 }
 
 func TestResolveProjectFilter_ResolvesAlias(t *testing.T) {

--- a/internal/projectsuggest/projectsuggest.go
+++ b/internal/projectsuggest/projectsuggest.go
@@ -1,0 +1,175 @@
+// Package projectsuggest produces "did you mean" suggestions for unknown
+// project names rejected by the trace endpoints. The matcher is biased
+// toward substring containment because the dominant failure mode is agents
+// passing a path-style or org-prefixed name (e.g. "ArdentAILabs/mono",
+// "ardent-mono") when the canonical project is the basename ("mono").
+package projectsuggest
+
+import (
+	"sort"
+	"strings"
+)
+
+// MaxSuggestions caps the number of "did you mean" candidates surfaced in
+// a rejection message. Keeps the error focused on the most likely retry.
+const MaxSuggestions = 3
+
+// Threshold is the minimum similarity (0..1) required for a candidate to
+// be surfaced. 0.5 admits substring-style matches like
+// "ardent-mono" → "mono", while filtering unrelated names.
+const Threshold = 0.5
+
+// Suggest returns up to MaxSuggestions known project names that resemble
+// the submitted string, ordered by descending similarity. Returns nil
+// when no candidate clears Threshold or the inputs are empty.
+func Suggest(submitted string, known []string) []string {
+	submitted = strings.TrimSpace(submitted)
+	if submitted == "" || len(known) == 0 {
+		return nil
+	}
+
+	type scored struct {
+		name  string
+		score float64
+	}
+
+	subLower := strings.ToLower(submitted)
+	scoredList := make([]scored, 0, len(known))
+	for _, k := range known {
+		if k == submitted {
+			continue
+		}
+		score := similarityScore(subLower, strings.ToLower(k))
+		if score >= Threshold {
+			scoredList = append(scoredList, scored{name: k, score: score})
+		}
+	}
+
+	sort.Slice(scoredList, func(i, j int) bool {
+		if scoredList[i].score != scoredList[j].score {
+			return scoredList[i].score > scoredList[j].score
+		}
+		return scoredList[i].name < scoredList[j].name
+	})
+
+	limit := MaxSuggestions
+	if len(scoredList) < limit {
+		limit = len(scoredList)
+	}
+	out := make([]string, 0, limit)
+	for i := 0; i < limit; i++ {
+		out = append(out, scoredList[i].name)
+	}
+	return out
+}
+
+// FormatRejectionSuffix builds the human-readable suffix appended to
+// "unknown project" rejection errors. Returns "" when there are no known
+// projects to enumerate. The result begins with a space so callers can
+// concatenate directly onto an existing message.
+func FormatRejectionSuffix(submitted string, known []string) string {
+	if len(known) == 0 {
+		return ""
+	}
+	suggestions := Suggest(submitted, known)
+
+	var b strings.Builder
+	if len(suggestions) > 0 {
+		b.WriteString(" Did you mean: ")
+		b.WriteString(joinQuoted(suggestions))
+		b.WriteString("?")
+	}
+
+	preview := known
+	const maxPreview = 10
+	truncated := false
+	if len(preview) > maxPreview {
+		preview = preview[:maxPreview]
+		truncated = true
+	}
+	b.WriteString(" Known projects: ")
+	b.WriteString(joinQuoted(preview))
+	if truncated {
+		b.WriteString(", …")
+	}
+	b.WriteString(".")
+	return b.String()
+}
+
+// similarityScore returns a 0..1 score for the closeness of a and b. Both
+// inputs are expected to already be lowercased. Substring containment scores
+// 0.9; otherwise the score is 1 - normalizedLevenshtein(a, b).
+func similarityScore(a, b string) float64 {
+	if a == "" || b == "" {
+		return 0
+	}
+	if strings.Contains(a, b) || strings.Contains(b, a) {
+		return 0.9
+	}
+	dist := levenshtein(a, b)
+	maxLen := len(a)
+	if len(b) > maxLen {
+		maxLen = len(b)
+	}
+	if maxLen == 0 {
+		return 0
+	}
+	return 1 - float64(dist)/float64(maxLen)
+}
+
+// levenshtein returns the edit distance between a and b using a single-row
+// dynamic programming table. Inputs are treated as byte slices, which is
+// adequate for project names (ASCII identifiers in practice).
+func levenshtein(a, b string) int {
+	if a == b {
+		return 0
+	}
+	if len(a) == 0 {
+		return len(b)
+	}
+	if len(b) == 0 {
+		return len(a)
+	}
+	prev := make([]int, len(b)+1)
+	curr := make([]int, len(b)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+	for i := 1; i <= len(a); i++ {
+		curr[0] = i
+		for j := 1; j <= len(b); j++ {
+			cost := 1
+			if a[i-1] == b[j-1] {
+				cost = 0
+			}
+			curr[j] = minInt(
+				prev[j]+1,      // deletion
+				curr[j-1]+1,    // insertion
+				prev[j-1]+cost, // substitution
+			)
+		}
+		prev, curr = curr, prev
+	}
+	return prev[len(b)]
+}
+
+func minInt(values ...int) int {
+	m := values[0]
+	for _, v := range values[1:] {
+		if v < m {
+			m = v
+		}
+	}
+	return m
+}
+
+func joinQuoted(items []string) string {
+	if len(items) == 0 {
+		return ""
+	}
+	parts := make([]string, len(items))
+	for i, s := range items {
+		parts[i] = `"` + s + `"`
+	}
+	return strings.Join(parts, ", ")
+}

--- a/internal/projectsuggest/projectsuggest_test.go
+++ b/internal/projectsuggest/projectsuggest_test.go
@@ -1,0 +1,157 @@
+package projectsuggest
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSuggest_SubstringMatch(t *testing.T) {
+	// The dominant incident pattern: an agent passes an org-prefixed or
+	// path-style name when the canonical is the basename. Substring
+	// containment must surface the canonical as the top suggestion.
+	known := []string{"akashi", "mono", "tiger"}
+
+	cases := []struct {
+		submitted string
+		want      string
+	}{
+		{"ardent-mono", "mono"},
+		{"ArdentAILabs/mono", "mono"},
+		{"AshitaAIlabs/mono", "mono"},
+		{"akashi-server", "akashi"},
+		{"tigers", "tiger"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.submitted, func(t *testing.T) {
+			got := Suggest(tc.submitted, known)
+			assert.Contains(t, got, tc.want, "expected %q in suggestions for %q (got %v)", tc.want, tc.submitted, got)
+		})
+	}
+}
+
+func TestSuggest_NoMatch(t *testing.T) {
+	// Genuinely unrelated names should not be suggested. This guards
+	// against a noisy error message that points the agent at the wrong
+	// canonical.
+	known := []string{"akashi", "mono", "tiger"}
+	cases := []string{
+		"casablanca",
+		"totally-hallucinated-xxx",
+		"riyadh-v1",
+	}
+	for _, tc := range cases {
+		t.Run(tc, func(t *testing.T) {
+			assert.Empty(t, Suggest(tc, known))
+		})
+	}
+}
+
+func TestSuggest_OrdersByScore(t *testing.T) {
+	// When several known projects clear the threshold, the closest match
+	// must come first so the agent's first-choice retry is the canonical.
+	known := []string{"mono-server", "mono", "monorepo"}
+	got := Suggest("monoo", known)
+	assert.NotEmpty(t, got)
+	assert.Equal(t, "mono", got[0], "exact-substring 'mono' should outrank longer matches")
+}
+
+func TestSuggest_LimitsToMax(t *testing.T) {
+	// Even when many candidates clear the threshold, we cap output so the
+	// rejection message stays scannable.
+	known := []string{"akashi", "akashi-1", "akashi-2", "akashi-3", "akashi-4"}
+	got := Suggest("akashi", known)
+	assert.LessOrEqual(t, len(got), MaxSuggestions)
+}
+
+func TestSuggest_SkipsExactMatch(t *testing.T) {
+	// If the submitted name is itself in the known list, callers shouldn't
+	// be in this code path. Defensive: never suggest "X" for "X".
+	known := []string{"mono", "akashi"}
+	got := Suggest("mono", known)
+	assert.NotContains(t, got, "mono")
+}
+
+func TestSuggest_EmptyInputs(t *testing.T) {
+	assert.Nil(t, Suggest("", []string{"a", "b"}))
+	assert.Nil(t, Suggest("foo", nil))
+	assert.Nil(t, Suggest("foo", []string{}))
+}
+
+func TestFormatRejectionSuffix_BothSections(t *testing.T) {
+	known := []string{"akashi", "mono", "tiger"}
+	msg := FormatRejectionSuffix("ardent-mono", known)
+	assert.Contains(t, msg, "Did you mean")
+	assert.Contains(t, msg, `"mono"`)
+	assert.Contains(t, msg, "Known projects")
+}
+
+func TestFormatRejectionSuffix_NoMatchOmitsDidYouMean(t *testing.T) {
+	// When nothing clears the threshold, the agent still benefits from
+	// seeing the full project list — but the misleading "Did you mean"
+	// header should not appear.
+	known := []string{"akashi", "mono", "tiger"}
+	msg := FormatRejectionSuffix("casablanca", known)
+	assert.NotContains(t, msg, "Did you mean")
+	assert.Contains(t, msg, "Known projects")
+}
+
+func TestFormatRejectionSuffix_TruncatesLongList(t *testing.T) {
+	// Prevent the rejection from becoming a wall of text in orgs with
+	// many projects.
+	many := make([]string, 25)
+	for i := range many {
+		many[i] = "p-" + string(rune('a'+i))
+	}
+	msg := FormatRejectionSuffix("zzz", many)
+	assert.Contains(t, msg, "…", "long lists should be truncated with an ellipsis marker")
+}
+
+func TestFormatRejectionSuffix_EmptyKnown(t *testing.T) {
+	// No projects in the org → suppress the appendix entirely. The
+	// "first project bootstrap" path handles this case upstream.
+	assert.Equal(t, "", FormatRejectionSuffix("anything", nil))
+}
+
+func TestLevenshtein_KnownDistances(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want int
+	}{
+		{"", "", 0},
+		{"abc", "", 3},
+		{"", "abc", 3},
+		{"abc", "abc", 0},
+		{"abc", "abd", 1},
+		{"kitten", "sitting", 3},
+		{"casablanca", "mono", 9},
+	}
+	for _, tc := range cases {
+		name := tc.a + "_" + tc.b
+		if name == "_" {
+			name = "both_empty"
+		}
+		t.Run(name, func(t *testing.T) {
+			got := levenshtein(tc.a, tc.b)
+			assert.Equal(t, tc.want, got, "levenshtein(%q,%q)", tc.a, tc.b)
+		})
+	}
+}
+
+func TestSimilarityScore_SubstringWinsOverEditDistance(t *testing.T) {
+	// "ardent-mono" → "mono": Levenshtein distance is 7, normalized
+	// similarity would be ~0.36 (below threshold). Substring containment
+	// must override so the canonical is suggested.
+	score := similarityScore("ardent-mono", "mono")
+	assert.GreaterOrEqual(t, score, Threshold,
+		"substring match must clear the suggestion threshold (got %.3f)", score)
+}
+
+func TestFormatRejectionSuffix_LeadingSpace(t *testing.T) {
+	// Callers concatenate this onto an existing sentence — the suffix
+	// must start with a space to avoid awkward joins.
+	known := []string{"mono"}
+	msg := FormatRejectionSuffix("ardent-mono", known)
+	assert.True(t, strings.HasPrefix(msg, " "), "suffix should start with a space, got %q", msg)
+}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -500,6 +500,20 @@ func (h *Handlers) NotifyCheckCalled(agentID string) {
 	h.hookChecks.Record(agentID)
 }
 
+// NotifyTraceComplete records the outcome of an akashi_trace tool call.
+// On error, the agent's most-recent-rejection marker is set so the
+// post-commit hook can warn at git commit time. On success, the marker is
+// cleared (the agent recovered, no warning needed). This wires the
+// "agent burned trace attempts and silently committed" failure mode to
+// a visible warning at the next commit.
+func (h *Handlers) NotifyTraceComplete(agentID string, isError bool, errMsg string) {
+	if isError {
+		h.hookChecks.MarkTraceErrored(agentID, errMsg)
+	} else {
+		h.hookChecks.ClearTraceError(agentID)
+	}
+}
+
 // CleanupHookChecks evicts expired entries from the hook check store.
 // Called periodically by the background cleanup loop in akashi.go.
 func (h *Handlers) CleanupHookChecks() {

--- a/internal/server/handlers_decisions.go
+++ b/internal/server/handlers_decisions.go
@@ -313,6 +313,14 @@ func (h *Handlers) buildTraceAgentContext(
 			}
 			return hasProjects
 		},
+		func() []string {
+			projects, err := h.db.DistinctProjects(r.Context(), orgID)
+			if err != nil {
+				h.logger.Warn("distinct projects lookup failed (suggestions suppressed)", "error", err)
+				return nil
+			}
+			return projects
+		},
 		h.logger,
 	); errMsg != "" {
 		return nil, errMsg

--- a/internal/server/handlers_hooks.go
+++ b/internal/server/handlers_hooks.go
@@ -32,18 +32,36 @@ const hookMaxBodyBytes int64 = 256 << 10
 // different agent running on the same machine. When the caller does not
 // supply an agent_id (e.g. legacy hook scripts), IsAnyRecent provides a
 // backwards-compatible fallback that behaves like the old global timestamp.
+//
+// It also tracks the most recent unresolved akashi_trace failure per agent
+// so the post-commit hook can warn when an agent commits after a rejected
+// trace — closing the "burn attempts then silently commit" failure mode.
 type hookCheckStore struct {
 	mu            sync.RWMutex
-	checks        map[string]time.Time // agent_id → last check time
-	emptyProjects map[string]time.Time // project → marked-at time (0 decisions + 0 conflicts)
+	checks        map[string]time.Time   // agent_id → last check time
+	emptyProjects map[string]time.Time   // project → marked-at time (0 decisions + 0 conflicts)
+	traceErrors   map[string]traceErrEnt // agent_id → most recent trace error (cleared by next success)
 }
 
 const hookCheckTTL = 10 * time.Minute
+
+// traceErrorTTL bounds how long a stale errored trace continues to surface
+// at commit time. Long enough to span "decided X, ran tests for 30 minutes,
+// fixed something, then committed", short enough that yesterday's error
+// doesn't leak into tomorrow's session.
+const traceErrorTTL = 1 * time.Hour
+
+// traceErrEnt records a single unresolved trace failure.
+type traceErrEnt struct {
+	at  time.Time
+	msg string
+}
 
 func newHookCheckStore() *hookCheckStore {
 	return &hookCheckStore{
 		checks:        make(map[string]time.Time),
 		emptyProjects: make(map[string]time.Time),
+		traceErrors:   make(map[string]traceErrEnt),
 	}
 }
 
@@ -80,7 +98,7 @@ func (s *hookCheckStore) IsAnyRecent() bool {
 	return false
 }
 
-// Cleanup evicts expired entries from both maps.
+// Cleanup evicts expired entries from all three maps.
 func (s *hookCheckStore) Cleanup() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -92,6 +110,11 @@ func (s *hookCheckStore) Cleanup() {
 	for project, t := range s.emptyProjects {
 		if time.Since(t) >= hookCheckTTL {
 			delete(s.emptyProjects, project)
+		}
+	}
+	for id, ent := range s.traceErrors {
+		if time.Since(ent.at) >= traceErrorTTL {
+			delete(s.traceErrors, id)
 		}
 	}
 }
@@ -129,6 +152,48 @@ func (s *hookCheckStore) ClearProjectEmpty(project string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	delete(s.emptyProjects, project)
+}
+
+// MarkTraceErrored records that the agent's most recent akashi_trace call
+// returned an error result. Empty agent_id is ignored — recording "" would
+// let any legacy caller (which also has agentID="") trigger the warning,
+// defeating per-agent isolation.
+func (s *hookCheckStore) MarkTraceErrored(agentID, msg string) {
+	if agentID == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.traceErrors[agentID] = traceErrEnt{at: time.Now(), msg: msg}
+}
+
+// ClearTraceError removes any errored-trace marker for the agent. Called
+// after a successful trace so the post-commit hook stops warning once the
+// agent has recovered.
+func (s *hookCheckStore) ClearTraceError(agentID string) {
+	if agentID == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.traceErrors, agentID)
+}
+
+// LastTraceError returns the most recent unresolved trace error for the
+// agent, or ("", false) if none exists or the marker has expired. The
+// returned message is the human-readable text the MCP server emitted to
+// the agent at rejection time.
+func (s *hookCheckStore) LastTraceError(agentID string) (string, bool) {
+	if agentID == "" {
+		return "", false
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	ent, ok := s.traceErrors[agentID]
+	if !ok || time.Since(ent.at) >= traceErrorTTL {
+		return "", false
+	}
+	return ent.msg, true
 }
 
 // hookSessionStartInput is the JSON body sent by Claude Code / Cursor on SessionStart.
@@ -286,6 +351,11 @@ func (h *Handlers) HandleHookPostToolUse(w http.ResponseWriter, r *http.Request)
 // the subject from `git log -1 --format=%s` instead of parsing the command
 // string. This correctly handles HEREDOC commits, --amend, and editor-based
 // messages that the old regex-based parser could not.
+//
+// If the agent's most recent akashi_trace was rejected, prepend a warning
+// so the rejection becomes visible at commit time. This catches the
+// "burned attempts then silently committed" failure mode where an agent
+// gives up on a trace and ships the commit anyway.
 func (h *Handlers) handlePostCommit(w http.ResponseWriter, input hookPostToolUseInput) {
 	commitMsg := gitCommitSubject(input.CWD)
 	if commitMsg == "" {
@@ -296,13 +366,21 @@ func (h *Handlers) handlePostCommit(w http.ResponseWriter, input hookPostToolUse
 		commitMsg = "commit (message not parsed)"
 	}
 
+	traceWarning := ""
+	if errMsg, ok := h.hookChecks.LastTraceError(input.AgentID); ok {
+		traceWarning = fmt.Sprintf(
+			"[akashi] WARNING: your last akashi_trace was rejected and never retried successfully — committing anyway. Last error: %s\n",
+			truncateHook(errMsg, 200),
+		)
+	}
+
 	if h.autoTrace {
 		go h.autoTraceCommit(input, commitMsg)
 		writeHookJSON(w, hookResponse{
 			Continue: true,
 			HookSpecificOutput: &hookSpecific{
 				HookEventName: "PostToolUse",
-				Message:       fmt.Sprintf("[akashi] auto-traced commit: %s", truncateHook(commitMsg, 80)),
+				Message:       traceWarning + fmt.Sprintf("[akashi] auto-traced commit: %s", truncateHook(commitMsg, 80)),
 			},
 		})
 		return
@@ -312,7 +390,7 @@ func (h *Handlers) handlePostCommit(w http.ResponseWriter, input hookPostToolUse
 		Continue: true,
 		HookSpecificOutput: &hookSpecific{
 			HookEventName: "PostToolUse",
-			Message: fmt.Sprintf(
+			Message: traceWarning + fmt.Sprintf(
 				"[akashi] Call akashi_trace with decision_type=\"implementation\", outcome=%q, confidence=0.6",
 				truncateHook(commitMsg, 100),
 			),

--- a/internal/server/handlers_hooks_test.go
+++ b/internal/server/handlers_hooks_test.go
@@ -1063,3 +1063,135 @@ func TestHandleHookPostToolUse_BashNonGitCommit(t *testing.T) {
 	assert.True(t, resp.Continue)
 	assert.True(t, resp.SuppressOutput)
 }
+
+func TestHookCheckStore_TraceErrorMarker(t *testing.T) {
+	t.Run("LastTraceError is empty by default", func(t *testing.T) {
+		s := newHookCheckStore()
+		_, ok := s.LastTraceError("agent-a")
+		assert.False(t, ok)
+	})
+
+	t.Run("MarkTraceErrored makes LastTraceError visible to same agent", func(t *testing.T) {
+		s := newHookCheckStore()
+		s.MarkTraceErrored("agent-a", "unknown project \"foo\"")
+		msg, ok := s.LastTraceError("agent-a")
+		assert.True(t, ok)
+		assert.Equal(t, "unknown project \"foo\"", msg)
+	})
+
+	t.Run("MarkTraceErrored does not bleed across agents", func(t *testing.T) {
+		// Per-agent isolation: agent-a's failure must not surface as a
+		// warning in agent-b's commit hook.
+		s := newHookCheckStore()
+		s.MarkTraceErrored("agent-a", "rejected")
+		_, ok := s.LastTraceError("agent-b")
+		assert.False(t, ok)
+	})
+
+	t.Run("ClearTraceError removes the marker", func(t *testing.T) {
+		// Successful trace after a failure clears the warning — the
+		// agent recovered, no need to surface the prior rejection at
+		// commit time.
+		s := newHookCheckStore()
+		s.MarkTraceErrored("agent-a", "rejected")
+		s.ClearTraceError("agent-a")
+		_, ok := s.LastTraceError("agent-a")
+		assert.False(t, ok)
+	})
+
+	t.Run("expired trace error returns false", func(t *testing.T) {
+		s := newHookCheckStore()
+		s.mu.Lock()
+		s.traceErrors["stale-agent"] = traceErrEnt{
+			at:  time.Now().Add(-(traceErrorTTL + time.Second)),
+			msg: "old rejection",
+		}
+		s.mu.Unlock()
+		_, ok := s.LastTraceError("stale-agent")
+		assert.False(t, ok, "errors older than the TTL should not surface")
+	})
+
+	t.Run("cleanup evicts expired trace errors", func(t *testing.T) {
+		s := newHookCheckStore()
+		s.MarkTraceErrored("fresh-agent", "fresh")
+		s.mu.Lock()
+		s.traceErrors["stale-agent"] = traceErrEnt{
+			at:  time.Now().Add(-(traceErrorTTL + time.Second)),
+			msg: "stale",
+		}
+		s.mu.Unlock()
+		s.Cleanup()
+		s.mu.RLock()
+		_, staleExists := s.traceErrors["stale-agent"]
+		_, freshExists := s.traceErrors["fresh-agent"]
+		s.mu.RUnlock()
+		assert.False(t, staleExists)
+		assert.True(t, freshExists)
+	})
+
+	t.Run("empty agent_id is ignored by Mark/Clear/LastTraceError", func(t *testing.T) {
+		// Mirrors Record's behavior: an empty agent_id must never set or
+		// match a marker, otherwise legacy callers that omit agent_id
+		// would all collide on a single key.
+		s := newHookCheckStore()
+		s.MarkTraceErrored("", "would collide")
+		_, ok := s.LastTraceError("")
+		assert.False(t, ok)
+	})
+}
+
+func TestNotifyTraceComplete_SetsAndClearsMarker(t *testing.T) {
+	h := &Handlers{hookChecks: newHookCheckStore()}
+
+	h.NotifyTraceComplete("agent-a", true, "unknown project \"ardent-mono\"")
+	msg, ok := h.hookChecks.LastTraceError("agent-a")
+	assert.True(t, ok, "errored trace should set the marker")
+	assert.Contains(t, msg, "ardent-mono")
+
+	h.NotifyTraceComplete("agent-a", false, "")
+	_, ok = h.hookChecks.LastTraceError("agent-a")
+	assert.False(t, ok, "successful trace should clear the marker")
+}
+
+func TestHandleHookPostToolUse_GitCommitWarnsAfterTraceError(t *testing.T) {
+	// End-to-end shape of the new flow: agent's last akashi_trace was
+	// rejected, agent commits anyway, the post-commit hook surfaces a
+	// visible warning so the rejection doesn't disappear silently.
+	h := &Handlers{
+		hookChecks: newHookCheckStore(),
+		autoTrace:  false,
+	}
+	h.NotifyTraceComplete("agent-a", true, `unknown project "ardent-mono": retry with cwd or repo_url`)
+
+	body := `{"session_id":"sess-1","agent_id":"agent-a","tool_name":"Bash","tool_input":{"command":"git commit -m 'fix'"},"cwd":"/tmp"}`
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/hooks/post-tool-use", strings.NewReader(body))
+	h.HandleHookPostToolUse(rec, req)
+
+	var resp hookResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	require.NotNil(t, resp.HookSpecificOutput)
+	assert.Contains(t, resp.HookSpecificOutput.Message, "WARNING")
+	assert.Contains(t, resp.HookSpecificOutput.Message, "ardent-mono",
+		"warning should embed the rejection text so the agent sees what to fix")
+}
+
+func TestHandleHookPostToolUse_GitCommitNoWarningWhenTraceSucceeded(t *testing.T) {
+	// Negative case: when the agent's last trace succeeded (or no recent
+	// trace happened at all), the commit hook is silent on the trace
+	// front. Prevents stale warnings polluting unrelated commits.
+	h := &Handlers{
+		hookChecks: newHookCheckStore(),
+		autoTrace:  false,
+	}
+
+	body := `{"session_id":"sess-1","agent_id":"agent-clean","tool_name":"Bash","tool_input":{"command":"git commit -m 'fix'"},"cwd":"/tmp"}`
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/hooks/post-tool-use", strings.NewReader(body))
+	h.HandleHookPostToolUse(rec, req)
+
+	var resp hookResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	require.NotNil(t, resp.HookSpecificOutput)
+	assert.NotContains(t, resp.HookSpecificOutput.Message, "WARNING")
+}

--- a/internal/server/project.go
+++ b/internal/server/project.go
@@ -5,6 +5,8 @@ import (
 	"net/url"
 	"path"
 	"strings"
+
+	"github.com/ashita-ai/akashi/internal/projectsuggest"
 )
 
 // repoNameFromURL extracts a repository name from a git remote URL.
@@ -52,12 +54,17 @@ func repoNameFromURL(rawURL string) string {
 //
 // When the project name changes, the original value is preserved under the
 // "project_submitted" key for the audit trail.
+//
+// listKnownProjects, when non-nil, supplies the org's known project names so
+// the rejection error can include "did you mean" suggestions. Errors from
+// the lookup are non-fatal — callers fall back to the bare rejection.
 func normalizeTraceProject(
 	clientCtx map[string]any,
 	serverProject string,
 	resolveAlias func(project string) string,
 	projectKnown func(project string) bool,
 	hasAnyProjects func() bool,
+	listKnownProjects func() []string,
 	logger *slog.Logger,
 ) string {
 	clientProject, _ := clientCtx["project"].(string)
@@ -119,7 +126,11 @@ func normalizeTraceProject(
 			"project", clientProject,
 		)
 		delete(clientCtx, "project")
-		return "unknown project " + clientProject + ": provide a valid repo_url or ask an admin to create a project alias"
+		suffix := ""
+		if listKnownProjects != nil {
+			suffix = projectsuggest.FormatRejectionSuffix(clientProject, listKnownProjects())
+		}
+		return "unknown project " + clientProject + ": provide a valid repo_url or ask an admin to create a project alias." + suffix
 	}
 
 	return ""

--- a/internal/server/project_test.go
+++ b/internal/server/project_test.go
@@ -38,7 +38,7 @@ func TestNormalizeTraceProject_ServerInferredOverridesClient(t *testing.T) {
 	clientCtx := map[string]any{"project": "dubai"}
 	logger := slog.Default()
 
-	errMsg := normalizeTraceProject(clientCtx, "akashi", nil, nil, nil, logger)
+	errMsg := normalizeTraceProject(clientCtx, "akashi", nil, nil, nil, nil, logger)
 
 	assert.Empty(t, errMsg)
 	assert.Equal(t, "akashi", clientCtx["project"])
@@ -49,7 +49,7 @@ func TestNormalizeTraceProject_ServerMatchesClient(t *testing.T) {
 	clientCtx := map[string]any{"project": "akashi"}
 	logger := slog.Default()
 
-	errMsg := normalizeTraceProject(clientCtx, "akashi", nil, nil, nil, logger)
+	errMsg := normalizeTraceProject(clientCtx, "akashi", nil, nil, nil, nil, logger)
 
 	assert.Empty(t, errMsg)
 	assert.Equal(t, "akashi", clientCtx["project"])
@@ -64,7 +64,7 @@ func TestNormalizeTraceProject_RepoURLOverridesClient(t *testing.T) {
 	}
 	logger := slog.Default()
 
-	errMsg := normalizeTraceProject(clientCtx, "", nil, nil, nil, logger)
+	errMsg := normalizeTraceProject(clientCtx, "", nil, nil, nil, nil, logger)
 
 	assert.Empty(t, errMsg)
 	assert.Equal(t, "akashi", clientCtx["project"])
@@ -84,7 +84,7 @@ func TestNormalizeTraceProject_AliasLookup(t *testing.T) {
 	clientCtx := map[string]any{"project": "bamako"}
 	logger := slog.Default()
 
-	errMsg := normalizeTraceProject(clientCtx, "", resolveAlias, nil, nil, logger)
+	errMsg := normalizeTraceProject(clientCtx, "", resolveAlias, nil, nil, nil, logger)
 
 	assert.Empty(t, errMsg)
 	assert.Equal(t, "akashi", clientCtx["project"])
@@ -99,7 +99,7 @@ func TestNormalizeTraceProject_NoChangeWhenCanonical(t *testing.T) {
 	resolveAlias := func(_ string) string { return "" }
 	projectKnown := func(project string) bool { return project == "akashi" }
 
-	errMsg := normalizeTraceProject(clientCtx, "", resolveAlias, projectKnown, nil, logger)
+	errMsg := normalizeTraceProject(clientCtx, "", resolveAlias, projectKnown, nil, nil, logger)
 
 	assert.Empty(t, errMsg)
 	assert.Equal(t, "akashi", clientCtx["project"])
@@ -113,7 +113,7 @@ func TestNormalizeTraceProject_EmptyClientProject_NewOrg(t *testing.T) {
 	logger := slog.Default()
 	hasAnyProjects := func() bool { return false }
 
-	errMsg := normalizeTraceProject(clientCtx, "", nil, nil, hasAnyProjects, logger)
+	errMsg := normalizeTraceProject(clientCtx, "", nil, nil, hasAnyProjects, nil, logger)
 
 	assert.Empty(t, errMsg)
 	_, hasProject := clientCtx["project"]
@@ -126,7 +126,7 @@ func TestNormalizeTraceProject_EmptyClientProject_ExistingOrg(t *testing.T) {
 	logger := slog.Default()
 	hasAnyProjects := func() bool { return true }
 
-	errMsg := normalizeTraceProject(clientCtx, "", nil, nil, hasAnyProjects, logger)
+	errMsg := normalizeTraceProject(clientCtx, "", nil, nil, hasAnyProjects, nil, logger)
 
 	assert.Contains(t, errMsg, "project is required")
 }
@@ -136,7 +136,7 @@ func TestNormalizeTraceProject_EmptyClientProject_NilHasAnyProjects(t *testing.T
 	clientCtx := map[string]any{}
 	logger := slog.Default()
 
-	errMsg := normalizeTraceProject(clientCtx, "", nil, nil, nil, logger)
+	errMsg := normalizeTraceProject(clientCtx, "", nil, nil, nil, nil, logger)
 
 	assert.Empty(t, errMsg)
 	_, hasProject := clientCtx["project"]
@@ -148,7 +148,7 @@ func TestNormalizeTraceProject_ServerInferredSetsProject(t *testing.T) {
 	clientCtx := map[string]any{"model": "claude-opus-4-6"}
 	logger := slog.Default()
 
-	errMsg := normalizeTraceProject(clientCtx, "akashi", nil, nil, nil, logger)
+	errMsg := normalizeTraceProject(clientCtx, "akashi", nil, nil, nil, nil, logger)
 
 	assert.Empty(t, errMsg)
 	assert.Equal(t, "akashi", clientCtx["project"])
@@ -164,7 +164,7 @@ func TestNormalizeTraceProject_ServerTakesPriorityOverRepoURL(t *testing.T) {
 	}
 	logger := slog.Default()
 
-	errMsg := normalizeTraceProject(clientCtx, "akashi", nil, nil, nil, logger)
+	errMsg := normalizeTraceProject(clientCtx, "akashi", nil, nil, nil, nil, logger)
 
 	assert.Empty(t, errMsg)
 	assert.Equal(t, "akashi", clientCtx["project"])
@@ -178,7 +178,7 @@ func TestNormalizeTraceProject_RejectsUnknownProject(t *testing.T) {
 	resolveAlias := func(_ string) string { return "" }
 	projectKnown := func(_ string) bool { return false }
 
-	errMsg := normalizeTraceProject(clientCtx, "", resolveAlias, projectKnown, nil, logger)
+	errMsg := normalizeTraceProject(clientCtx, "", resolveAlias, projectKnown, nil, nil, logger)
 
 	assert.Contains(t, errMsg, "unknown project winnipeg-v1")
 	_, hasProject := clientCtx["project"]
@@ -192,8 +192,27 @@ func TestNormalizeTraceProject_NilProjectKnownAcceptsValue(t *testing.T) {
 
 	resolveAlias := func(_ string) string { return "" }
 
-	errMsg := normalizeTraceProject(clientCtx, "", resolveAlias, nil, nil, logger)
+	errMsg := normalizeTraceProject(clientCtx, "", resolveAlias, nil, nil, nil, logger)
 
 	assert.Empty(t, errMsg)
 	assert.Equal(t, "new-project", clientCtx["project"])
+}
+
+func TestNormalizeTraceProject_RejectionIncludesSuggestion(t *testing.T) {
+	// Reproduces the mono incident: an agent submits an org-prefixed name
+	// when the canonical is the basename. The rejection error must point
+	// the agent at the canonical so it can recover without guessing again.
+	clientCtx := map[string]any{"project": "ardent-mono"}
+	logger := slog.Default()
+
+	resolveAlias := func(_ string) string { return "" }
+	projectKnown := func(_ string) bool { return false }
+	listKnownProjects := func() []string { return []string{"akashi", "mono", "tiger"} }
+
+	errMsg := normalizeTraceProject(clientCtx, "", resolveAlias, projectKnown, nil, listKnownProjects, logger)
+
+	assert.Contains(t, errMsg, "unknown project ardent-mono")
+	assert.Contains(t, errMsg, "Did you mean")
+	assert.Contains(t, errMsg, `"mono"`)
+	assert.Contains(t, errMsg, "Known projects")
 }

--- a/internal/storage/sqlite/project_links.go
+++ b/internal/storage/sqlite/project_links.go
@@ -34,3 +34,9 @@ func (l *LiteDB) ProjectExists(_ context.Context, _ uuid.UUID, _ string) (bool, 
 func (l *LiteDB) HasAnyProjects(_ context.Context, _ uuid.UUID) (bool, error) {
 	return false, nil
 }
+
+// DistinctProjects returns nil in lite mode. Project suggestions are a
+// server-mode feature; lite mode skips the validation that would surface them.
+func (l *LiteDB) DistinctProjects(_ context.Context, _ uuid.UUID) ([]string, error) {
+	return nil, nil
+}

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -124,6 +124,11 @@ type Store interface {
 	// in the org. Used to distinguish first-ever project from unknown project.
 	HasAnyProjects(ctx context.Context, orgID uuid.UUID) (bool, error)
 
+	// DistinctProjects returns all distinct project names used in active
+	// decisions within the org. Used to surface "did you mean" suggestions
+	// when an unknown project name is rejected.
+	DistinctProjects(ctx context.Context, orgID uuid.UUID) ([]string, error)
+
 	// ---- Decision Type Aliases ----
 
 	// ResolveDecisionTypeAlias returns the canonical decision type for the given


### PR DESCRIPTION
## Summary
- Fuzzy "did you mean" suggestions in `unknown project` trace rejections — surfaces canonical names like `mono` when an agent submits `ardent-mono` or `ArdentAILabs/mono`.
- Post-commit hook warns at `git commit` time when the agent's last `akashi_trace` was rejected and never retried successfully, closing the "burn attempts then silently commit" failure mode that motivated this work.
- Implements items (2) and (6) of the six-part hardening plan in decision [`3ae464af`](https://github.com/ashita-ai/akashi/commit/93dd924) (item (1), `cwd`/`repo_url` plumbing, shipped in #699).

## Notable design choices
- New neutral package `internal/projectsuggest` is consumed by both `internal/server` (HTTP path) and `internal/mcp` (MCP path). `mcp` doesn't import `server`, avoiding a layer-violation smell.
- Matcher biases substring containment (score 0.9) over normalized Levenshtein. The dominant failure mode is path-style or org-prefixed names (`ArdentAILabs/mono` → `mono`), which raw edit distance fails to surface.
- `handleTrace` uses a deferred named-return wrapper to fire the trace-complete notifier on every return path — adding new error paths in the future doesn't require remembering to instrument each one.
- Errored-trace marker has a 1h TTL (vs 10m for the check marker). Agents commonly run tests for half an hour between deciding and committing; a shorter TTL would miss the warning window.

## Test plan
- [x] `go build ./...` clean
- [x] `go test -race -count=1 ./...` — full unit suite passes including new `internal/projectsuggest` (13 tests) and 5 new tests in `handlers_hooks_test.go`
- [x] `go test -race -count=1 -tags integration ./internal/mcp/ ./internal/server/` — integration tests for the rejection-with-suggestion flow and the post-commit warning round-trip pass with testcontainers
- [x] `go vet ./...` clean
- [x] `golangci-lint run` clean on touched packages (`broker_test.go` staticcheck warnings are pre-existing — confirmed via stashed baseline)
- [x] `go mod tidy` no diff
- [x] `atlas migrate validate` no migration changes

> Marsh lights burn quiet
> Below, the unspoken dead
> Sam holds the lamp low