### PR TITLE
feat(conflicts): suppress assessment re-measurement from contradiction classification

### DIFF
--- a/internal/conflicts/metrics.go
+++ b/internal/conflicts/metrics.go
@@ -25,10 +25,11 @@ type Metrics struct {
 	selfCorrectionFiltered metric.Int64Counter
 	outcomeSimFiltered     metric.Int64Counter
 
-	confidenceFloorFiltered metric.Int64Counter
-	noopClaimGateFiltered   metric.Int64Counter
-	transitiveGroupFiltered metric.Int64Counter
-	fpPatternFiltered       metric.Int64Counter
+	confidenceFloorFiltered      metric.Int64Counter
+	noopClaimGateFiltered        metric.Int64Counter
+	transitiveGroupFiltered      metric.Int64Counter
+	fpPatternFiltered            metric.Int64Counter
+	temporalReassessmentFiltered metric.Int64Counter
 
 	scoringDuration    metric.Float64Histogram
 	llmCallDuration    metric.Float64Histogram
@@ -185,6 +186,14 @@ func (s *Scorer) registerMetrics() {
 	if err != nil {
 		s.logger.Warn("conflicts: failed to create akashi.conflicts.fp_pattern_filtered metric", "error", err)
 		s.metrics.fpPatternFiltered, _ = meter.Int64Counter("akashi.conflicts.fp_pattern_filtered.fallback")
+	}
+
+	s.metrics.temporalReassessmentFiltered, err = meter.Int64Counter("akashi.conflicts.temporal_reassessment_filtered",
+		metric.WithDescription("Candidate pairs filtered as same-project review-type re-measurements separated by ≥ temporalReassessmentWindow (issue #705)"),
+	)
+	if err != nil {
+		s.logger.Warn("conflicts: failed to create akashi.conflicts.temporal_reassessment_filtered metric", "error", err)
+		s.metrics.temporalReassessmentFiltered, _ = meter.Int64Counter("akashi.conflicts.temporal_reassessment_filtered.fallback")
 	}
 
 	// --- Histograms ---

--- a/internal/conflicts/scorer.go
+++ b/internal/conflicts/scorer.go
@@ -641,6 +641,21 @@ func (s *Scorer) scoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 			continue
 		}
 
+		// Temporal re-assessment filter: two review-type decisions on the
+		// same project, recorded sufficiently far apart with no precedent
+		// link, are re-measurements rather than contradictions. Quantitative
+		// metrics in assessments (FP rates, scores, percentages) drift over
+		// time without invalidating earlier snapshots. See issue #705.
+		if isTemporalReassessment(d, sc.cand) {
+			s.metrics.temporalReassessmentFiltered.Add(ctx, 1)
+			s.logger.Debug("conflict scorer: temporal re-assessment suppressed pair",
+				"decision_a", decisionID, "decision_b", sc.cand.ID,
+				"type_a", d.DecisionType, "type_b", sc.cand.DecisionType,
+				"project", derefString(d.Project),
+				"delta", d.ValidFrom.Sub(sc.cand.ValidFrom).Abs())
+			continue
+		}
+
 		// Outcome similarity floor: when outcome embeddings are nearly
 		// identical AND the pair did not qualify for the directToScorer
 		// bypass, suppress as complementary. This catches coordinated
@@ -1417,6 +1432,50 @@ func isSameBranchSelfCorrection(d, cand model.Decision) bool {
 	branchB := nestedContextString(cand.AgentContext, "git_branch")
 
 	return branchA != "" && branchB != "" && branchA == branchB
+}
+
+// temporalReassessmentWindow is the minimum time delta between two
+// review-type decisions on the same project for the pair to be treated as a
+// re-measurement rather than a contradiction. Quantitative observations
+// (FP rates, scores, percentages) are time-bound — a snapshot taken weeks
+// later does not contradict an earlier snapshot just because the numbers
+// moved. 7 days matches the SessionStart "recent" window used elsewhere
+// for conflict-relevance filtering.
+const temporalReassessmentWindow = 7 * 24 * time.Hour
+
+// isTemporalReassessment returns true when two decisions are both
+// review/assessment types on the same project, separated by at least
+// temporalReassessmentWindow, with neither citing the other and not in
+// the same session. This is the re-measurement pattern: the newer
+// assessment updates a prior measurement of the same system and naturally
+// has different numbers without contradicting the earlier conclusions.
+//
+// Pairs caught by this filter would otherwise embed close together (same
+// domain) and produce a CONTRADICTION verdict from the LLM whenever quoted
+// metrics differ — see issue #705. Linked or same-session re-assessments
+// are deliberately excluded so the LLM can still classify intentional
+// supersessions.
+func isTemporalReassessment(d, cand model.Decision) bool {
+	if !reviewTypes[strings.ToLower(d.DecisionType)] {
+		return false
+	}
+	if !reviewTypes[strings.ToLower(cand.DecisionType)] {
+		return false
+	}
+	if derefString(d.Project) != derefString(cand.Project) {
+		return false
+	}
+	if isPrecedentLinked(d, cand) {
+		return false
+	}
+	if d.SessionID != nil && cand.SessionID != nil && *d.SessionID == *cand.SessionID {
+		return false
+	}
+	delta := d.ValidFrom.Sub(cand.ValidFrom)
+	if delta < 0 {
+		delta = -delta
+	}
+	return delta >= temporalReassessmentWindow
 }
 
 // isPrecedentLinked returns true if either decision cites the other via

--- a/internal/conflicts/temporal_filter_test.go
+++ b/internal/conflicts/temporal_filter_test.go
@@ -1,0 +1,350 @@
+package conflicts
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ashita-ai/akashi/internal/model"
+)
+
+// tStrPtr is a local helper that mirrors the integration-only strPtr.
+// Defined here so this file builds under plain `go test` (no -tags=integration).
+func tStrPtr(s string) *string { return &s }
+
+func TestIsTemporalReassessment(t *testing.T) {
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	sessionA := uuid.New()
+	sessionB := uuid.New()
+	declID := uuid.New()
+	otherID := uuid.New()
+
+	tests := []struct {
+		name     string
+		d        model.Decision
+		cand     model.Decision
+		expected bool
+	}{
+		{
+			name: "two assessments, same project, 14 days apart → suppressed",
+			d: model.Decision{
+				ID:           declID,
+				DecisionType: "assessment",
+				Project:      tStrPtr("akashi"),
+				ValidFrom:    now,
+			},
+			cand: model.Decision{
+				ID:           otherID,
+				DecisionType: "assessment",
+				Project:      tStrPtr("akashi"),
+				ValidFrom:    now.Add(-14 * 24 * time.Hour),
+			},
+			expected: true,
+		},
+		{
+			name: "two code_reviews, same project, 30 days apart → suppressed",
+			d: model.Decision{
+				ID:           declID,
+				DecisionType: "code_review",
+				Project:      tStrPtr("akashi"),
+				ValidFrom:    now,
+			},
+			cand: model.Decision{
+				ID:           otherID,
+				DecisionType: "code_review",
+				Project:      tStrPtr("akashi"),
+				ValidFrom:    now.Add(-30 * 24 * time.Hour),
+			},
+			expected: true,
+		},
+		{
+			name: "audit + assessment, same project, 10 days apart → suppressed (mixed review types)",
+			d: model.Decision{
+				ID:           declID,
+				DecisionType: "audit",
+				Project:      tStrPtr("akashi"),
+				ValidFrom:    now,
+			},
+			cand: model.Decision{
+				ID:           otherID,
+				DecisionType: "assessment",
+				Project:      tStrPtr("akashi"),
+				ValidFrom:    now.Add(-10 * 24 * time.Hour),
+			},
+			expected: true,
+		},
+		{
+			name: "two assessments, same project, 2 days apart → not suppressed (window not crossed)",
+			d: model.Decision{
+				ID:           declID,
+				DecisionType: "assessment",
+				Project:      tStrPtr("akashi"),
+				ValidFrom:    now,
+			},
+			cand: model.Decision{
+				ID:           otherID,
+				DecisionType: "assessment",
+				Project:      tStrPtr("akashi"),
+				ValidFrom:    now.Add(-2 * 24 * time.Hour),
+			},
+			expected: false,
+		},
+		{
+			name: "two assessments, exactly 7 days apart → suppressed (boundary inclusive)",
+			d: model.Decision{
+				ID:           declID,
+				DecisionType: "assessment",
+				Project:      tStrPtr("akashi"),
+				ValidFrom:    now,
+			},
+			cand: model.Decision{
+				ID:           otherID,
+				DecisionType: "assessment",
+				Project:      tStrPtr("akashi"),
+				ValidFrom:    now.Add(-7 * 24 * time.Hour),
+			},
+			expected: true,
+		},
+		{
+			name: "two assessments, different projects → not suppressed",
+			d: model.Decision{
+				ID:           declID,
+				DecisionType: "assessment",
+				Project:      tStrPtr("akashi"),
+				ValidFrom:    now,
+			},
+			cand: model.Decision{
+				ID:           otherID,
+				DecisionType: "assessment",
+				Project:      tStrPtr("ardent-mono"),
+				ValidFrom:    now.Add(-30 * 24 * time.Hour),
+			},
+			expected: false,
+		},
+		{
+			name: "two assessments linked via precedent_ref → not suppressed (LLM decides)",
+			d: model.Decision{
+				ID:           declID,
+				DecisionType: "assessment",
+				Project:      tStrPtr("akashi"),
+				ValidFrom:    now,
+				PrecedentRef: &otherID,
+			},
+			cand: model.Decision{
+				ID:           otherID,
+				DecisionType: "assessment",
+				Project:      tStrPtr("akashi"),
+				ValidFrom:    now.Add(-30 * 24 * time.Hour),
+			},
+			expected: false,
+		},
+		{
+			name: "two assessments in same session → not suppressed",
+			d: model.Decision{
+				ID:           declID,
+				DecisionType: "assessment",
+				Project:      tStrPtr("akashi"),
+				ValidFrom:    now,
+				SessionID:    &sessionA,
+			},
+			cand: model.Decision{
+				ID:           otherID,
+				DecisionType: "assessment",
+				Project:      tStrPtr("akashi"),
+				ValidFrom:    now.Add(-30 * 24 * time.Hour),
+				SessionID:    &sessionA,
+			},
+			expected: false,
+		},
+		{
+			name: "two assessments in different sessions, same project, 14d → suppressed",
+			d: model.Decision{
+				ID:           declID,
+				DecisionType: "assessment",
+				Project:      tStrPtr("akashi"),
+				ValidFrom:    now,
+				SessionID:    &sessionA,
+			},
+			cand: model.Decision{
+				ID:           otherID,
+				DecisionType: "assessment",
+				Project:      tStrPtr("akashi"),
+				ValidFrom:    now.Add(-14 * 24 * time.Hour),
+				SessionID:    &sessionB,
+			},
+			expected: true,
+		},
+		{
+			name: "assessment + architecture → not suppressed (architecture is not a review type)",
+			d: model.Decision{
+				ID:           declID,
+				DecisionType: "assessment",
+				Project:      tStrPtr("akashi"),
+				ValidFrom:    now,
+			},
+			cand: model.Decision{
+				ID:           otherID,
+				DecisionType: "architecture",
+				Project:      tStrPtr("akashi"),
+				ValidFrom:    now.Add(-30 * 24 * time.Hour),
+			},
+			expected: false,
+		},
+		{
+			name: "two architecture decisions → not suppressed (neither is a review type)",
+			d: model.Decision{
+				ID:           declID,
+				DecisionType: "architecture",
+				Project:      tStrPtr("akashi"),
+				ValidFrom:    now,
+			},
+			cand: model.Decision{
+				ID:           otherID,
+				DecisionType: "architecture",
+				Project:      tStrPtr("akashi"),
+				ValidFrom:    now.Add(-30 * 24 * time.Hour),
+			},
+			expected: false,
+		},
+		{
+			name: "case-insensitive type match (CODE_REVIEW)",
+			d: model.Decision{
+				ID:           declID,
+				DecisionType: "CODE_REVIEW",
+				Project:      tStrPtr("akashi"),
+				ValidFrom:    now,
+			},
+			cand: model.Decision{
+				ID:           otherID,
+				DecisionType: "Assessment",
+				Project:      tStrPtr("akashi"),
+				ValidFrom:    now.Add(-30 * 24 * time.Hour),
+			},
+			expected: true,
+		},
+		{
+			name: "both projects nil → suppressed when types match (same null scope)",
+			d: model.Decision{
+				ID:           declID,
+				DecisionType: "assessment",
+				ValidFrom:    now,
+			},
+			cand: model.Decision{
+				ID:           otherID,
+				DecisionType: "assessment",
+				ValidFrom:    now.Add(-30 * 24 * time.Hour),
+			},
+			expected: true,
+		},
+		{
+			name: "reverse temporal order (cand newer than d) → still suppressed",
+			d: model.Decision{
+				ID:           declID,
+				DecisionType: "assessment",
+				Project:      tStrPtr("akashi"),
+				ValidFrom:    now.Add(-30 * 24 * time.Hour),
+			},
+			cand: model.Decision{
+				ID:           otherID,
+				DecisionType: "assessment",
+				Project:      tStrPtr("akashi"),
+				ValidFrom:    now,
+			},
+			expected: true,
+		},
+		{
+			name: "precedent_ref on d points to cand → not suppressed",
+			d: model.Decision{
+				ID:           declID,
+				DecisionType: "assessment",
+				Project:      tStrPtr("akashi"),
+				ValidFrom:    now,
+				PrecedentRef: &otherID,
+			},
+			cand: model.Decision{
+				ID:           otherID,
+				DecisionType: "assessment",
+				Project:      tStrPtr("akashi"),
+				ValidFrom:    now.Add(-30 * 24 * time.Hour),
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isTemporalReassessment(tt.d, tt.cand))
+		})
+	}
+}
+
+func TestFormatPrompt_TemporalReassessmentHint(t *testing.T) {
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+
+	t.Run("two assessments 14 days apart → hint present", func(t *testing.T) {
+		prompt := formatPrompt(ValidateInput{
+			OutcomeA: "FP rate measured at 76% on rolling 30 days.",
+			OutcomeB: "FP rate measured at 51% during prior review.",
+			TypeA:    "assessment",
+			TypeB:    "assessment",
+			AgentA:   "claude-code",
+			AgentB:   "senior-engineer",
+			CreatedA: now,
+			CreatedB: now.Add(-14 * 24 * time.Hour),
+		})
+		assert.Contains(t, prompt, "TEMPORAL RE-MEASUREMENT",
+			"hint should fire for review-type pairs past the temporal window")
+		assert.Contains(t, prompt, "time-bound",
+			"hint body should explain the time-bound nature of metrics")
+	})
+
+	t.Run("two assessments 2 days apart → no hint", func(t *testing.T) {
+		prompt := formatPrompt(ValidateInput{
+			OutcomeA: "FP rate at 60%.",
+			OutcomeB: "FP rate at 58%.",
+			TypeA:    "assessment",
+			TypeB:    "assessment",
+			AgentA:   "agent-a",
+			AgentB:   "agent-b",
+			CreatedA: now,
+			CreatedB: now.Add(-2 * 24 * time.Hour),
+		})
+		assert.NotContains(t, prompt, "TEMPORAL RE-MEASUREMENT",
+			"hint should not fire when within the temporal window")
+	})
+
+	t.Run("assessment + architecture 30 days apart → no hint", func(t *testing.T) {
+		prompt := formatPrompt(ValidateInput{
+			OutcomeA: "Audited the validator.",
+			OutcomeB: "Chose Redis for caching.",
+			TypeA:    "assessment",
+			TypeB:    "architecture",
+			AgentA:   "agent-a",
+			AgentB:   "agent-b",
+			CreatedA: now,
+			CreatedB: now.Add(-30 * 24 * time.Hour),
+		})
+		assert.NotContains(t, prompt, "TEMPORAL RE-MEASUREMENT",
+			"hint should not fire when one decision is not a review type")
+	})
+
+	t.Run("case-insensitive on decision type", func(t *testing.T) {
+		prompt := formatPrompt(ValidateInput{
+			OutcomeA: "review of system.",
+			OutcomeB: "review of system, later.",
+			TypeA:    "CODE_REVIEW",
+			TypeB:    "Assessment",
+			AgentA:   "agent-a",
+			AgentB:   "agent-b",
+			CreatedA: now,
+			CreatedB: now.Add(-14 * 24 * time.Hour),
+		})
+		// Hint relies on canonical lowercased lookup in reviewTypes.
+		if !strings.Contains(prompt, "TEMPORAL RE-MEASUREMENT") {
+			t.Fatalf("hint missing for case-insensitive review-type match; prompt:\n%s", prompt)
+		}
+	})
+}

--- a/internal/conflicts/validator.go
+++ b/internal/conflicts/validator.go
@@ -206,6 +206,20 @@ func formatPrompt(input ValidateInput) string {
 			input.TypeA, input.TypeB)
 	}
 
+	// --- Temporal re-measurement hint (#705) ---
+	// Two review-type decisions of the same system, recorded weeks apart,
+	// are re-measurements rather than contradictions. The structural filter
+	// in the scorer already suppresses the strict same-project case before
+	// reaching the LLM; this hint covers the borderline cases that get past
+	// it (missing project metadata, cross-org alias) so the model has the
+	// right interpretive frame.
+	if reviewTypes[strings.ToLower(input.TypeA)] && reviewTypes[strings.ToLower(input.TypeB)] && timeDelta >= temporalReassessmentWindow {
+		fmt.Fprintf(&b, "TEMPORAL RE-MEASUREMENT: Both decisions assess the same kind of subject and were recorded %s apart. "+
+			"Quantitative observations (rates, percentages, scores, counts) are time-bound — different numbers in two snapshots reflect natural drift over time, NOT contradiction. "+
+			"Classify as REFINEMENT (the newer updates the older) or SUPERSESSION (the newer explicitly replaces the older), never CONTRADICTION, unless the later decision EXPLICITLY states the earlier conclusion was wrong.\n",
+			deltaStr)
+	}
+
 	// --- Classification instructions ---
 	b.WriteString(`
 Classify the RELATIONSHIP between these two decisions:


### PR DESCRIPTION
## Summary

- Closes #705. Stops the validator from labelling two review-type decisions of the same system, recorded weeks apart, as **CONTRADICTION** whenever their quoted measurements differ. The case-in-point that motivated this PR fired this morning: my own audit at 76% FP rate vs an earlier senior-engineer review at 51% FP rate, both true at their respective times, both about the same pipeline, classified as a critical-severity contradiction.
- Adds `isTemporalReassessment(d, cand)` structural pre-filter to `internal/conflicts/scorer.go`. Two review-type decisions, same project, ≥ 7 days apart, neither cites the other, not in the same session → suppressed before LLM call. Same 7-day window as the SessionStart conflict-relevance filter (PR #702) for consistency.
- Adds a TEMPORAL RE-MEASUREMENT hint to the validator prompt in `internal/conflicts/validator.go`. Catches borderline pairs the structural filter is conservative about (missing project metadata, cross-org alias) by framing quoted metrics as time-bound observations and steering classification toward REFINEMENT or SUPERSESSION.
- Adds `akashi.conflicts.temporal_reassessment_filtered` OTel counter so we can watch how often this filter fires in production.

## Why this is the right shape

The scorer already has six structural pre-filters (workflow, coordinated-change, cross-branch mechanical, same-branch self-correction, outcome-similarity floor, FP pattern). None of them match cross-agent assessment→assessment pairs, which is why the meta-conflict slipped through. This PR fills exactly that gap — narrow, precedent-aware (skips precedent-linked pairs so genuine supersession still reaches the LLM), and additive to the existing chain.

The 7-day window is conservative. Sub-7d re-assessments still go to the LLM — that's the right place to handle short-window disagreements where temporal drift is unlikely to explain the divergence.

## Test plan

- [x] 15 unit tests on `isTemporalReassessment` cover: same project / different project, exactly-at-window boundary, sub-window pair, mixed review types (audit + assessment), precedent-linked, same-session, non-review types, case-insensitive type match, both-projects-nil, reversed temporal order, precedent_ref direction.
- [x] 4 unit tests on `formatPrompt` confirm the temporal hint appears under the right conditions and stays absent otherwise.
- [x] `go test -race -count=1 ./...` passes module-wide (full unit suite, integration tests not run in this commit).
- [x] All five mandatory pre-commit checks: `go mod tidy` clean, `go build ./...` clean, `go vet ./...` clean, `golangci-lint run ./...` 0 issues, `atlas migrate validate` clean.
- [ ] After merge: re-run conflict scoring on existing assessment pairs (or wait for organic backfill) and observe `temporal_reassessment_filtered` counter increment + the assessment-pair conflict count drop.

## Out of scope (intentional)

- Auto-resolving the existing meta-conflict `28c9a6e4-83ea-4cd8-9a2d-3f8b2048e360` — that's a one-off `akashi_resolve` call by a human reviewer.
- Auto-suggesting `supersedes_id` on assessment traces — separate issue, complementary.
- Tuning the 7-day window per-org — current default is fine; revisit only if production data motivates it.

> Mithrandir at the doors of Moria knew the riddle had not changed; he had simply read it wrong before. \"Speak, friend, and enter\" was always the answer — what shifted was his understanding of the question, not the door. The audit trail's job is the same: the senior-engineer's 51% and my 76% are not opposing claims about an unchanging system, they are the same kind of measurement taken at two times, and the validator has finally learned to read the runes that way.