### PR TITLE
feat(conflicts): supersedes_id suggestion surface via decision_supersedes (#710)

### DIFF
--- a/akashi.go
+++ b/akashi.go
@@ -1271,10 +1271,15 @@ func (a *App) autoResolveLoop(ctx context.Context) {
 }
 
 // runRetention processes data retention policies for all orgs that have a
-// retention_days set. Each org gets its own deletion_log entry.
+// retention_days set. Each org gets its own deletion_log entry. A global
+// pass also prunes detector-inferred supersedes suggestions older than
+// SupersedesSuggestionTTL — these are operational hints, not user data, and
+// are pruned on a single global TTL regardless of per-org policy.
 func (a *App) runRetention(ctx context.Context) {
 	opCtx, cancel := context.WithTimeout(ctx, a.cfg.RetentionInterval/2)
 	defer cancel()
+
+	a.pruneStaleSupersedesSuggestions(opCtx)
 
 	orgs, err := a.db.GetOrgsWithRetention(opCtx)
 	if err != nil {
@@ -1323,6 +1328,26 @@ func (a *App) runRetention(ctx context.Context) {
 				"cutoff", cutoff,
 			)
 		}
+	}
+}
+
+// pruneStaleSupersedesSuggestions removes detector-inferred supersedes
+// suggestions that an agent never confirmed. Suggestions confirmed by a
+// re-trace are retired by the migration-106 trigger at confirm time; this
+// global TTL pass cleans up the long tail. Failures are warn-logged but do
+// not abort the retention run — the next tick will retry.
+func (a *App) pruneStaleSupersedesSuggestions(ctx context.Context) {
+	if a.cfg.SupersedesSuggestionTTL <= 0 {
+		return
+	}
+	cutoff := time.Now().UTC().Add(-a.cfg.SupersedesSuggestionTTL)
+	n, err := a.db.DeleteOldSupersedesSuggestions(ctx, cutoff)
+	if err != nil {
+		a.logger.Warn("retention: prune supersedes suggestions failed", "error", err, "cutoff", cutoff)
+		return
+	}
+	if n > 0 {
+		a.logger.Info("retention: pruned stale supersedes suggestions", "count", n, "cutoff", cutoff)
 	}
 }
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -4417,6 +4417,52 @@ components:
             True when the conflict list query failed due to a transient error.
             The conflicts array may be empty or incomplete. Callers should
             exercise extra caution before proceeding.
+        supersedes_suggestions:
+          type: array
+          description: >
+            Detector-inferred latent supersedes_id links for the returned
+            decisions. Each entry names a probable superseded predecessor
+            for one of the decisions in this response. To confirm a
+            suggestion, re-trace the superseding decision with supersedes_id
+            set to the suggested superseded_id; the server records the
+            confirmed link and retires the suggestion atomically. To
+            dismiss, take no action — the retention loop prunes stale
+            suggestions.
+          items:
+            $ref: "#/components/schemas/SupersedesSuggestion"
+
+    SupersedesSuggestion:
+      type: object
+      required: [superseding_id, superseded_id, suggested_by, recorded_at]
+      properties:
+        superseding_id:
+          type: string
+          format: uuid
+          description: The newer decision the detector believes supersedes another.
+        superseded_id:
+          type: string
+          format: uuid
+          description: The probable predecessor that the newer decision retires.
+        suggested_by:
+          type: string
+          description: >
+            Detector identifier (e.g. "detector:same_agent_same_ticket").
+            Low-cardinality so callers can distinguish suggestion sources.
+        confidence:
+          type: number
+          format: float
+          minimum: 0
+          maximum: 1
+          description: >
+            Detector pre-suppression similarity score for the pair (typically
+            the topic-embedding cosine similarity at filter time). Optional.
+        reason:
+          type: string
+          description: >
+            Short human-readable explanation, e.g. agent identity and ticket.
+        recorded_at:
+          type: string
+          format: date-time
 
     # ── Health schemas ───────────────────────────────────────────────
     HealthResponse:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -267,6 +267,7 @@ Akashi supports per-org data retention policies that automatically delete decisi
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `AKASHI_RETENTION_INTERVAL` | `24h` | How often the background retention worker runs. Set to `0` to disable. |
+| `AKASHI_SUPERSEDES_SUGGESTION_TTL` | `720h` (30d) | Lifetime of unconfirmed detector-inferred supersedes suggestions before pruning. The retention loop deletes `decision_supersedes` rows with `relationship='suggested'` older than this. Set to `0` to disable pruning. |
 
 ## Claim embedding retry
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -131,6 +131,7 @@ type Config struct {
 	MaxRequestBodyBytes           int64         // Maximum request body size in bytes.
 	ExportPageSize                int           // Page size for streaming NDJSON exports (default 100).
 	RetentionInterval             time.Duration // How often the background retention worker runs (default 24h).
+	SupersedesSuggestionTTL       time.Duration // Lifetime of unconfirmed detector-inferred supersedes suggestions before pruning (default 30 days, 0 disables).
 	ClaimRetryInterval            time.Duration // How often to retry failed claim embeddings (default 2m).
 	PercentileRefreshInterval     time.Duration // How often to refresh signal percentile caches (default 1h).
 	AutoResolveInterval           time.Duration // How often the auto-resolution worker runs (default 1h, 0 disables).
@@ -296,6 +297,7 @@ func Load() (Config, error) {
 	cfg.IdempotencyCompletedTTL, errs = collectDuration(errs, "AKASHI_IDEMPOTENCY_COMPLETED_TTL", 7*24*time.Hour)
 	cfg.IdempotencyAbandonedTTL, errs = collectDuration(errs, "AKASHI_IDEMPOTENCY_ABANDONED_TTL", 24*time.Hour)
 	cfg.RetentionInterval, errs = collectDuration(errs, "AKASHI_RETENTION_INTERVAL", 24*time.Hour)
+	cfg.SupersedesSuggestionTTL, errs = collectDuration(errs, "AKASHI_SUPERSEDES_SUGGESTION_TTL", 30*24*time.Hour)
 	cfg.ClaimRetryInterval, errs = collectDuration(errs, "AKASHI_CLAIM_RETRY_INTERVAL", 2*time.Minute)
 	cfg.PercentileRefreshInterval, errs = collectDuration(errs, "AKASHI_PERCENTILE_REFRESH_INTERVAL", 1*time.Hour)
 	cfg.AutoResolveInterval, errs = collectDuration(errs, "AKASHI_AUTO_RESOLVE_INTERVAL", 1*time.Hour)

--- a/internal/conflicts/scorer.go
+++ b/internal/conflicts/scorer.go
@@ -647,13 +647,16 @@ func (s *Scorer) scoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 		// rather than a self-contradiction. Broader than the same-branch
 		// filter above — refinements can span branches (e.g. layer-2 PR
 		// followed by layer-3 PR on the same ticket).
-		// See issue #709; PR-2 (#710) will surface a supersedes_id suggestion.
+		// See issue #709; the suggestion record (PR-2, #710) is written
+		// below so akashi_check can surface it on the agent's next call.
 		if isSameAgentSameTicketRefinement(d, sc.cand) {
 			s.metrics.supersedesCandidateFiltered.Add(ctx, 1)
+			ticket := extractTicketRef(d)
 			s.logger.Debug("conflict scorer: same-agent same-ticket refinement suppressed pair",
 				"decision_a", decisionID, "decision_b", sc.cand.ID,
 				"agent_id", d.AgentID,
-				"ticket_ref", extractTicketRef(d))
+				"ticket_ref", ticket)
+			s.recordSupersedesSuggestion(ctx, d, sc.cand, sc.topicSim, ticket)
 			continue
 		}
 
@@ -1448,6 +1451,45 @@ func isSameBranchSelfCorrection(d, cand model.Decision) bool {
 	branchB := nestedContextString(cand.AgentContext, "git_branch")
 
 	return branchA != "" && branchB != "" && branchA == branchB
+}
+
+// recordSupersedesSuggestion writes the detector-inferred supersedes link
+// for a suppressed same-agent same-ticket pair so akashi_check can surface
+// it on the agent's next call (PR-2 of #708, see issue #710). Fire-and-forget:
+// suggestion-write failures are logged at warn but never block scoring or
+// fail the pair — the conflict has already been filtered.
+//
+// The "later" decision (by ValidFrom) is treated as the superseding side.
+// This mirrors how a manually set supersedes_id link works: the newer trace
+// retires the older one. Suggestion confidence is the topic similarity at
+// filter time — agents see how strongly the detector believed the pair was
+// the same work. Cosine similarity is mathematically in [-1, 1] but the
+// API contract bounds confidence to [0, 1]; we clamp here so callers and
+// dashboards never see a value that violates the schema.
+func (s *Scorer) recordSupersedesSuggestion(ctx context.Context, d, cand model.Decision, topicSim float64, ticket string) {
+	superseding, superseded := d, cand
+	if cand.ValidFrom.After(d.ValidFrom) {
+		superseding, superseded = cand, d
+	}
+	switch {
+	case topicSim < 0:
+		topicSim = 0
+	case topicSim > 1:
+		topicSim = 1
+	}
+	conf := float32(topicSim)
+	reason := fmt.Sprintf("same agent %q, same ticket %q", d.AgentID, ticket)
+	if err := s.db.InsertSupersedesSuggestion(ctx, storage.SupersedesSuggestionInsert{
+		OrgID:         d.OrgID,
+		SupersedingID: superseding.ID,
+		SupersededID:  superseded.ID,
+		SuggestedBy:   "detector:same_agent_same_ticket",
+		Confidence:    &conf,
+		Reason:        reason,
+	}); err != nil {
+		s.logger.Warn("conflict scorer: insert supersedes suggestion failed",
+			"superseding_id", superseding.ID, "superseded_id", superseded.ID, "error", err)
+	}
 }
 
 // isSameAgentSameTicketRefinement returns true when the same agent traces

--- a/internal/conflicts/scorer_test.go
+++ b/internal/conflicts/scorer_test.go
@@ -3154,3 +3154,88 @@ func TestBenchmarkDataset_HasFPCategories(t *testing.T) {
 	assert.Equal(t, 40, labelCounts["related_not_contradicting"], "10 original + 30 FP category pairs")
 	assert.Equal(t, 10, labelCounts["unrelated_false_positive"])
 }
+
+// TestScoreForDecision_SameAgentSameTicketSuggestion verifies that when the
+// same-agent same-ticket refinement filter fires, the scorer (a) does NOT
+// emit a conflict for the pair and (b) writes a 'suggested' row to
+// decision_supersedes that akashi_check can later surface to the agent.
+// See PR-2 of #708 (issue #710).
+func TestScoreForDecision_SameAgentSameTicketSuggestion(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	orgID := uuid.Nil
+
+	suffix := uuid.New().String()[:8]
+	agentID := "ssr-suggest-" + suffix
+	_, err := testDB.CreateAgent(ctx, model.Agent{
+		AgentID: agentID, OrgID: orgID, Name: agentID, Role: model.RoleAgent,
+	})
+	require.NoError(t, err)
+
+	runA := createRun(t, agentID, orgID)
+	runB := createRun(t, agentID, orgID)
+
+	// Same topic embedding (high topic similarity). Outcome embeddings differ
+	// enough that the pair would otherwise be flagged a conflict — but the
+	// ticket reference matches via agent_context.task on both sides, so the
+	// filter must catch it before the LLM ever runs.
+	topicEmb := makeEmbedding(0, 1.0)
+	outcomeEmbA := makeEmbedding(1, 1.0)
+	outcomeEmbB := makeEmbedding(2, 1.0)
+
+	taskCtx := func(task, branch string) map[string]any {
+		return map[string]any{"client": map[string]any{"task": task, "git_branch": branch}}
+	}
+
+	earlier, err := testDB.CreateDecision(ctx, model.Decision{
+		RunID: runA.ID, AgentID: agentID, OrgID: orgID,
+		DecisionType: "implementation",
+		Outcome:      "ARD-958 layer-2 implementation",
+		Confidence:   0.8,
+		Embedding:    &topicEmb, OutcomeEmbedding: &outcomeEmbA,
+		AgentContext: taskCtx("ARD-958 PR-1", "evanvolgas/ard-958-layer-2"),
+		ValidFrom:    time.Now().Add(-2 * time.Hour),
+	})
+	require.NoError(t, err)
+
+	later, err := testDB.CreateDecision(ctx, model.Decision{
+		RunID: runB.ID, AgentID: agentID, OrgID: orgID,
+		DecisionType: "implementation",
+		Outcome:      "ARD-958 layer-3 follow-up",
+		Confidence:   0.85,
+		Embedding:    &topicEmb, OutcomeEmbedding: &outcomeEmbB,
+		AgentContext: taskCtx("ARD-958 PR-2", "evanvolgas/ard-958-layer-3"),
+		ValidFrom:    time.Now(),
+	})
+	require.NoError(t, err)
+
+	// Use a non-noop validator so the directToScorer bypass doesn't kick in
+	// before our filter — the filter must run regardless.
+	scorer := NewScorer(testDB, logger, 0.1, stubConflictValidator{}, 0, 0)
+	scorer = scorer.WithCandidateFinder(storage.NewPgCandidateFinder(testDB))
+
+	scorer.ScoreForDecision(ctx, later.ID, orgID)
+
+	// Assert: no conflict was inserted for this pair.
+	conflicts, err := testDB.ListConflicts(ctx, orgID, storage.ConflictFilters{}, 100, 0)
+	require.NoError(t, err)
+	for _, c := range conflicts {
+		aIs := c.DecisionAID == earlier.ID || c.DecisionBID == earlier.ID
+		bIs := c.DecisionAID == later.ID || c.DecisionBID == later.ID
+		assert.Falsef(t, aIs && bIs,
+			"same-agent same-ticket pair must be suppressed (got conflict %s)", c.ID)
+	}
+
+	// Assert: a suggestion row was written, with later as the superseding side.
+	suggestions, err := testDB.ListSupersedesSuggestionsForDecisions(ctx, orgID, []uuid.UUID{later.ID})
+	require.NoError(t, err)
+	require.Len(t, suggestions, 1, "expected exactly one suggestion for the later decision")
+	assert.Equal(t, later.ID, suggestions[0].SupersedingID)
+	assert.Equal(t, earlier.ID, suggestions[0].SupersededID)
+	assert.Equal(t, "detector:same_agent_same_ticket", suggestions[0].SuggestedBy)
+	require.NotNil(t, suggestions[0].Confidence)
+	assert.InDelta(t, 1.0, *suggestions[0].Confidence, 0.01,
+		"identical topic embeddings should yield confidence ≈ 1.0")
+	assert.Contains(t, suggestions[0].Reason, "ARD-958")
+	assert.Contains(t, suggestions[0].Reason, agentID)
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -53,6 +53,14 @@ WHAT YOU GET BACK:
   akashi_trace to build explicitly on the validated approach. This is the
   mechanism that prevents agents from resurrecting losing approaches after
   a conflict has been formally resolved.
+- supersedes_suggestions: latent supersedes_id links the detector inferred
+  for the returned decisions — typically same-agent same-ticket refinements
+  where supersedes_id was not set on the newer trace. Each entry names a
+  superseding_id (one of the returned decisions) and a probable
+  superseded_id predecessor. To CONFIRM, re-trace the superseding decision
+  with supersedes_id set to the suggested superseded_id; the server records
+  the confirmed link and retires the suggestion atomically. To DISMISS,
+  take no action — the retention loop prunes stale suggestions.
 - precedent_ref_hint: UUID to copy into akashi_trace's precedent_ref field
 
 decision_type is optional. When omitted the search spans all types —
@@ -652,6 +660,21 @@ func (s *Server) handleCheck(ctx context.Context, request mcplib.CallToolRequest
 	for i, r := range resp.PriorResolutions {
 		compactResolutions[i] = compactResolution(r)
 	}
+	compactSuggestions := make([]map[string]any, len(resp.SupersedesSuggestions))
+	for i, sug := range resp.SupersedesSuggestions {
+		entry := map[string]any{
+			"superseding_id": sug.SupersedingID.String(),
+			"superseded_id":  sug.SupersededID.String(),
+			"suggested_by":   sug.SuggestedBy,
+		}
+		if sug.Confidence != nil {
+			entry["confidence"] = *sug.Confidence
+		}
+		if sug.Reason != "" {
+			entry["reason"] = sug.Reason
+		}
+		compactSuggestions[i] = entry
+	}
 
 	summary := generateCheckSummary(resp.Decisions, resp.Conflicts)
 	if resp.ConflictsUnavailable {
@@ -660,15 +683,19 @@ func (s *Server) handleCheck(ctx context.Context, request mcplib.CallToolRequest
 	if len(resp.PriorResolutions) > 0 {
 		summary += fmt.Sprintf(" %d prior conflict(s) for this decision type were formally resolved; winning approach(es) listed in prior_resolutions.", len(resp.PriorResolutions))
 	}
+	if len(resp.SupersedesSuggestions) > 0 {
+		summary += fmt.Sprintf(" %d supersedes_id suggestion(s) — re-trace with supersedes_id set to confirm, or ignore to dismiss.", len(resp.SupersedesSuggestions))
+	}
 
 	result := map[string]any{
-		"has_precedent":     resp.HasPrecedent,
-		"summary":           summary,
-		"action_needed":     actionNeeded(resp.Conflicts) || resp.ConflictsUnavailable,
-		"relevant_count":    len(resp.Decisions),
-		"decisions":         compactDecs,
-		"conflicts":         compactConfs,
-		"prior_resolutions": compactResolutions,
+		"has_precedent":          resp.HasPrecedent,
+		"summary":                summary,
+		"action_needed":          actionNeeded(resp.Conflicts) || resp.ConflictsUnavailable,
+		"relevant_count":         len(resp.Decisions),
+		"decisions":              compactDecs,
+		"conflicts":              compactConfs,
+		"prior_resolutions":      compactResolutions,
+		"supersedes_suggestions": compactSuggestions,
 	}
 
 	if resp.ConflictsUnavailable {

--- a/internal/model/query.go
+++ b/internal/model/query.go
@@ -115,6 +115,30 @@ type ConflictResolution struct {
 	ResolvedAt        time.Time `json:"resolved_at"`
 }
 
+// SupersedesSuggestion is a detector-inferred latent supersedes_id link
+// surfaced to agents through akashi_check. The conflict scorer writes a
+// suggestion when it observes a same-agent same-ticket refinement that would
+// otherwise produce a self-contradiction; the agent confirms by re-tracing
+// with supersedes_id set, which (per migration 106) creates a confirmed
+// 'supersedes' row for the new trace and retires the original suggestion.
+// Stale suggestions that are never confirmed are pruned by the retention
+// loop. See #710.
+type SupersedesSuggestion struct {
+	SupersedingID uuid.UUID `json:"superseding_id"`
+	SupersededID  uuid.UUID `json:"superseded_id"`
+	// SuggestedBy identifies the detector that produced the suggestion
+	// (e.g. "detector:same_agent_same_ticket"). Low-cardinality string so
+	// agents and dashboards can distinguish suggestion sources.
+	SuggestedBy string `json:"suggested_by"`
+	// Confidence is the detector's pre-suppression similarity score for the
+	// pair (typically the topic similarity at filter time). Optional.
+	Confidence *float32 `json:"confidence,omitempty"`
+	// Reason is a short human-readable explanation, e.g.
+	// "same agent \"claude-code\", same ticket \"ARD-958\"".
+	Reason     string    `json:"reason,omitempty"`
+	RecordedAt time.Time `json:"recorded_at"`
+}
+
 // CheckResponse is the response for POST /v1/check.
 type CheckResponse struct {
 	HasPrecedent bool               `json:"has_precedent"`
@@ -130,4 +154,13 @@ type CheckResponse struct {
 	// (losing_outcome / losing_agent). Use winning_decision_id as precedent_ref
 	// in akashi_trace to build on the validated approach.
 	PriorResolutions []ConflictResolution `json:"prior_resolutions,omitempty"`
+	// SupersedesSuggestions are latent supersedes_id links the detector
+	// inferred for the returned decisions. Each entry names a probable
+	// superseded predecessor for one of the decisions in this response. To
+	// confirm a suggestion, re-trace the superseding decision with
+	// supersedes_id set to the suggestion's superseded_id; the trigger
+	// installed by migration 106 creates the confirmed link and retires the
+	// suggestion atomically. To dismiss, take no action — the retention loop
+	// prunes stale suggestions.
+	SupersedesSuggestions []SupersedesSuggestion `json:"supersedes_suggestions,omitempty"`
 }

--- a/internal/service/decisions/helpers_test.go
+++ b/internal/service/decisions/helpers_test.go
@@ -483,6 +483,21 @@ func (m *mockStore) GetDecisionEmbeddings(_ context.Context, _ []uuid.UUID, _ uu
 	return m.embeddings, m.embeddingsErr
 }
 
+// Supersedes-suggestion helpers default to empty / no-op so the Check path
+// doesn't panic during unit tests that don't exercise the suggestion surface.
+// Tests that care assert the wired behavior in the integration suite.
+func (m *mockStore) ListSupersedesSuggestionsForDecisions(_ context.Context, _ uuid.UUID, _ []uuid.UUID) ([]model.SupersedesSuggestion, error) {
+	return nil, nil
+}
+
+func (m *mockStore) InsertSupersedesSuggestion(_ context.Context, _ storage.SupersedesSuggestionInsert) error {
+	return nil
+}
+
+func (m *mockStore) DeleteOldSupersedesSuggestions(_ context.Context, _ time.Time) (int64, error) {
+	return 0, nil
+}
+
 func (m *mockStore) FindRetriableClaimFailures(_ context.Context, _ int, _ int) ([]storage.ClaimRetryRef, error) {
 	return m.retriableFailures, m.retriableErr
 }

--- a/internal/service/decisions/service.go
+++ b/internal/service/decisions/service.go
@@ -737,12 +737,31 @@ func (s *Service) Check(ctx context.Context, orgID uuid.UUID, input CheckInput) 
 		return model.CheckResponse{}, searchErr
 	}
 
+	// 4. Fetch detector-inferred supersedes suggestions for the returned
+	// decisions. Sequential after wg.Wait because the input set is the IDs
+	// from lookup #1. Non-fatal: a failure here only loses the suggestion
+	// surface for this call — the precedent lookup itself stands. See #710.
+	var suggestions []model.SupersedesSuggestion
+	if len(decisions) > 0 {
+		ids := make([]uuid.UUID, len(decisions))
+		for i, d := range decisions {
+			ids[i] = d.ID
+		}
+		got, err := s.db.ListSupersedesSuggestionsForDecisions(ctx, orgID, ids)
+		if err != nil {
+			s.logger.Warn("check: list supersedes suggestions", "error", err)
+		} else {
+			suggestions = got
+		}
+	}
+
 	resp := model.CheckResponse{
-		HasPrecedent:         len(decisions) > 0,
-		Decisions:            decisions,
-		Conflicts:            conflicts,
-		ConflictsUnavailable: conflictErr != nil,
-		PriorResolutions:     resolutions,
+		HasPrecedent:          len(decisions) > 0,
+		Decisions:             decisions,
+		Conflicts:             conflicts,
+		ConflictsUnavailable:  conflictErr != nil,
+		PriorResolutions:      resolutions,
+		SupersedesSuggestions: suggestions,
 	}
 
 	return resp, nil

--- a/internal/service/decisions/service_test.go
+++ b/internal/service/decisions/service_test.go
@@ -162,6 +162,87 @@ func TestCheck_StructuredQuery(t *testing.T) {
 	assert.Equal(t, "security", resp.Decisions[0].DecisionType)
 }
 
+func TestCheck_SurfacesSupersedesSuggestions(t *testing.T) {
+	ctx := context.Background()
+	agentID := "check-suggest-" + uuid.New().String()[:8]
+	createAgent(t, agentID)
+
+	// Two decisions on the same ticket — but no embedding/Qdrant in this
+	// suite, so we won't trigger the scorer's suggestion-write path here.
+	// Instead we exercise the Check service against a suggestion row we
+	// insert directly. The scorer-side write is covered by
+	// TestScoreForDecision_SameAgentSameTicketSuggestion in conflicts_test.
+	earlier, err := testSvc.Trace(ctx, uuid.Nil, decisions.TraceInput{
+		AgentID: agentID,
+		Decision: model.TraceDecision{
+			DecisionType: "implementation",
+			Outcome:      "ARD-958 layer-2 implementation",
+			Confidence:   0.8,
+		},
+	})
+	require.NoError(t, err)
+	later, err := testSvc.Trace(ctx, uuid.Nil, decisions.TraceInput{
+		AgentID: agentID,
+		Decision: model.TraceDecision{
+			DecisionType: "implementation",
+			Outcome:      "ARD-958 layer-3 follow-up",
+			Confidence:   0.85,
+		},
+	})
+	require.NoError(t, err)
+
+	conf := float32(0.91)
+	require.NoError(t, testDB.InsertSupersedesSuggestion(ctx, storage.SupersedesSuggestionInsert{
+		OrgID:         uuid.Nil,
+		SupersedingID: later.DecisionID,
+		SupersededID:  earlier.DecisionID,
+		SuggestedBy:   "detector:same_agent_same_ticket",
+		Confidence:    &conf,
+		Reason:        `same agent "` + agentID + `", same ticket "ARD-958"`,
+	}))
+
+	resp, err := testSvc.Check(ctx, uuid.Nil, decisions.CheckInput{
+		DecisionType: "implementation",
+		AgentID:      agentID,
+		Limit:        5,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.Decisions, "Check should return the agent's recent decisions")
+	require.Len(t, resp.SupersedesSuggestions, 1,
+		"Check must surface the suggestion for the returned superseding decision")
+	got := resp.SupersedesSuggestions[0]
+	assert.Equal(t, later.DecisionID, got.SupersedingID)
+	assert.Equal(t, earlier.DecisionID, got.SupersededID)
+	assert.Equal(t, "detector:same_agent_same_ticket", got.SuggestedBy)
+	require.NotNil(t, got.Confidence)
+	assert.InDelta(t, 0.91, *got.Confidence, 0.001)
+}
+
+func TestCheck_NoSuggestionsWhenAbsent(t *testing.T) {
+	ctx := context.Background()
+	agentID := "check-no-suggest-" + uuid.New().String()[:8]
+	createAgent(t, agentID)
+
+	_, err := testSvc.Trace(ctx, uuid.Nil, decisions.TraceInput{
+		AgentID: agentID,
+		Decision: model.TraceDecision{
+			DecisionType: "architecture",
+			Outcome:      "isolated decision with no peers",
+			Confidence:   0.9,
+		},
+	})
+	require.NoError(t, err)
+
+	resp, err := testSvc.Check(ctx, uuid.Nil, decisions.CheckInput{
+		DecisionType: "architecture",
+		AgentID:      agentID,
+		Limit:        5,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, resp.SupersedesSuggestions,
+		"absent suggestions must omit the field (slice is nil/empty, not present-but-empty)")
+}
+
 func TestResolveOrCreateAgent_Existing(t *testing.T) {
 	ctx := context.Background()
 	agentID := "existing-" + uuid.New().String()[:8]

--- a/internal/storage/sqlite/schema.sql
+++ b/internal/storage/sqlite/schema.sql
@@ -92,16 +92,28 @@ CREATE INDEX IF NOT EXISTS idx_decisions_precedent_ref
 CREATE INDEX IF NOT EXISTS idx_decisions_project
     ON decisions(org_id, project) WHERE project IS NOT NULL;
 
+-- Note: schema evolution in lite-mode is fresh-install only — see ADR-009.
+-- Existing local SQLite databases predating columns suggested_by, suggested_confidence,
+-- suggested_reason will need to be deleted and re-created to pick up the new columns.
 CREATE TABLE IF NOT EXISTS decision_supersedes (
-    superseding_id TEXT NOT NULL REFERENCES decisions(id) ON DELETE CASCADE,
-    superseded_id  TEXT NOT NULL REFERENCES decisions(id) ON DELETE CASCADE,
-    org_id         TEXT NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
-    relationship   TEXT NOT NULL DEFAULT 'supersedes',
-    is_primary     INTEGER NOT NULL DEFAULT 0,
-    recorded_at    TEXT NOT NULL DEFAULT (datetime('now')),
+    superseding_id        TEXT NOT NULL REFERENCES decisions(id) ON DELETE CASCADE,
+    superseded_id         TEXT NOT NULL REFERENCES decisions(id) ON DELETE CASCADE,
+    org_id                TEXT NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    relationship          TEXT NOT NULL DEFAULT 'supersedes',
+    is_primary            INTEGER NOT NULL DEFAULT 0,
+    recorded_at           TEXT NOT NULL DEFAULT (datetime('now')),
+    suggested_by          TEXT,
+    suggested_confidence  REAL,
+    suggested_reason      TEXT,
     PRIMARY KEY (superseding_id, superseded_id),
     CHECK (superseding_id <> superseded_id),
-    CHECK (relationship IN ('supersedes', 'reconciles'))
+    CHECK (relationship IN ('supersedes', 'reconciles', 'suggested')),
+    CHECK (
+        (relationship = 'suggested' AND suggested_by IS NOT NULL)
+        OR
+        (relationship <> 'suggested' AND suggested_by IS NULL AND suggested_confidence IS NULL AND suggested_reason IS NULL)
+    ),
+    CHECK (relationship <> 'suggested' OR is_primary = 0)
 );
 CREATE INDEX IF NOT EXISTS idx_decision_supersedes_superseded
     ON decision_supersedes(org_id, superseded_id);
@@ -110,11 +122,22 @@ CREATE INDEX IF NOT EXISTS idx_decision_supersedes_superseding
 CREATE UNIQUE INDEX IF NOT EXISTS idx_decision_supersedes_primary
     ON decision_supersedes(superseding_id)
     WHERE is_primary = 1;
+CREATE INDEX IF NOT EXISTS idx_decision_supersedes_suggested
+    ON decision_supersedes(org_id, superseding_id, recorded_at DESC)
+    WHERE relationship = 'suggested';
+CREATE INDEX IF NOT EXISTS idx_decision_supersedes_suggested_recorded_at
+    ON decision_supersedes(recorded_at)
+    WHERE relationship = 'suggested';
 INSERT OR IGNORE INTO decision_supersedes (superseding_id, superseded_id, org_id, relationship, is_primary)
 SELECT id, supersedes_id, org_id, 'supersedes', 1
 FROM decisions
 WHERE supersedes_id IS NOT NULL;
 
+-- The retire-suggestion DELETE inside these triggers mirrors PG migration 106:
+-- when an agent confirms a supersedes_id link, drop any latent suggestion
+-- from the same agent that proposed the same predecessor. Without this the
+-- 'suggested' row would survive alongside the new confirmed one and keep
+-- showing up in akashi_check responses indefinitely.
 CREATE TRIGGER IF NOT EXISTS trg_decisions_sync_supersedes_insert
 AFTER INSERT ON decisions
 WHEN NEW.supersedes_id IS NOT NULL
@@ -130,6 +153,16 @@ BEGIN
     VALUES (NEW.id, NEW.supersedes_id, NEW.org_id, 'supersedes', 1)
     ON CONFLICT (superseding_id, superseded_id) DO UPDATE
     SET is_primary = 1;
+
+    DELETE FROM decision_supersedes
+    WHERE relationship = 'suggested'
+      AND org_id = NEW.org_id
+      AND superseded_id = NEW.supersedes_id
+      AND superseding_id IN (
+          SELECT id FROM decisions
+          WHERE org_id = NEW.org_id
+            AND agent_id = NEW.agent_id
+      );
 END;
 
 CREATE TRIGGER IF NOT EXISTS trg_decisions_sync_supersedes_update
@@ -147,6 +180,16 @@ BEGIN
     VALUES (NEW.id, NEW.supersedes_id, NEW.org_id, 'supersedes', 1)
     ON CONFLICT (superseding_id, superseded_id) DO UPDATE
     SET is_primary = 1;
+
+    DELETE FROM decision_supersedes
+    WHERE relationship = 'suggested'
+      AND org_id = NEW.org_id
+      AND superseded_id = NEW.supersedes_id
+      AND superseding_id IN (
+          SELECT id FROM decisions
+          WHERE org_id = NEW.org_id
+            AND agent_id = NEW.agent_id
+      );
 END;
 
 CREATE TRIGGER IF NOT EXISTS trg_decisions_sync_supersedes_clear

--- a/internal/storage/sqlite/supersedes_suggestions.go
+++ b/internal/storage/sqlite/supersedes_suggestions.go
@@ -1,0 +1,136 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/ashita-ai/akashi/internal/model"
+	"github.com/ashita-ai/akashi/internal/storage"
+)
+
+// InsertSupersedesSuggestion writes a detector-inferred supersedes link as a
+// 'suggested' row in decision_supersedes. Mirrors the Postgres behavior:
+// idempotent, no-op when a row already exists for (superseding_id,
+// superseded_id) — confirmed links are never overwritten by suggestions.
+func (l *LiteDB) InsertSupersedesSuggestion(ctx context.Context, s storage.SupersedesSuggestionInsert) error {
+	if s.SuggestedBy == "" {
+		return errors.New("sqlite: suggested_by is required for supersedes suggestion")
+	}
+	if s.SupersedingID == s.SupersededID {
+		return errors.New("sqlite: superseding_id and superseded_id must differ")
+	}
+	var conf any
+	if s.Confidence != nil {
+		conf = *s.Confidence
+	}
+	var reason any
+	if s.Reason != "" {
+		reason = s.Reason
+	}
+	// Explicit recorded_at ensures the stored format (RFC 3339) matches what
+	// DeleteOldSupersedesSuggestions writes when comparing — SQLite's default
+	// datetime('now') uses a space-separated format that breaks lexicographic
+	// comparison against RFC 3339 (' ' < 'T' in ASCII).
+	_, err := l.db.ExecContext(ctx,
+		`INSERT INTO decision_supersedes
+		    (superseding_id, superseded_id, org_id, relationship, is_primary,
+		     suggested_by, suggested_confidence, suggested_reason, recorded_at)
+		 VALUES (?, ?, ?, 'suggested', 0, ?, ?, ?, ?)
+		 ON CONFLICT (superseding_id, superseded_id) DO NOTHING`,
+		uuidStr(s.SupersedingID), uuidStr(s.SupersededID), uuidStr(s.OrgID),
+		s.SuggestedBy, conf, reason, timeStr(time.Now().UTC()),
+	)
+	if err != nil {
+		return fmt.Errorf("sqlite: insert supersedes suggestion: %w", err)
+	}
+	return nil
+}
+
+// ListSupersedesSuggestionsForDecisions returns suggested supersedes links
+// where the superseding decision is in the supplied set, mirroring the
+// Postgres ordering (superseding_id, recorded_at DESC).
+func (l *LiteDB) ListSupersedesSuggestionsForDecisions(ctx context.Context, orgID uuid.UUID, supersedingIDs []uuid.UUID) ([]model.SupersedesSuggestion, error) {
+	if len(supersedingIDs) == 0 {
+		return nil, nil
+	}
+
+	placeholders := make([]string, len(supersedingIDs))
+	args := make([]any, 0, 1+len(supersedingIDs))
+	args = append(args, uuidStr(orgID))
+	for i, id := range supersedingIDs {
+		placeholders[i] = "?"
+		args = append(args, uuidStr(id))
+	}
+
+	// Placeholders are a fixed sequence of "?" tokens — no caller input is
+	// concatenated into the SQL. The args slice carries the actual values
+	// through QueryContext's parameter binding.
+	q := `SELECT superseding_id, superseded_id, suggested_by, ` + //nolint:gosec // G202: only "?" placeholders are concatenated
+		`             suggested_confidence, suggested_reason, recorded_at
+	      FROM decision_supersedes
+	      WHERE org_id = ?
+	        AND relationship = 'suggested'
+	        AND superseding_id IN (` + strings.Join(placeholders, ",") + `)
+	      ORDER BY superseding_id, recorded_at DESC`
+
+	rows, err := l.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("sqlite: list supersedes suggestions: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck
+
+	// No capacity hint: a single superseding decision can have multiple
+	// suggested predecessors, so len(supersedingIDs) is a poor lower bound.
+	var out []model.SupersedesSuggestion
+	for rows.Next() {
+		var (
+			supID, subID, suggestedBy, recordedAt string
+			conf                                  sql.NullFloat64
+			reason                                sql.NullString
+		)
+		if err := rows.Scan(&supID, &subID, &suggestedBy, &conf, &reason, &recordedAt); err != nil {
+			return nil, fmt.Errorf("sqlite: scan supersedes suggestion: %w", err)
+		}
+		s := model.SupersedesSuggestion{
+			SupersedingID: parseUUID(supID),
+			SupersededID:  parseUUID(subID),
+			SuggestedBy:   suggestedBy,
+			RecordedAt:    parseTime(recordedAt),
+		}
+		if conf.Valid {
+			f := float32(conf.Float64)
+			s.Confidence = &f
+		}
+		if reason.Valid {
+			s.Reason = reason.String
+		}
+		out = append(out, s)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("sqlite: iterate supersedes suggestions: %w", err)
+	}
+	return out, nil
+}
+
+// DeleteOldSupersedesSuggestions removes suggested rows older than cutoff.
+// Mirrors the Postgres semantics: confirmed rows are untouched.
+func (l *LiteDB) DeleteOldSupersedesSuggestions(ctx context.Context, before time.Time) (int64, error) {
+	res, err := l.db.ExecContext(ctx,
+		`DELETE FROM decision_supersedes
+		 WHERE relationship = 'suggested' AND recorded_at < ?`,
+		timeStr(before))
+	if err != nil {
+		return 0, fmt.Errorf("sqlite: delete old supersedes suggestions: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("sqlite: rows affected: %w", err)
+	}
+	return n, nil
+}

--- a/internal/storage/sqlite/supersedes_suggestions_test.go
+++ b/internal/storage/sqlite/supersedes_suggestions_test.go
@@ -1,0 +1,305 @@
+package sqlite_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ashita-ai/akashi/internal/model"
+	"github.com/ashita-ai/akashi/internal/storage"
+)
+
+func TestInsertSupersedesSuggestion_BasicAndIdempotent(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	require.NoError(t, db.EnsureDefaultOrg(ctx))
+	orgID := uuid.Nil
+
+	a := createTestDecision(t, db, orgID, "claude-code", "ARD-958 layer-2 implementation")
+	b := createTestDecision(t, db, orgID, "claude-code", "ARD-958 layer-3 refinement")
+
+	conf := float32(0.82)
+	first := storage.SupersedesSuggestionInsert{
+		OrgID:         orgID,
+		SupersedingID: b.ID,
+		SupersededID:  a.ID,
+		SuggestedBy:   "detector:same_agent_same_ticket",
+		Confidence:    &conf,
+		Reason:        `same agent "claude-code", same ticket "ARD-958"`,
+	}
+	require.NoError(t, db.InsertSupersedesSuggestion(ctx, first))
+
+	got, err := db.ListSupersedesSuggestionsForDecisions(ctx, orgID, []uuid.UUID{b.ID})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, b.ID, got[0].SupersedingID)
+	assert.Equal(t, a.ID, got[0].SupersededID)
+	assert.Equal(t, "detector:same_agent_same_ticket", got[0].SuggestedBy)
+	require.NotNil(t, got[0].Confidence)
+	assert.InDelta(t, 0.82, *got[0].Confidence, 0.001)
+	assert.Equal(t, `same agent "claude-code", same ticket "ARD-958"`, got[0].Reason)
+
+	// Re-insert is a no-op (ON CONFLICT DO NOTHING). Different reason on
+	// retry is intentionally discarded — the first detector observation wins.
+	second := first
+	second.Reason = "noop on retry"
+	require.NoError(t, db.InsertSupersedesSuggestion(ctx, second))
+
+	got, err = db.ListSupersedesSuggestionsForDecisions(ctx, orgID, []uuid.UUID{b.ID})
+	require.NoError(t, err)
+	require.Len(t, got, 1, "duplicate insert must not create a second row")
+	assert.Equal(t, `same agent "claude-code", same ticket "ARD-958"`, got[0].Reason,
+		"first observation's reason is preserved on retry")
+}
+
+func TestInsertSupersedesSuggestion_RejectsEmptySource(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	require.NoError(t, db.EnsureDefaultOrg(ctx))
+	orgID := uuid.Nil
+
+	a := createTestDecision(t, db, orgID, "agent", "first")
+	b := createTestDecision(t, db, orgID, "agent", "second")
+
+	err := db.InsertSupersedesSuggestion(ctx, storage.SupersedesSuggestionInsert{
+		OrgID:         orgID,
+		SupersedingID: b.ID,
+		SupersededID:  a.ID,
+		SuggestedBy:   "",
+	})
+	require.Error(t, err, "empty suggested_by must be rejected")
+}
+
+func TestInsertSupersedesSuggestion_RejectsSelfReference(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	require.NoError(t, db.EnsureDefaultOrg(ctx))
+	orgID := uuid.Nil
+
+	a := createTestDecision(t, db, orgID, "agent", "only")
+
+	err := db.InsertSupersedesSuggestion(ctx, storage.SupersedesSuggestionInsert{
+		OrgID:         orgID,
+		SupersedingID: a.ID,
+		SupersededID:  a.ID,
+		SuggestedBy:   "detector:test",
+	})
+	require.Error(t, err, "self-supersession must be rejected")
+}
+
+func TestListSupersedesSuggestionsForDecisions_FiltersByOrgAndIDs(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	require.NoError(t, db.EnsureDefaultOrg(ctx))
+	orgID := uuid.Nil
+
+	a := createTestDecision(t, db, orgID, "agent", "a")
+	b := createTestDecision(t, db, orgID, "agent", "b")
+	c := createTestDecision(t, db, orgID, "agent", "c")
+
+	require.NoError(t, db.InsertSupersedesSuggestion(ctx, storage.SupersedesSuggestionInsert{
+		OrgID: orgID, SupersedingID: b.ID, SupersededID: a.ID,
+		SuggestedBy: "detector:t",
+	}))
+	require.NoError(t, db.InsertSupersedesSuggestion(ctx, storage.SupersedesSuggestionInsert{
+		OrgID: orgID, SupersedingID: c.ID, SupersededID: a.ID,
+		SuggestedBy: "detector:t",
+	}))
+
+	// Empty input → nil, no error.
+	out, err := db.ListSupersedesSuggestionsForDecisions(ctx, orgID, nil)
+	require.NoError(t, err)
+	assert.Empty(t, out)
+
+	// Single ID returns its suggestion only.
+	out, err = db.ListSupersedesSuggestionsForDecisions(ctx, orgID, []uuid.UUID{c.ID})
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	assert.Equal(t, c.ID, out[0].SupersedingID)
+
+	// Multiple IDs — both rows returned.
+	out, err = db.ListSupersedesSuggestionsForDecisions(ctx, orgID, []uuid.UUID{b.ID, c.ID})
+	require.NoError(t, err)
+	require.Len(t, out, 2)
+
+	// Unknown ID returns no results without error.
+	out, err = db.ListSupersedesSuggestionsForDecisions(ctx, orgID, []uuid.UUID{uuid.New()})
+	require.NoError(t, err)
+	assert.Empty(t, out)
+}
+
+func TestListSupersedesSuggestions_ExcludesConfirmedRows(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	require.NoError(t, db.EnsureDefaultOrg(ctx))
+	orgID := uuid.Nil
+
+	a := createTestDecision(t, db, orgID, "agent", "first")
+	// Confirmed link via supersedes_id triggers the migration-104 trigger,
+	// which inserts a 'supersedes' row, not a 'suggested' one.
+	supersedesA := a.ID
+	_, b, err := db.CreateTraceTx(ctx, storage.CreateTraceParams{
+		AgentID: "agent",
+		OrgID:   orgID,
+		Decision: model.Decision{
+			DecisionType: "test-type",
+			Outcome:      "explicit supersession",
+			Confidence:   0.9,
+			SupersedesID: &supersedesA,
+		},
+	})
+	require.NoError(t, err)
+
+	got, err := db.ListSupersedesSuggestionsForDecisions(ctx, orgID, []uuid.UUID{b.ID})
+	require.NoError(t, err)
+	assert.Empty(t, got, "confirmed 'supersedes' rows must not appear in the suggestion list")
+}
+
+func TestDeleteOldSupersedesSuggestions(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	require.NoError(t, db.EnsureDefaultOrg(ctx))
+	orgID := uuid.Nil
+
+	a := createTestDecision(t, db, orgID, "agent", "a")
+	b := createTestDecision(t, db, orgID, "agent", "b")
+
+	require.NoError(t, db.InsertSupersedesSuggestion(ctx, storage.SupersedesSuggestionInsert{
+		OrgID: orgID, SupersedingID: b.ID, SupersededID: a.ID,
+		SuggestedBy: "detector:t",
+	}))
+
+	// Cutoff in the past — no rows pruned.
+	n, err := db.DeleteOldSupersedesSuggestions(ctx, time.Now().Add(-time.Hour))
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n)
+
+	out, err := db.ListSupersedesSuggestionsForDecisions(ctx, orgID, []uuid.UUID{b.ID})
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+
+	// Cutoff in the future — row pruned.
+	n, err = db.DeleteOldSupersedesSuggestions(ctx, time.Now().Add(time.Hour))
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), n)
+
+	out, err = db.ListSupersedesSuggestionsForDecisions(ctx, orgID, []uuid.UUID{b.ID})
+	require.NoError(t, err)
+	assert.Empty(t, out)
+}
+
+func TestDeleteOldSupersedesSuggestions_DoesNotTouchConfirmedRows(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	require.NoError(t, db.EnsureDefaultOrg(ctx))
+	orgID := uuid.Nil
+
+	a := createTestDecision(t, db, orgID, "agent", "first")
+	supersedesA := a.ID
+	_, _, err := db.CreateTraceTx(ctx, storage.CreateTraceParams{
+		AgentID: "agent",
+		OrgID:   orgID,
+		Decision: model.Decision{
+			DecisionType: "test-type",
+			Outcome:      "explicit supersession",
+			Confidence:   0.9,
+			SupersedesID: &supersedesA,
+		},
+	})
+	require.NoError(t, err)
+
+	// Wide cutoff — would prune everything if the WHERE clause was wrong.
+	n, err := db.DeleteOldSupersedesSuggestions(ctx, time.Now().Add(time.Hour))
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n, "confirmed rows must be untouched by the suggestion-only delete")
+}
+
+// TestTrigger_RetiresMatchingSuggestionOnConfirm verifies the SQLite mirror
+// of migration 106's PG trigger extension: when an agent confirms a
+// supersedes_id link, the matching latent suggestion from the same agent is
+// dropped atomically with the confirmed-row insert.
+func TestTrigger_RetiresMatchingSuggestionOnConfirm(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	require.NoError(t, db.EnsureDefaultOrg(ctx))
+	orgID := uuid.Nil
+
+	earlier := createTestDecision(t, db, orgID, "claude-code", "ARD-958 layer-2")
+	latent := createTestDecision(t, db, orgID, "claude-code", "ARD-958 layer-3")
+
+	require.NoError(t, db.InsertSupersedesSuggestion(ctx, storage.SupersedesSuggestionInsert{
+		OrgID:         orgID,
+		SupersedingID: latent.ID,
+		SupersededID:  earlier.ID,
+		SuggestedBy:   "detector:same_agent_same_ticket",
+	}))
+
+	got, err := db.ListSupersedesSuggestionsForDecisions(ctx, orgID, []uuid.UUID{latent.ID})
+	require.NoError(t, err)
+	require.Len(t, got, 1, "precondition: suggestion visible before confirm")
+
+	supersedesEarlier := earlier.ID
+	_, _, err = db.CreateTraceTx(ctx, storage.CreateTraceParams{
+		AgentID: "claude-code",
+		OrgID:   orgID,
+		Decision: model.Decision{
+			DecisionType: "implementation",
+			Outcome:      "ARD-958 explicit supersession",
+			Confidence:   0.9,
+			SupersedesID: &supersedesEarlier,
+		},
+	})
+	require.NoError(t, err)
+
+	got, err = db.ListSupersedesSuggestionsForDecisions(ctx, orgID, []uuid.UUID{latent.ID})
+	require.NoError(t, err)
+	assert.Empty(t, got, "trigger must retire the latent suggestion on confirm")
+}
+
+// TestTrigger_RetireSuggestionScopedByAgent verifies the SQLite trigger only
+// retires suggestions from the SAME agent that confirmed — suggestions from
+// other agents pointing at the same predecessor must survive.
+func TestTrigger_RetireSuggestionScopedByAgent(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	require.NoError(t, db.EnsureDefaultOrg(ctx))
+	orgID := uuid.Nil
+
+	earlier := createTestDecision(t, db, orgID, "agent-A", "shared predecessor")
+	latentA := createTestDecision(t, db, orgID, "agent-A", "agent A latent")
+	latentB := createTestDecision(t, db, orgID, "agent-B", "agent B latent")
+
+	require.NoError(t, db.InsertSupersedesSuggestion(ctx, storage.SupersedesSuggestionInsert{
+		OrgID: orgID, SupersedingID: latentA.ID, SupersededID: earlier.ID,
+		SuggestedBy: "detector:same_agent_same_ticket",
+	}))
+	require.NoError(t, db.InsertSupersedesSuggestion(ctx, storage.SupersedesSuggestionInsert{
+		OrgID: orgID, SupersedingID: latentB.ID, SupersededID: earlier.ID,
+		SuggestedBy: "detector:same_agent_same_ticket",
+	}))
+
+	supersedesEarlier := earlier.ID
+	_, _, err := db.CreateTraceTx(ctx, storage.CreateTraceParams{
+		AgentID: "agent-A",
+		OrgID:   orgID,
+		Decision: model.Decision{
+			DecisionType: "implementation",
+			Outcome:      "agent A explicit supersession",
+			Confidence:   0.9,
+			SupersedesID: &supersedesEarlier,
+		},
+	})
+	require.NoError(t, err)
+
+	gotA, err := db.ListSupersedesSuggestionsForDecisions(ctx, orgID, []uuid.UUID{latentA.ID})
+	require.NoError(t, err)
+	assert.Empty(t, gotA, "agent A's suggestion retired by their own confirm")
+
+	gotB, err := db.ListSupersedesSuggestionsForDecisions(ctx, orgID, []uuid.UUID{latentB.ID})
+	require.NoError(t, err)
+	assert.Len(t, gotB, 1, "agent B's suggestion must survive — A's confirm is not B's")
+}

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -12522,3 +12522,250 @@ func TestFindReopenedResolution_ExcludesSameDecisions(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, match, "should exclude conflicts involving the same decisions")
 }
+
+// ---------------------------------------------------------------------------
+// SupersedesSuggestions (issue #710 / PR-2 of #708)
+// ---------------------------------------------------------------------------
+
+func TestInsertSupersedesSuggestion_BasicAndIdempotent_PG(t *testing.T) {
+	ctx := context.Background()
+	suffix := uuid.New().String()[:8]
+	agentID := "supersedes-suggest-" + suffix
+
+	_, a, err := testDB.CreateTraceTx(ctx, storage.CreateTraceParams{
+		AgentID:  agentID,
+		OrgID:    uuid.Nil,
+		Decision: model.Decision{DecisionType: "implementation", Outcome: "ARD-958 layer-2", Confidence: 0.8},
+	})
+	require.NoError(t, err)
+	_, b, err := testDB.CreateTraceTx(ctx, storage.CreateTraceParams{
+		AgentID:  agentID,
+		OrgID:    uuid.Nil,
+		Decision: model.Decision{DecisionType: "implementation", Outcome: "ARD-958 layer-3", Confidence: 0.85},
+	})
+	require.NoError(t, err)
+
+	conf := float32(0.82)
+	ins := storage.SupersedesSuggestionInsert{
+		OrgID:         uuid.Nil,
+		SupersedingID: b.ID,
+		SupersededID:  a.ID,
+		SuggestedBy:   "detector:same_agent_same_ticket",
+		Confidence:    &conf,
+		Reason:        `same agent "` + agentID + `", same ticket "ARD-958"`,
+	}
+	require.NoError(t, testDB.InsertSupersedesSuggestion(ctx, ins))
+	require.NoError(t, testDB.InsertSupersedesSuggestion(ctx, ins), "duplicate insert is a no-op")
+
+	got, err := testDB.ListSupersedesSuggestionsForDecisions(ctx, uuid.Nil, []uuid.UUID{b.ID})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, b.ID, got[0].SupersedingID)
+	assert.Equal(t, a.ID, got[0].SupersededID)
+	assert.Equal(t, "detector:same_agent_same_ticket", got[0].SuggestedBy)
+	require.NotNil(t, got[0].Confidence)
+	assert.InDelta(t, 0.82, *got[0].Confidence, 0.001)
+}
+
+func TestInsertSupersedesSuggestion_RejectedBySuggestionFieldsCheck_PG(t *testing.T) {
+	ctx := context.Background()
+	suffix := uuid.New().String()[:8]
+
+	_, a, err := testDB.CreateTraceTx(ctx, storage.CreateTraceParams{
+		AgentID: "ssr-reject-" + suffix, OrgID: uuid.Nil,
+		Decision: model.Decision{DecisionType: "x", Outcome: "first", Confidence: 0.5},
+	})
+	require.NoError(t, err)
+	_, b, err := testDB.CreateTraceTx(ctx, storage.CreateTraceParams{
+		AgentID: "ssr-reject-" + suffix, OrgID: uuid.Nil,
+		Decision: model.Decision{DecisionType: "x", Outcome: "second", Confidence: 0.5},
+	})
+	require.NoError(t, err)
+
+	// Empty SuggestedBy is caught at the application layer before SQL.
+	err = testDB.InsertSupersedesSuggestion(ctx, storage.SupersedesSuggestionInsert{
+		OrgID:         uuid.Nil,
+		SupersedingID: b.ID,
+		SupersededID:  a.ID,
+	})
+	require.Error(t, err)
+}
+
+func TestListSupersedesSuggestions_ExcludesConfirmedRows_PG(t *testing.T) {
+	ctx := context.Background()
+	suffix := uuid.New().String()[:8]
+	agentID := "ssr-confirmed-" + suffix
+
+	_, a, err := testDB.CreateTraceTx(ctx, storage.CreateTraceParams{
+		AgentID:  agentID,
+		OrgID:    uuid.Nil,
+		Decision: model.Decision{DecisionType: "x", Outcome: "first", Confidence: 0.7},
+	})
+	require.NoError(t, err)
+
+	supersedesA := a.ID
+	_, b, err := testDB.CreateTraceTx(ctx, storage.CreateTraceParams{
+		AgentID: agentID, OrgID: uuid.Nil,
+		Decision: model.Decision{
+			DecisionType: "x", Outcome: "explicit supersession", Confidence: 0.7,
+			SupersedesID: &supersedesA,
+		},
+	})
+	require.NoError(t, err)
+
+	got, err := testDB.ListSupersedesSuggestionsForDecisions(ctx, uuid.Nil, []uuid.UUID{b.ID})
+	require.NoError(t, err)
+	assert.Empty(t, got, "the confirmed 'supersedes' row inserted by the trace path must not appear in the suggestion list")
+}
+
+func TestDeleteOldSupersedesSuggestions_PG(t *testing.T) {
+	ctx := context.Background()
+	suffix := uuid.New().String()[:8]
+	agentID := "ssr-prune-" + suffix
+
+	_, a, err := testDB.CreateTraceTx(ctx, storage.CreateTraceParams{
+		AgentID: agentID, OrgID: uuid.Nil,
+		Decision: model.Decision{DecisionType: "x", Outcome: "first", Confidence: 0.5},
+	})
+	require.NoError(t, err)
+	_, b, err := testDB.CreateTraceTx(ctx, storage.CreateTraceParams{
+		AgentID: agentID, OrgID: uuid.Nil,
+		Decision: model.Decision{DecisionType: "x", Outcome: "second", Confidence: 0.5},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, testDB.InsertSupersedesSuggestion(ctx, storage.SupersedesSuggestionInsert{
+		OrgID: uuid.Nil, SupersedingID: b.ID, SupersededID: a.ID,
+		SuggestedBy: "detector:t",
+	}))
+
+	n, err := testDB.DeleteOldSupersedesSuggestions(ctx, time.Now().Add(-time.Hour))
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n)
+
+	n, err = testDB.DeleteOldSupersedesSuggestions(ctx, time.Now().Add(time.Hour))
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, n, int64(1), "at least the row we just inserted should be pruned")
+}
+
+// TestTrigger_RetiresMatchingSuggestionOnConfirm_PG verifies the migration-106
+// extension to sync_decision_supersedes_primary: when an agent re-traces with
+// supersedes_id set, any latent 'suggested' row from the same agent that
+// proposed the same predecessor is deleted atomically with the confirmed-row
+// insert. Without this, akashi_check would keep returning the stale hint
+// alongside the new confirmed link.
+func TestTrigger_RetiresMatchingSuggestionOnConfirm_PG(t *testing.T) {
+	ctx := context.Background()
+	suffix := uuid.New().String()[:8]
+	agentID := "ssr-confirm-" + suffix
+
+	_, earlier, err := testDB.CreateTraceTx(ctx, storage.CreateTraceParams{
+		AgentID: agentID, OrgID: uuid.Nil,
+		Decision: model.Decision{DecisionType: "implementation", Outcome: "ARD-958 layer-2", Confidence: 0.8},
+	})
+	require.NoError(t, err)
+	_, latent, err := testDB.CreateTraceTx(ctx, storage.CreateTraceParams{
+		AgentID: agentID, OrgID: uuid.Nil,
+		Decision: model.Decision{DecisionType: "implementation", Outcome: "ARD-958 layer-3", Confidence: 0.85},
+	})
+	require.NoError(t, err)
+
+	// Detector inserts a suggestion: latent supersedes earlier (same agent
+	// forgot the link).
+	conf := float32(0.91)
+	require.NoError(t, testDB.InsertSupersedesSuggestion(ctx, storage.SupersedesSuggestionInsert{
+		OrgID:         uuid.Nil,
+		SupersedingID: latent.ID,
+		SupersededID:  earlier.ID,
+		SuggestedBy:   "detector:same_agent_same_ticket",
+		Confidence:    &conf,
+		Reason:        "test fixture",
+	}))
+
+	got, err := testDB.ListSupersedesSuggestionsForDecisions(ctx, uuid.Nil, []uuid.UUID{latent.ID})
+	require.NoError(t, err)
+	require.Len(t, got, 1, "precondition: suggestion should be visible before confirmation")
+
+	// Agent confirms by re-tracing a new decision with supersedes_id=earlier.
+	supersedesEarlier := earlier.ID
+	_, confirmed, err := testDB.CreateTraceTx(ctx, storage.CreateTraceParams{
+		AgentID: agentID, OrgID: uuid.Nil,
+		Decision: model.Decision{
+			DecisionType: "implementation",
+			Outcome:      "ARD-958 explicit supersession",
+			Confidence:   0.9,
+			SupersedesID: &supersedesEarlier,
+		},
+	})
+	require.NoError(t, err)
+
+	// The original 'suggested' row pointing at `latent` must now be gone —
+	// the trigger retired it when the confirmation landed.
+	got, err = testDB.ListSupersedesSuggestionsForDecisions(ctx, uuid.Nil, []uuid.UUID{latent.ID})
+	require.NoError(t, err)
+	assert.Empty(t, got, "trigger must retire latent suggestions when the agent confirms the predecessor link")
+
+	// And a confirmed 'supersedes' row exists for the new decision.
+	row, err := testDB.GetDecision(ctx, uuid.Nil, confirmed.ID, storage.GetDecisionOpts{})
+	require.NoError(t, err)
+	require.NotNil(t, row.SupersedesID)
+	assert.Equal(t, earlier.ID, *row.SupersedesID)
+}
+
+// TestTrigger_RetireSuggestionScopedByAgent_PG verifies that the migration-106
+// retire-on-confirm clause does NOT delete suggestions from other agents that
+// happen to point at the same predecessor — those represent independent
+// detector observations and must survive.
+func TestTrigger_RetireSuggestionScopedByAgent_PG(t *testing.T) {
+	ctx := context.Background()
+	suffix := uuid.New().String()[:8]
+	agentA := "ssr-confirm-A-" + suffix
+	agentB := "ssr-confirm-B-" + suffix
+
+	_, earlier, err := testDB.CreateTraceTx(ctx, storage.CreateTraceParams{
+		AgentID: agentA, OrgID: uuid.Nil,
+		Decision: model.Decision{DecisionType: "implementation", Outcome: "shared predecessor", Confidence: 0.8},
+	})
+	require.NoError(t, err)
+
+	_, latentA, err := testDB.CreateTraceTx(ctx, storage.CreateTraceParams{
+		AgentID: agentA, OrgID: uuid.Nil,
+		Decision: model.Decision{DecisionType: "implementation", Outcome: "agent A latent successor", Confidence: 0.8},
+	})
+	require.NoError(t, err)
+	_, latentB, err := testDB.CreateTraceTx(ctx, storage.CreateTraceParams{
+		AgentID: agentB, OrgID: uuid.Nil,
+		Decision: model.Decision{DecisionType: "implementation", Outcome: "agent B latent successor", Confidence: 0.8},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, testDB.InsertSupersedesSuggestion(ctx, storage.SupersedesSuggestionInsert{
+		OrgID: uuid.Nil, SupersedingID: latentA.ID, SupersededID: earlier.ID,
+		SuggestedBy: "detector:same_agent_same_ticket",
+	}))
+	require.NoError(t, testDB.InsertSupersedesSuggestion(ctx, storage.SupersedesSuggestionInsert{
+		OrgID: uuid.Nil, SupersedingID: latentB.ID, SupersededID: earlier.ID,
+		SuggestedBy: "detector:same_agent_same_ticket",
+	}))
+
+	// Agent A confirms — trigger should retire only A's suggestion.
+	supersedesEarlier := earlier.ID
+	_, _, err = testDB.CreateTraceTx(ctx, storage.CreateTraceParams{
+		AgentID: agentA, OrgID: uuid.Nil,
+		Decision: model.Decision{
+			DecisionType: "implementation",
+			Outcome:      "agent A explicit supersession",
+			Confidence:   0.9,
+			SupersedesID: &supersedesEarlier,
+		},
+	})
+	require.NoError(t, err)
+
+	gotA, err := testDB.ListSupersedesSuggestionsForDecisions(ctx, uuid.Nil, []uuid.UUID{latentA.ID})
+	require.NoError(t, err)
+	assert.Empty(t, gotA, "agent A's suggestion must be retired by their own confirmation")
+
+	gotB, err := testDB.ListSupersedesSuggestionsForDecisions(ctx, uuid.Nil, []uuid.UUID{latentB.ID})
+	require.NoError(t, err)
+	assert.Len(t, gotB, 1, "agent B's suggestion must survive — confirmation by agent A is not their confirmation")
+}

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -130,6 +130,24 @@ type Store interface {
 	// when an unknown project name is rejected.
 	DistinctProjects(ctx context.Context, orgID uuid.UUID) ([]string, error)
 
+	// ---- Supersedes Suggestions ----
+
+	// InsertSupersedesSuggestion writes a detector-inferred latent
+	// supersedes_id link as a 'suggested' row in decision_supersedes.
+	// Idempotent: a row already present for (superseding_id, superseded_id) —
+	// confirmed or earlier-suggested — is left intact.
+	InsertSupersedesSuggestion(ctx context.Context, s SupersedesSuggestionInsert) error
+
+	// ListSupersedesSuggestionsForDecisions returns all 'suggested' rows
+	// where superseding_id is in supersedingIDs. Ordered by superseding_id,
+	// recorded_at DESC. Returns nil for an empty input set.
+	ListSupersedesSuggestionsForDecisions(ctx context.Context, orgID uuid.UUID, supersedingIDs []uuid.UUID) ([]model.SupersedesSuggestion, error)
+
+	// DeleteOldSupersedesSuggestions removes 'suggested' rows older than
+	// before. Confirmed rows ('supersedes', 'reconciles') are not touched.
+	// Returns the number of rows deleted.
+	DeleteOldSupersedesSuggestions(ctx context.Context, before time.Time) (int64, error)
+
 	// ---- Decision Type Aliases ----
 
 	// ResolveDecisionTypeAlias returns the canonical decision type for the given

--- a/internal/storage/supersedes_suggestions.go
+++ b/internal/storage/supersedes_suggestions.go
@@ -1,0 +1,116 @@
+//go:build !lite
+
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/ashita-ai/akashi/internal/model"
+)
+
+// InsertSupersedesSuggestion writes a detector-inferred supersedes link as a
+// 'suggested' row in decision_supersedes. Idempotent: if a row already exists
+// for (superseding_id, superseded_id) — whether confirmed or earlier-suggested
+// — the insert is a no-op, leaving any confirmed link intact.
+//
+// SuggestedBy must be non-empty (enforced by migration 105's CHECK constraint).
+// SupersedingID and SupersededID must be distinct (enforced by table CHECK).
+func (db *DB) InsertSupersedesSuggestion(ctx context.Context, s SupersedesSuggestionInsert) error {
+	if s.SuggestedBy == "" {
+		return errors.New("storage: suggested_by is required for supersedes suggestion")
+	}
+	if s.SupersedingID == s.SupersededID {
+		return errors.New("storage: superseding_id and superseded_id must differ")
+	}
+	_, err := db.pool.Exec(ctx,
+		`INSERT INTO decision_supersedes
+		    (superseding_id, superseded_id, org_id, relationship, is_primary,
+		     suggested_by, suggested_confidence, suggested_reason)
+		 VALUES ($1, $2, $3, 'suggested', FALSE, $4, $5, $6)
+		 ON CONFLICT (superseding_id, superseded_id) DO NOTHING`,
+		s.SupersedingID, s.SupersededID, s.OrgID,
+		s.SuggestedBy, s.Confidence, nullableString(s.Reason),
+	)
+	if err != nil {
+		return fmt.Errorf("storage: insert supersedes suggestion: %w", err)
+	}
+	return nil
+}
+
+// ListSupersedesSuggestionsForDecisions returns all detector-suggested
+// supersedes links where the superseding decision is in the supplied set.
+// Returned in (superseding_id, recorded_at DESC) order so callers can group
+// by superseding decision and present newest-first.
+//
+// Returns an empty slice when supersedingIDs is empty.
+func (db *DB) ListSupersedesSuggestionsForDecisions(ctx context.Context, orgID uuid.UUID, supersedingIDs []uuid.UUID) ([]model.SupersedesSuggestion, error) {
+	if len(supersedingIDs) == 0 {
+		return nil, nil
+	}
+	rows, err := db.pool.Query(ctx,
+		`SELECT superseding_id, superseded_id, suggested_by,
+		        suggested_confidence, suggested_reason, recorded_at
+		 FROM decision_supersedes
+		 WHERE org_id = $1
+		   AND relationship = 'suggested'
+		   AND superseding_id = ANY($2)
+		 ORDER BY superseding_id, recorded_at DESC`,
+		orgID, supersedingIDs)
+	if err != nil {
+		return nil, fmt.Errorf("storage: list supersedes suggestions: %w", err)
+	}
+	defer rows.Close()
+
+	// No capacity hint: a single superseding decision can have multiple
+	// suggested predecessors, so len(supersedingIDs) is a poor lower bound.
+	var out []model.SupersedesSuggestion
+	for rows.Next() {
+		var s model.SupersedesSuggestion
+		var reason *string
+		if err := rows.Scan(&s.SupersedingID, &s.SupersededID, &s.SuggestedBy,
+			&s.Confidence, &reason, &s.RecordedAt); err != nil {
+			return nil, fmt.Errorf("storage: scan supersedes suggestion: %w", err)
+		}
+		if reason != nil {
+			s.Reason = *reason
+		}
+		out = append(out, s)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("storage: iterate supersedes suggestions: %w", err)
+	}
+	return out, nil
+}
+
+// DeleteOldSupersedesSuggestions removes 'suggested' rows older than the
+// given cutoff. Confirmed rows (relationship='supersedes' or 'reconciles')
+// are never touched. Returns the number of rows deleted.
+//
+// Used by the retention worker to bound suggestion-table growth — agents
+// either confirm a suggestion (which promotes the row via the trigger from
+// migration 104) or implicitly dismiss it by letting the cutoff pass.
+func (db *DB) DeleteOldSupersedesSuggestions(ctx context.Context, before time.Time) (int64, error) {
+	tag, err := db.pool.Exec(ctx,
+		`DELETE FROM decision_supersedes
+		 WHERE relationship = 'suggested' AND recorded_at < $1`,
+		before)
+	if err != nil {
+		return 0, fmt.Errorf("storage: delete old supersedes suggestions: %w", err)
+	}
+	return tag.RowsAffected(), nil
+}
+
+// nullableString returns nil for empty strings so the database stores NULL
+// rather than the empty string. Used for optional VARCHAR columns where the
+// distinction matters for CHECK constraints.
+func nullableString(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -434,3 +434,15 @@ func clampPagination(limit, offset, defaultLimit, maxLimit int) (int, int) {
 	}
 	return limit, offset
 }
+
+// SupersedesSuggestionInsert is the input shape for InsertSupersedesSuggestion.
+// Mirrors model.SupersedesSuggestion but carries OrgID (stored on the row but
+// not surfaced in agent-facing responses).
+type SupersedesSuggestionInsert struct {
+	OrgID         uuid.UUID
+	SupersedingID uuid.UUID
+	SupersededID  uuid.UUID
+	SuggestedBy   string
+	Confidence    *float32
+	Reason        string
+}

--- a/migrations/105_supersedes_suggestions.sql
+++ b/migrations/105_supersedes_suggestions.sql
@@ -1,0 +1,53 @@
+-- 105: Extend decision_supersedes with the 'suggested' relationship for
+-- detector-inferred latent supersedes_id links (PR-2 of #708, see #710).
+--
+-- A 'suggested' row is the conflict scorer's hypothesis that a newer trace
+-- intended to supersede an older one but the agent forgot to set
+-- supersedes_id. akashi_check returns these so agents can confirm by
+-- re-tracing with supersedes_id set, at which point the trigger from
+-- migration 104 promotes the row to relationship='supersedes' is_primary=TRUE.
+--
+-- Suggestions always have is_primary=FALSE; the unique partial index from 104
+-- (idx_decision_supersedes_primary) prevents accidental promotion.
+
+ALTER TABLE decision_supersedes
+    DROP CONSTRAINT decision_supersedes_relationship_check;
+
+ALTER TABLE decision_supersedes
+    ADD CONSTRAINT decision_supersedes_relationship_check
+    CHECK (relationship IN ('supersedes', 'reconciles', 'suggested'));
+
+ALTER TABLE decision_supersedes
+    ADD COLUMN suggested_by           TEXT,
+    ADD COLUMN suggested_confidence   REAL,
+    ADD COLUMN suggested_reason       TEXT;
+
+-- Suggestions must carry source attribution; non-suggested rows must not.
+-- Enforced as a CHECK so accidental writes from the trace path can't pollute
+-- the suggestion columns and so suggestion writers can't omit the source.
+ALTER TABLE decision_supersedes
+    ADD CONSTRAINT decision_supersedes_suggestion_fields_check
+    CHECK (
+        (relationship = 'suggested' AND suggested_by IS NOT NULL)
+        OR
+        (relationship <> 'suggested' AND suggested_by IS NULL AND suggested_confidence IS NULL AND suggested_reason IS NULL)
+    );
+
+-- Suggestions must never be promoted to primary (primary is reserved for
+-- agent-confirmed supersedes/reconciles links).
+ALTER TABLE decision_supersedes
+    ADD CONSTRAINT decision_supersedes_suggestion_not_primary_check
+    CHECK (relationship <> 'suggested' OR is_primary = FALSE);
+
+-- Read-path index for the akashi_check fan-out: "for these decision IDs
+-- (caller's recent traces), find any suggestions where they are the
+-- superseding side". Partial-index keeps it lean — the table is otherwise
+-- dominated by confirmed 'supersedes' rows.
+CREATE INDEX idx_decision_supersedes_suggested
+    ON decision_supersedes(org_id, superseding_id, recorded_at DESC)
+    WHERE relationship = 'suggested';
+
+-- Cleanup index for retention worker: prune by recorded_at across orgs.
+CREATE INDEX idx_decision_supersedes_suggested_recorded_at
+    ON decision_supersedes(recorded_at)
+    WHERE relationship = 'suggested';

--- a/migrations/106_supersedes_suggestion_confirm.sql
+++ b/migrations/106_supersedes_suggestion_confirm.sql
@@ -1,0 +1,63 @@
+-- 106: Make migration 104's trigger retire matching latent suggestions when
+-- an agent confirms a supersedes_id link, so the audit trail does not show
+-- a stale 'suggested' row alongside the new confirmed one. Closes the
+-- promotion gap noted in code review of #710.
+--
+-- The agent's confirmation flow is: detector writes
+--   ('suggested', superseding_id=X, superseded_id=Y)
+-- where X is an existing decision by the agent on the same ticket as Y.
+-- The agent then traces a NEW decision X' with supersedes_id=Y. Because X'
+-- gets a fresh UUID, the migration-104 ON CONFLICT path never fires on the
+-- existing 'suggested' row — it inserts a parallel ('supersedes', X', Y).
+-- Without this migration the original ('suggested', X, Y) row sits stale
+-- forever, polluting akashi_check responses and the audit story.
+--
+-- This migration replaces the trigger function with a version that, after
+-- writing the confirmed link, deletes any 'suggested' rows from the same
+-- agent that proposed the now-explicitly-superseded predecessor. The match
+-- is by (org_id, superseded_id, agent_id) — narrow enough that suggestions
+-- from other agents are untouched.
+
+CREATE OR REPLACE FUNCTION sync_decision_supersedes_primary()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF NEW.supersedes_id IS NULL THEN
+        UPDATE decision_supersedes
+        SET is_primary = FALSE
+        WHERE superseding_id = NEW.id
+          AND org_id = NEW.org_id
+          AND is_primary;
+        RETURN NEW;
+    END IF;
+
+    UPDATE decision_supersedes
+    SET is_primary = FALSE
+    WHERE superseding_id = NEW.id
+      AND org_id = NEW.org_id
+      AND superseded_id <> NEW.supersedes_id
+      AND is_primary;
+
+    INSERT INTO decision_supersedes (superseding_id, superseded_id, org_id, relationship, is_primary)
+    VALUES (NEW.id, NEW.supersedes_id, NEW.org_id, 'supersedes', TRUE)
+    ON CONFLICT (superseding_id, superseded_id) DO UPDATE
+    SET is_primary = TRUE;
+
+    -- Retire latent suggestions from the same agent that proposed the
+    -- predecessor we just confirmed. The new confirmed row above is the
+    -- canonical record — keeping the suggestion would surface a stale
+    -- hint on every subsequent akashi_check call.
+    DELETE FROM decision_supersedes
+    WHERE relationship = 'suggested'
+      AND org_id = NEW.org_id
+      AND superseded_id = NEW.supersedes_id
+      AND superseding_id IN (
+          SELECT id FROM decisions
+          WHERE org_id = NEW.org_id
+            AND agent_id = NEW.agent_id
+      );
+
+    RETURN NEW;
+END;
+$$;

--- a/migrations/atlas.sum
+++ b/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:IznV+I78BZv+38s8ViDhgMU9LPrvW7FlyNfcmD5M9rg=
+h1:8dCmQ5v5inHp7IPu0auq0e2CBpF+64Z4MIQJV0PzIQ4=
 001_initial.sql h1:uhyGXto+QacAaGYb9ZTGjsBs5chlKi8O0eHz9aCQsrY=
 022_full_text_search.sql h1:9iwtA8MgCzAxDV9YkUBn0CLT9ePSmj3GcPoMGg8TXf0=
 023_fix_outbox_index.sql h1:OtMEFBcMRWej02+ghnBXlPr6BVq+LoA62Id9XUWfDNI=
@@ -83,3 +83,5 @@ h1:IznV+I78BZv+38s8ViDhgMU9LPrvW7FlyNfcmD5M9rg=
 102_drop_dead_schema.sql h1:8pKT1tSvKyH936Kd/sd7vSI+CfbUSb0QWA75upeEVrA=
 103_git_branch_index.sql h1:zomzfqVrP4FDLw3p2jLN0cjkDGtKwRirUmetLcfuEZ8=
 104_decision_supersedes.sql h1:U8KFFLRxcTFB6UWEQLI6id+tBfDOwGyNWwZ6bBYf+/Y=
+105_supersedes_suggestions.sql h1:NRLOXI4i7N9UbblP1uN6uS5x3NsBHAomH3g4PjG8Fn8=
+106_supersedes_suggestion_confirm.sql h1:eLUrgPvmBCscAcfcXmS9rhYzcO5CMI7KC/IjT+5Yxe4=

--- a/sdk/go/akashi/types.go
+++ b/sdk/go/akashi/types.go
@@ -267,13 +267,28 @@ type ConflictResolution struct {
 	ResolvedAt        time.Time `json:"resolved_at"`
 }
 
+// SupersedesSuggestion is a detector-inferred latent supersedes_id link the
+// server returns alongside Check results. To confirm one, re-trace the
+// superseding decision with SupersedesID set to SupersededID; the server
+// records the confirmed link and retires the suggestion atomically. To
+// dismiss, take no action — the retention loop prunes stale suggestions.
+type SupersedesSuggestion struct {
+	SupersedingID uuid.UUID `json:"superseding_id"`
+	SupersededID  uuid.UUID `json:"superseded_id"`
+	SuggestedBy   string    `json:"suggested_by"`
+	Confidence    *float32  `json:"confidence,omitempty"`
+	Reason        string    `json:"reason,omitempty"`
+	RecordedAt    time.Time `json:"recorded_at"`
+}
+
 // CheckResponse is the output of Client.Check.
 type CheckResponse struct {
-	HasPrecedent         bool                 `json:"has_precedent"`
-	Decisions            []Decision           `json:"decisions"`
-	Conflicts            []DecisionConflict   `json:"conflicts,omitempty"`
-	ConflictsUnavailable bool                 `json:"conflicts_unavailable,omitempty"`
-	PriorResolutions     []ConflictResolution `json:"prior_resolutions,omitempty"`
+	HasPrecedent          bool                   `json:"has_precedent"`
+	Decisions             []Decision             `json:"decisions"`
+	Conflicts             []DecisionConflict     `json:"conflicts,omitempty"`
+	ConflictsUnavailable  bool                   `json:"conflicts_unavailable,omitempty"`
+	PriorResolutions      []ConflictResolution   `json:"prior_resolutions,omitempty"`
+	SupersedesSuggestions []SupersedesSuggestion `json:"supersedes_suggestions,omitempty"`
 }
 
 // TraceResponse is the output of Client.Trace.

--- a/sdk/python/src/akashi/__init__.py
+++ b/sdk/python/src/akashi/__init__.py
@@ -49,6 +49,7 @@ from akashi.types import (
     SearchResponse,
     SearchResult,
     SubscriptionEvent,
+    SupersedesSuggestion,
     TemporalQueryRequest,
     TimePeriod,
     TimeRange,
@@ -117,6 +118,7 @@ __all__ = [
     "TimePeriod",
     "TimeRange",
     "AssessmentSummary",
+    "SupersedesSuggestion",
     # OTEL helpers
     "trace_id_from_context",
     # Exceptions

--- a/sdk/python/src/akashi/types.py
+++ b/sdk/python/src/akashi/types.py
@@ -386,6 +386,23 @@ class ConflictResolution(BaseModel):
     resolved_at: datetime
 
 
+class SupersedesSuggestion(BaseModel):
+    """Detector-inferred latent supersedes_id link surfaced by ``akashi_check``.
+
+    To confirm, re-trace the superseding decision with ``supersedes_id`` set to
+    ``superseded_id``; the server records the confirmed link and retires the
+    suggestion atomically. To dismiss, take no action — the retention loop
+    prunes stale suggestions.
+    """
+
+    superseding_id: UUID
+    superseded_id: UUID
+    suggested_by: str
+    confidence: float | None = None
+    reason: str = ""
+    recorded_at: datetime
+
+
 class CheckResponse(BaseModel):
     """Response from a precedent check."""
 
@@ -394,6 +411,7 @@ class CheckResponse(BaseModel):
     conflicts: list[DecisionConflict] = Field(default_factory=list)
     conflicts_unavailable: bool = False
     prior_resolutions: list[ConflictResolution] = Field(default_factory=list)
+    supersedes_suggestions: list[SupersedesSuggestion] = Field(default_factory=list)
 
 
 class QueryResponse(BaseModel):

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -83,6 +83,7 @@ export type {
   SearchResult,
   SessionSummary,
   SessionViewResponse,
+  SupersedesSuggestion,
   AutoResolveWinner,
   ReopenedPolicy,
   TimePeriod,

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -347,12 +347,29 @@ export interface ConflictResolution {
   resolved_at: string;
 }
 
+/**
+ * Detector-inferred latent supersedes_id link surfaced by `akashi_check`.
+ * To confirm, re-trace the superseding decision with supersedes_id set to
+ * the suggested superseded_id; the server records the confirmed link and
+ * retires the suggestion atomically. To dismiss, take no action — the
+ * retention loop prunes stale suggestions.
+ */
+export interface SupersedesSuggestion {
+  superseding_id: string;
+  superseded_id: string;
+  suggested_by: string;
+  confidence?: number;
+  reason?: string;
+  recorded_at: string;
+}
+
 export interface CheckResponse {
   has_precedent: boolean;
   decisions: Decision[];
   conflicts?: DecisionConflict[];
   conflicts_unavailable?: boolean;
   prior_resolutions?: ConflictResolution[];
+  supersedes_suggestions?: SupersedesSuggestion[];
 }
 
 export interface QueryResponse {


### PR DESCRIPTION
## Summary

- Adds `decision_supersedes.relationship='suggested'` rows so the conflict scorer can stash a latent supersedes_id hypothesis whenever the PR-1 filter (#709) suppresses a same-agent same-ticket pair.
- New `akashi_check` field `supersedes_suggestions` surfaces those hints to the agent on the next call, with `superseding_id`, `superseded_id`, `suggested_by`, `confidence`, and a short reason.
- Migration 105 extends `decision_supersedes` with `(suggested_by, suggested_confidence, suggested_reason)` plus the partial indexes that make the read-fanout cheap. Migration 106 extends migration 104's trigger to retire the matching latent suggestion atomically when the agent confirms by re-tracing with `supersedes_id` set.
- Retention loop wires up a global TTL prune (`AKASHI_SUPERSEDES_SUGGESTION_TTL`, default 30d, 0 disables) so unconfirmed hints don't accumulate forever.
- SDKs (Go, Python, TypeScript) and `api/openapi.yaml` carry the new shape end-to-end.

PR-2 of #708. Closes #710.

## Why

PR-1 (#711, merged) suppressed the false-positive conflict but left the *latent* link silent — the agent never learned that they probably meant to set `supersedes_id`. This PR makes the inference visible: every suppressed pair becomes an actionable hint on the next `akashi_check`, and confirmation is a single re-trace away. The on-confirm retire keeps the audit trail clean (no stale `suggested` rows hanging around alongside the new confirmed link).

## Behavior

- **Write path:** when the same-agent same-ticket filter fires, the scorer fire-and-forgets a `'suggested'` row keyed on `(superseding_id, superseded_id)`. Idempotent — duplicates are dropped via `ON CONFLICT DO NOTHING`. Confidence is the topic-similarity at filter time, clamped to `[0, 1]`.
- **Read path:** `akashi_check` joins recent decisions to suggestions where `superseding_id` is in the result set; payload is appended under `supersedes_suggestions`.
- **Confirm path:** when the agent re-traces with `supersedes_id` set, migration 106's trigger inserts the canonical `'supersedes'` row *and* deletes any matching `'suggested'` row from the same agent — atomic, no orphans.
- **Dismiss path:** no action required. The retention worker prunes suggestions older than `AKASHI_SUPERSEDES_SUGGESTION_TTL`.

CHECK constraints enforce: `suggested` rows must carry `suggested_by`, must never be `is_primary=TRUE`, and non-suggested rows can't carry suggestion fields.

## Test plan

- [x] \`go build ./...\`, \`go vet ./...\`, \`golangci-lint run ./...\` (0 issues), \`go mod tidy\` (clean), \`atlas migrate validate\` ✓
- [x] \`go test -race -count=1\` green for \`internal/conflicts\`, \`internal/model\`, \`internal/service/decisions\`, \`internal/storage/sqlite\`, \`internal/mcp\`
- [x] PG integration suite compiles cleanly under \`-tags integration\` (CI exercises with testcontainers)
- [x] New tests:
  - \`TestInsertSupersedesSuggestion_BasicAndIdempotent_PG\` / SQLite parity
  - \`TestInsertSupersedesSuggestion_RejectedBySuggestionFieldsCheck_PG\`, \`_RejectsSelfReference\`
  - \`TestListSupersedesSuggestions_ExcludesConfirmedRows_PG\` / SQLite parity
  - \`TestDeleteOldSupersedesSuggestions_PG\` / SQLite parity, plus \`_DoesNotTouchConfirmedRows\`
  - \`TestTrigger_RetiresMatchingSuggestionOnConfirm_PG\` / SQLite parity
  - \`TestTrigger_RetireSuggestionScopedByAgent_PG\` / SQLite parity (other agents' suggestions for the same predecessor must survive)
  - \`TestScoreForDecision_SameAgentSameTicketSuggestion\` (end-to-end scorer write)
  - \`TestCheck_SurfacesSupersedesSuggestions\`, \`TestCheck_NoSuggestionsWhenAbsent\`

## Out of scope

- UI surface for suggestions (tracked separately).
- LLM validation of suggestions before surfacing — relies on the upstream filter's precision instead.
- Per-org TTL override; one global TTL knob for now.

> One Ring to find them,
> two decisions, both yours, none linked —
> Mordor's audit log.