### PR TITLE
feat(hooks): scope SessionStart conflicts to recent + repo_url inference

### DIFF
--- a/.claude/hooks/akashi-hook.sh
+++ b/.claude/hooks/akashi-hook.sh
@@ -37,6 +37,25 @@ if [ -n "$AGENT_ID" ]; then
   INPUT=$(echo "$INPUT" | jq --arg aid "$AGENT_ID" '. + {agent_id: $aid}' 2>/dev/null || echo "$INPUT")
 fi
 
+# Inject repo_url into the hook JSON payload by resolving `git remote get-url
+# origin` on the host. The akashi server may run inside Docker, where the
+# host's cwd path is invisible — making in-server git resolution fail. The
+# hook script always runs on the host, so it's the only place that can
+# reliably extract the repo identity from the filesystem. The server prefers
+# its own cwd-based git invocation when available (e.g., host installs) and
+# falls back to this repo_url string otherwise.
+HOOK_CWD=$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null || true)
+if [ -n "$HOOK_CWD" ] && [ -d "$HOOK_CWD" ]; then
+  # `git remote get-url origin` is a local config read, not a network call,
+  # so no timeout is needed. Discard stderr — failures here (no remote, not
+  # a git repo, detached) are legitimate and must not pollute the hook
+  # output, which the IDE parses as JSON.
+  REPO_URL=$(git -C "$HOOK_CWD" remote get-url origin 2>/dev/null || true)
+  if [ -n "$REPO_URL" ]; then
+    INPUT=$(echo "$INPUT" | jq --arg ru "$REPO_URL" '. + {repo_url: $ru}' 2>/dev/null || echo "$INPUT")
+  fi
+fi
+
 # Determine the hook event from the input JSON or the AKASHI_HOOK_EVENT env var.
 # Claude Code sets hook_event_name in the JSON; Cursor uses similar conventions.
 HOOK_EVENT="${AKASHI_HOOK_EVENT:-}"

--- a/internal/server/handlers_hooks.go
+++ b/internal/server/handlers_hooks.go
@@ -51,6 +51,20 @@ const hookCheckTTL = 10 * time.Minute
 // doesn't leak into tomorrow's session.
 const traceErrorTTL = 1 * time.Hour
 
+// sessionStartConflictWindow bounds how recent a conflict group's
+// last_detected_at must be to surface in the SessionStart additionalContext.
+// Conflicts older than this are still in the database and dashboard
+// (/v1/conflicts), but are filtered out of the per-session nudge so
+// weeks-old unresolved disagreements don't drown out fresh signal.
+//
+// 7 days roughly matches typical sprint/work cadences: a conflict that
+// hasn't been re-detected in a week is unlikely to be relevant to the
+// agent's current task, and rehearsing it on every session-start trains
+// agents to dismiss the conflict surface as noise. Recent decisions are
+// not filtered by this window — when a project is quiet, showing the
+// last few decisions (even if older) is informative context, not noise.
+const sessionStartConflictWindow = 7 * 24 * time.Hour
+
 // traceErrEnt records a single unresolved trace failure.
 type traceErrEnt struct {
 	at  time.Time
@@ -197,9 +211,17 @@ func (s *hookCheckStore) LastTraceError(agentID string) (string, bool) {
 }
 
 // hookSessionStartInput is the JSON body sent by Claude Code / Cursor on SessionStart.
+//
+// RepoURL is an akashi-specific extension injected by akashi-hook.sh after it
+// runs `git -C $CWD remote get-url origin` on the host. It exists because the
+// akashi server may run inside a Docker container, where the host's CWD path
+// is not visible — making in-server git resolution impossible. The hook
+// script, which always runs on the host, is the only place that can reliably
+// resolve the project name from the filesystem.
 type hookSessionStartInput struct {
 	SessionID string `json:"session_id"`
 	CWD       string `json:"cwd"`
+	RepoURL   string `json:"repo_url"`
 	Source    string `json:"source"` // "startup", "resume", etc.
 	Model     string `json:"model"`
 }
@@ -212,6 +234,7 @@ type hookPreToolUseInput struct {
 	ToolInput     map[string]any `json:"tool_input"`
 	HookEventName string         `json:"hook_event_name"`
 	CWD           string         `json:"cwd"`
+	RepoURL       string         `json:"repo_url"`
 }
 
 // hookPostToolUseInput is the JSON body sent on PostToolUse events.
@@ -223,6 +246,7 @@ type hookPostToolUseInput struct {
 	ToolResponse  string         `json:"tool_response"`
 	HookEventName string         `json:"hook_event_name"`
 	CWD           string         `json:"cwd"`
+	RepoURL       string         `json:"repo_url"`
 }
 
 // hookResponse is the JSON output format expected by Claude Code and Cursor hooks.
@@ -254,7 +278,7 @@ func (h *Handlers) HandleHookSessionStart(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	project := inferProjectFromCWD(input.CWD)
+	project := inferProjectFromHook(input.CWD, input.RepoURL)
 	taskLabel := suggestedTaskLabel(input.CWD)
 	recentContext := h.buildSessionContext(r.Context(), project, taskLabel)
 
@@ -301,9 +325,9 @@ func (h *Handlers) HandleHookPreToolUse(w http.ResponseWriter, r *http.Request) 
 
 	// Short-circuit: if the project has no decision history, don't gate edits.
 	// The empty marker is set during SessionStart and cleared on first trace.
-	// This check comes after IsRecent because inferProjectFromCWD spawns a
+	// This check comes after IsRecent because project inference may spawn a
 	// git subprocess, whereas IsRecent is a pure map lookup.
-	if project := inferProjectFromCWD(input.CWD); h.hookChecks.IsProjectEmpty(project) {
+	if project := inferProjectFromHook(input.CWD, input.RepoURL); h.hookChecks.IsProjectEmpty(project) {
 		writeHookJSON(w, hookResponse{Continue: true, SuppressOutput: true})
 		return
 	}
@@ -331,7 +355,7 @@ func (h *Handlers) HandleHookPostToolUse(w http.ResponseWriter, r *http.Request)
 		h.hookChecks.Record(input.AgentID)
 		// If a decision was just traced, the project is no longer empty.
 		if strings.Contains(input.ToolName, "trace") {
-			if project := inferProjectFromCWD(input.CWD); project != "" {
+			if project := inferProjectFromHook(input.CWD, input.RepoURL); project != "" {
 				h.hookChecks.ClearProjectEmpty(project)
 			}
 		}
@@ -411,9 +435,10 @@ func (h *Handlers) autoTraceCommit(input hookPostToolUseInput, commitMsg string)
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	project := inferProjectFromCWD(input.CWD)
+	project := inferProjectFromHook(input.CWD, input.RepoURL)
 	if project == "" {
-		h.logger.Warn("auto-trace skipped: could not detect project from git remote", "cwd", input.CWD)
+		h.logger.Warn("auto-trace skipped: could not detect project from cwd or repo_url",
+			"cwd", input.CWD, "repo_url_present", input.RepoURL != "")
 		return
 	}
 
@@ -603,11 +628,16 @@ func (h *Handlers) buildSessionContext(ctx context.Context, project, taskLabel s
 		recent = nil
 	}
 
-	// Query open conflict groups — scoped by project when known.
-	// Use conflict_groups with open_count > 0 (not individual scored_conflicts)
-	// to show the deduplicated count of unresolved disagreements.
+	// Query open conflict groups — scoped by project when known and bounded
+	// by sessionStartConflictWindow so old, long-unresolved disagreements
+	// don't dominate the per-session nudge. The full list is still available
+	// at /v1/conflicts.
 	openStatus := "open"
-	groupFilter := storage.ConflictGroupFilters{Status: &openStatus}
+	since := time.Now().Add(-sessionStartConflictWindow)
+	groupFilter := storage.ConflictGroupFilters{
+		Status:        &openStatus,
+		DetectedSince: &since,
+	}
 	if project != "" {
 		groupFilter.Project = &project
 	}
@@ -617,23 +647,38 @@ func (h *Handlers) buildSessionContext(ctx context.Context, project, taskLabel s
 		conflictGroups = nil
 	}
 
+	// True count of recent open conflict groups, so the header is honest when
+	// the displayed list is truncated to 5. The same filter is applied to
+	// both queries so the header number and the listed items always agree
+	// on what "recent open" means.
+	openCount, err := h.db.CountConflictGroups(ctx, orgID, groupFilter)
+	if err != nil {
+		h.logger.Debug("hook session-start: count conflict groups failed", "error", err)
+		openCount = len(conflictGroups)
+	}
+
 	// Track whether this project has any decision history.
 	// Empty projects get a relaxed edit gate in HandleHookPreToolUse.
 	if project != "" {
-		if len(recent) == 0 && len(conflictGroups) == 0 {
+		if len(recent) == 0 && openCount == 0 {
 			h.hookChecks.MarkProjectEmpty(project)
 		} else {
 			h.hookChecks.ClearProjectEmpty(project)
 		}
 	}
 
-	// Build header — report deduplicated conflict group count, not raw scored_conflicts.
+	// Build header. The conflict label spells out the recency window so the
+	// count is interpretable on its own — agents reading "5 open conflicts"
+	// without context will assume "ever," but post-PR it means "in the last
+	// N days." Older disagreements remain queryable at /v1/conflicts.
+	windowDays := int(sessionStartConflictWindow / (24 * time.Hour))
+	conflictsLabel := fmt.Sprintf("%d open conflicts (last %dd)", openCount, windowDays)
 	if project != "" {
-		parts = append(parts, fmt.Sprintf("[akashi] Project: %s | %d recent decisions | %d open conflicts",
-			project, len(recent), len(conflictGroups)))
+		parts = append(parts, fmt.Sprintf("[akashi] Project: %s | %d recent decisions | %s",
+			project, len(recent), conflictsLabel))
 	} else {
-		parts = append(parts, fmt.Sprintf("[akashi] %d recent decisions | %d open conflicts",
-			len(recent), len(conflictGroups)))
+		parts = append(parts, fmt.Sprintf("[akashi] %d recent decisions | %s",
+			len(recent), conflictsLabel))
 	}
 
 	// Compact decision summaries.
@@ -649,8 +694,14 @@ func (h *Handlers) buildSessionContext(ctx context.Context, project, taskLabel s
 	}
 
 	// Conflict group summary — use the representative conflict for display.
+	// When the count exceeds what we listed, surface "showing N of M" so
+	// the agent knows the dashboard has more.
 	if len(conflictGroups) > 0 {
-		parts = append(parts, "\nOpen conflicts:")
+		header := "\nOpen conflicts:"
+		if openCount > len(conflictGroups) {
+			header = fmt.Sprintf("\nOpen conflicts (showing %d of %d):", len(conflictGroups), openCount)
+		}
+		parts = append(parts, header)
 		for _, g := range conflictGroups {
 			severity := "unknown"
 			explanation := ""
@@ -724,6 +775,26 @@ func inferProjectFromCWD(cwd string) string {
 		return ""
 	}
 	return gitRepoNameFromPath(cwd)
+}
+
+// inferProjectFromHook resolves the project name from the hook payload using
+// two server-verifiable signals, in order of preference:
+//
+//  1. cwd via `git -C <cwd> remote get-url origin` — only works when the
+//     server can reach the same filesystem as the IDE (host installs).
+//  2. repo_url — parsed locally without filesystem access. The hook script
+//     resolves the remote on the host and injects this field, which is the
+//     only reliable signal when akashi runs in Docker.
+//
+// Returns "" if neither signal yields a name. Both paths are considered
+// trustworthy: cwd is verified by the server's own git invocation, and
+// repo_url comes from the hook script (host shell), which is the same
+// trust boundary that already injects agent_id.
+func inferProjectFromHook(cwd, repoURL string) string {
+	if name := inferProjectFromCWD(cwd); name != "" {
+		return name
+	}
+	return repoNameFromURL(repoURL)
 }
 
 // gitRepoNameFromPath runs git to get the origin remote name for a path.

--- a/internal/server/handlers_hooks_test.go
+++ b/internal/server/handlers_hooks_test.go
@@ -1027,6 +1027,50 @@ func TestHandleHookPreToolUse_EditAfterCheck(t *testing.T) {
 	assert.True(t, resp.SuppressOutput)
 }
 
+// TestInferProjectFromHook covers the project resolution path used by all
+// three hook handlers. cwd-based resolution is preferred when it works;
+// repo_url is the fallback and is the only working path when the akashi
+// server runs in Docker (the host's cwd path is invisible inside the
+// container, so `git -C <cwd>` always fails there).
+func TestInferProjectFromHook(t *testing.T) {
+	t.Run("cwd resolves on host installs", func(t *testing.T) {
+		dir := makeTestGitRepo(t)
+		// Repo created with origin = github.com/test/test-repo.git
+		// (see makeTestGitRepo above) — basename without .git is "test-repo".
+		assert.Equal(t, "test-repo", inferProjectFromHook(dir, ""))
+	})
+
+	t.Run("repo_url is used when cwd resolution fails", func(t *testing.T) {
+		// /nonexistent has no .git, so cwd-based inference returns "".
+		// repo_url is parsed locally and produces the canonical name.
+		assert.Equal(t, "akashi", inferProjectFromHook("/nonexistent",
+			"git@github.com:ashita-ai/akashi.git"))
+	})
+
+	t.Run("cwd takes precedence when both succeed", func(t *testing.T) {
+		dir := makeTestGitRepo(t)
+		// cwd resolves to "test-repo" but repo_url claims "other".
+		// cwd is server-verified (the server ran git itself), so it wins.
+		assert.Equal(t, "test-repo", inferProjectFromHook(dir,
+			"git@github.com:other-org/other.git"))
+	})
+
+	t.Run("returns empty when neither signal works", func(t *testing.T) {
+		assert.Empty(t, inferProjectFromHook("", ""))
+		assert.Empty(t, inferProjectFromHook("/nonexistent", ""))
+		assert.Empty(t, inferProjectFromHook("", "   "))
+	})
+
+	t.Run("malformed repo_url returns empty without crashing", func(t *testing.T) {
+		// url.Parse rejects inputs with an unparseable scheme. SessionStart
+		// callers feed the result into a project-equality filter, so a
+		// non-empty garbage string would just match no rows — but returning
+		// "" is cleaner and matches repoNameFromURL's documented contract
+		// for malformed inputs.
+		assert.Empty(t, inferProjectFromHook("", "://malformed"))
+	})
+}
+
 // TestHandleHookSessionStart_ValidBody exercises HandleHookSessionStart
 // with a valid JSON body. Since buildSessionContext calls h.db which panics
 // with nil, we just test the invalid JSON path and the response shape.

--- a/internal/storage/conflicts.go
+++ b/internal/storage/conflicts.go
@@ -905,6 +905,11 @@ func conflictGroupWhere(f ConflictGroupFilters, argOffset int) (string, []any) {
 	if f.Project != nil {
 		clause += fmt.Sprintf(" AND EXISTS (SELECT 1 FROM scored_conflicts sc_p WHERE sc_p.group_id = cg.id AND (sc_p.project_a = $%d OR sc_p.project_b = $%d))", argOffset, argOffset)
 		args = append(args, *f.Project)
+		argOffset++
+	}
+	if f.DetectedSince != nil {
+		clause += fmt.Sprintf(" AND cg.last_detected_at >= $%d", argOffset)
+		args = append(args, *f.DetectedSince)
 		argOffset++ //nolint:ineffassign
 	}
 	return clause, args

--- a/internal/storage/sqlite/conflicts.go
+++ b/internal/storage/sqlite/conflicts.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -53,16 +54,13 @@ func (l *LiteDB) ListConflicts(ctx context.Context, orgID uuid.UUID, filters sto
 	return scanConflictRows(rows)
 }
 
-// ListConflictGroups returns grouped conflicts.
-func (l *LiteDB) ListConflictGroups(ctx context.Context, orgID uuid.UUID, filters storage.ConflictGroupFilters, limit, offset int) ([]model.ConflictGroup, error) {
-	if limit <= 0 {
-		limit = 20
-	}
-
-	var conds []string
-	var args []any
-	conds = append(conds, "cg.org_id = ?")
-	args = append(args, uuidStr(orgID))
+// conflictGroupWhere builds the shared WHERE clause for ListConflictGroups
+// and CountConflictGroups. Pre-pends "cg.org_id = ?" so callers don't have
+// to. Status is intentionally excluded — it requires aggregation over
+// scored_conflicts and is built per-call as a HAVING clause.
+func conflictGroupWhere(orgID uuid.UUID, filters storage.ConflictGroupFilters) (string, []any) {
+	conds := []string{"cg.org_id = ?"}
+	args := []any{uuidStr(orgID)}
 
 	if filters.DecisionType != nil {
 		conds = append(conds, "cg.decision_type = ?")
@@ -80,8 +78,27 @@ func (l *LiteDB) ListConflictGroups(ctx context.Context, orgID uuid.UUID, filter
 		conds = append(conds, "EXISTS (SELECT 1 FROM scored_conflicts sc_p WHERE sc_p.group_id = cg.id AND (sc_p.project_a = ? OR sc_p.project_b = ?))")
 		args = append(args, *filters.Project, *filters.Project)
 	}
+	if filters.DetectedSince != nil {
+		// last_detected_at is written by the column DEFAULT (datetime('now'),
+		// space-separated, no fractional seconds). Callers pass RFC3339Nano
+		// (T-separated, with Z). These don't compare correctly as raw text:
+		// space (0x20) sorts before T (0x54), so a stale local-format time
+		// can collate after a fresher ISO time. Wrap both sides in datetime()
+		// to canonicalize to UTC second precision.
+		conds = append(conds, "datetime(cg.last_detected_at) >= datetime(?)")
+		args = append(args, filters.DetectedSince.UTC().Format(time.RFC3339Nano))
+	}
 
-	where := "WHERE " + strings.Join(conds, " AND ")
+	return "WHERE " + strings.Join(conds, " AND "), args
+}
+
+// ListConflictGroups returns grouped conflicts.
+func (l *LiteDB) ListConflictGroups(ctx context.Context, orgID uuid.UUID, filters storage.ConflictGroupFilters, limit, offset int) ([]model.ConflictGroup, error) {
+	if limit <= 0 {
+		limit = 20
+	}
+
+	where, args := conflictGroupWhere(orgID, filters)
 
 	// Status filter semantics:
 	//   - "open": groups with at least one open conflict
@@ -171,6 +188,56 @@ func (l *LiteDB) ListConflictGroups(ctx context.Context, orgID uuid.UUID, filter
 		return []model.ConflictGroup{}, nil
 	}
 	return groups, nil
+}
+
+// CountConflictGroups returns the total number of conflict groups matching
+// the filters. Mirrors the Postgres semantics: when Status is set, the count
+// reflects groups whose member scored_conflicts satisfy the status predicate
+// ("open" = at least one open; "resolved" = all closed; "false_positive" =
+// all closed and at least one labeled false_positive).
+func (l *LiteDB) CountConflictGroups(ctx context.Context, orgID uuid.UUID, filters storage.ConflictGroupFilters) (int, error) {
+	where, args := conflictGroupWhere(orgID, filters)
+
+	if filters.Status == nil {
+		q := fmt.Sprintf( //nolint:gosec // G201
+			`SELECT COUNT(*) FROM conflict_groups cg %s`, where,
+		)
+		var n int
+		if err := l.db.QueryRowContext(ctx, q, args...).Scan(&n); err != nil {
+			return 0, fmt.Errorf("sqlite: count conflict groups: %w", err)
+		}
+		return n, nil
+	}
+
+	// Status branch: wrap the per-group filter in a sub-SELECT and apply the
+	// same EXISTS-based predicates ListConflictGroups uses, so counts and
+	// listings always agree.
+	var statusPred string
+	switch *filters.Status {
+	case "open":
+		statusPred = "EXISTS (SELECT 1 FROM scored_conflicts sc WHERE sc.group_id = cg.id AND sc.status = ?)"
+		args = append(args, *filters.Status)
+	case "resolved":
+		statusPred = "NOT EXISTS (SELECT 1 FROM scored_conflicts sc WHERE sc.group_id = cg.id AND sc.status = 'open')" +
+			" AND EXISTS (SELECT 1 FROM scored_conflicts sc WHERE sc.group_id = cg.id)"
+	case "false_positive":
+		statusPred = "NOT EXISTS (SELECT 1 FROM scored_conflicts sc WHERE sc.group_id = cg.id AND sc.status = 'open')" +
+			" AND EXISTS (SELECT 1 FROM scored_conflicts sc WHERE sc.group_id = cg.id AND sc.status = 'false_positive')"
+	default:
+		statusPred = "EXISTS (SELECT 1 FROM scored_conflicts sc WHERE sc.group_id = cg.id AND sc.status = ?)"
+		args = append(args, *filters.Status)
+	}
+
+	q := fmt.Sprintf( //nolint:gosec // G201
+		`SELECT COUNT(*) FROM conflict_groups cg %s AND %s`,
+		where, statusPred,
+	)
+
+	var n int
+	if err := l.db.QueryRowContext(ctx, q, args...).Scan(&n); err != nil {
+		return 0, fmt.Errorf("sqlite: count conflict groups (status=%s): %w", *filters.Status, err)
+	}
+	return n, nil
 }
 
 // loadRepresentativeConflict loads the most significant open conflict in a group.

--- a/internal/storage/sqlite/sqlite_test.go
+++ b/internal/storage/sqlite/sqlite_test.go
@@ -5894,6 +5894,185 @@ func TestListConflictGroups_DefaultLimit(t *testing.T) {
 	assert.Empty(t, groups)
 }
 
+// TestListConflictGroups_DetectedSinceFilter verifies that the DetectedSince
+// filter excludes groups whose last_detected_at is older than the cutoff.
+// This is what powers the SessionStart hook's recency window — without it,
+// weeks-old unresolved disagreements dominate the per-session nudge.
+//
+// The test seeds two groups with explicit last_detected_at values (one fresh,
+// one stale) bypassing the column DEFAULT, since `datetime('now')` cannot
+// produce a past timestamp. It also covers the cross-format comparison
+// concern: the filter wraps both sides in datetime() so the column's stored
+// format (RFC3339Nano vs SQLite default) doesn't break the comparison.
+func TestListConflictGroups_DetectedSinceFilter(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	require.NoError(t, db.EnsureDefaultOrg(ctx))
+	orgID := uuid.Nil
+
+	_, err := db.CreateAgent(ctx, model.Agent{
+		AgentID: "ds-agent-a", OrgID: orgID, Name: "A", Role: model.RoleAgent,
+		Tags: []string{}, Metadata: map[string]any{},
+		CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+
+	_, dA, err := db.CreateTraceTx(ctx, storage.CreateTraceParams{
+		AgentID: "ds-agent-a", OrgID: orgID, Metadata: map[string]any{},
+		Decision: model.Decision{
+			DecisionType: "architecture", Outcome: "fresh-a", Confidence: 0.8,
+			Metadata: map[string]any{},
+		},
+	})
+	require.NoError(t, err)
+
+	_, dB, err := db.CreateTraceTx(ctx, storage.CreateTraceParams{
+		AgentID: "ds-agent-a", OrgID: orgID, Metadata: map[string]any{},
+		Decision: model.Decision{
+			DecisionType: "architecture", Outcome: "fresh-b", Confidence: 0.7,
+			Metadata: map[string]any{},
+		},
+	})
+	require.NoError(t, err)
+
+	_, dC, err := db.CreateTraceTx(ctx, storage.CreateTraceParams{
+		AgentID: "ds-agent-a", OrgID: orgID, Metadata: map[string]any{},
+		Decision: model.Decision{
+			DecisionType: "architecture", Outcome: "stale-a", Confidence: 0.8,
+			Metadata: map[string]any{},
+		},
+	})
+	require.NoError(t, err)
+
+	_, dD, err := db.CreateTraceTx(ctx, storage.CreateTraceParams{
+		AgentID: "ds-agent-a", OrgID: orgID, Metadata: map[string]any{},
+		Decision: model.Decision{
+			DecisionType: "architecture", Outcome: "stale-b", Confidence: 0.7,
+			Metadata: map[string]any{},
+		},
+	})
+	require.NoError(t, err)
+
+	// Two groups with explicit last_detected_at values: one 1 hour old
+	// (within window), one 30 days old (outside the 7-day window the
+	// SessionStart hook applies).
+	freshID := uuid.New()
+	staleID := uuid.New()
+	now := time.Now().UTC()
+	fresh := now.Add(-1 * time.Hour).Format(time.RFC3339Nano)
+	stale := now.Add(-30 * 24 * time.Hour).Format(time.RFC3339Nano)
+
+	rawDB := db.RawDB()
+	_, err = rawDB.ExecContext(ctx,
+		`INSERT INTO conflict_groups (id, org_id, agent_a, agent_b, conflict_kind, decision_type, first_detected_at, last_detected_at)
+		 VALUES (?,?,?,?,?,?,?,?)`,
+		freshID.String(), orgID.String(), "ds-agent-a", "ds-agent-a", "self_contradiction", "architecture", fresh, fresh,
+	)
+	require.NoError(t, err)
+
+	// Use a different conflict_kind to satisfy the
+	// (org_id, agent_a, agent_b, conflict_kind, decision_type) UNIQUE constraint.
+	_, err = rawDB.ExecContext(ctx,
+		`INSERT INTO conflict_groups (id, org_id, agent_a, agent_b, conflict_kind, decision_type, first_detected_at, last_detected_at)
+		 VALUES (?,?,?,?,?,?,?,?)`,
+		staleID.String(), orgID.String(), "ds-agent-a", "ds-agent-a", "cross_agent", "architecture", stale, stale,
+	)
+	require.NoError(t, err)
+
+	insertConflict(t, db, orgID, dA.ID, dB.ID, map[string]string{
+		"kind": "self_contradiction", "agent_a": "ds-agent-a", "agent_b": "ds-agent-a",
+		"group_id": freshID.String(), "decision_type_a": "architecture", "decision_type_b": "architecture",
+	})
+	insertConflict(t, db, orgID, dC.ID, dD.ID, map[string]string{
+		"kind": "cross_agent", "agent_a": "ds-agent-a", "agent_b": "ds-agent-a",
+		"group_id": staleID.String(), "decision_type_a": "architecture", "decision_type_b": "architecture",
+	})
+
+	t.Run("no filter returns both", func(t *testing.T) {
+		groups, err := db.ListConflictGroups(ctx, orgID, storage.ConflictGroupFilters{}, 10, 0)
+		require.NoError(t, err)
+		assert.Len(t, groups, 2)
+	})
+
+	t.Run("7-day window excludes stale", func(t *testing.T) {
+		since := now.Add(-7 * 24 * time.Hour)
+		groups, err := db.ListConflictGroups(ctx, orgID, storage.ConflictGroupFilters{
+			DetectedSince: &since,
+		}, 10, 0)
+		require.NoError(t, err)
+		require.Len(t, groups, 1)
+		assert.Equal(t, freshID, groups[0].ID, "only the fresh group should remain")
+	})
+
+	t.Run("31-day window includes both", func(t *testing.T) {
+		since := now.Add(-31 * 24 * time.Hour)
+		groups, err := db.ListConflictGroups(ctx, orgID, storage.ConflictGroupFilters{
+			DetectedSince: &since,
+		}, 10, 0)
+		require.NoError(t, err)
+		assert.Len(t, groups, 2)
+	})
+
+	t.Run("future window excludes both", func(t *testing.T) {
+		since := now.Add(1 * time.Hour)
+		groups, err := db.ListConflictGroups(ctx, orgID, storage.ConflictGroupFilters{
+			DetectedSince: &since,
+		}, 10, 0)
+		require.NoError(t, err)
+		assert.Empty(t, groups)
+	})
+
+	t.Run("Status=open combined with DetectedSince", func(t *testing.T) {
+		// Mirror how buildSessionContext composes the filter — both flags
+		// active together. Regression test against future refactors that
+		// might thread DetectedSince through a code path that bypasses
+		// the Status-driven HAVING aggregation.
+		openStatus := "open"
+		since := now.Add(-7 * 24 * time.Hour)
+		groups, err := db.ListConflictGroups(ctx, orgID, storage.ConflictGroupFilters{
+			Status:        &openStatus,
+			DetectedSince: &since,
+		}, 10, 0)
+		require.NoError(t, err)
+		require.Len(t, groups, 1)
+		assert.Equal(t, freshID, groups[0].ID)
+	})
+
+	t.Run("CountConflictGroups agrees with ListConflictGroups", func(t *testing.T) {
+		// CountConflictGroups must apply the same filters as ListConflictGroups,
+		// so the SessionStart header (which uses count) and the displayed list
+		// never disagree on what "recent open" means. Cover the same windows
+		// the list test exercises.
+		openStatus := "open"
+
+		n, err := db.CountConflictGroups(ctx, orgID, storage.ConflictGroupFilters{})
+		require.NoError(t, err)
+		assert.Equal(t, 2, n, "no filter")
+
+		since7 := now.Add(-7 * 24 * time.Hour)
+		n, err = db.CountConflictGroups(ctx, orgID, storage.ConflictGroupFilters{
+			DetectedSince: &since7,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 1, n, "7-day window")
+
+		n, err = db.CountConflictGroups(ctx, orgID, storage.ConflictGroupFilters{
+			Status:        &openStatus,
+			DetectedSince: &since7,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 1, n, "Status=open + 7-day window")
+
+		since31 := now.Add(-31 * 24 * time.Hour)
+		n, err = db.CountConflictGroups(ctx, orgID, storage.ConflictGroupFilters{
+			Status:        &openStatus,
+			DetectedSince: &since31,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 2, n, "Status=open + 31-day window")
+	})
+}
+
 // ---------------------------------------------------------------------------
 // QueryDecisions — filter branches
 // ---------------------------------------------------------------------------

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -5518,6 +5518,184 @@ func TestListConflictGroups_Limits(t *testing.T) {
 	_ = groups
 }
 
+// TestListConflictGroups_DetectedSinceFilter exercises the recency window
+// the SessionStart hook applies. Without this filter, weeks-old unresolved
+// disagreements dominate the per-session nudge regardless of whether they
+// relate to the agent's current task. The test seeds two isolated groups
+// (with unique decision_type suffixes to avoid colliding with concurrent
+// tests against the shared testDB) and asserts that DetectedSince correctly
+// partitions them by last_detected_at.
+func TestListConflictGroups_DetectedSinceFilter(t *testing.T) {
+	ctx := context.Background()
+	suffix := uuid.New().String()[:8]
+	decType := "ds_filter_" + suffix
+	agentA := "ds-a-" + suffix
+	agentB := "ds-b-" + suffix
+
+	runA, err := testDB.CreateRun(ctx, model.CreateRunRequest{AgentID: agentA})
+	require.NoError(t, err)
+	runB, err := testDB.CreateRun(ctx, model.CreateRunRequest{AgentID: agentB})
+	require.NoError(t, err)
+
+	// Four decisions — two distinct (a,b) pairs — because
+	// scored_conflicts has UNIQUE(decision_a_id, decision_b_id) and the
+	// ON CONFLICT upsert reassigns the row's group_id, which would
+	// collapse both groups into one populated group.
+	dA1, err := testDB.CreateDecision(ctx, model.Decision{
+		RunID: runA.ID, AgentID: agentA, DecisionType: decType,
+		Outcome: "fresh-a", Confidence: 0.7,
+	})
+	require.NoError(t, err)
+	dB1, err := testDB.CreateDecision(ctx, model.Decision{
+		RunID: runB.ID, AgentID: agentB, DecisionType: decType,
+		Outcome: "fresh-b", Confidence: 0.7,
+	})
+	require.NoError(t, err)
+	dA2, err := testDB.CreateDecision(ctx, model.Decision{
+		RunID: runA.ID, AgentID: agentA, DecisionType: decType,
+		Outcome: "stale-a", Confidence: 0.7,
+	})
+	require.NoError(t, err)
+	dB2, err := testDB.CreateDecision(ctx, model.Decision{
+		RunID: runB.ID, AgentID: agentB, DecisionType: decType,
+		Outcome: "stale-b", Confidence: 0.7,
+	})
+	require.NoError(t, err)
+
+	now := time.Now().UTC()
+	freshAt := now.Add(-1 * time.Hour)
+	staleAt := now.Add(-30 * 24 * time.Hour)
+
+	// Two groups distinguished by conflict_kind to satisfy the
+	// (org_id, agent_a, agent_b, conflict_kind, decision_type) UNIQUE constraint.
+	var freshID, staleID uuid.UUID
+	err = testDB.Pool().QueryRow(ctx,
+		`INSERT INTO conflict_groups (org_id, agent_a, agent_b, conflict_kind, decision_type, group_topic, first_detected_at, last_detected_at)
+		 VALUES ($1, $2, $3, 'cross_agent', $4, 'recency-test', $5, $5)
+		 RETURNING id`,
+		uuid.Nil, agentA, agentB, decType, freshAt,
+	).Scan(&freshID)
+	require.NoError(t, err)
+
+	err = testDB.Pool().QueryRow(ctx,
+		`INSERT INTO conflict_groups (org_id, agent_a, agent_b, conflict_kind, decision_type, group_topic, first_detected_at, last_detected_at)
+		 VALUES ($1, $2, $3, 'self_contradiction', $4, 'recency-test', $5, $5)
+		 RETURNING id`,
+		uuid.Nil, agentA, agentB, decType, staleAt,
+	).Scan(&staleID)
+	require.NoError(t, err)
+
+	// Each group needs at least one open scored_conflict so the Status="open"
+	// filter (which the hook always applies) leaves it visible.
+	topicSim := 0.9
+	outcomeDiv := 0.85
+	sig := topicSim * outcomeDiv
+	_, err = testDB.InsertScoredConflict(ctx, model.DecisionConflict{
+		ConflictKind: model.ConflictKindCrossAgent, DecisionAID: dA1.ID, DecisionBID: dB1.ID,
+		OrgID: uuid.Nil, AgentA: agentA, AgentB: agentB,
+		DecisionTypeA: decType, DecisionTypeB: decType,
+		OutcomeA: "fresh-a", OutcomeB: "fresh-b",
+		TopicSimilarity: &topicSim, OutcomeDivergence: &outcomeDiv,
+		Significance: &sig, ScoringMethod: "text", GroupID: &freshID,
+	})
+	require.NoError(t, err)
+
+	_, err = testDB.InsertScoredConflict(ctx, model.DecisionConflict{
+		ConflictKind: model.ConflictKindSelfContradiction, DecisionAID: dA2.ID, DecisionBID: dB2.ID,
+		OrgID: uuid.Nil, AgentA: agentA, AgentB: agentB,
+		DecisionTypeA: decType, DecisionTypeB: decType,
+		OutcomeA: "stale-a", OutcomeB: "stale-b",
+		TopicSimilarity: &topicSim, OutcomeDivergence: &outcomeDiv,
+		Significance: &sig, ScoringMethod: "text", GroupID: &staleID,
+	})
+	require.NoError(t, err)
+
+	// InsertScoredConflict bumps the parent group's last_detected_at to now()
+	// as a side effect. Override both groups back to the timestamps we want
+	// the recency filter to see — without this, both groups would appear
+	// "fresh" and the test would prove nothing.
+	_, err = testDB.Pool().Exec(ctx,
+		`UPDATE conflict_groups SET last_detected_at = $1, first_detected_at = $1 WHERE id = $2`,
+		freshAt, freshID)
+	require.NoError(t, err)
+	_, err = testDB.Pool().Exec(ctx,
+		`UPDATE conflict_groups SET last_detected_at = $1, first_detected_at = $1 WHERE id = $2`,
+		staleAt, staleID)
+	require.NoError(t, err)
+
+	// Filter to this test's decision_type so other tests' rows can't pollute
+	// the assertions when the suite is run against a shared DB.
+	dt := decType
+
+	t.Run("no DetectedSince returns both", func(t *testing.T) {
+		groups, err := testDB.ListConflictGroups(ctx, uuid.Nil, storage.ConflictGroupFilters{
+			DecisionType: &dt,
+		}, 50, 0)
+		require.NoError(t, err)
+		assert.Len(t, groups, 2)
+	})
+
+	t.Run("7-day window excludes stale", func(t *testing.T) {
+		since := now.Add(-7 * 24 * time.Hour)
+		groups, err := testDB.ListConflictGroups(ctx, uuid.Nil, storage.ConflictGroupFilters{
+			DecisionType:  &dt,
+			DetectedSince: &since,
+		}, 50, 0)
+		require.NoError(t, err)
+		require.Len(t, groups, 1)
+		assert.Equal(t, freshID, groups[0].ID, "only the fresh group should remain")
+	})
+
+	t.Run("31-day window includes both", func(t *testing.T) {
+		since := now.Add(-31 * 24 * time.Hour)
+		groups, err := testDB.ListConflictGroups(ctx, uuid.Nil, storage.ConflictGroupFilters{
+			DecisionType:  &dt,
+			DetectedSince: &since,
+		}, 50, 0)
+		require.NoError(t, err)
+		assert.Len(t, groups, 2)
+	})
+
+	t.Run("future window excludes both", func(t *testing.T) {
+		since := now.Add(1 * time.Hour)
+		groups, err := testDB.ListConflictGroups(ctx, uuid.Nil, storage.ConflictGroupFilters{
+			DecisionType:  &dt,
+			DetectedSince: &since,
+		}, 50, 0)
+		require.NoError(t, err)
+		assert.Empty(t, groups)
+	})
+
+	t.Run("CountConflictGroups honors DetectedSince", func(t *testing.T) {
+		since := now.Add(-7 * 24 * time.Hour)
+		count, err := testDB.CountConflictGroups(ctx, uuid.Nil, storage.ConflictGroupFilters{
+			DecisionType:  &dt,
+			DetectedSince: &since,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 1, count, "CountConflictGroups must apply the same recency filter")
+	})
+
+	t.Run("Status=open combined with DetectedSince", func(t *testing.T) {
+		// Mirror how buildSessionContext composes the filter — both flags
+		// active together. Both groups have at least one open conflict, so
+		// the Status filter alone admits both; only DetectedSince narrows
+		// to the fresh one. Regression test against future refactors that
+		// might place DetectedSince in a clause where it gets excluded by
+		// the HAVING-driven Status branch.
+		openStatus := "open"
+		since := now.Add(-7 * 24 * time.Hour)
+		groups, err := testDB.ListConflictGroups(ctx, uuid.Nil, storage.ConflictGroupFilters{
+			DecisionType:  &dt,
+			Status:        &openStatus,
+			DetectedSince: &since,
+		}, 50, 0)
+		require.NoError(t, err)
+		require.Len(t, groups, 1)
+		assert.Equal(t, freshID, groups[0].ID)
+	})
+}
+
 // ---------------------------------------------------------------------------
 // Tests: GetAgentWinRates
 // ---------------------------------------------------------------------------

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -64,6 +64,7 @@ type Store interface {
 
 	ListConflicts(ctx context.Context, orgID uuid.UUID, filters ConflictFilters, limit, offset int) ([]model.DecisionConflict, error)
 	ListConflictGroups(ctx context.Context, orgID uuid.UUID, filters ConflictGroupFilters, limit, offset int) ([]model.ConflictGroup, error)
+	CountConflictGroups(ctx context.Context, orgID uuid.UUID, filters ConflictGroupFilters) (int, error)
 	GetConflict(ctx context.Context, id, orgID uuid.UUID) (*model.DecisionConflict, error)
 	GetConflictCount(ctx context.Context, decisionID, orgID uuid.UUID) (int, error)
 	GetConflictCountsBatch(ctx context.Context, ids []uuid.UUID, orgID uuid.UUID) (map[uuid.UUID]int, error)

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -137,6 +137,12 @@ type ConflictGroupFilters struct {
 	// conflict matching this exact status (e.g. "open", "resolved",
 	// "false_positive"). When nil, all groups are returned.
 	Status *string
+	// DetectedSince restricts results to groups whose last_detected_at is
+	// at or after this timestamp. Used by the SessionStart hook to keep old,
+	// long-unresolved disagreements from dominating the surfaced list — the
+	// reasoning being that a group quiet for weeks is unlikely to be relevant
+	// to the agent's current task. When nil, no time bound is applied.
+	DetectedSince *time.Time
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- SessionStart was surfacing every open conflict ever recorded, drowning out fresh signal. Adds a `DetectedSince` filter on `ConflictGroupFilters`, applies a 7-day window in `buildSessionContext`, and surfaces "N open conflicts (last 7d)" using a true count from a new `CountConflictGroups` method (added to `Store` + SQLite backend with a shared WHERE-clause helper so List and Count cannot drift). When the listed items are truncated, the section reads "Open conflicts (showing X of M):" so older items remain discoverable at `/v1/conflicts`.
- Project inference now works when akashi runs in Docker. `akashi-hook.sh` resolves `git remote get-url origin` on the host and injects `repo_url` into the hook payload; `inferProjectFromHook` falls back to `repo_url` when the server's own cwd-based git invocation fails because the host filesystem is invisible inside the container. All three hook input structs and all four call sites are wired through.

## Verification

- [x] `go build ./...`, `go vet ./...`, `atlas migrate validate` clean.
- [x] `go test -race -count=1 ./internal/storage/sqlite/... ./internal/server/...` passes; new SQLite tests cover the `Status × DetectedSince` interaction for both List and Count.
- [ ] `golangci-lint` skipped — local install was built against Go 1.25 but project targets 1.26.1 (pre-existing env issue, not introduced here).
- [ ] No API or config changes.

## Risk / Rollout Notes

- No migration. The `DetectedSince` filter is opt-in (nil = old behavior) and the new SQLite `CountConflictGroups` is additive. The hook script change is backward-compatible: missing `repo_url` falls back to the existing cwd path.

> Old chronicles fade
> Fresh disturbances ripple
> Through the Force, briefly