### PR TITLE
Add reconciliation conflict primitive

### DIFF
--- a/adrs/ADR-016-synthesis-decisions-and-multi-target-supersedes.md
+++ b/adrs/ADR-016-synthesis-decisions-and-multi-target-supersedes.md
@@ -1,0 +1,107 @@
+# ADR-016: Synthesis decisions and multi-target supersedes
+
+## Status
+
+Accepted
+
+## Context
+
+Two existing primitives cover most of the conflict-resolution space:
+
+1. `akashi_resolve` (`PATCH /v1/conflicts/{id}`) picks a winner from {A, B} or marks the conflict false-positive. Mutates conflict state; does not create a decision record. The winner is constrained to one of the two decisions in the conflict (`internal/server/handlers_conflicts.go:159`, `storage.ErrWinningDecisionNotInConflict`).
+2. `akashi_trace(supersedes_id=X)` creates a new decision that explicitly replaces X. The trace pipeline auto-invalidates X (`valid_to`) and cascade-resolves X's open conflicts via `AutoResolveSupersededConflictsTx` (`internal/storage/trace.go:222`).
+
+A third primitive exists at the HTTP boundary but is not exposed via MCP: `POST /v1/conflicts/{id}/adjudicate` creates an adjudication decision atomically with conflict resolution via `CreateTraceAndAdjudicateConflictTx`. It does **not** set `supersedes_id` on either side of the conflict — the adjudication trace lives parallel to A and B rather than replacing them.
+
+There is no clean primitive for the **synthesis** case: when the right answer to a conflict between decisions A and B is a third decision C that integrates parts of both, with A and B both formally retired. Operators today either pick a false binary or fall back to unstructured `resolution_note` prose — both of which erode the audit trail's utility. The pattern surfaces in akashi's own decision trail: open conflict `cd205a26` is a self-reversal where `claude-code` replaced its Go+Kong choice for the local Supabase orchestrator (ARD-847) with TypeScript+Caddy. The system can model "we picked TS+Caddy" or "we superseded Go+Kong" in isolation but not the structural fact that the second decision retires the first as a strategic course-correction.
+
+Issue [#703](https://github.com/ashita-ai/akashi/issues/703) proposed three changes: (1) relax `akashi_resolve.winning_decision_id` to admit any decision, (2) add an `akashi_reconcile` primitive, (3) make `supersedes_id` multi-valued. After working through the codebase the design diverges from the issue in two places.
+
+## Decision
+
+### Preserve the `winning_decision_id` constraint
+
+Migration 046 introduced `winning_decision_id` with a deliberate split from `resolution_decision_id`, noted in the migration comment: *"Distinct from `resolution_decision_id` (the narrative trace created to document the resolution)."* The first column answers "which side prevailed head-to-head?"; the second points at the trace narrating the resolution.
+
+`winning_decision_id` stays strictly ∈ {A, B, NULL}. The synthesis pointer goes in `resolution_decision_id` (which already has the right semantics) plus rows in a new `decision_supersedes` table. This preserves the queryable head-to-head signal that a relaxed field would lose, and avoids overloading one column with three meanings.
+
+This supersedes the issue's step 1.
+
+### Multi-target supersedes via a join table, not an array column
+
+Add a new table:
+
+```sql
+CREATE TABLE decision_supersedes (
+    superseding_id UUID NOT NULL REFERENCES decisions(id) ON DELETE RESTRICT,
+    superseded_id  UUID NOT NULL REFERENCES decisions(id) ON DELETE RESTRICT,
+    org_id         UUID NOT NULL REFERENCES organizations(id),
+    relationship   TEXT NOT NULL DEFAULT 'supersedes',  -- supersedes | reconciles
+    is_primary     BOOLEAN NOT NULL DEFAULT FALSE,
+    recorded_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (superseding_id, superseded_id)
+);
+CREATE INDEX idx_decision_supersedes_superseded ON decision_supersedes(superseded_id);
+CREATE INDEX idx_decision_supersedes_org ON decision_supersedes(org_id);
+```
+
+`decisions.supersedes_id` is retained as a denormalized "primary" pointer. An invariant — enforced in storage or by trigger — keeps the row marked `is_primary=TRUE` for a given `superseding_id` in sync with `decisions.supersedes_id`. Backfill is one `INSERT … SELECT` from existing non-null `supersedes_id` values (each becomes one row with `is_primary=TRUE`, `relationship='supersedes'`).
+
+Rejected alternative: turn `supersedes_id` into `supersedes_ids UUID[]`. Reasons:
+
+- `decisions` is hot, append-only, and protected by hard immutability triggers (migration 036). ALTER on every row plus carving out the trigger is materially riskier than an additive table.
+- The existing reverse-lookup index (`idx_decisions_supersedes ON decisions(supersedes_id) WHERE supersedes_id IS NOT NULL`) maps directly to a btree on `decision_supersedes(superseded_id)`. Arrays force GIN, which is strictly slower for the "given X, who supersedes it?" direction.
+- Any future per-relationship metadata (relationship type, reason, recorded-by-agent, recorded-at) becomes columns on the join table. With arrays it becomes parallel arrays kept in sync, or JSONB-stuffing — i.e. reinventing the join table badly.
+- Concurrent extension of supersedes (any future "retroactive deprecation" case) is independent inserts on the join table vs lost-update-prone read-modify-write on an array.
+- `EXPLAIN` output for standard JOINs is more readable than for `ANY()` on arrays — operational debuggability matters.
+
+The cost is the two-source-of-truth concern between `decisions.supersedes_id` and the join table. It is bounded by the strict invariant: fixed maintenance, not growing. `integrity.ComputeContentHash` does **not** include `supersedes_id`, so neither approach forces hash recomputation.
+
+### Reconciliation as a distinct decision type
+
+Introduce `decision_type='reconciliation'`. Migration 091 established `decision_type` as a queryable health-signal axis; a flag would create cross-products with every existing type (architecture+reconcile_flag, security+reconcile_flag, …) that complicate aggregation. Reconciliations also have categorically different downstream behavior (≥2 supersedes targets, conflict_id linkage), enough divergence to deserve a name. `decision_type='conflict_resolution'` (already used by adjudicate's default) stays for the case where one of {A, B} wins and the trace narrates *why*; `reconciliation` is the case where neither wins outright and a synthesis retires both.
+
+Reconciliations are assessable via `akashi_assess` like any other decision. They can be wrong (politically convenient mush is a real failure mode); aggregate signal is reconciliation rate per area, correctness stays per-decision.
+
+### Extend adjudicate as substrate; expose reconcile via MCP
+
+`CreateTraceAndAdjudicateConflictTx` is the right substrate. Extend the request to accept `supersedes` (a list of decision IDs); when set, the same transaction writes one `decision_supersedes` row per target with `relationship='reconciles'`, sets `valid_to=now()` on each target, and skips the embedding cascade for the explicit pair (cascade still fires on sibling conflicts in the same group — the explicit pair is already resolved directly).
+
+`HandleAdjudicateConflict` remains the HTTP/API substrate for formal adjudications. It is useful for dashboards and administrative flows that need a linked `resolution_decision_id`, but exposing the generic operation directly to agents would make the MCP surface ask agents to choose between two overlapping "create a decision while resolving a conflict" tools. That is not the gap #703 set out to close.
+
+`akashi_reconcile` is the MCP primitive: it calls the extended adjudicate substrate with `supersedes=[A, B]` and `decision_type='reconciliation'`. `akashi_resolve` stays narrow (governance bookkeeping) — the issue's "What NOT to do" section argues correctly that resolutions and reconciliations are distinct primitives at distinct grains.
+
+### Sequencing
+
+#566 (explicit supersedes suppresses conflict detection) ships **before** the reconcile work. This is a hard precondition, not a parallel ticket. A synthesis decision C with `supersedes_id=A` (and a `decision_supersedes` row for B) embeds close to both A and B by construction; without scorer-side suppression, the next conflict-scoring pass detects new C↔A and C↔B conflicts, semantically undoing the reconcile.
+
+Order:
+
+1. **#566** — conflict scorer reads `decision_supersedes` (and existing `supersedes_id`) and skips pairs in an explicit supersedes relationship.
+2. `decision_supersedes` migration + backfill + invariant trigger.
+3. Extend `CreateTraceAndAdjudicateConflictTx` and `HandleAdjudicateConflict` to write multi-target supersedes.
+4. Add `akashi_reconcile` as the MCP tool for synthesis.
+
+## Consequences
+
+- The audit graph gains a first-class shape for synthesis decisions. Queries like "every conflict resolved by reconciliation" become expressible as `decision_type='reconciliation'` filtered by `resolution_decision_id` join.
+- `winning_decision_id` retains a single, queryable meaning (head-to-head winner). The "who wins head-to-head?" signal stays clean.
+- The single-target supersedes case is unchanged — the existing `supersedes_id` paths keep working with no SDK or storage churn. Only `decision_supersedes` is new.
+- Schema-level evolution of supersedes relationships (per-relationship metadata, future relationship types like `deprecates`) is easy — add columns to `decision_supersedes`.
+- The denormalization invariant between `decisions.supersedes_id` and `decision_supersedes(is_primary=TRUE)` adds a small write-path cost: every insert/update of `supersedes_id` requires a paired write to the join table. Enforced in `internal/storage/trace.go` and `internal/storage/decisions.go` (and the SQLite mirrors), with triggers mirroring the primary pointer as a safety net.
+- The conflict scorer becomes aware of explicit supersedes relationships (#566). This is a behavior change for any agent that today relies on the scorer re-detecting a pair after one side is superseded — none in-tree, but documented in the #566 changelog.
+- A high reconciliation rate in a project area becomes a project-health signal — synthesis-prone domains may warrant out-of-band discussion (ADRs, design reviews). This is opt-in observation; not built into auto-actions.
+- The cascade-resolve embedding heuristic (cosine ≥ 0.80 on outcome embeddings) is **not** removed. It still applies for sibling conflicts in the same group; only the explicit pair is skipped.
+
+## References
+
+- [Issue #703](https://github.com/ashita-ai/akashi/issues/703) — original proposal (this ADR supersedes the issue's step 1)
+- [Issue #566](https://github.com/ashita-ai/akashi/issues/566) — explicit supersedes suppression in conflict detection (precondition)
+- akashi decision `12849064-1c68-4581-98ab-7fe28112a1d8` — design call traced in the audit log
+- `migrations/046_winning_decision_id.sql` — establishes the `winning_decision_id` vs `resolution_decision_id` distinction this ADR preserves
+- `migrations/038_conflict_precision.sql` — adds `resolution_decision_id` to `scored_conflicts`
+- `migrations/036_decision_immutability.sql` — immutability triggers that motivate the join-table choice
+- `migrations/091_decision_type_aliases.sql` — establishes `decision_type` as a queryable axis
+- `internal/storage/trace.go` — `CreateTraceAndAdjudicateConflictTx`, the substrate that gets extended
+- `internal/server/handlers_conflicts.go` — `HandleAdjudicateConflict`, the HTTP/API surface extended with multi-target supersedes
+- `internal/conflicts/scorer.go` — where #566 lands

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -4055,8 +4055,7 @@ components:
           description: Why this adjudication was chosen.
         decision_type:
           type: string
-          default: conflict_resolution
-          description: Decision type for the adjudication trace (defaults to "conflict_resolution").
+          description: Decision type for the adjudication trace. Defaults to "conflict_resolution", or "reconciliation" when multiple supersedes entries are supplied.
         winning_decision_id:
           type: string
           format: uuid
@@ -4064,6 +4063,16 @@ components:
             Optional. The decision judged to be correct. Must be decision_a_id or
             decision_b_id of the conflict being adjudicated. When omitted, the conflict
             is resolved without declaring a winner.
+        supersedes:
+          type: array
+          description: |
+            Optional. Conflict-side decisions retired by the adjudication decision.
+            Each entry must be decision_a_id or decision_b_id. When multiple entries
+            are supplied, the adjudication is a synthesis/reconciliation decision.
+          items:
+            type: string
+            format: uuid
+          uniqueItems: true
 
     # ── API Key schemas ─────────────────────────────────────────────
     APIKey:

--- a/internal/conflicts/lite_scorer.go
+++ b/internal/conflicts/lite_scorer.go
@@ -48,6 +48,20 @@ func (s *LiteScorer) ScoreForDecision(ctx context.Context, decisionID, orgID uui
 		return
 	}
 
+	// Build the revision chain set for the source. Any candidate in this chain
+	// is an intentional supersession (or a prior revision of the same line of
+	// thought), not a conflict — exclude it explicitly. Today the trace pipeline
+	// also sets valid_to on direct supersedes targets so loadCandidates would
+	// filter them out anyway, but explicit chain consultation makes the contract
+	// independent of that side effect (matches the full Scorer at scorer.go:414)
+	// and is forward-compatible with multi-target supersedes (decision_supersedes
+	// join table per ADR-016) and any future relationship that does not invalidate.
+	revisionChain, err := queryRevisionChainIDs(ctx, s.db, decisionID, orgID)
+	if err != nil {
+		s.logger.Warn("lite conflict scorer: revision chain query failed", "decision_id", decisionID, "error", err)
+		revisionChain = nil
+	}
+
 	// 2. Load recent same-type decisions from other agents (candidate pool).
 	candidates, err := s.loadCandidates(ctx, orgID, src)
 	if err != nil {
@@ -60,6 +74,10 @@ func (s *LiteScorer) ScoreForDecision(ctx context.Context, decisionID, orgID uui
 
 	// 3. Score each candidate pair.
 	for _, cand := range candidates {
+		if _, inChain := revisionChain[cand.id]; inChain {
+			continue
+		}
+
 		candClaims := SplitClaims(cand.outcome)
 		if len(candClaims) == 0 {
 			continue
@@ -360,4 +378,75 @@ func jaccardSimilarity(a, b map[string]bool) float32 {
 		return 0
 	}
 	return float32(intersection) / float32(union)
+}
+
+// queryRevisionChainIDs returns all decision IDs in the same supersedes chain
+// as the given decision, walking forward (decisions that supersede this one)
+// and backward (decisions this one supersedes), capped at 100 hops in each
+// direction. The result excludes the input ID itself. Mirrors the PostgreSQL
+// helper at internal/storage/decisions.go:GetRevisionChainIDs so that lite mode
+// has the same explicit chain-exclusion contract as full mode.
+func queryRevisionChainIDs(ctx context.Context, db *sql.DB, id, orgID uuid.UUID) (map[uuid.UUID]struct{}, error) {
+	const q = `
+	WITH RECURSIVE
+	edges AS (
+		SELECT id AS superseding_id, supersedes_id AS superseded_id, org_id
+		FROM decisions
+		WHERE supersedes_id IS NOT NULL AND org_id = ?
+		UNION
+		SELECT superseding_id, superseded_id, org_id
+		FROM decision_supersedes
+		WHERE org_id = ?
+	),
+	forward_chain(id, supersedes_id, depth) AS (
+		SELECT id, supersedes_id, 0 FROM decisions WHERE id = ? AND org_id = ?
+		UNION ALL
+		SELECT d.id, d.supersedes_id, fc.depth + 1
+		FROM edges e
+		INNER JOIN decisions d ON d.id = e.superseding_id AND d.org_id = e.org_id
+		INNER JOIN forward_chain fc ON e.superseded_id = fc.id
+		WHERE e.org_id = ? AND fc.depth < 100
+	),
+	backward_chain(id, supersedes_id, depth) AS (
+		SELECT id, supersedes_id, 0 FROM decisions WHERE id = ? AND org_id = ?
+		UNION ALL
+		SELECT d.id, d.supersedes_id, bc.depth + 1
+		FROM edges e
+		INNER JOIN decisions d ON d.id = e.superseded_id AND d.org_id = e.org_id
+		INNER JOIN backward_chain bc ON e.superseding_id = bc.id
+		WHERE e.org_id = ? AND bc.depth < 100
+	)
+	SELECT DISTINCT chain_id FROM (
+		SELECT id AS chain_id FROM forward_chain WHERE id != ?
+		UNION
+		SELECT id AS chain_id FROM backward_chain WHERE id != ?
+	)`
+
+	rows, err := db.QueryContext(ctx, q,
+		orgID.String(),
+		orgID.String(),
+		id.String(), orgID.String(),
+		orgID.String(),
+		id.String(), orgID.String(),
+		orgID.String(),
+		id.String(), id.String(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query revision chain: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck
+
+	chain := make(map[uuid.UUID]struct{})
+	for rows.Next() {
+		var idStr string
+		if err := rows.Scan(&idStr); err != nil {
+			return nil, fmt.Errorf("scan revision chain id: %w", err)
+		}
+		cid, err := uuid.Parse(idStr)
+		if err != nil {
+			return nil, fmt.Errorf("parse revision chain id %q: %w", idStr, err)
+		}
+		chain[cid] = struct{}{}
+	}
+	return chain, rows.Err()
 }

--- a/internal/conflicts/lite_scorer_test.go
+++ b/internal/conflicts/lite_scorer_test.go
@@ -34,6 +34,7 @@ func openTestDB(t *testing.T) *sql.DB {
 			confidence REAL NOT NULL,
 			reasoning TEXT,
 			embedding BLOB,
+			supersedes_id TEXT,
 			valid_from TEXT NOT NULL,
 			valid_to TEXT,
 			project TEXT,
@@ -80,6 +81,15 @@ func openTestDB(t *testing.T) *sql.DB {
 			group_topic TEXT,
 			first_detected_at TEXT NOT NULL DEFAULT (datetime('now')),
 			last_detected_at TEXT NOT NULL DEFAULT (datetime('now'))
+		);
+		CREATE TABLE decision_supersedes (
+			superseding_id TEXT NOT NULL,
+			superseded_id TEXT NOT NULL,
+			org_id TEXT NOT NULL,
+			relationship TEXT NOT NULL DEFAULT 'supersedes',
+			is_primary INTEGER NOT NULL DEFAULT 0,
+			recorded_at TEXT NOT NULL DEFAULT (datetime('now')),
+			PRIMARY KEY (superseding_id, superseded_id)
 		)`)
 	require.NoError(t, err)
 	return db
@@ -92,6 +102,38 @@ func insertTestDecision(t *testing.T, db *sql.DB, id, orgID uuid.UUID, agentID, 
 		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
 		id.String(), orgID.String(), agentID, decType, outcome, 0.9,
 		time.Now().UTC().Format(time.RFC3339Nano),
+	)
+	require.NoError(t, err)
+}
+
+// insertSupersedingDecision inserts a decision that supersedes another. The
+// caller must explicitly set the superseded decision's valid_to in tests where
+// that side effect matters — this helper does not invalidate the target,
+// because some tests need to verify chain exclusion independently of the
+// valid_to filter (which would otherwise mask the presence or absence of the
+// chain check).
+func insertSupersedingDecision(t *testing.T, db *sql.DB, id, orgID uuid.UUID, agentID, decType, outcome string, supersedesID uuid.UUID) {
+	t.Helper()
+	_, err := db.Exec(
+		`INSERT INTO decisions (id, org_id, agent_id, decision_type, outcome, confidence, supersedes_id, valid_from)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		id.String(), orgID.String(), agentID, decType, outcome, 0.9,
+		supersedesID.String(),
+		time.Now().UTC().Format(time.RFC3339Nano),
+	)
+	require.NoError(t, err)
+}
+
+func insertSupersedesEdge(t *testing.T, db *sql.DB, supersedingID, supersededID, orgID uuid.UUID, relationship string, isPrimary bool) {
+	t.Helper()
+	primary := 0
+	if isPrimary {
+		primary = 1
+	}
+	_, err := db.Exec(
+		`INSERT INTO decision_supersedes (superseding_id, superseded_id, org_id, relationship, is_primary)
+		 VALUES (?, ?, ?, ?, ?)`,
+		supersedingID.String(), supersededID.String(), orgID.String(), relationship, primary,
 	)
 	require.NoError(t, err)
 }
@@ -440,4 +482,159 @@ func TestLiteScorer_ProjectScoping(t *testing.T) {
 	// but with different non-nil projects they should not match.
 	// This depends on the SQL logic — verify the actual behavior.
 	assert.LessOrEqual(t, count, 1, "different-project decisions may or may not conflict depending on SQL scoping")
+}
+
+// TestLiteScorer_RevisionChainExcluded verifies that a decision in the source's
+// supersedes chain is NOT flagged as a conflict, even when its outcome diverges
+// from the source's. This guards the contract independently of the valid_to
+// filter — the test inserts the chain ancestor as still-active so a chain-blind
+// scorer would create a conflict.
+func TestLiteScorer_RevisionChainExcluded(t *testing.T) {
+	db := openTestDB(t)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	scorer := NewLiteScorer(db, logger)
+	ctx := context.Background()
+	orgID := uuid.New()
+
+	older := uuid.New()
+	newer := uuid.New()
+	insertTestDecision(t, db, older, orgID, "agent-a", "architecture",
+		"Use PostgreSQL for persistent storage with connection pooling and read replicas")
+	insertSupersedingDecision(t, db, newer, orgID, "agent-a", "architecture",
+		"Use MongoDB for persistent storage with sharding and replica sets",
+		older,
+	)
+
+	scorer.ScoreForDecision(ctx, newer, orgID)
+
+	var count int
+	require.NoError(t, db.QueryRow("SELECT COUNT(*) FROM scored_conflicts").Scan(&count))
+	assert.Equal(t, 0, count, "the older decision is in newer's supersedes chain — not a conflict")
+}
+
+// TestLiteScorer_TransitiveChainExcluded verifies multi-hop chain walking.
+// A → B → C: when C is scored, both A and B should be excluded as chain
+// members even though the only direct supersedes pointer on C points at B.
+func TestLiteScorer_TransitiveChainExcluded(t *testing.T) {
+	db := openTestDB(t)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	scorer := NewLiteScorer(db, logger)
+	ctx := context.Background()
+	orgID := uuid.New()
+
+	a := uuid.New()
+	b := uuid.New()
+	c := uuid.New()
+	insertTestDecision(t, db, a, orgID, "agent-a", "architecture",
+		"Use Redis for caching with 5-minute TTL and LRU eviction")
+	insertSupersedingDecision(t, db, b, orgID, "agent-a", "architecture",
+		"Use Memcached for caching with 10-minute TTL and consistent hashing",
+		a,
+	)
+	insertSupersedingDecision(t, db, c, orgID, "agent-a", "architecture",
+		"Use Hazelcast for caching with 1-minute TTL and partition-aware routing",
+		b,
+	)
+
+	scorer.ScoreForDecision(ctx, c, orgID)
+
+	var count int
+	require.NoError(t, db.QueryRow("SELECT COUNT(*) FROM scored_conflicts").Scan(&count))
+	assert.Equal(t, 0, count, "transitive chain ancestors A and B must both be excluded when scoring C")
+}
+
+// TestLiteScorer_BackwardChainExcluded verifies that walking backward from the
+// source (decisions the source supersedes) is also excluded. This direction
+// matters when the scorer is invoked on an older decision that has been
+// superseded by a newer one — the newer decision must not be flagged as a
+// conflict against the older one.
+func TestLiteScorer_BackwardChainExcluded(t *testing.T) {
+	db := openTestDB(t)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	scorer := NewLiteScorer(db, logger)
+	ctx := context.Background()
+	orgID := uuid.New()
+
+	older := uuid.New()
+	newer := uuid.New()
+	insertTestDecision(t, db, older, orgID, "agent-a", "architecture",
+		"Use PostgreSQL for persistent storage with connection pooling and read replicas")
+	insertSupersedingDecision(t, db, newer, orgID, "agent-a", "architecture",
+		"Use MongoDB for persistent storage with sharding and replica sets",
+		older,
+	)
+
+	// Score the older decision. The newer (which supersedes it) is reachable
+	// via the forward direction of the chain walk and must be excluded.
+	scorer.ScoreForDecision(ctx, older, orgID)
+
+	var count int
+	require.NoError(t, db.QueryRow("SELECT COUNT(*) FROM scored_conflicts").Scan(&count))
+	assert.Equal(t, 0, count, "the newer decision supersedes older — not a conflict in either direction")
+}
+
+// TestLiteScorer_UnrelatedDecisionStillConflicts verifies that the chain
+// exclusion is targeted: a decision NOT in the chain still produces a conflict
+// when its outcome diverges from the source. Guards against the chain query
+// returning a too-wide result (e.g., walking via NULL joins) that would mask
+// real conflicts.
+func TestLiteScorer_UnrelatedDecisionStillConflicts(t *testing.T) {
+	db := openTestDB(t)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	scorer := NewLiteScorer(db, logger)
+	ctx := context.Background()
+	orgID := uuid.New()
+
+	chainOlder := uuid.New()
+	chainNewer := uuid.New()
+	unrelated := uuid.New()
+
+	insertTestDecision(t, db, chainOlder, orgID, "agent-a", "architecture",
+		"Use PostgreSQL for persistent storage with connection pooling and read replicas")
+	insertSupersedingDecision(t, db, chainNewer, orgID, "agent-a", "architecture",
+		"Use MongoDB for persistent storage with sharding and replica sets",
+		chainOlder,
+	)
+	// Unrelated decision: same topic, different agent, no supersedes link.
+	insertTestDecision(t, db, unrelated, orgID, "agent-b", "architecture",
+		"Use Cassandra for persistent storage with multi-datacenter replication and tunable consistency")
+
+	scorer.ScoreForDecision(ctx, chainNewer, orgID)
+
+	var count int
+	require.NoError(t, db.QueryRow(
+		`SELECT COUNT(*) FROM scored_conflicts
+		 WHERE (decision_a_id = ? AND decision_b_id = ?)
+		    OR (decision_a_id = ? AND decision_b_id = ?)`,
+		chainNewer.String(), unrelated.String(),
+		unrelated.String(), chainNewer.String(),
+	).Scan(&count))
+	assert.Equal(t, 1, count, "unrelated decision with no chain link must still conflict")
+}
+
+func TestLiteScorer_DecisionSupersedesEdgeExcluded(t *testing.T) {
+	db := openTestDB(t)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	scorer := NewLiteScorer(db, logger)
+	ctx := context.Background()
+	orgID := uuid.New()
+
+	a := uuid.New()
+	b := uuid.New()
+	c := uuid.New()
+	insertTestDecision(t, db, a, orgID, "agent-a", "architecture",
+		"Use PostgreSQL for persistent storage with connection pooling and read replicas")
+	insertTestDecision(t, db, b, orgID, "agent-b", "architecture",
+		"Use MySQL for persistent storage with read replicas and connection pooling")
+	insertTestDecision(t, db, c, orgID, "agent-c", "architecture",
+		"Use MongoDB for persistent storage with sharding and replica sets")
+
+	insertSupersedesEdge(t, db, c, a, orgID, "reconciles", true)
+	insertSupersedesEdge(t, db, c, b, orgID, "reconciles", false)
+
+	scorer.ScoreForDecision(ctx, c, orgID)
+
+	var count int
+	require.NoError(t, db.QueryRow("SELECT COUNT(*) FROM scored_conflicts").Scan(&count))
+	assert.Equal(t, 0, count, "decision_supersedes join-table targets must be excluded even without direct supersedes_id")
 }

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -39,6 +39,7 @@ TOOLS:
 - akashi_query: filter or search the audit trail by type, agent, confidence, or free-text
 - akashi_conflicts: list and filter open conflicts between agents
 - akashi_resolve: resolve a conflict or mark it as a false positive (set winner or false_positive)
+- akashi_reconcile: resolve a conflict with a synthesis decision that retires both sides
 - akashi_assess: record whether a prior decision turned out to be correct
 - akashi_stats: aggregate health metrics for the decision trail
 

--- a/internal/mcp/prompts.go
+++ b/internal/mcp/prompts.go
@@ -157,6 +157,7 @@ can learn from it, and so the decision is provable later.
 - akashi_query: Query the audit trail — structured filters or natural-language query for semantic search
 - akashi_conflicts: List open conflicts between agents
 - akashi_resolve: Resolve a conflict or mark it as a false positive (set winner or false_positive)
+- akashi_reconcile: Resolve a conflict with a synthesis decision that retires both sides
 - akashi_assess: Record whether a past decision turned out to be correct
 - akashi_stats: Aggregate health metrics for the decision trail
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -469,6 +469,32 @@ EXAMPLE: After a user says "go with approach A", call akashi_resolve with
 		),
 		s.handleResolve,
 	)
+
+	// akashi_reconcile — synthesize a new decision that retires both conflict sides.
+	s.mcpServer.AddTool(
+		mcplib.NewTool("akashi_reconcile",
+			mcplib.WithDescription(`Resolve a conflict with a synthesis decision that retires both original decisions.
+
+Use this when neither side should win outright. The tool records a
+decision_type="reconciliation" trace, resolves the conflict, writes supersedes
+edges for both sides, and invalidates both original decisions in one transaction.`),
+			mcplib.WithDestructiveHintAnnotation(false),
+			mcplib.WithIdempotentHintAnnotation(false),
+			mcplib.WithOpenWorldHintAnnotation(true),
+			mcplib.WithString("conflict_id",
+				mcplib.Description("UUID of the scored conflict to reconcile"),
+				mcplib.Required(),
+			),
+			mcplib.WithString("outcome",
+				mcplib.Description("The synthesized decision that replaces both conflict sides"),
+				mcplib.Required(),
+			),
+			mcplib.WithString("reasoning",
+				mcplib.Description("Optional explanation for the synthesis"),
+			),
+		),
+		s.handleReconcile,
+	)
 }
 
 // resolveProjectFilter returns the project filter to apply to a read operation.
@@ -1911,6 +1937,132 @@ func (s *Server) handleResolve(ctx context.Context, request mcplib.CallToolReque
 
 	// Not a scored_conflict ID — try resolving as a conflict_group ID.
 	return s.resolveGroup(ctx, conflictID, orgID, status, resolvedBy, actorRole, resolutionNote, winningDecisionID, fpLabel)
+}
+
+func (s *Server) handleReconcile(ctx context.Context, request mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+	orgID := ctxutil.OrgIDFromContext(ctx)
+	claims := ctxutil.ClaimsFromContext(ctx)
+	if claims == nil {
+		return errorResult("authentication required"), nil
+	}
+
+	conflictIDStr := request.GetString("conflict_id", "")
+	if conflictIDStr == "" {
+		return errorResult("conflict_id is required"), nil
+	}
+	conflictID, err := uuid.Parse(conflictIDStr)
+	if err != nil {
+		return errorResult("conflict_id must be a valid UUID"), nil
+	}
+
+	outcome := strings.TrimSpace(request.GetString("outcome", ""))
+	if outcome == "" {
+		return errorResult("outcome is required"), nil
+	}
+	if len(outcome) > model.MaxOutcomeLen {
+		return errorResult(fmt.Sprintf("outcome exceeds maximum length of %d bytes", model.MaxOutcomeLen)), nil
+	}
+	reasoning := strings.TrimSpace(request.GetString("reasoning", ""))
+	if len(reasoning) > model.MaxReasoningLen {
+		return errorResult(fmt.Sprintf("reasoning exceeds maximum length of %d bytes", model.MaxReasoningLen)), nil
+	}
+	var reasoningPtr *string
+	if reasoning != "" {
+		reasoningPtr = &reasoning
+	}
+
+	conflict, err := s.db.GetConflict(ctx, conflictID, orgID)
+	if err != nil {
+		return errorResult(fmt.Sprintf("failed to get conflict: %v", err)), nil
+	}
+	if conflict == nil {
+		return errorResult("conflict not found"), nil
+	}
+
+	supersedesIDs := []uuid.UUID{conflict.DecisionAID, conflict.DecisionBID}
+	const decisionType = "reconciliation"
+	resolvedBy := claims.AgentID
+	if resolvedBy == "" {
+		resolvedBy = claims.Subject
+	}
+	if err := model.ValidateAgentID(resolvedBy); err != nil {
+		return errorResult(fmt.Sprintf("invalid agent_id: %v", err)), nil
+	}
+	autoRegAudit := &storage.MutationAuditEntry{
+		OrgID:        orgID,
+		ActorAgentID: claims.AgentID,
+		ActorRole:    string(claims.Role),
+		Endpoint:     "mcp/akashi_reconcile",
+	}
+	if _, err := s.decisionSvc.ResolveOrCreateAgent(ctx, orgID, resolvedBy, claims.Role, autoRegAudit); err != nil {
+		return errorResult(err.Error()), nil
+	}
+
+	auditMeta := &ctxutil.AuditMeta{
+		RequestID:    uuid.New().String(),
+		OrgID:        orgID,
+		ActorAgentID: resolvedBy,
+		ActorRole:    string(claims.Role),
+		HTTPMethod:   "MCP",
+		Endpoint:     "akashi_reconcile",
+	}
+	conflictAudit := storage.MutationAuditEntry{
+		RequestID:    auditMeta.RequestID,
+		OrgID:        orgID,
+		ActorAgentID: resolvedBy,
+		ActorRole:    string(claims.Role),
+		HTTPMethod:   "MCP",
+		Endpoint:     "mcp/akashi_reconcile",
+		Operation:    "conflict_reconciled_with_decision",
+		ResourceType: "conflict",
+		ResourceID:   conflictID.String(),
+		Metadata:     map[string]any{"resolved_by": resolvedBy},
+	}
+
+	note := "Resolved by reconciliation trace"
+	result, err := s.decisionSvc.AdjudicateConflictWithTrace(ctx, orgID, decisions.TraceInput{
+		AgentID: resolvedBy,
+		Decision: model.TraceDecision{
+			DecisionType: decisionType,
+			Outcome:      outcome,
+			Confidence:   1.0,
+			Reasoning:    reasoningPtr,
+		},
+		SupersedesIDs: supersedesIDs,
+		APIKeyID:      claims.APIKeyID,
+		AuditMeta:     auditMeta,
+	}, storage.AdjudicateConflictInTraceParams{
+		ConflictID:    conflictID,
+		ResolvedBy:    resolvedBy,
+		ResNote:       &note,
+		Audit:         conflictAudit,
+		SupersedesIDs: supersedesIDs,
+		Relationship:  "reconciles",
+	})
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return errorResult("conflict not found"), nil
+		}
+		if errors.Is(err, storage.ErrSupersededDecisionNotInConflict) {
+			return errorResult("supersedes entries must be one of the two decisions in this conflict"), nil
+		}
+		return errorResult(fmt.Sprintf("failed to reconcile conflict: %v", err)), nil
+	}
+
+	resultData, _ := json.MarshalIndent(map[string]any{
+		"conflict_id":       conflictID,
+		"decision_id":       result.DecisionID,
+		"decision_type":     decisionType,
+		"status":            "resolved",
+		"resolved_by":       resolvedBy,
+		"supersedes":        supersedesIDs,
+		"embedding_skipped": result.EmbeddingSkipped,
+	}, "", "  ")
+	return &mcplib.CallToolResult{
+		Content: []mcplib.Content{
+			mcplib.TextContent{Type: "text", Text: string(resultData)},
+		},
+	}, nil
 }
 
 // resolveSingleConflict attempts to resolve the given ID as a scored_conflict.

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -770,12 +770,11 @@ func TestHandleTrace_NonAdminCrossTrace(t *testing.T) {
 	assert.Contains(t, parseToolText(t, result), "agents can only record decisions for their own agent_id")
 }
 
-// ---------- Verify all 5 tools are registered ----------
+// ---------- Verify tools are registered ----------
 
 func TestRegisterTools(t *testing.T) {
 	// The server's registerTools is called during New(). Verify the MCPServer
-	// has the 6 expected tools registered: akashi_check, akashi_trace,
-	// akashi_query, akashi_conflicts, akashi_assess, akashi_stats.
+	// has the expected tools registered.
 	// We verify indirectly by ensuring the server is initialized correctly.
 	assert.NotNil(t, testServer.mcpServer, "MCPServer should be initialized")
 	assert.NotNil(t, testServer.MCPServer(), "MCPServer() accessor should work")
@@ -2758,6 +2757,15 @@ func resolveRequest(args map[string]any) mcplib.CallToolRequest {
 	}
 }
 
+func reconcileRequest(args map[string]any) mcplib.CallToolRequest {
+	return mcplib.CallToolRequest{
+		Params: mcplib.CallToolParams{
+			Name:      "akashi_reconcile",
+			Arguments: args,
+		},
+	}
+}
+
 // seedConflictWithDecisions creates two decisions and a conflict, returning
 // the conflict ID and both decision IDs for use in resolve tests.
 func seedConflictWithDecisions(t *testing.T) (conflictID uuid.UUID, decAID, decBID string) {
@@ -2833,6 +2841,73 @@ func TestHandleResolve_WithWinner(t *testing.T) {
 	assert.Equal(t, "open", resp.OldStatus)
 	assert.Equal(t, "resolved", resp.NewStatus)
 	assert.Equal(t, testAdminID, resp.ResolvedBy)
+}
+
+func TestHandleReconcile_Success(t *testing.T) {
+	ctx := adminCtx()
+	conflictID, decAID, decBID := seedConflictWithDecisions(t)
+
+	result, err := testServer.handleReconcile(ctx, reconcileRequest(map[string]any{
+		"conflict_id": conflictID.String(),
+		"outcome":     "synthesized approach C",
+		"reasoning":   "A has the right scope, B has the right sequencing",
+	}))
+	require.NoError(t, err)
+	require.False(t, result.IsError, "reconcile should succeed: %s", parseToolText(t, result))
+
+	var resp struct {
+		ConflictID   string   `json:"conflict_id"`
+		DecisionID   string   `json:"decision_id"`
+		DecisionType string   `json:"decision_type"`
+		Status       string   `json:"status"`
+		ResolvedBy   string   `json:"resolved_by"`
+		Supersedes   []string `json:"supersedes"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(parseToolText(t, result)), &resp))
+	assert.Equal(t, conflictID.String(), resp.ConflictID)
+	assert.Equal(t, "reconciliation", resp.DecisionType)
+	assert.Equal(t, "resolved", resp.Status)
+	assert.Equal(t, testAdminID, resp.ResolvedBy)
+	assert.ElementsMatch(t, []string{decAID, decBID}, resp.Supersedes)
+
+	reconciliationID, err := uuid.Parse(resp.DecisionID)
+	require.NoError(t, err)
+	parsedA, err := uuid.Parse(decAID)
+	require.NoError(t, err)
+	parsedB, err := uuid.Parse(decBID)
+	require.NoError(t, err)
+
+	updated, err := testDB.GetConflict(ctx, conflictID, uuid.Nil)
+	require.NoError(t, err)
+	require.NotNil(t, updated)
+	assert.Equal(t, "resolved", updated.Status)
+	require.NotNil(t, updated.ResolutionDecisionID)
+	assert.Equal(t, reconciliationID, *updated.ResolutionDecisionID)
+	assert.Nil(t, updated.WinningDecisionID, "reconciliation should not declare either side the binary winner")
+
+	reconciliation, err := testDB.GetDecision(ctx, uuid.Nil, reconciliationID, storage.GetDecisionOpts{})
+	require.NoError(t, err)
+	assert.Equal(t, "reconciliation", reconciliation.DecisionType)
+	require.NotNil(t, reconciliation.SupersedesID)
+	assert.Contains(t, []uuid.UUID{parsedA, parsedB}, *reconciliation.SupersedesID)
+
+	decisionA, err := testDB.GetDecision(ctx, uuid.Nil, parsedA, storage.GetDecisionOpts{})
+	require.NoError(t, err)
+	require.NotNil(t, decisionA.ValidTo)
+	decisionB, err := testDB.GetDecision(ctx, uuid.Nil, parsedB, storage.GetDecisionOpts{})
+	require.NoError(t, err)
+	require.NotNil(t, decisionB.ValidTo)
+
+	var edgeCount int
+	require.NoError(t, testDB.Pool().QueryRow(ctx, `
+		SELECT COUNT(*)
+		FROM decision_supersedes
+		WHERE org_id = $1
+		  AND superseding_id = $2
+		  AND relationship = 'reconciles'`,
+		uuid.Nil, reconciliationID,
+	).Scan(&edgeCount))
+	assert.Equal(t, 2, edgeCount)
 }
 
 func TestHandleResolve_FalsePositive(t *testing.T) {

--- a/internal/server/handlers_conflicts.go
+++ b/internal/server/handlers_conflicts.go
@@ -294,10 +294,11 @@ func (h *Handlers) HandleAdjudicateConflict(w http.ResponseWriter, r *http.Reque
 	}
 
 	var req struct {
-		Outcome           string     `json:"outcome"`
-		Reasoning         *string    `json:"reasoning,omitempty"`
-		DecisionType      string     `json:"decision_type,omitempty"`
-		WinningDecisionID *uuid.UUID `json:"winning_decision_id,omitempty"`
+		Outcome           string      `json:"outcome"`
+		Reasoning         *string     `json:"reasoning,omitempty"`
+		DecisionType      string      `json:"decision_type,omitempty"`
+		WinningDecisionID *uuid.UUID  `json:"winning_decision_id,omitempty"`
+		Supersedes        []uuid.UUID `json:"supersedes,omitempty"`
 	}
 	if err := decodeJSON(w, r, &req, h.maxRequestBodyBytes); err != nil {
 		handleDecodeError(w, r, err)
@@ -308,7 +309,11 @@ func (h *Handlers) HandleAdjudicateConflict(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	if req.DecisionType == "" {
-		req.DecisionType = "conflict_resolution"
+		if len(req.Supersedes) > 1 {
+			req.DecisionType = "reconciliation"
+		} else {
+			req.DecisionType = "conflict_resolution"
+		}
 	}
 
 	// Verify the conflict exists and belongs to this org.
@@ -323,6 +328,13 @@ func (h *Handlers) HandleAdjudicateConflict(w http.ResponseWriter, r *http.Reque
 		if *req.WinningDecisionID != conflict.DecisionAID && *req.WinningDecisionID != conflict.DecisionBID {
 			writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput,
 				"winning_decision_id must be one of the two decisions in this conflict")
+			return
+		}
+	}
+	for _, supersededID := range req.Supersedes {
+		if supersededID != conflict.DecisionAID && supersededID != conflict.DecisionBID {
+			writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput,
+				"supersedes entries must be one of the two decisions in this conflict")
 			return
 		}
 	}
@@ -357,18 +369,26 @@ func (h *Handlers) HandleAdjudicateConflict(w http.ResponseWriter, r *http.Reque
 			Confidence:   1.0, // Adjudication decisions are definitive.
 			Reasoning:    req.Reasoning,
 		},
-		APIKeyID:  claims.APIKeyID,
-		AuditMeta: h.buildAuditMeta(r, orgID),
+		SupersedesIDs: req.Supersedes,
+		APIKeyID:      claims.APIKeyID,
+		AuditMeta:     h.buildAuditMeta(r, orgID),
 	}, storage.AdjudicateConflictInTraceParams{
 		ConflictID:        id,
 		ResolvedBy:        resolverAgent,
 		ResNote:           &note,
 		Audit:             conflictAudit,
 		WinningDecisionID: req.WinningDecisionID,
+		SupersedesIDs:     req.Supersedes,
+		Relationship:      "reconciles",
 	})
 	if err != nil {
 		if isNotFoundError(err) {
 			writeError(w, r, http.StatusNotFound, model.ErrCodeNotFound, "conflict not found")
+			return
+		}
+		if errors.Is(err, storage.ErrSupersededDecisionNotInConflict) {
+			writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput,
+				"supersedes entries must be one of the two decisions in this conflict")
 			return
 		}
 		h.writeInternalError(w, r, "failed to adjudicate conflict", err)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -589,7 +589,7 @@ func TestMCPListTools(t *testing.T) {
 
 	toolsResult, err := c.ListTools(ctx, mcplib.ListToolsRequest{})
 	require.NoError(t, err)
-	assert.Len(t, toolsResult.Tools, 7)
+	assert.Len(t, toolsResult.Tools, 8)
 
 	toolNames := make(map[string]bool)
 	for _, tool := range toolsResult.Tools {
@@ -600,6 +600,7 @@ func TestMCPListTools(t *testing.T) {
 	assert.True(t, toolNames["akashi_query"], "expected akashi_query tool")
 	assert.True(t, toolNames["akashi_conflicts"], "expected akashi_conflicts tool")
 	assert.True(t, toolNames["akashi_resolve"], "expected akashi_resolve tool")
+	assert.True(t, toolNames["akashi_reconcile"], "expected akashi_reconcile tool")
 	assert.True(t, toolNames["akashi_stats"], "expected akashi_stats tool")
 	assert.True(t, toolNames["akashi_assess"], "expected akashi_assess tool")
 }

--- a/internal/service/decisions/service.go
+++ b/internal/service/decisions/service.go
@@ -217,6 +217,7 @@ type TraceInput struct {
 	PrecedentRef    *uuid.UUID
 	PrecedentReason *string
 	SupersedesID    *uuid.UUID     // Decision this one explicitly replaces.
+	SupersedesIDs   []uuid.UUID    // Decisions this one explicitly replaces.
 	SessionID       *uuid.UUID     // MCP session or X-Akashi-Session header.
 	AgentContext    map[string]any // Merged server-extracted + client-supplied context.
 	APIKeyID        *uuid.UUID     // Managed API key that authenticated this request.
@@ -306,6 +307,11 @@ func (s *Service) AdjudicateConflictWithTrace(ctx context.Context, orgID uuid.UU
 // scoring, alternatives, evidence, and audit entry construction. Returns the
 // fully-prepared CreateTraceParams ready for a transactional write.
 func (s *Service) prepareTrace(ctx context.Context, orgID uuid.UUID, input TraceInput) (storage.CreateTraceParams, error) {
+	if input.SupersedesID == nil && len(input.SupersedesIDs) > 0 {
+		primary := input.SupersedesIDs[0]
+		input.SupersedesID = &primary
+	}
+
 	// 0. Normalize decision_type to lowercase. This is the canonical
 	// normalization point — all paths (HTTP, MCP, SDK) converge here.
 	input.Decision.DecisionType = strings.ToLower(strings.TrimSpace(input.Decision.DecisionType))
@@ -583,7 +589,7 @@ func (s *Service) postTraceAsync(ctx context.Context, orgID uuid.UUID, input Tra
 
 	// Auto-assess based on observable signals. Runs in a goroutine so it
 	// doesn't block the trace response (DB queries + assessment writes).
-	if s.autoAssessor != nil && (input.SupersedesID != nil || input.PrecedentRef != nil) {
+	if s.autoAssessor != nil && (input.SupersedesID != nil || len(input.SupersedesIDs) > 0 || input.PrecedentRef != nil) {
 		s.asyncWg.Add(1)
 		go func() {
 			defer s.asyncWg.Done()
@@ -597,6 +603,12 @@ func (s *Service) postTraceAsync(ctx context.Context, orgID uuid.UUID, input Tra
 
 			if input.SupersedesID != nil {
 				s.autoAssessor.OnSuperseded(assessCtx, orgID, *input.SupersedesID, decision.ID)
+			}
+			for _, supersededID := range input.SupersedesIDs {
+				if input.SupersedesID != nil && supersededID == *input.SupersedesID {
+					continue
+				}
+				s.autoAssessor.OnSuperseded(assessCtx, orgID, supersededID, decision.ID)
 			}
 			if input.PrecedentRef != nil {
 				citCount, err := s.db.GetPrecedentCitationCount(assessCtx, orgID, *input.PrecedentRef)

--- a/internal/storage/decisions.go
+++ b/internal/storage/decisions.go
@@ -208,6 +208,9 @@ func (db *DB) ReviseDecision(ctx context.Context, originalID uuid.UUID, revised 
 		if err != nil {
 			return fmt.Errorf("storage: insert revised decision: %w", err)
 		}
+		if err := insertDecisionSupersedesRowsTx(ctx, tx, revised.OrgID, revised.ID, []uuid.UUID{originalID}, &originalID, "supersedes"); err != nil {
+			return err
+		}
 
 		// Queue search index updates: delete the old decision, upsert the new one.
 		if err := queueSearchOutbox(ctx, tx, originalID, revised.OrgID, "delete"); err != nil {
@@ -1361,21 +1364,32 @@ func (db *DB) GetDecisionRevisions(ctx context.Context, orgID, id uuid.UUID) ([]
 func (db *DB) GetRevisionChainIDs(ctx context.Context, id, orgID uuid.UUID) ([]uuid.UUID, error) {
 	query := `
 	WITH RECURSIVE
+	edges AS (
+		SELECT id AS superseding_id, supersedes_id AS superseded_id, org_id
+		FROM decisions
+		WHERE supersedes_id IS NOT NULL AND org_id = $2
+		UNION
+		SELECT superseding_id, superseded_id, org_id
+		FROM decision_supersedes
+		WHERE org_id = $2
+	),
 	forward_chain AS (
 		SELECT id, supersedes_id, 0 AS depth FROM decisions WHERE id = $1 AND org_id = $2
 		UNION ALL
 		SELECT d.id, d.supersedes_id, fc.depth + 1
-		FROM decisions d
-		INNER JOIN forward_chain fc ON d.supersedes_id = fc.id
-		WHERE d.org_id = $2 AND fc.depth < 100
+		FROM edges e
+		INNER JOIN decisions d ON d.id = e.superseding_id AND d.org_id = e.org_id
+		INNER JOIN forward_chain fc ON e.superseded_id = fc.id
+		WHERE e.org_id = $2 AND fc.depth < 100
 	),
 	backward_chain AS (
 		SELECT id, supersedes_id, 0 AS depth FROM decisions WHERE id = $1 AND org_id = $2
 		UNION ALL
 		SELECT d.id, d.supersedes_id, bc.depth + 1
-		FROM decisions d
-		INNER JOIN backward_chain bc ON bc.supersedes_id = d.id
-		WHERE d.org_id = $2 AND bc.depth < 100
+		FROM edges e
+		INNER JOIN decisions d ON d.id = e.superseded_id AND d.org_id = e.org_id
+		INNER JOIN backward_chain bc ON e.superseding_id = bc.id
+		WHERE e.org_id = $2 AND bc.depth < 100
 	)
 	SELECT DISTINCT id FROM (
 		SELECT id FROM forward_chain WHERE id != $1

--- a/internal/storage/errors.go
+++ b/internal/storage/errors.go
@@ -16,6 +16,10 @@ var ErrWinningAgentNotInGroup = errors.New("storage: winning agent is not a part
 // does not match either decision_a_id or decision_b_id of the conflict.
 var ErrWinningDecisionNotInConflict = errors.New("storage: winning decision is not a participant in this conflict")
 
+// ErrSupersededDecisionNotInConflict is returned when adjudication tries to
+// supersede a decision that is not one of the target conflict's two sides.
+var ErrSupersededDecisionNotInConflict = errors.New("storage: superseded decision is not a participant in this conflict")
+
 // ErrRevisedDecisions is returned when a resolution requiring a decisions JOIN
 // finds no current (valid_to IS NULL) decisions, typically because the referenced
 // decisions have been superseded by revisions.

--- a/internal/storage/sqlite/decisions.go
+++ b/internal/storage/sqlite/decisions.go
@@ -36,11 +36,27 @@ func (l *LiteDB) CreateTraceTx(ctx context.Context, params storage.CreateTracePa
 
 // CreateTraceAndAdjudicateConflictTx creates a trace and resolves a conflict atomically.
 func (l *LiteDB) CreateTraceAndAdjudicateConflictTx(ctx context.Context, traceParams storage.CreateTraceParams, conflictParams storage.AdjudicateConflictInTraceParams) (model.AgentRun, model.Decision, error) {
+	supersedesIDs := uniqueUUIDs(conflictParams.SupersedesIDs)
+	if len(supersedesIDs) > 0 {
+		if traceParams.Decision.SupersedesID == nil {
+			primary := supersedesIDs[0]
+			traceParams.Decision.SupersedesID = &primary
+		} else if !uuidInSlice(*traceParams.Decision.SupersedesID, supersedesIDs) {
+			return model.AgentRun{}, model.Decision{}, storage.ErrSupersededDecisionNotInConflict
+		}
+	}
+
 	tx, err := l.db.BeginTx(ctx, nil)
 	if err != nil {
 		return model.AgentRun{}, model.Decision{}, fmt.Errorf("sqlite: begin tx: %w", err)
 	}
 	defer tx.Rollback() //nolint:errcheck
+
+	if len(supersedesIDs) > 0 {
+		if err := validateAdjudicationSupersedes(ctx, tx, traceParams.OrgID, conflictParams.ConflictID, supersedesIDs); err != nil {
+			return model.AgentRun{}, model.Decision{}, err
+		}
+	}
 
 	run, dec, err := createTraceInTx(ctx, tx, traceParams)
 	if err != nil {
@@ -68,14 +84,152 @@ func (l *LiteDB) CreateTraceAndAdjudicateConflictTx(ctx context.Context, tracePa
 		return model.AgentRun{}, model.Decision{}, fmt.Errorf("sqlite: conflict: %w", storage.ErrNotFound)
 	}
 
+	conflictParams.Audit.ResourceID = conflictParams.ConflictID.String()
+	afterData := map[string]any{
+		"status":                 "resolved",
+		"resolved_by":            conflictParams.ResolvedBy,
+		"resolution_decision_id": dec.ID.String(),
+	}
+	if conflictParams.WinningDecisionID != nil {
+		afterData["winning_decision_id"] = conflictParams.WinningDecisionID.String()
+	}
+	conflictParams.Audit.AfterData = afterData
 	if err := insertAuditTx(ctx, tx, conflictParams.Audit); err != nil {
 		return model.AgentRun{}, model.Decision{}, err
+	}
+
+	if len(supersedesIDs) > 0 {
+		relationship := conflictParams.Relationship
+		if relationship == "" {
+			relationship = "supersedes"
+		}
+		if err := insertDecisionSupersedesRowsTx(ctx, tx, traceParams.OrgID, dec.ID, supersedesIDs, traceParams.Decision.SupersedesID, relationship); err != nil {
+			return model.AgentRun{}, model.Decision{}, err
+		}
+		for _, supersededID := range supersedesIDs {
+			if traceParams.Decision.SupersedesID != nil && supersededID == *traceParams.Decision.SupersedesID {
+				continue
+			}
+			if err := invalidateSupersededDecisionInTraceTx(ctx, tx, traceParams.OrgID, traceParams.AgentID, supersededID, dec.ID, dec.ValidFrom); err != nil {
+				return model.AgentRun{}, model.Decision{}, err
+			}
+		}
 	}
 
 	if err := tx.Commit(); err != nil {
 		return model.AgentRun{}, model.Decision{}, fmt.Errorf("sqlite: commit trace+adjudicate: %w", err)
 	}
 	return run, dec, nil
+}
+
+func uniqueUUIDs(ids []uuid.UUID) []uuid.UUID {
+	seen := make(map[uuid.UUID]struct{}, len(ids))
+	out := make([]uuid.UUID, 0, len(ids))
+	for _, id := range ids {
+		if id == uuid.Nil {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	return out
+}
+
+func uuidInSlice(needle uuid.UUID, haystack []uuid.UUID) bool {
+	for _, id := range haystack {
+		if id == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func validateAdjudicationSupersedes(ctx context.Context, tx *sql.Tx, orgID, conflictID uuid.UUID, supersedesIDs []uuid.UUID) error {
+	var decisionAStr, decisionBStr string
+	if err := tx.QueryRowContext(ctx,
+		`SELECT decision_a_id, decision_b_id FROM scored_conflicts WHERE id = ? AND org_id = ?`,
+		uuidStr(conflictID), uuidStr(orgID),
+	).Scan(&decisionAStr, &decisionBStr); err != nil {
+		return fmt.Errorf("sqlite: conflict: %w", storage.ErrNotFound)
+	}
+	decisionAID, err := uuid.Parse(decisionAStr)
+	if err != nil {
+		return fmt.Errorf("sqlite: parse conflict decision_a_id: %w", err)
+	}
+	decisionBID, err := uuid.Parse(decisionBStr)
+	if err != nil {
+		return fmt.Errorf("sqlite: parse conflict decision_b_id: %w", err)
+	}
+	for _, id := range supersedesIDs {
+		if id != decisionAID && id != decisionBID {
+			return storage.ErrSupersededDecisionNotInConflict
+		}
+	}
+	return nil
+}
+
+func insertDecisionSupersedesRowsTx(ctx context.Context, tx *sql.Tx, orgID, supersedingID uuid.UUID, supersededIDs []uuid.UUID, primaryID *uuid.UUID, relationship string) error {
+	for _, supersededID := range supersededIDs {
+		isPrimary := 0
+		if primaryID != nil && supersededID == *primaryID {
+			isPrimary = 1
+			if _, err := tx.ExecContext(ctx,
+				`UPDATE decision_supersedes SET is_primary = 0
+				 WHERE superseding_id = ? AND org_id = ? AND superseded_id != ? AND is_primary = 1`,
+				uuidStr(supersedingID), uuidStr(orgID), uuidStr(supersededID),
+			); err != nil {
+				return fmt.Errorf("sqlite: clear primary supersedes row: %w", err)
+			}
+		}
+		if _, err := tx.ExecContext(ctx,
+			`INSERT INTO decision_supersedes (superseding_id, superseded_id, org_id, relationship, is_primary)
+			 VALUES (?, ?, ?, ?, ?)
+			 ON CONFLICT(superseding_id, superseded_id) DO UPDATE
+			 SET relationship = excluded.relationship,
+			     is_primary = excluded.is_primary`,
+			uuidStr(supersedingID), uuidStr(supersededID), uuidStr(orgID), relationship, isPrimary,
+		); err != nil {
+			return fmt.Errorf("sqlite: insert decision supersedes row: %w", err)
+		}
+	}
+	return nil
+}
+
+func invalidateSupersededDecisionInTraceTx(ctx context.Context, tx *sql.Tx, orgID uuid.UUID, agentID string, supersededID, newDecisionID uuid.UUID, validTo time.Time) error {
+	if validTo.IsZero() {
+		validTo = time.Now().UTC()
+	}
+	res, err := tx.ExecContext(ctx,
+		`UPDATE decisions SET valid_to = ? WHERE id = ? AND org_id = ? AND valid_to IS NULL`,
+		timeStr(validTo), uuidStr(supersededID), uuidStr(orgID),
+	)
+	if err != nil {
+		return fmt.Errorf("sqlite: close superseded decision: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return fmt.Errorf("sqlite: superseded decision %s not found (or already superseded): %w", supersededID, storage.ErrNotFound)
+	}
+	if err := insertAuditTx(ctx, tx, storage.MutationAuditEntry{
+		OrgID:        orgID,
+		ActorAgentID: agentID,
+		ActorRole:    "agent",
+		Operation:    "supersede_decision",
+		ResourceType: "decision",
+		ResourceID:   supersededID.String(),
+		BeforeData:   map[string]any{"valid_to": nil},
+		AfterData: map[string]any{
+			"valid_to":        validTo,
+			"superseded_by":   newDecisionID,
+			"new_decision_id": newDecisionID,
+			"superseded_id":   supersededID,
+		},
+	}); err != nil {
+		return err
+	}
+	return nil
 }
 
 func createTraceInTx(ctx context.Context, tx *sql.Tx, p storage.CreateTraceParams) (model.AgentRun, model.Decision, error) {
@@ -231,6 +385,9 @@ func createTraceInTx(ctx context.Context, tx *sql.Tx, p storage.CreateTraceParam
 
 	// 5. Supersession: if this decision supersedes another, close the old one.
 	if d.SupersedesID != nil {
+		if err := insertDecisionSupersedesRowsTx(ctx, tx, p.OrgID, d.ID, []uuid.UUID{*d.SupersedesID}, d.SupersedesID, "supersedes"); err != nil {
+			return model.AgentRun{}, model.Decision{}, err
+		}
 		_, err = tx.ExecContext(ctx,
 			`UPDATE decisions SET valid_to = ? WHERE id = ? AND org_id = ? AND valid_to IS NULL`,
 			timeStr(d.ValidFrom), uuidStr(*d.SupersedesID), uuidStr(d.OrgID),

--- a/internal/storage/sqlite/schema.sql
+++ b/internal/storage/sqlite/schema.sql
@@ -92,6 +92,74 @@ CREATE INDEX IF NOT EXISTS idx_decisions_precedent_ref
 CREATE INDEX IF NOT EXISTS idx_decisions_project
     ON decisions(org_id, project) WHERE project IS NOT NULL;
 
+CREATE TABLE IF NOT EXISTS decision_supersedes (
+    superseding_id TEXT NOT NULL REFERENCES decisions(id) ON DELETE CASCADE,
+    superseded_id  TEXT NOT NULL REFERENCES decisions(id) ON DELETE CASCADE,
+    org_id         TEXT NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    relationship   TEXT NOT NULL DEFAULT 'supersedes',
+    is_primary     INTEGER NOT NULL DEFAULT 0,
+    recorded_at    TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (superseding_id, superseded_id),
+    CHECK (superseding_id <> superseded_id),
+    CHECK (relationship IN ('supersedes', 'reconciles'))
+);
+CREATE INDEX IF NOT EXISTS idx_decision_supersedes_superseded
+    ON decision_supersedes(org_id, superseded_id);
+CREATE INDEX IF NOT EXISTS idx_decision_supersedes_superseding
+    ON decision_supersedes(org_id, superseding_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_decision_supersedes_primary
+    ON decision_supersedes(superseding_id)
+    WHERE is_primary = 1;
+INSERT OR IGNORE INTO decision_supersedes (superseding_id, superseded_id, org_id, relationship, is_primary)
+SELECT id, supersedes_id, org_id, 'supersedes', 1
+FROM decisions
+WHERE supersedes_id IS NOT NULL;
+
+CREATE TRIGGER IF NOT EXISTS trg_decisions_sync_supersedes_insert
+AFTER INSERT ON decisions
+WHEN NEW.supersedes_id IS NOT NULL
+BEGIN
+    UPDATE decision_supersedes
+    SET is_primary = 0
+    WHERE superseding_id = NEW.id
+      AND org_id = NEW.org_id
+      AND superseded_id <> NEW.supersedes_id
+      AND is_primary = 1;
+
+    INSERT INTO decision_supersedes (superseding_id, superseded_id, org_id, relationship, is_primary)
+    VALUES (NEW.id, NEW.supersedes_id, NEW.org_id, 'supersedes', 1)
+    ON CONFLICT (superseding_id, superseded_id) DO UPDATE
+    SET is_primary = 1;
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_decisions_sync_supersedes_update
+AFTER UPDATE OF supersedes_id ON decisions
+WHEN NEW.supersedes_id IS NOT NULL
+BEGIN
+    UPDATE decision_supersedes
+    SET is_primary = 0
+    WHERE superseding_id = NEW.id
+      AND org_id = NEW.org_id
+      AND superseded_id <> NEW.supersedes_id
+      AND is_primary = 1;
+
+    INSERT INTO decision_supersedes (superseding_id, superseded_id, org_id, relationship, is_primary)
+    VALUES (NEW.id, NEW.supersedes_id, NEW.org_id, 'supersedes', 1)
+    ON CONFLICT (superseding_id, superseded_id) DO UPDATE
+    SET is_primary = 1;
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_decisions_sync_supersedes_clear
+AFTER UPDATE OF supersedes_id ON decisions
+WHEN NEW.supersedes_id IS NULL
+BEGIN
+    UPDATE decision_supersedes
+    SET is_primary = 0
+    WHERE superseding_id = NEW.id
+      AND org_id = NEW.org_id
+      AND is_primary = 1;
+END;
+
 -- FTS5 virtual table for full-text search over decisions.
 CREATE VIRTUAL TABLE IF NOT EXISTS decisions_fts USING fts5(
     outcome,

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -6520,6 +6520,123 @@ func TestCreateTraceAndAdjudicateConflictTx(t *testing.T) {
 	assert.Equal(t, dA.ID, *conflict.WinningDecisionID)
 }
 
+func TestCreateTraceAndAdjudicateConflictTx_WithSupersedes(t *testing.T) {
+	ctx := context.Background()
+	suffix := uuid.New().String()[:8]
+
+	agentA := "reconcile-a-" + suffix
+	agentB := "reconcile-b-" + suffix
+	decisionType := "reconcile_type_" + suffix
+
+	runA, err := testDB.CreateRun(ctx, model.CreateRunRequest{AgentID: agentA})
+	require.NoError(t, err)
+	runB, err := testDB.CreateRun(ctx, model.CreateRunRequest{AgentID: agentB})
+	require.NoError(t, err)
+
+	dA, err := testDB.CreateDecision(ctx, model.Decision{
+		RunID: runA.ID, AgentID: agentA,
+		DecisionType: decisionType, Outcome: "use queue based ingestion",
+		Confidence: 0.8, Metadata: map[string]any{},
+	})
+	require.NoError(t, err)
+	dB, err := testDB.CreateDecision(ctx, model.Decision{
+		RunID: runB.ID, AgentID: agentB,
+		DecisionType: decisionType, Outcome: "use direct synchronous ingestion",
+		Confidence: 0.7, Metadata: map[string]any{},
+	})
+	require.NoError(t, err)
+
+	topicSim := 0.9
+	outcomeDiv := 0.8
+	sig := topicSim * outcomeDiv
+	conflictID, err := testDB.InsertScoredConflict(ctx, model.DecisionConflict{
+		ConflictKind:      model.ConflictKindCrossAgent,
+		DecisionAID:       dA.ID,
+		DecisionBID:       dB.ID,
+		OrgID:             uuid.Nil,
+		AgentA:            agentA,
+		AgentB:            agentB,
+		DecisionTypeA:     decisionType,
+		DecisionTypeB:     decisionType,
+		OutcomeA:          dA.Outcome,
+		OutcomeB:          dB.Outcome,
+		TopicSimilarity:   &topicSim,
+		OutcomeDivergence: &outcomeDiv,
+		Significance:      &sig,
+		ScoringMethod:     "text",
+	})
+	require.NoError(t, err)
+
+	adjudicatorAgent := "reconciler-" + suffix
+	resNote := "synthesized a durable hybrid"
+	_, decision, err := testDB.CreateTraceAndAdjudicateConflictTx(ctx,
+		storage.CreateTraceParams{
+			AgentID:  adjudicatorAgent,
+			OrgID:    uuid.Nil,
+			Metadata: map[string]any{"purpose": "reconciliation"},
+			Decision: model.Decision{
+				DecisionType: "reconciliation",
+				Outcome:      "use queue based ingestion with synchronous validation at boundaries",
+				Confidence:   0.95,
+			},
+			AuditEntry: &storage.MutationAuditEntry{
+				RequestID:    uuid.New().String(),
+				OrgID:        uuid.Nil,
+				ActorAgentID: adjudicatorAgent,
+				ActorRole:    "admin",
+				HTTPMethod:   "POST",
+				Endpoint:     "/v1/trace",
+				Operation:    "create_trace",
+				ResourceType: "decision",
+			},
+		},
+		storage.AdjudicateConflictInTraceParams{
+			ConflictID:    conflictID,
+			ResolvedBy:    adjudicatorAgent,
+			ResNote:       &resNote,
+			SupersedesIDs: []uuid.UUID{dA.ID, dB.ID},
+			Relationship:  "reconciles",
+			Audit: storage.MutationAuditEntry{
+				RequestID:    uuid.New().String(),
+				OrgID:        uuid.Nil,
+				ActorAgentID: adjudicatorAgent,
+				ActorRole:    "admin",
+				HTTPMethod:   "POST",
+				Endpoint:     "/v1/trace",
+				Operation:    "adjudicate_conflict",
+				ResourceType: "conflict",
+			},
+		},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, decision.SupersedesID)
+	assert.Equal(t, dA.ID, *decision.SupersedesID)
+
+	conflict, err := testDB.GetConflict(ctx, conflictID, uuid.Nil)
+	require.NoError(t, err)
+	require.NotNil(t, conflict)
+	assert.Equal(t, "resolved", conflict.Status)
+	assert.Equal(t, decision.ID, *conflict.ResolutionDecisionID)
+
+	var edgeCount, primaryCount int
+	require.NoError(t, testDB.Pool().QueryRow(ctx,
+		`SELECT COUNT(*), COUNT(*) FILTER (WHERE is_primary)
+		 FROM decision_supersedes
+		 WHERE org_id = $1 AND superseding_id = $2 AND relationship = 'reconciles'`,
+		uuid.Nil, decision.ID,
+	).Scan(&edgeCount, &primaryCount))
+	assert.Equal(t, 2, edgeCount)
+	assert.Equal(t, 1, primaryCount)
+
+	var activeCount int
+	require.NoError(t, testDB.Pool().QueryRow(ctx,
+		`SELECT COUNT(*) FROM decisions
+		 WHERE org_id = $1 AND id = ANY($2) AND valid_to IS NULL`,
+		uuid.Nil, []uuid.UUID{dA.ID, dB.ID},
+	).Scan(&activeCount))
+	assert.Equal(t, 0, activeCount)
+}
+
 func TestCreateTraceAndAdjudicateConflictTx_ConflictNotFound(t *testing.T) {
 	ctx := context.Background()
 	suffix := uuid.New().String()[:8]

--- a/internal/storage/trace.go
+++ b/internal/storage/trace.go
@@ -4,6 +4,7 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -37,7 +38,22 @@ func (db *DB) CreateTraceTx(ctx context.Context, params CreateTraceParams) (mode
 func (db *DB) CreateTraceAndAdjudicateConflictTx(ctx context.Context, traceParams CreateTraceParams, conflictParams AdjudicateConflictInTraceParams) (model.AgentRun, model.Decision, error) {
 	var run model.AgentRun
 	var d model.Decision
+	supersedesIDs := uniqueUUIDs(conflictParams.SupersedesIDs)
+	if len(supersedesIDs) > 0 {
+		if traceParams.Decision.SupersedesID == nil {
+			primary := supersedesIDs[0]
+			traceParams.Decision.SupersedesID = &primary
+		} else if !uuidInSlice(*traceParams.Decision.SupersedesID, supersedesIDs) {
+			return model.AgentRun{}, model.Decision{}, ErrSupersededDecisionNotInConflict
+		}
+	}
 	err := db.WithTx(ctx, func(ctx context.Context, tx pgx.Tx) error {
+		if len(supersedesIDs) > 0 {
+			if err := validateAdjudicationSupersedes(ctx, tx, traceParams.OrgID, conflictParams.ConflictID, supersedesIDs); err != nil {
+				return err
+			}
+		}
+
 		var txErr error
 		run, d, txErr = db.createTraceInTx(ctx, tx, traceParams)
 		if txErr != nil {
@@ -73,12 +89,155 @@ func (db *DB) CreateTraceAndAdjudicateConflictTx(ctx context.Context, traceParam
 		if err := InsertMutationAuditTx(ctx, tx, conflictParams.Audit); err != nil {
 			return fmt.Errorf("storage: audit in trace+adjudicate tx: %w", err)
 		}
+		if len(supersedesIDs) > 0 {
+			relationship := conflictParams.Relationship
+			if relationship == "" {
+				relationship = "supersedes"
+			}
+			if err := insertDecisionSupersedesRowsTx(ctx, tx, traceParams.OrgID, d.ID, supersedesIDs, traceParams.Decision.SupersedesID, relationship); err != nil {
+				return err
+			}
+			for _, supersededID := range supersedesIDs {
+				if traceParams.Decision.SupersedesID != nil && supersededID == *traceParams.Decision.SupersedesID {
+					continue
+				}
+				if err := invalidateSupersededDecisionInTraceTx(ctx, tx, run.ID, traceParams.OrgID, traceParams.AgentID, supersededID, d.ID, d.ValidFrom); err != nil {
+					return err
+				}
+			}
+		}
 		return nil
 	})
 	if err != nil {
 		return model.AgentRun{}, model.Decision{}, err
 	}
 	return run, d, nil
+}
+
+func uniqueUUIDs(ids []uuid.UUID) []uuid.UUID {
+	seen := make(map[uuid.UUID]struct{}, len(ids))
+	out := make([]uuid.UUID, 0, len(ids))
+	for _, id := range ids {
+		if id == uuid.Nil {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	return out
+}
+
+func uuidInSlice(needle uuid.UUID, haystack []uuid.UUID) bool {
+	for _, id := range haystack {
+		if id == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func validateAdjudicationSupersedes(ctx context.Context, tx pgx.Tx, orgID, conflictID uuid.UUID, supersedesIDs []uuid.UUID) error {
+	var decisionAID, decisionBID uuid.UUID
+	if err := tx.QueryRow(ctx,
+		`SELECT decision_a_id, decision_b_id FROM scored_conflicts WHERE id = $1 AND org_id = $2 FOR UPDATE`,
+		conflictID, orgID,
+	).Scan(&decisionAID, &decisionBID); err != nil {
+		if !errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("storage: load conflict for adjudication supersedes: %w", err)
+		}
+		return fmt.Errorf("storage: conflict: %w", ErrNotFound)
+	}
+	for _, id := range supersedesIDs {
+		if id != decisionAID && id != decisionBID {
+			return ErrSupersededDecisionNotInConflict
+		}
+	}
+	return nil
+}
+
+func insertDecisionSupersedesRowsTx(ctx context.Context, tx pgx.Tx, orgID, supersedingID uuid.UUID, supersededIDs []uuid.UUID, primaryID *uuid.UUID, relationship string) error {
+	for _, supersededID := range supersededIDs {
+		isPrimary := primaryID != nil && supersededID == *primaryID
+		if isPrimary {
+			if _, err := tx.Exec(ctx,
+				`UPDATE decision_supersedes SET is_primary = FALSE
+				 WHERE superseding_id = $1 AND org_id = $2 AND superseded_id != $3 AND is_primary`,
+				supersedingID, orgID, supersededID,
+			); err != nil {
+				return fmt.Errorf("storage: clear primary supersedes row: %w", err)
+			}
+		}
+		if _, err := tx.Exec(ctx,
+			`INSERT INTO decision_supersedes (superseding_id, superseded_id, org_id, relationship, is_primary)
+			 VALUES ($1, $2, $3, $4, $5)
+			 ON CONFLICT (superseding_id, superseded_id) DO UPDATE
+			 SET relationship = EXCLUDED.relationship,
+			     is_primary = EXCLUDED.is_primary`,
+			supersedingID, supersededID, orgID, relationship, isPrimary,
+		); err != nil {
+			return fmt.Errorf("storage: insert decision supersedes row: %w", err)
+		}
+	}
+	return nil
+}
+
+func invalidateSupersededDecisionInTraceTx(ctx context.Context, tx pgx.Tx, runID, orgID uuid.UUID, agentID string, supersededID, newDecisionID uuid.UUID, validTo time.Time) error {
+	if validTo.IsZero() {
+		validTo = time.Now().UTC()
+	}
+	tag, err := tx.Exec(ctx,
+		`UPDATE decisions SET valid_to = $1 WHERE id = $2 AND org_id = $3 AND valid_to IS NULL`,
+		validTo, supersededID, orgID,
+	)
+	if err != nil {
+		return fmt.Errorf("storage: invalidate superseded decision: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("storage: superseded decision %s not found (or already superseded): %w", supersededID, ErrNotFound)
+	}
+	if err := queueSearchOutbox(ctx, tx, supersededID, orgID, "delete"); err != nil {
+		return fmt.Errorf("storage: queue search outbox delete for superseded: %w", err)
+	}
+	if _, err := AutoResolveSupersededConflictsTx(ctx, tx, orgID, supersededID, newDecisionID); err != nil {
+		return fmt.Errorf("storage: auto-resolve superseded conflicts in trace: %w", err)
+	}
+
+	var seqNum int64
+	if err := tx.QueryRow(ctx, `SELECT nextval('event_sequence_num_seq')`).Scan(&seqNum); err != nil {
+		return fmt.Errorf("storage: reserve sequence num for supersession event: %w", err)
+	}
+	if _, err := tx.Exec(ctx,
+		`INSERT INTO agent_events (id, run_id, org_id, event_type, sequence_num, occurred_at, agent_id, payload, created_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+		uuid.New(), runID, orgID, string(model.EventDecisionSuperseded), seqNum,
+		validTo, agentID, map[string]any{
+			"superseded_decision_id": supersededID.String(),
+			"new_decision_id":        newDecisionID.String(),
+		}, validTo,
+	); err != nil {
+		return fmt.Errorf("storage: insert supersession event: %w", err)
+	}
+	if err := InsertMutationAuditTx(ctx, tx, MutationAuditEntry{
+		OrgID:        orgID,
+		ActorAgentID: agentID,
+		ActorRole:    "agent",
+		Operation:    "supersede_decision",
+		ResourceType: "decision",
+		ResourceID:   supersededID.String(),
+		BeforeData:   map[string]any{"valid_to": nil},
+		AfterData: map[string]any{
+			"valid_to":        validTo,
+			"superseded_by":   newDecisionID,
+			"new_decision_id": newDecisionID,
+			"superseded_id":   supersededID,
+		},
+	}); err != nil {
+		return fmt.Errorf("storage: audit supersession in trace tx: %w", err)
+	}
+	return nil
 }
 
 // createTraceInTx is the transactional core shared by CreateTraceTx and
@@ -220,6 +379,9 @@ func (db *DB) createTraceInTx(ctx context.Context, tx pgx.Tx, params CreateTrace
 	// 4c. Handle explicit supersession: invalidate the superseded decision and
 	// auto-resolve its open conflicts, matching the ReviseDecision pattern.
 	if d.SupersedesID != nil {
+		if err := insertDecisionSupersedesRowsTx(ctx, tx, params.OrgID, d.ID, []uuid.UUID{*d.SupersedesID}, d.SupersedesID, "supersedes"); err != nil {
+			return model.AgentRun{}, model.Decision{}, err
+		}
 		tag, err := tx.Exec(ctx,
 			`UPDATE decisions SET valid_to = $1 WHERE id = $2 AND org_id = $3 AND valid_to IS NULL`,
 			now, *d.SupersedesID, params.OrgID,

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -63,6 +63,8 @@ type AdjudicateConflictInTraceParams struct {
 	ResNote           *string
 	Audit             MutationAuditEntry
 	WinningDecisionID *uuid.UUID // optional; must be decision_a_id or decision_b_id if set
+	SupersedesIDs     []uuid.UUID
+	Relationship      string // "supersedes" or "reconciles"; defaults to "supersedes"
 }
 
 // ---------------------------------------------------------------------------

--- a/migrations/104_decision_supersedes.sql
+++ b/migrations/104_decision_supersedes.sql
@@ -1,0 +1,64 @@
+-- 104: Add multi-target decision supersedes relationship table.
+CREATE TABLE decision_supersedes (
+    superseding_id UUID NOT NULL REFERENCES decisions(id) ON DELETE CASCADE,
+    superseded_id  UUID NOT NULL REFERENCES decisions(id) ON DELETE CASCADE,
+    org_id         UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    relationship   TEXT NOT NULL DEFAULT 'supersedes',
+    is_primary     BOOLEAN NOT NULL DEFAULT FALSE,
+    recorded_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (superseding_id, superseded_id),
+    CONSTRAINT decision_supersedes_not_self CHECK (superseding_id <> superseded_id),
+    CONSTRAINT decision_supersedes_relationship_check CHECK (relationship IN ('supersedes', 'reconciles'))
+);
+
+CREATE INDEX idx_decision_supersedes_superseded
+    ON decision_supersedes(org_id, superseded_id);
+
+CREATE INDEX idx_decision_supersedes_superseding
+    ON decision_supersedes(org_id, superseding_id);
+
+CREATE UNIQUE INDEX idx_decision_supersedes_primary
+    ON decision_supersedes(superseding_id)
+    WHERE is_primary;
+
+INSERT INTO decision_supersedes (superseding_id, superseded_id, org_id, relationship, is_primary)
+SELECT id, supersedes_id, org_id, 'supersedes', TRUE
+FROM decisions
+WHERE supersedes_id IS NOT NULL
+ON CONFLICT (superseding_id, superseded_id) DO NOTHING;
+
+CREATE OR REPLACE FUNCTION sync_decision_supersedes_primary()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF NEW.supersedes_id IS NULL THEN
+        UPDATE decision_supersedes
+        SET is_primary = FALSE
+        WHERE superseding_id = NEW.id
+          AND org_id = NEW.org_id
+          AND is_primary;
+        RETURN NEW;
+    END IF;
+
+    UPDATE decision_supersedes
+    SET is_primary = FALSE
+    WHERE superseding_id = NEW.id
+      AND org_id = NEW.org_id
+      AND superseded_id <> NEW.supersedes_id
+      AND is_primary;
+
+    INSERT INTO decision_supersedes (superseding_id, superseded_id, org_id, relationship, is_primary)
+    VALUES (NEW.id, NEW.supersedes_id, NEW.org_id, 'supersedes', TRUE)
+    ON CONFLICT (superseding_id, superseded_id) DO UPDATE
+    SET is_primary = TRUE;
+
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_decisions_sync_supersedes ON decisions;
+CREATE TRIGGER trg_decisions_sync_supersedes
+AFTER INSERT OR UPDATE OF supersedes_id ON decisions
+FOR EACH ROW
+EXECUTE FUNCTION sync_decision_supersedes_primary();

--- a/migrations/atlas.sum
+++ b/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:sCbbKI6aMWj45R8/3Q2k0ABLFCsEkO3hmPA72OHyN5k=
+h1:IznV+I78BZv+38s8ViDhgMU9LPrvW7FlyNfcmD5M9rg=
 001_initial.sql h1:uhyGXto+QacAaGYb9ZTGjsBs5chlKi8O0eHz9aCQsrY=
 022_full_text_search.sql h1:9iwtA8MgCzAxDV9YkUBn0CLT9ePSmj3GcPoMGg8TXf0=
 023_fix_outbox_index.sql h1:OtMEFBcMRWej02+ghnBXlPr6BVq+LoA62Id9XUWfDNI=
@@ -82,3 +82,4 @@ h1:sCbbKI6aMWj45R8/3Q2k0ABLFCsEkO3hmPA72OHyN5k=
 101_rename_stale_indexes.sql h1:fOnIzZKgPZDXjlcOtXSDxTYoK0fZV41ad+JMAwck8aY=
 102_drop_dead_schema.sql h1:8pKT1tSvKyH936Kd/sd7vSI+CfbUSb0QWA75upeEVrA=
 103_git_branch_index.sql h1:zomzfqVrP4FDLw3p2jLN0cjkDGtKwRirUmetLcfuEZ8=
+104_decision_supersedes.sql h1:U8KFFLRxcTFB6UWEQLI6id+tBfDOwGyNWwZ6bBYf+/Y=

--- a/sdk/go/akashi/types.go
+++ b/sdk/go/akashi/types.go
@@ -185,18 +185,18 @@ type CheckRequest struct {
 
 // TraceRequest is the input for Client.Trace.
 type TraceRequest struct {
-	DecisionType string             `json:"decision_type"`
-	Outcome      string             `json:"outcome"`
-	Confidence   float32            `json:"confidence"`
-	Reasoning    *string            `json:"reasoning,omitempty"`
+	DecisionType    string             `json:"decision_type"`
+	Outcome         string             `json:"outcome"`
+	Confidence      float32            `json:"confidence"`
+	Reasoning       *string            `json:"reasoning,omitempty"`
 	PrecedentRef    *uuid.UUID         `json:"precedent_ref,omitempty"`
 	PrecedentReason *string            `json:"precedent_reason,omitempty"`
 	SupersedesID    *uuid.UUID         `json:"supersedes_id,omitempty"`
 	TraceID         *string            `json:"trace_id,omitempty"` // OTEL trace ID correlation
 	Alternatives    []TraceAlternative `json:"alternatives,omitempty"`
-	Evidence     []TraceEvidence    `json:"evidence,omitempty"`
-	Metadata     map[string]any     `json:"metadata,omitempty"`
-	Context      map[string]any     `json:"context,omitempty"`
+	Evidence        []TraceEvidence    `json:"evidence,omitempty"`
+	Metadata        map[string]any     `json:"metadata,omitempty"`
+	Context         map[string]any     `json:"context,omitempty"`
 
 	// IdempotencyKey is an optional client-provided key for safe retries.
 	// If empty, a random UUID is generated automatically. Sent as the
@@ -255,16 +255,16 @@ type QueryOptions struct {
 // It tells an agent which approach prevailed so they can avoid resurrecting the
 // losing side of an already-resolved disagreement.
 type ConflictResolution struct {
-	ID                uuid.UUID  `json:"id"`
-	DecisionType      string     `json:"decision_type"`
-	WinningDecisionID uuid.UUID  `json:"winning_decision_id"`
-	WinningAgent      string     `json:"winning_agent"`
-	WinningOutcome    string     `json:"winning_outcome"`
-	LosingAgent       string     `json:"losing_agent"`
-	LosingOutcome     string     `json:"losing_outcome"`
-	Explanation       *string    `json:"explanation,omitempty"`
-	ResolutionNote    *string    `json:"resolution_note,omitempty"`
-	ResolvedAt        time.Time  `json:"resolved_at"`
+	ID                uuid.UUID `json:"id"`
+	DecisionType      string    `json:"decision_type"`
+	WinningDecisionID uuid.UUID `json:"winning_decision_id"`
+	WinningAgent      string    `json:"winning_agent"`
+	WinningOutcome    string    `json:"winning_outcome"`
+	LosingAgent       string    `json:"losing_agent"`
+	LosingOutcome     string    `json:"losing_outcome"`
+	Explanation       *string   `json:"explanation,omitempty"`
+	ResolutionNote    *string   `json:"resolution_note,omitempty"`
+	ResolvedAt        time.Time `json:"resolved_at"`
 }
 
 // CheckResponse is the output of Client.Check.
@@ -334,19 +334,19 @@ type AgentRun struct {
 type EventType string
 
 const (
-	EventAgentRunStarted        EventType = "AgentRunStarted"
-	EventAgentRunCompleted      EventType = "AgentRunCompleted"
-	EventAgentRunFailed         EventType = "AgentRunFailed"
-	EventDecisionStarted EventType = "DecisionStarted"
-	EventDecisionMade    EventType = "DecisionMade"
-	EventDecisionRevised        EventType = "DecisionRevised"
-	EventDecisionSuperseded     EventType = "DecisionSuperseded"
-	EventDecisionRetracted      EventType = "DecisionRetracted"
-	EventDecisionErased         EventType = "DecisionErased"
-	EventToolCallStarted        EventType = "ToolCallStarted"
-	EventToolCallCompleted      EventType = "ToolCallCompleted"
-	EventAgentHandoff     EventType = "AgentHandoff"
-	EventConflictDetected EventType = "ConflictDetected"
+	EventAgentRunStarted    EventType = "AgentRunStarted"
+	EventAgentRunCompleted  EventType = "AgentRunCompleted"
+	EventAgentRunFailed     EventType = "AgentRunFailed"
+	EventDecisionStarted    EventType = "DecisionStarted"
+	EventDecisionMade       EventType = "DecisionMade"
+	EventDecisionRevised    EventType = "DecisionRevised"
+	EventDecisionSuperseded EventType = "DecisionSuperseded"
+	EventDecisionRetracted  EventType = "DecisionRetracted"
+	EventDecisionErased     EventType = "DecisionErased"
+	EventToolCallStarted    EventType = "ToolCallStarted"
+	EventToolCallCompleted  EventType = "ToolCallCompleted"
+	EventAgentHandoff       EventType = "AgentHandoff"
+	EventConflictDetected   EventType = "ConflictDetected"
 )
 
 // AgentEvent is an append-only event in the event log.
@@ -578,53 +578,53 @@ type AssessResponse struct {
 // are serialized at the top level alongside recommendation and reopens_resolution.
 type ConflictDetail struct {
 	// All DecisionConflict fields are inlined at the top level.
-	ID                uuid.UUID    `json:"id"`
-	ConflictKind      ConflictKind `json:"conflict_kind"`
-	DecisionAID       uuid.UUID    `json:"decision_a_id"`
-	DecisionBID       uuid.UUID    `json:"decision_b_id"`
-	OrgID             uuid.UUID    `json:"org_id"`
-	AgentA            string       `json:"agent_a"`
-	AgentB            string       `json:"agent_b"`
-	RunA              uuid.UUID    `json:"run_a"`
-	RunB              uuid.UUID    `json:"run_b"`
-	DecisionType      string       `json:"decision_type"`
-	DecisionTypeA     *string      `json:"decision_type_a,omitempty"`
-	DecisionTypeB     *string      `json:"decision_type_b,omitempty"`
-	OutcomeA          string       `json:"outcome_a"`
-	OutcomeB          string       `json:"outcome_b"`
-	ConfidenceA       float32      `json:"confidence_a"`
-	ConfidenceB       float32      `json:"confidence_b"`
-	ReasoningA        *string      `json:"reasoning_a,omitempty"`
-	ReasoningB        *string      `json:"reasoning_b,omitempty"`
-	DecidedAtA        time.Time    `json:"decided_at_a"`
-	DecidedAtB        time.Time    `json:"decided_at_b"`
-	DetectedAt        time.Time    `json:"detected_at"`
-	TopicSimilarity   *float64     `json:"topic_similarity,omitempty"`
-	OutcomeDivergence *float64     `json:"outcome_divergence,omitempty"`
-	Significance      *float64     `json:"significance,omitempty"`
-	ScoringMethod     string       `json:"scoring_method,omitempty"`
-	Explanation       *string      `json:"explanation,omitempty"`
-	Category          *string      `json:"category,omitempty"`
-	Severity          *string      `json:"severity,omitempty"`
-	Status            string       `json:"status"`
-	ResolvedBy        *string      `json:"resolved_by,omitempty"`
-	ResolvedAt        *time.Time   `json:"resolved_at,omitempty"`
-	ResolutionNote    *string      `json:"resolution_note,omitempty"`
-	Relationship      *string      `json:"relationship,omitempty"`
-	ConfidenceWeight  *float64     `json:"confidence_weight,omitempty"`
-	TemporalDecay     *float64     `json:"temporal_decay,omitempty"`
-	ResolutionDecisionID *uuid.UUID `json:"resolution_decision_id,omitempty"`
-	WinningDecisionID    *uuid.UUID `json:"winning_decision_id,omitempty"`
-	GroupID              *uuid.UUID `json:"group_id,omitempty"`
-	ClaimTextA        *string      `json:"claim_text_a,omitempty"`
-	ClaimTextB        *string      `json:"claim_text_b,omitempty"`
-	ReopensResolutionID *uuid.UUID `json:"reopens_resolution_id,omitempty"`
-	ProjectA          *string      `json:"project_a,omitempty"`
-	ProjectB          *string      `json:"project_b,omitempty"`
+	ID                   uuid.UUID    `json:"id"`
+	ConflictKind         ConflictKind `json:"conflict_kind"`
+	DecisionAID          uuid.UUID    `json:"decision_a_id"`
+	DecisionBID          uuid.UUID    `json:"decision_b_id"`
+	OrgID                uuid.UUID    `json:"org_id"`
+	AgentA               string       `json:"agent_a"`
+	AgentB               string       `json:"agent_b"`
+	RunA                 uuid.UUID    `json:"run_a"`
+	RunB                 uuid.UUID    `json:"run_b"`
+	DecisionType         string       `json:"decision_type"`
+	DecisionTypeA        *string      `json:"decision_type_a,omitempty"`
+	DecisionTypeB        *string      `json:"decision_type_b,omitempty"`
+	OutcomeA             string       `json:"outcome_a"`
+	OutcomeB             string       `json:"outcome_b"`
+	ConfidenceA          float32      `json:"confidence_a"`
+	ConfidenceB          float32      `json:"confidence_b"`
+	ReasoningA           *string      `json:"reasoning_a,omitempty"`
+	ReasoningB           *string      `json:"reasoning_b,omitempty"`
+	DecidedAtA           time.Time    `json:"decided_at_a"`
+	DecidedAtB           time.Time    `json:"decided_at_b"`
+	DetectedAt           time.Time    `json:"detected_at"`
+	TopicSimilarity      *float64     `json:"topic_similarity,omitempty"`
+	OutcomeDivergence    *float64     `json:"outcome_divergence,omitempty"`
+	Significance         *float64     `json:"significance,omitempty"`
+	ScoringMethod        string       `json:"scoring_method,omitempty"`
+	Explanation          *string      `json:"explanation,omitempty"`
+	Category             *string      `json:"category,omitempty"`
+	Severity             *string      `json:"severity,omitempty"`
+	Status               string       `json:"status"`
+	ResolvedBy           *string      `json:"resolved_by,omitempty"`
+	ResolvedAt           *time.Time   `json:"resolved_at,omitempty"`
+	ResolutionNote       *string      `json:"resolution_note,omitempty"`
+	Relationship         *string      `json:"relationship,omitempty"`
+	ConfidenceWeight     *float64     `json:"confidence_weight,omitempty"`
+	TemporalDecay        *float64     `json:"temporal_decay,omitempty"`
+	ResolutionDecisionID *uuid.UUID   `json:"resolution_decision_id,omitempty"`
+	WinningDecisionID    *uuid.UUID   `json:"winning_decision_id,omitempty"`
+	GroupID              *uuid.UUID   `json:"group_id,omitempty"`
+	ClaimTextA           *string      `json:"claim_text_a,omitempty"`
+	ClaimTextB           *string      `json:"claim_text_b,omitempty"`
+	ReopensResolutionID  *uuid.UUID   `json:"reopens_resolution_id,omitempty"`
+	ProjectA             *string      `json:"project_a,omitempty"`
+	ProjectB             *string      `json:"project_b,omitempty"`
 
 	// Detail-only fields.
 	Recommendation    *ConflictRecommendation `json:"recommendation,omitempty"`
-	ReopensResolution *ConflictResolution      `json:"reopens_resolution,omitempty"`
+	ReopensResolution *ConflictResolution     `json:"reopens_resolution,omitempty"`
 }
 
 // ConflictRecommendation is the server's suggested resolution for a conflict.
@@ -725,10 +725,11 @@ type EraseDecisionResponse struct {
 
 // AdjudicateConflictRequest is the input for Client.AdjudicateConflict.
 type AdjudicateConflictRequest struct {
-	Outcome           string     `json:"outcome"`
-	Reasoning         string     `json:"reasoning,omitempty"`
-	DecisionType      string     `json:"decision_type,omitempty"`
-	WinningDecisionID *uuid.UUID `json:"winning_decision_id,omitempty"`
+	Outcome           string      `json:"outcome"`
+	Reasoning         string      `json:"reasoning,omitempty"`
+	DecisionType      string      `json:"decision_type,omitempty"`
+	WinningDecisionID *uuid.UUID  `json:"winning_decision_id,omitempty"`
+	Supersedes        []uuid.UUID `json:"supersedes,omitempty"`
 }
 
 // ConflictStatusUpdate is the input for Client.PatchConflict.
@@ -785,12 +786,12 @@ type ConflictGroupOptions struct {
 // ConflictAnalyticsResponse is the output of Client.GetConflictAnalytics.
 // Matches canonical model.ConflictAnalytics.
 type ConflictAnalyticsResponse struct {
-	Period         TimePeriod                  `json:"period"`
-	Summary        ConflictAnalyticsSummary    `json:"summary"`
-	ByAgentPair    []ConflictAgentPairStats    `json:"by_agent_pair"`
-	ByDecisionType []ConflictTypeStats         `json:"by_decision_type"`
-	BySeverity     []ConflictSeverityStats     `json:"by_severity"`
-	Trend          []ConflictTrendPoint        `json:"trend"`
+	Period         TimePeriod               `json:"period"`
+	Summary        ConflictAnalyticsSummary `json:"summary"`
+	ByAgentPair    []ConflictAgentPairStats `json:"by_agent_pair"`
+	ByDecisionType []ConflictTypeStats      `json:"by_decision_type"`
+	BySeverity     []ConflictSeverityStats  `json:"by_severity"`
+	Trend          []ConflictTrendPoint     `json:"trend"`
 }
 
 // TimePeriod defines the start and end of an analytics window.

--- a/sdk/python/src/akashi/types.py
+++ b/sdk/python/src/akashi/types.py
@@ -561,8 +561,9 @@ class ConflictStatusUpdate(BaseModel):
 class AdjudicateConflictRequest(BaseModel):
     outcome: str
     reasoning: str | None = None
-    decision_type: str = "conflict_resolution"
+    decision_type: str | None = None
     winning_decision_id: UUID | None = None
+    supersedes: list[UUID] = Field(default_factory=list)
 
 
 class ResolveConflictGroupRequest(BaseModel):

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -836,7 +836,7 @@ export class AkashiClient {
     return this.get<ConflictDetail>(`/v1/conflicts/${encodeURIComponent(conflictId)}`);
   }
 
-  /** Adjudicate a conflict by choosing a winner. */
+  /** Adjudicate a conflict by recording a linked resolution decision. */
   async adjudicateConflict(conflictId: string, req: AdjudicateConflictRequest): Promise<ConflictDetail> {
     return this.post<ConflictDetail>(
       `/v1/conflicts/${encodeURIComponent(conflictId)}/adjudicate`,

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -498,6 +498,7 @@ export interface AdjudicateConflictRequest {
   reasoning?: string;
   decision_type?: string;
   winning_decision_id?: string;
+  supersedes?: string[];
 }
 
 export interface ConflictStatusUpdate {


### PR DESCRIPTION
## Summary

- Adds first-class reconciliation for synthesis conflicts: `akashi_reconcile`, multi-target `decision_supersedes`, adjudication `supersedes`, and conflict-scorer suppression for explicit supersedes.
- Preserves `winning_decision_id` as an A/B-only signal while linking synthesis decisions through `resolution_decision_id`, with ADR-016 plus OpenAPI and SDK updates.

## Verification

- [x] I ran relevant tests locally (`go test ./...` and `go test -count=1 -tags integration ./...`).
- [x] I updated docs/openapi for API and behavior changes.
- [x] Config vars unchanged; no config docs/env updates required.
- [x] `python3 scripts/check_doc_config_consistency.py` passes.
- [x] `go build ./...`, `go vet ./...`, `~/go/bin/golangci-lint run ./...`, and `atlas migrate validate --dir file://migrations` pass.

## Risk / Rollout Notes

- Adds migration 104 for `decision_supersedes`; apply it before using reconciliation writes.
- Backwards compatible with existing single-target `supersedes_id`, `akashi_resolve`, and HTTP adjudication semantics.

> Star Trek beats Star Wars when the hard problem is governance: it asks whether a crew can make better decisions under shared procedure, not whether one prodigy can improvise loudly enough. Akashi wants more of that bridge-console discipline than another dramatic throne-room reveal.
