### PR TITLE
feat(conflicts): suppress same-agent same-ticket refinement false positives (#709)

### DIFF
--- a/internal/conflicts/eval.go
+++ b/internal/conflicts/eval.go
@@ -294,6 +294,37 @@ func DefaultEvalDataset() []EvalPair {
 			},
 			ExpectedRelationship: "refinement",
 		},
+		// LLM defense-in-depth for the same-agent same-ticket pattern caught
+		// upstream by isSameAgentSameTicketRefinement (see issue #709). Filter
+		// suppresses the pair before the validator runs; this fixture covers
+		// the case where ticket extraction misses (e.g. agent omitted refs from
+		// every source) and the LLM must still classify it correctly.
+		{
+			Label: "same_agent_same_ticket_refinement: ARD-958 layer-2 then layer-3 by same agent",
+			Input: ValidateInput{
+				OutcomeA: "ARD-958 S2 implemented on branch evanvolgas/ard-958-stream-wal-concurrent-snapshot — concurrent snapshot worker with WAL replay coordination",
+				OutcomeB: "ARD-958 S3 implemented on branch evanvolgas/ard-958-layer-3-fatal-class — recorder cross-references pgstream.quarantine at markSnapshotCompleted, plumbs ConnectorID + DataLossThreshold",
+				TypeA:    "implementation", TypeB: "implementation",
+				AgentA: "claude-code", AgentB: "claude-code",
+				CreatedA: now, CreatedB: now.Add(3 * h),
+				ProjectA: "ardent-mono", ProjectB: "ardent-mono",
+				BranchA: "evanvolgas/ard-958-stream-wal-concurrent-snapshot",
+				BranchB: "evanvolgas/ard-958-layer-3-fatal-class",
+			},
+			ExpectedRelationship: "refinement",
+		},
+		{
+			Label: "same_agent_same_ticket_refinement: paraphrased follow-up without keyword markers",
+			Input: ValidateInput{
+				OutcomeA: "ARD-957 PR-1 added pre-flight source-side validator; checks pgx pool capacity and replication-slot availability before snapshot start",
+				OutcomeB: "Applied review fixes for ARD-957 PR-1: tightened the pool-size threshold, added per-table validator hook, and fixed the cancellation race in the pre-flight goroutine",
+				TypeA:    "implementation", TypeB: "implementation",
+				AgentA: "claude-code", AgentB: "claude-code",
+				CreatedA: now, CreatedB: now.Add(2 * h),
+				ProjectA: "ardent-mono", ProjectB: "ardent-mono",
+			},
+			ExpectedRelationship: "refinement",
+		},
 
 		// =====================================================================
 		// DIFFERENT SCOPE (false positive pattern)

--- a/internal/conflicts/metrics.go
+++ b/internal/conflicts/metrics.go
@@ -30,6 +30,7 @@ type Metrics struct {
 	transitiveGroupFiltered      metric.Int64Counter
 	fpPatternFiltered            metric.Int64Counter
 	temporalReassessmentFiltered metric.Int64Counter
+	supersedesCandidateFiltered  metric.Int64Counter
 
 	scoringDuration    metric.Float64Histogram
 	llmCallDuration    metric.Float64Histogram
@@ -194,6 +195,14 @@ func (s *Scorer) registerMetrics() {
 	if err != nil {
 		s.logger.Warn("conflicts: failed to create akashi.conflicts.temporal_reassessment_filtered metric", "error", err)
 		s.metrics.temporalReassessmentFiltered, _ = meter.Int64Counter("akashi.conflicts.temporal_reassessment_filtered.fallback")
+	}
+
+	s.metrics.supersedesCandidateFiltered, err = meter.Int64Counter("akashi.conflicts.supersedes_candidate_filtered",
+		metric.WithDescription("Candidate pairs suppressed as same-agent same-ticket refinements that probably warrant a supersedes_id link (issue #709)"),
+	)
+	if err != nil {
+		s.logger.Warn("conflicts: failed to create akashi.conflicts.supersedes_candidate_filtered metric", "error", err)
+		s.metrics.supersedesCandidateFiltered, _ = meter.Int64Counter("akashi.conflicts.supersedes_candidate_filtered.fallback")
 	}
 
 	// --- Histograms ---

--- a/internal/conflicts/scorer.go
+++ b/internal/conflicts/scorer.go
@@ -641,6 +641,22 @@ func (s *Scorer) scoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 			continue
 		}
 
+		// Same-agent same-ticket refinement filter: when the same agent
+		// traces a refinement of their own prior decision on the same ticket
+		// without setting supersedes_id, treat it as a missed-link refinement
+		// rather than a self-contradiction. Broader than the same-branch
+		// filter above — refinements can span branches (e.g. layer-2 PR
+		// followed by layer-3 PR on the same ticket).
+		// See issue #709; PR-2 (#710) will surface a supersedes_id suggestion.
+		if isSameAgentSameTicketRefinement(d, sc.cand) {
+			s.metrics.supersedesCandidateFiltered.Add(ctx, 1)
+			s.logger.Debug("conflict scorer: same-agent same-ticket refinement suppressed pair",
+				"decision_a", decisionID, "decision_b", sc.cand.ID,
+				"agent_id", d.AgentID,
+				"ticket_ref", extractTicketRef(d))
+			continue
+		}
+
 		// Temporal re-assessment filter: two review-type decisions on the
 		// same project, recorded sufficiently far apart with no precedent
 		// link, are re-measurements rather than contradictions. Quantitative
@@ -1432,6 +1448,46 @@ func isSameBranchSelfCorrection(d, cand model.Decision) bool {
 	branchB := nestedContextString(cand.AgentContext, "git_branch")
 
 	return branchA != "" && branchB != "" && branchA == branchB
+}
+
+// isSameAgentSameTicketRefinement returns true when the same agent traces
+// what looks like a clean refinement of their own prior decision on the same
+// ticket without setting supersedes_id. The newer decision likely intends
+// to supersede the earlier one but the agent forgot to set the link.
+//
+// Sibling of isSameBranchSelfCorrection: that filter requires identical
+// git_branch metadata. This one is broader — refinements can span branches
+// (e.g. layer-2 PR followed by layer-3 PR on the same ticket) so the join key
+// is an extracted ticket reference (see extractTicketRef in ticket_extract.go).
+//
+// Excluded:
+//   - precedent-linked pairs (the agent already linked them — let LLM judge)
+//   - outcomes containing supersession keywords (probable explicit reversal,
+//     not a forgotten link — let LLM judge)
+//   - different agents
+//   - missing or differing ticket references
+//
+// Tracks issue #709 (PR-1 of #708). PR-2 (#710) will surface a supersedes_id
+// suggestion to the agent via akashi_check.
+func isSameAgentSameTicketRefinement(d, cand model.Decision) bool {
+	if d.AgentID != cand.AgentID {
+		return false
+	}
+	if isPrecedentLinked(d, cand) {
+		return false
+	}
+	later := d
+	if cand.ValidFrom.After(d.ValidFrom) {
+		later = cand
+	}
+	if containsSupersessionKeyword(later.Outcome) {
+		return false
+	}
+	refA := extractTicketRef(d)
+	if refA == "" {
+		return false
+	}
+	return refA == extractTicketRef(cand)
 }
 
 // temporalReassessmentWindow is the minimum time delta between two

--- a/internal/conflicts/ticket_extract.go
+++ b/internal/conflicts/ticket_extract.go
@@ -1,0 +1,51 @@
+package conflicts
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/ashita-ai/akashi/internal/model"
+)
+
+// ticketRefPattern matches ticket references like ARD-958, ENG-42, RFC-7234.
+// The 3-letter prefix floor avoids accidental matches on HTTP-2, IPv4-4, and
+// other version-style strings; this still admits the conventional 3+ letter
+// project keys used by Linear, Jira, GitHub, and most issue trackers.
+var ticketRefPattern = regexp.MustCompile(`(?i)\b([A-Z]{3,10})-(\d+)\b`)
+
+// extractTicketRef returns the canonical ticket reference for a decision, or
+// "" if none can be inferred. Checks three sources in priority order:
+//
+//  1. agent_context.task   — agent-supplied free text (most explicit)
+//  2. agent_context.git_branch — e.g. "evanvolgas/ard-958-snapshot-errors"
+//  3. outcome text         — e.g. "ARD-958 S2 implemented..."
+//
+// Returns the canonical uppercase form ("ARD-958"). When multiple references
+// appear in the same source, returns the first match — agents conventionally
+// place the primary ticket first.
+//
+// Used by isSameAgentSameTicketRefinement to suppress false-positive
+// contradictions when the same agent refines their own prior decision on the
+// same ticket without setting supersedes_id.
+func extractTicketRef(d model.Decision) string {
+	if ref := matchTicketRef(nestedContextString(d.AgentContext, "task")); ref != "" {
+		return ref
+	}
+	if ref := matchTicketRef(nestedContextString(d.AgentContext, "git_branch")); ref != "" {
+		return ref
+	}
+	return matchTicketRef(d.Outcome)
+}
+
+// matchTicketRef applies ticketRefPattern to s and returns the canonical
+// uppercase ticket reference (e.g. "ARD-958"), or "" if none found.
+func matchTicketRef(s string) string {
+	if s == "" {
+		return ""
+	}
+	m := ticketRefPattern.FindStringSubmatch(s)
+	if m == nil {
+		return ""
+	}
+	return strings.ToUpper(m[1]) + "-" + m[2]
+}

--- a/internal/conflicts/ticket_extract_test.go
+++ b/internal/conflicts/ticket_extract_test.go
@@ -1,0 +1,315 @@
+package conflicts
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ashita-ai/akashi/internal/model"
+)
+
+func TestMatchTicketRef(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"empty input", "", ""},
+		{"canonical uppercase", "ARD-958", "ARD-958"},
+		{"lowercase canonicalised", "ard-958", "ARD-958"},
+		{"mixed case canonicalised", "Ard-958", "ARD-958"},
+		{"in branch path", "evanvolgas/ard-958-snapshot-errors", "ARD-958"},
+		{"in outcome prose", "ARD-958 S2 implemented end-to-end on branch", "ARD-958"},
+		{"task with stage suffix returns base ticket", "ARD-958 PR-1", "ARD-958"},
+		{"first match wins when multiple present", "ARD-958 then ARD-960 follow-up", "ARD-958"},
+		{"three-letter prefix accepted", "ENG-42 ship it", "ENG-42"},
+		{"ten-letter prefix accepted", "PROJECTABC-1 ok", "PROJECTABC-1"},
+		{"two-letter prefix rejected", "PR-7 only", ""},
+		{"http-2 admitted (4-letter prefix passes 3-letter floor — known limitation)", "HTTP-2 spec", "HTTP-2"},
+		{"single-digit ticket admitted", "ARD-1 first ticket", "ARD-1"},
+		{"adjacent word boundary required (no match when embedded in word)", "noARD-958boundary", ""},
+		{"eleven-letter prefix rejected", "ABCDEFGHIJK-1 too long", ""},
+		{"underscore neighbours not a boundary in RE2 (no match)", "fix_ARD-958_branch", ""},
+		{"slash boundary in path", "/ard-958/", "ARD-958"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, matchTicketRef(tt.input))
+		})
+	}
+}
+
+func TestExtractTicketRef_PrioritySources(t *testing.T) {
+	tests := []struct {
+		name     string
+		decision model.Decision
+		expected string
+	}{
+		{
+			name: "task field preferred over branch and outcome",
+			decision: model.Decision{
+				AgentContext: map[string]any{
+					"client": map[string]any{
+						"task":       "ARD-958 PR-1",
+						"git_branch": "evanvolgas/ard-960-other",
+					},
+				},
+				Outcome: "Implemented something for ARD-961",
+			},
+			expected: "ARD-958",
+		},
+		{
+			name: "branch fallback when task absent",
+			decision: model.Decision{
+				AgentContext: map[string]any{
+					"client": map[string]any{
+						"git_branch": "evanvolgas/ard-958-stream-wal",
+					},
+				},
+				Outcome: "Implemented something for ARD-961",
+			},
+			expected: "ARD-958",
+		},
+		{
+			name: "outcome fallback when task and branch absent",
+			decision: model.Decision{
+				AgentContext: map[string]any{},
+				Outcome:      "ARD-958 S2 implemented end-to-end",
+			},
+			expected: "ARD-958",
+		},
+		{
+			name: "server namespace task respected (mirrors nestedContextString fallback)",
+			decision: model.Decision{
+				AgentContext: map[string]any{
+					"server": map[string]any{"task": "ARD-958 review"},
+				},
+			},
+			expected: "ARD-958",
+		},
+		{
+			name: "flat agent_context.task respected (legacy layout)",
+			decision: model.Decision{
+				AgentContext: map[string]any{"task": "ARD-958 review"},
+			},
+			expected: "ARD-958",
+		},
+		{
+			name: "nil agent_context, no outcome match",
+			decision: model.Decision{
+				AgentContext: nil,
+				Outcome:      "Refactored the storage layer",
+			},
+			expected: "",
+		},
+		{
+			name: "nothing extractable from any source",
+			decision: model.Decision{
+				AgentContext: map[string]any{
+					"client": map[string]any{"git_branch": "main"},
+				},
+				Outcome: "Refactored the storage layer",
+			},
+			expected: "",
+		},
+		{
+			name: "branch with no ticket falls through to outcome match",
+			decision: model.Decision{
+				AgentContext: map[string]any{
+					"client": map[string]any{"git_branch": "feature/caching"},
+				},
+				Outcome: "ARD-958 implementation",
+			},
+			expected: "ARD-958",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, extractTicketRef(tt.decision))
+		})
+	}
+}
+
+func TestIsSameAgentSameTicketRefinement(t *testing.T) {
+	now := time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC)
+	idA := uuid.New()
+	idB := uuid.New()
+
+	taskCtx := func(task, branch string) map[string]any {
+		client := map[string]any{}
+		if task != "" {
+			client["task"] = task
+		}
+		if branch != "" {
+			client["git_branch"] = branch
+		}
+		return map[string]any{"client": client}
+	}
+
+	tests := []struct {
+		name     string
+		d        model.Decision
+		cand     model.Decision
+		expected bool
+	}{
+		{
+			name: "same agent, same ticket via task field, cross-branch → suppressed",
+			d: model.Decision{
+				ID: idA, AgentID: "claude-code",
+				AgentContext: taskCtx("ARD-958 PR-1", "evanvolgas/ard-958-layer-2"),
+				Outcome:      "Implemented validator", ValidFrom: now,
+			},
+			cand: model.Decision{
+				ID: idB, AgentID: "claude-code",
+				AgentContext: taskCtx("ARD-958 PR-2", "evanvolgas/ard-958-layer-3"),
+				Outcome:      "Refactored validator with batched embedding", ValidFrom: now.Add(time.Hour),
+			},
+			expected: true,
+		},
+		{
+			name: "same agent, same ticket extracted from branch only → suppressed",
+			d: model.Decision{
+				ID: idA, AgentID: "claude-code",
+				AgentContext: taskCtx("", "evanvolgas/ard-958-stream-wal"),
+				Outcome:      "Initial WAL streaming impl", ValidFrom: now,
+			},
+			cand: model.Decision{
+				ID: idB, AgentID: "claude-code",
+				AgentContext: taskCtx("", "evanvolgas/ard-958-rewrite"),
+				Outcome:      "Rewrote streaming layer", ValidFrom: now.Add(time.Hour),
+			},
+			expected: true,
+		},
+		{
+			name: "same agent, same ticket extracted from outcome only → suppressed",
+			d: model.Decision{
+				ID: idA, AgentID: "claude-code",
+				AgentContext: nil,
+				Outcome:      "ARD-958 S2 implemented", ValidFrom: now,
+			},
+			cand: model.Decision{
+				ID: idB, AgentID: "claude-code",
+				AgentContext: nil,
+				Outcome:      "ARD-958 follow-up adjustments", ValidFrom: now.Add(time.Hour),
+			},
+			expected: true,
+		},
+		{
+			name: "ticket extracted from outcome on one side, branch on the other → suppressed",
+			d: model.Decision{
+				ID: idA, AgentID: "claude-code",
+				AgentContext: taskCtx("", "evanvolgas/ard-958-stream-wal"),
+				Outcome:      "Streaming layer first cut", ValidFrom: now,
+			},
+			cand: model.Decision{
+				ID: idB, AgentID: "claude-code",
+				AgentContext: nil,
+				Outcome:      "ARD-958 follow-up adjustments", ValidFrom: now.Add(time.Hour),
+			},
+			expected: true,
+		},
+		{
+			name: "different agents, same ticket → not suppressed",
+			d: model.Decision{
+				ID: idA, AgentID: "claude-code",
+				AgentContext: taskCtx("ARD-958", ""), Outcome: "Impl", ValidFrom: now,
+			},
+			cand: model.Decision{
+				ID: idB, AgentID: "reviewer",
+				AgentContext: taskCtx("ARD-958", ""), Outcome: "Different take", ValidFrom: now.Add(time.Hour),
+			},
+			expected: false,
+		},
+		{
+			name: "same agent, different tickets → not suppressed",
+			d: model.Decision{
+				ID: idA, AgentID: "claude-code",
+				AgentContext: taskCtx("ARD-958", ""), Outcome: "Impl", ValidFrom: now,
+			},
+			cand: model.Decision{
+				ID: idB, AgentID: "claude-code",
+				AgentContext: taskCtx("ARD-960", ""), Outcome: "Other impl", ValidFrom: now.Add(time.Hour),
+			},
+			expected: false,
+		},
+		{
+			name: "same agent, no ticket on either side → not suppressed",
+			d: model.Decision{
+				ID: idA, AgentID: "claude-code",
+				AgentContext: nil, Outcome: "Refactored storage layer", ValidFrom: now,
+			},
+			cand: model.Decision{
+				ID: idB, AgentID: "claude-code",
+				AgentContext: nil, Outcome: "Refactored storage layer differently", ValidFrom: now.Add(time.Hour),
+			},
+			expected: false,
+		},
+		{
+			name: "same agent, ticket only on one side → not suppressed (no shared join key)",
+			d: model.Decision{
+				ID: idA, AgentID: "claude-code",
+				AgentContext: taskCtx("ARD-958", ""), Outcome: "Impl", ValidFrom: now,
+			},
+			cand: model.Decision{
+				ID: idB, AgentID: "claude-code",
+				AgentContext: nil, Outcome: "Refactored storage layer", ValidFrom: now.Add(time.Hour),
+			},
+			expected: false,
+		},
+		{
+			name: "same agent, same ticket, but precedent_ref linked → not suppressed (LLM decides)",
+			d: model.Decision{
+				ID: idA, AgentID: "claude-code",
+				AgentContext: taskCtx("ARD-958", ""), Outcome: "Impl", ValidFrom: now,
+				PrecedentRef: &idB,
+			},
+			cand: model.Decision{
+				ID: idB, AgentID: "claude-code",
+				AgentContext: taskCtx("ARD-958", ""), Outcome: "Earlier work", ValidFrom: now.Add(-time.Hour),
+			},
+			expected: false,
+		},
+		{
+			name: "same agent, same ticket, but later outcome reverses prior choice → not suppressed",
+			d: model.Decision{
+				ID: idA, AgentID: "claude-code",
+				AgentContext: taskCtx("ARD-958", ""),
+				Outcome:      "Reverted ARD-958 caching strategy; switched to write-through instead",
+				ValidFrom:    now.Add(time.Hour),
+			},
+			cand: model.Decision{
+				ID: idB, AgentID: "claude-code",
+				AgentContext: taskCtx("ARD-958", ""),
+				Outcome:      "Chose write-back caching for ARD-958",
+				ValidFrom:    now,
+			},
+			expected: false,
+		},
+		{
+			name: "same agent, same ticket, reversal keyword on the EARLIER outcome → still suppressed (we only inspect later)",
+			d: model.Decision{
+				ID: idA, AgentID: "claude-code",
+				AgentContext: taskCtx("ARD-958", ""),
+				Outcome:      "Reverted prior approach for ARD-958",
+				ValidFrom:    now,
+			},
+			cand: model.Decision{
+				ID: idB, AgentID: "claude-code",
+				AgentContext: taskCtx("ARD-958", ""),
+				Outcome:      "Refined ARD-958 implementation further",
+				ValidFrom:    now.Add(time.Hour),
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isSameAgentSameTicketRefinement(tt.d, tt.cand))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `isSameAgentSameTicketRefinement` to the conflict scorer's filter chain — catches cross-branch refinements where the same agent forgot to set `supersedes_id` on a follow-up trace for the same ticket.
- New `extractTicketRef` helper resolves a canonical ticket ref (e.g. `ARD-958`) from `agent_context.task` → `agent_context.git_branch` → `outcome` text.
- New `akashi.conflicts.supersedes_candidate_filtered` metric exposes how often the filter fires.
- Two LLM defense-in-depth fixtures added to `DefaultEvalDataset` for the case where ticket extraction misses entirely.

PR-1 of #708. PR-2 (#710) will turn each suppressed pair into an agent-visible `supersedes_id` suggestion via `decision_supersedes` (ADR-016) and surface them through `akashi_check`.

## Why

The existing `isSameBranchSelfCorrection` filter only fires when both decisions share an identical `git_branch`. Real refinements regularly span branches (layer-2 PR followed by layer-3 PR on the same ticket) and the detector then emits a high-severity self-contradiction. Concrete examples this org observed: `d811901a` → `0260ea45`, plus the ARD-958/957/970/952/870 cluster.

Sibling of #566 (which checks the *explicit* supersedes chain) — this issue handles the *latent* chain when the link wasn't set.

## Behavior

Pair is suppressed when ALL hold:
- same `agent_id`
- ticket reference extracted from at least one of (task, branch, outcome) — same value on both sides
- not `precedent_ref`-linked
- the later outcome does NOT contain a supersession keyword (`reverted`, `replaced`, `instead of`, …)

Anything failing those gates still reaches the LLM validator.

## Test plan

- [x] `go build ./...` ✓
- [x] `go vet ./...` ✓
- [x] `golangci-lint run ./...` 0 issues
- [x] `go mod tidy` clean
- [x] `atlas migrate validate` ✓
- [x] `go test -race -count=1 ./...` ✓ — full repo green incl. `internal/conflicts` (8.9s), `internal/storage/sqlite` (19.5s)
- [x] 36 new unit cases: `TestMatchTicketRef` (17), `TestExtractTicketRef_PrioritySources` (8), `TestIsSameAgentSameTicketRefinement` (11). Table-test parity with `TestIsSameBranchSelfCorrection`.

## Out of scope

- Suggestion surface to agents (PR-2, tracked by #710).
- Per-org ticket-prefix allow-lists. Default 3-letter prefix floor admits `HTTP-2` but rejects `PR-7`; the trade is documented in the regex comment.
- Cross-org ticket inference.

> Strider, Estel, King —
> all one ranger, many names;
> mistake them, you war.