### PR TITLE
docs(site): swap akashi_stats for akashi_reconcile in MCP tools grid

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -1468,8 +1468,8 @@ go run ./scripts/genkey -out data/
         <p>List grouped conflicts between agents. Filter by severity, category, and status. Returns representative examples per conflict group.</p>
       </div>
       <div class="mcp-cell">
-        <div class="mcp-name">akashi_stats</div>
-        <p>Aggregate health metrics: decision volume, conflict rate, mean confidence, and assessment outcomes across the org.</p>
+        <div class="mcp-name">akashi_reconcile</div>
+        <p>Resolve a conflict by recording a synthesis decision that supersedes both originals. One call traces, supersedes, and closes — without forcing a binary winner.</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary

- Replaces the `akashi_stats` cell in section 05 (MCP integration) of `site/index.html` with an `akashi_reconcile` cell.
- Forward-looking: `akashi_reconcile` is not yet implemented — proposed in #703. This change updates the marketing surface to reflect the intended primitive set ahead of implementation.

## Why this swap

`akashi_stats` is an aggregate metrics primitive — useful, but not on the critical path of the audit-trail value proposition. `akashi_reconcile` (per #703) closes a real gap: today there is no first-class primitive for resolving a conflict via a *synthesis* decision that supersedes both originals. Without it, operators are pushed toward false binaries or unstructured `resolution_note` text, both of which erode the audit graph.

Replacing the stats cell keeps the grid at six tools while elevating the more strategically important primitive.

## Notes

- The implementation work for `akashi_reconcile` should land before this site change goes live in production. Treat this PR as ready-to-merge once #703 ships, or merge now if you're comfortable with a short window where the docs lead the implementation.
- Stats is not removed from the product — `akashi_stats` remains available; it's only no longer surfaced in the homepage tools grid.

## Test plan

- [ ] Visual review of section 05 in `site/index.html` (the MCP tools grid) — confirm 6 cells, last one is `akashi_reconcile`, layout intact.
- [ ] Confirm no other references to `akashi_stats` exist on the site that need updating (grep already shows this is the only mention in `site/`).

Closes part of #703.