### PR TITLE
fix(conflicts): strict project scoping in lite scorer (#714)

### DIFF
--- a/internal/conflicts/lite_scorer.go
+++ b/internal/conflicts/lite_scorer.go
@@ -227,6 +227,13 @@ func (s *LiteScorer) conflictExists(ctx context.Context, a, b uuid.UUID) (bool, 
 	return count > 0, err
 }
 
+func nullableProject(project *string) sql.NullString {
+	if project == nil || *project == "" {
+		return sql.NullString{}
+	}
+	return sql.NullString{String: *project, Valid: true}
+}
+
 func (s *LiteScorer) insertConflict(ctx context.Context, orgID uuid.UUID, conflictKind string, a, b liteDecision, topicSim, outcomeDivergence, significance float32, severity, explanation string) error {
 	conflictID := uuid.New()
 	now := time.Now().UTC().Format(time.RFC3339Nano)
@@ -243,8 +250,9 @@ func (s *LiteScorer) insertConflict(ctx context.Context, orgID uuid.UUID, confli
 			agent_a, agent_b, decision_type_a, decision_type_b,
 			outcome_a, outcome_b,
 			topic_similarity, outcome_divergence, significance, scoring_method,
-			explanation, detected_at, severity, status, group_id
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			explanation, detected_at, severity, status, group_id,
+			project_a, project_b
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		conflictID.String(), conflictKind,
 		a.id.String(), b.id.String(), orgID.String(),
 		a.agentID, b.agentID,
@@ -252,7 +260,7 @@ func (s *LiteScorer) insertConflict(ctx context.Context, orgID uuid.UUID, confli
 		compact.Truncate(a.outcome, 500), compact.Truncate(b.outcome, 500),
 		topicSim, outcomeDivergence, significance,
 		"text_claims", explanation, now, severity, "open",
-		groupID.String(),
+		groupID.String(), nullableProject(a.project), nullableProject(b.project),
 	)
 	return err
 }

--- a/internal/conflicts/lite_scorer.go
+++ b/internal/conflicts/lite_scorer.go
@@ -174,10 +174,19 @@ func (s *LiteScorer) loadCandidates(ctx context.Context, orgID uuid.UUID, src li
 	        AND valid_to IS NULL`
 	args := []any{orgID.String(), src.decisionType, src.id.String()}
 
-	// Scope to same project if the source has one.
+	// Strict project scoping: a decision in project A is only scored against
+	// other decisions in project A; a decision with no project is only scored
+	// against other untagged decisions. This mirrors the cloud pre-filter in
+	// internal/search/local.go:163-181 (and the qdrant/PgCandidateFinder paths)
+	// shipped in #372, closing the cross-project FP gap (issue #714) for the
+	// SQLite/MCP-stdio path. Lite mode has no project_links table, so there is
+	// no opt-in for cross-project comparison here — the cloud Scorer handles
+	// that case via storage.LinkedProjects.
 	if src.project != nil {
-		q += ` AND (project = ? OR project IS NULL)`
+		q += ` AND project = ?`
 		args = append(args, *src.project)
+	} else {
+		q += ` AND project IS NULL`
 	}
 
 	q += ` ORDER BY valid_from DESC LIMIT 50`

--- a/internal/conflicts/lite_scorer_test.go
+++ b/internal/conflicts/lite_scorer_test.go
@@ -13,6 +13,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ashita-ai/akashi/internal/compact"
+	"github.com/ashita-ai/akashi/internal/model"
+	"github.com/ashita-ai/akashi/internal/storage"
+	sqlitestorage "github.com/ashita-ai/akashi/internal/storage/sqlite"
 
 	_ "modernc.org/sqlite"
 )
@@ -632,6 +635,61 @@ func TestLiteScorer_ProjectScoping_MixedPoolPicksOnlySameProject(t *testing.T) {
 	wantOther := sameProjectID.String()
 	matched := (got[0] == wantSrc && got[1] == wantOther) || (got[0] == wantOther && got[1] == wantSrc)
 	assert.True(t, matched, "the produced conflict must be between the source and the same-project candidate; got %v", got)
+}
+
+func TestLiteScorer_ProjectScoping_RealSQLiteTraceContext(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	liteDB, err := sqlitestorage.New(ctx, ":memory:", logger)
+	require.NoError(t, err)
+	t.Cleanup(func() { liteDB.Close(ctx) })
+	require.NoError(t, liteDB.EnsureDefaultOrg(ctx))
+	orgID := uuid.Nil
+
+	for _, agentID := range []string{"agent-a", "agent-b"} {
+		_, err := liteDB.CreateAgent(ctx, model.Agent{
+			AgentID: agentID, OrgID: orgID, Name: agentID, Role: model.RoleAgent,
+			Tags: []string{}, Metadata: map[string]any{},
+			CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC(),
+		})
+		require.NoError(t, err)
+	}
+
+	_, src, err := liteDB.CreateTraceTx(ctx, storage.CreateTraceParams{
+		AgentID:  "agent-a",
+		OrgID:    orgID,
+		Metadata: map[string]any{},
+		AgentContext: map[string]any{
+			"client": map[string]any{"project": "project-alpha"},
+		},
+		Decision: model.Decision{
+			DecisionType: "architecture", Outcome: pgProjectOutcome,
+			Confidence: 0.9, Metadata: map[string]any{},
+		},
+	})
+	require.NoError(t, err)
+	_, _, err = liteDB.CreateTraceTx(ctx, storage.CreateTraceParams{
+		AgentID:  "agent-b",
+		OrgID:    orgID,
+		Metadata: map[string]any{},
+		AgentContext: map[string]any{
+			"client": map[string]any{"project": "project-beta"},
+		},
+		Decision: model.Decision{
+			DecisionType: "architecture", Outcome: mongoProjectOutcome,
+			Confidence: 0.9, Metadata: map[string]any{},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, src.Project, "sqlite trace storage must persist project from agent_context")
+	assert.Equal(t, "project-alpha", *src.Project)
+
+	scorer := NewLiteScorer(liteDB.RawDB(), logger)
+	scorer.ScoreForDecision(ctx, src.ID, orgID)
+
+	var count int
+	require.NoError(t, liteDB.RawDB().QueryRow("SELECT COUNT(*) FROM scored_conflicts").Scan(&count))
+	assert.Equal(t, 0, count, "real lite traces in different projects must not generate a conflict")
 }
 
 // TestLiteScorer_RevisionChainExcluded verifies that a decision in the source's

--- a/internal/conflicts/lite_scorer_test.go
+++ b/internal/conflicts/lite_scorer_test.go
@@ -72,6 +72,8 @@ func openTestDB(t *testing.T) *sql.DB {
 			resolution_decision_id TEXT,
 			winning_decision_id TEXT,
 			group_id TEXT,
+			project_a TEXT,
+			project_b TEXT,
 			UNIQUE(decision_a_id, decision_b_id)
 		);
 		CREATE TABLE conflict_groups (
@@ -567,6 +569,13 @@ func TestLiteScorer_ProjectScoping_SameProjectStillConflicts(t *testing.T) {
 	var count int
 	require.NoError(t, db.QueryRow("SELECT COUNT(*) FROM scored_conflicts").Scan(&count))
 	assert.Equal(t, 1, count, "contradicting decisions in the same project must still produce a conflict")
+
+	var projectA, projectB sql.NullString
+	require.NoError(t, db.QueryRow("SELECT project_a, project_b FROM scored_conflicts").Scan(&projectA, &projectB))
+	require.True(t, projectA.Valid)
+	require.True(t, projectB.Valid)
+	assert.Equal(t, "project-alpha", projectA.String)
+	assert.Equal(t, "project-alpha", projectB.String)
 }
 
 // TestLiteScorer_ProjectScoping_BothUntaggedStillConflicts is the second
@@ -690,6 +699,80 @@ func TestLiteScorer_ProjectScoping_RealSQLiteTraceContext(t *testing.T) {
 	var count int
 	require.NoError(t, liteDB.RawDB().QueryRow("SELECT COUNT(*) FROM scored_conflicts").Scan(&count))
 	assert.Equal(t, 0, count, "real lite traces in different projects must not generate a conflict")
+}
+
+func TestLiteScorer_ProjectScoping_ConflictProjectsAreQueryable(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	liteDB, err := sqlitestorage.New(ctx, ":memory:", logger)
+	require.NoError(t, err)
+	t.Cleanup(func() { liteDB.Close(ctx) })
+	require.NoError(t, liteDB.EnsureDefaultOrg(ctx))
+	orgID := uuid.Nil
+
+	for _, agentID := range []string{"agent-a", "agent-b"} {
+		_, err := liteDB.CreateAgent(ctx, model.Agent{
+			AgentID: agentID, OrgID: orgID, Name: agentID, Role: model.RoleAgent,
+			Tags: []string{}, Metadata: map[string]any{},
+			CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC(),
+		})
+		require.NoError(t, err)
+	}
+
+	project := "project-alpha"
+	_, src, err := liteDB.CreateTraceTx(ctx, storage.CreateTraceParams{
+		AgentID:  "agent-a",
+		OrgID:    orgID,
+		Metadata: map[string]any{},
+		AgentContext: map[string]any{
+			"client": map[string]any{"project": project},
+		},
+		Decision: model.Decision{
+			DecisionType: "architecture", Outcome: pgProjectOutcome,
+			Confidence: 0.9, Metadata: map[string]any{},
+		},
+	})
+	require.NoError(t, err)
+	_, _, err = liteDB.CreateTraceTx(ctx, storage.CreateTraceParams{
+		AgentID:  "agent-b",
+		OrgID:    orgID,
+		Metadata: map[string]any{},
+		AgentContext: map[string]any{
+			"client": map[string]any{"project": project},
+		},
+		Decision: model.Decision{
+			DecisionType: "architecture", Outcome: mongoProjectOutcome,
+			Confidence: 0.9, Metadata: map[string]any{},
+		},
+	})
+	require.NoError(t, err)
+
+	scorer := NewLiteScorer(liteDB.RawDB(), logger)
+	scorer.ScoreForDecision(ctx, src.ID, orgID)
+
+	var projectA, projectB sql.NullString
+	require.NoError(t, liteDB.RawDB().QueryRow("SELECT project_a, project_b FROM scored_conflicts").Scan(&projectA, &projectB))
+	require.True(t, projectA.Valid)
+	require.True(t, projectB.Valid)
+	assert.Equal(t, project, projectA.String)
+	assert.Equal(t, project, projectB.String)
+
+	conflicts, err := liteDB.ListConflicts(ctx, orgID, storage.ConflictFilters{Project: &project}, 10, 0)
+	require.NoError(t, err)
+	require.Len(t, conflicts, 1, "project-scoped conflict listing must include the lite-scored conflict")
+	require.NotNil(t, conflicts[0].ProjectA)
+	require.NotNil(t, conflicts[0].ProjectB)
+	assert.Equal(t, project, *conflicts[0].ProjectA)
+	assert.Equal(t, project, *conflicts[0].ProjectB)
+
+	groups, err := liteDB.ListConflictGroups(ctx, orgID, storage.ConflictGroupFilters{Project: &project}, 10, 0)
+	require.NoError(t, err)
+	assert.Len(t, groups, 1, "project-scoped group listing must include the lite-scored conflict")
+
+	otherProject := "project-beta"
+	conflicts, err = liteDB.ListConflicts(ctx, orgID, storage.ConflictFilters{Project: &otherProject}, 10, 0)
+	require.NoError(t, err)
+	assert.Empty(t, conflicts, "unrelated project filters must not see the lite-scored conflict")
 }
 
 // TestLiteScorer_RevisionChainExcluded verifies that a decision in the source's

--- a/internal/conflicts/lite_scorer_test.go
+++ b/internal/conflicts/lite_scorer_test.go
@@ -442,46 +442,196 @@ func TestTruncate_LiteScorer(t *testing.T) {
 	assert.Equal(t, "こん...", compact.Truncate("こんにちは", 2))
 }
 
-// TestLiteScorer_ProjectScoping verifies that the scorer scopes candidates
-// by project when the source decision has one.
-func TestLiteScorer_ProjectScoping(t *testing.T) {
+// insertTestDecisionWithProject inserts a decision with an explicit project tag.
+// Passing project == "" inserts a NULL project (matches Postgres' "untagged"
+// semantic via sql.NullString).
+func insertTestDecisionWithProject(t *testing.T, db *sql.DB, id, orgID uuid.UUID, agentID, decType, outcome, project string) {
+	t.Helper()
+	var proj sql.NullString
+	if project != "" {
+		proj = sql.NullString{String: project, Valid: true}
+	}
+	_, err := db.Exec(
+		`INSERT INTO decisions (id, org_id, agent_id, decision_type, outcome, confidence, valid_from, project)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		id.String(), orgID.String(), agentID, decType, outcome, 0.9,
+		time.Now().UTC().Format(time.RFC3339Nano), proj,
+	)
+	require.NoError(t, err)
+}
+
+// Two contradicting architecture outcomes used as a fixed pair across the
+// project-scoping tests below. Pre-fix, this pair scored a conflict in every
+// project combination the scorer encountered; post-fix, it scores a conflict
+// only when both decisions are in the same project (or both untagged).
+const (
+	pgProjectOutcome        = "Use PostgreSQL for the primary database with read replicas and connection pooling for high availability"
+	mongoProjectOutcome     = "Use MongoDB for the primary database with sharding and replica sets for horizontal scalability"
+	cassandraProjectOutcome = "Use Cassandra for the primary database with multi-datacenter replication and tunable consistency"
+)
+
+// TestLiteScorer_ProjectScoping_DifferentProjects verifies the issue #714 fix:
+// a decision in project A must NOT generate a conflict against a contradicting
+// decision in project B. Pre-fix the SQL was `project = ? OR project IS NULL`,
+// which matched same-project rows but the test previously tolerated a 0-or-1
+// outcome because the strict equality contract was not yet enforced.
+func TestLiteScorer_ProjectScoping_DifferentProjects(t *testing.T) {
 	db := openTestDB(t)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	scorer := NewLiteScorer(db, logger)
 	ctx := context.Background()
 	orgID := uuid.New()
 
-	d1 := uuid.New()
-	d2 := uuid.New()
+	srcID := uuid.New()
+	otherID := uuid.New()
+	insertTestDecisionWithProject(t, db, srcID, orgID, "agent-a", "architecture", pgProjectOutcome, "project-alpha")
+	insertTestDecisionWithProject(t, db, otherID, orgID, "agent-b", "architecture", mongoProjectOutcome, "project-beta")
 
-	// Insert decisions with different projects.
-	_, err := db.Exec(
-		`INSERT INTO decisions (id, org_id, agent_id, decision_type, outcome, confidence, valid_from, project)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-		d1.String(), orgID.String(), "agent-a", "architecture",
-		"Use PostgreSQL for the primary database with read replicas and connection pooling for high availability",
-		0.9, time.Now().UTC().Format(time.RFC3339Nano), "project-alpha",
-	)
-	require.NoError(t, err)
-
-	_, err = db.Exec(
-		`INSERT INTO decisions (id, org_id, agent_id, decision_type, outcome, confidence, valid_from, project)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-		d2.String(), orgID.String(), "agent-b", "architecture",
-		"Use MongoDB for the primary database with sharding and replica sets for horizontal scalability",
-		0.9, time.Now().UTC().Format(time.RFC3339Nano), "project-beta",
-	)
-	require.NoError(t, err)
-
-	// Score d1 — since d2 is in a different project, should not conflict.
-	scorer.ScoreForDecision(ctx, d1, orgID)
+	scorer.ScoreForDecision(ctx, srcID, orgID)
 
 	var count int
 	require.NoError(t, db.QueryRow("SELECT COUNT(*) FROM scored_conflicts").Scan(&count))
-	// They can still conflict because loadCandidates uses `project = ? OR project IS NULL`,
-	// but with different non-nil projects they should not match.
-	// This depends on the SQL logic — verify the actual behavior.
-	assert.LessOrEqual(t, count, 1, "different-project decisions may or may not conflict depending on SQL scoping")
+	assert.Equal(t, 0, count, "decisions in different non-null projects must not generate a conflict")
+}
+
+// TestLiteScorer_ProjectScoping_TaggedSourceUntaggedCandidate verifies that a
+// project-tagged source does NOT pull in an untagged candidate. Pre-fix this
+// was the dominant cross-project leak path: `project = ? OR project IS NULL`
+// matched every untagged row in the org. Post-fix the source's project must
+// match exactly.
+func TestLiteScorer_ProjectScoping_TaggedSourceUntaggedCandidate(t *testing.T) {
+	db := openTestDB(t)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	scorer := NewLiteScorer(db, logger)
+	ctx := context.Background()
+	orgID := uuid.New()
+
+	srcID := uuid.New()
+	otherID := uuid.New()
+	insertTestDecisionWithProject(t, db, srcID, orgID, "agent-a", "architecture", pgProjectOutcome, "project-alpha")
+	insertTestDecisionWithProject(t, db, otherID, orgID, "agent-b", "architecture", mongoProjectOutcome, "")
+
+	scorer.ScoreForDecision(ctx, srcID, orgID)
+
+	var count int
+	require.NoError(t, db.QueryRow("SELECT COUNT(*) FROM scored_conflicts").Scan(&count))
+	assert.Equal(t, 0, count, "project-tagged source must not match untagged candidates")
+}
+
+// TestLiteScorer_ProjectScoping_UntaggedSourceTaggedCandidate verifies the
+// symmetric case: when the source has no project, the scorer must NOT pull in
+// project-tagged candidates. Pre-fix the source-has-no-project branch applied
+// no project filter at all, so an untagged source compared against every row
+// in the org regardless of project — the most aggressive cross-project leak.
+func TestLiteScorer_ProjectScoping_UntaggedSourceTaggedCandidate(t *testing.T) {
+	db := openTestDB(t)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	scorer := NewLiteScorer(db, logger)
+	ctx := context.Background()
+	orgID := uuid.New()
+
+	srcID := uuid.New()
+	otherID := uuid.New()
+	insertTestDecisionWithProject(t, db, srcID, orgID, "agent-a", "architecture", pgProjectOutcome, "")
+	insertTestDecisionWithProject(t, db, otherID, orgID, "agent-b", "architecture", mongoProjectOutcome, "project-alpha")
+
+	scorer.ScoreForDecision(ctx, srcID, orgID)
+
+	var count int
+	require.NoError(t, db.QueryRow("SELECT COUNT(*) FROM scored_conflicts").Scan(&count))
+	assert.Equal(t, 0, count, "untagged source must not match project-tagged candidates")
+}
+
+// TestLiteScorer_ProjectScoping_SameProjectStillConflicts is the negative
+// control: tightening the project filter must not suppress real same-project
+// conflicts. Two contradicting decisions in project-alpha must still produce
+// one conflict — this test is what would catch an over-eager filter that
+// accidentally dropped same-project pairs (e.g., an `AND project != ?` typo).
+func TestLiteScorer_ProjectScoping_SameProjectStillConflicts(t *testing.T) {
+	db := openTestDB(t)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	scorer := NewLiteScorer(db, logger)
+	ctx := context.Background()
+	orgID := uuid.New()
+
+	srcID := uuid.New()
+	otherID := uuid.New()
+	insertTestDecisionWithProject(t, db, srcID, orgID, "agent-a", "architecture", pgProjectOutcome, "project-alpha")
+	insertTestDecisionWithProject(t, db, otherID, orgID, "agent-b", "architecture", mongoProjectOutcome, "project-alpha")
+
+	scorer.ScoreForDecision(ctx, srcID, orgID)
+
+	var count int
+	require.NoError(t, db.QueryRow("SELECT COUNT(*) FROM scored_conflicts").Scan(&count))
+	assert.Equal(t, 1, count, "contradicting decisions in the same project must still produce a conflict")
+}
+
+// TestLiteScorer_ProjectScoping_BothUntaggedStillConflicts is the second
+// negative control: two untagged decisions must still be compared against each
+// other. Pre-fix the untagged-source branch applied no project filter, so this
+// case worked by accident; post-fix the filter is explicit (`project IS NULL`)
+// and we need a regression test to lock the behavior.
+func TestLiteScorer_ProjectScoping_BothUntaggedStillConflicts(t *testing.T) {
+	db := openTestDB(t)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	scorer := NewLiteScorer(db, logger)
+	ctx := context.Background()
+	orgID := uuid.New()
+
+	srcID := uuid.New()
+	otherID := uuid.New()
+	insertTestDecisionWithProject(t, db, srcID, orgID, "agent-a", "architecture", pgProjectOutcome, "")
+	insertTestDecisionWithProject(t, db, otherID, orgID, "agent-b", "architecture", mongoProjectOutcome, "")
+
+	scorer.ScoreForDecision(ctx, srcID, orgID)
+
+	var count int
+	require.NoError(t, db.QueryRow("SELECT COUNT(*) FROM scored_conflicts").Scan(&count))
+	assert.Equal(t, 1, count, "contradicting decisions both untagged must still produce a conflict")
+}
+
+// TestLiteScorer_ProjectScoping_MixedPoolPicksOnlySameProject combines the
+// three negative cases above into one pool to verify that with five candidates
+// spanning project-alpha / project-beta / untagged, scoring a project-alpha
+// source produces exactly one conflict — against the other project-alpha
+// candidate — and ignores the other three.
+func TestLiteScorer_ProjectScoping_MixedPoolPicksOnlySameProject(t *testing.T) {
+	db := openTestDB(t)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	scorer := NewLiteScorer(db, logger)
+	ctx := context.Background()
+	orgID := uuid.New()
+
+	srcID := uuid.New()
+	sameProjectID := uuid.New()
+	otherProjectID := uuid.New()
+	untaggedID := uuid.New()
+
+	insertTestDecisionWithProject(t, db, srcID, orgID, "agent-a", "architecture", pgProjectOutcome, "project-alpha")
+	insertTestDecisionWithProject(t, db, sameProjectID, orgID, "agent-b", "architecture", mongoProjectOutcome, "project-alpha")
+	insertTestDecisionWithProject(t, db, otherProjectID, orgID, "agent-c", "architecture", cassandraProjectOutcome, "project-beta")
+	insertTestDecisionWithProject(t, db, untaggedID, orgID, "agent-d", "architecture", cassandraProjectOutcome, "")
+
+	scorer.ScoreForDecision(ctx, srcID, orgID)
+
+	rows, err := db.Query("SELECT decision_a_id, decision_b_id FROM scored_conflicts")
+	require.NoError(t, err)
+	defer rows.Close() //nolint:errcheck
+
+	var pairs [][2]string
+	for rows.Next() {
+		var a, b string
+		require.NoError(t, rows.Scan(&a, &b))
+		pairs = append(pairs, [2]string{a, b})
+	}
+	require.NoError(t, rows.Err())
+
+	require.Len(t, pairs, 1, "exactly one same-project conflict must be produced from the mixed pool")
+	got := pairs[0]
+	wantSrc := srcID.String()
+	wantOther := sameProjectID.String()
+	matched := (got[0] == wantSrc && got[1] == wantOther) || (got[0] == wantOther && got[1] == wantSrc)
+	assert.True(t, matched, "the produced conflict must be between the source and the same-project candidate; got %v", got)
 }
 
 // TestLiteScorer_RevisionChainExcluded verifies that a decision in the source's

--- a/internal/storage/sqlite/decisions.go
+++ b/internal/storage/sqlite/decisions.go
@@ -232,6 +232,59 @@ func invalidateSupersededDecisionInTraceTx(ctx context.Context, tx *sql.Tx, orgI
 	return nil
 }
 
+func fillAttributionColumnsFromContext(d *model.Decision) {
+	if d.AgentContext == nil {
+		return
+	}
+	if d.Tool == nil {
+		if v := contextString(d.AgentContext, "server", "tool"); v != "" {
+			d.Tool = &v
+		} else if v := contextString(d.AgentContext, "tool"); v != "" {
+			d.Tool = &v
+		}
+	}
+	if d.Model == nil {
+		if v := contextString(d.AgentContext, "client", "model"); v != "" {
+			d.Model = &v
+		} else if v := contextString(d.AgentContext, "server", "model"); v != "" {
+			d.Model = &v
+		} else if v := contextString(d.AgentContext, "model"); v != "" {
+			d.Model = &v
+		}
+	}
+	if d.Project == nil {
+		if v := contextString(d.AgentContext, "client", "project"); v != "" {
+			d.Project = &v
+		} else if v := contextString(d.AgentContext, "server", "project"); v != "" {
+			d.Project = &v
+		} else if v := contextString(d.AgentContext, "project"); v != "" {
+			d.Project = &v
+		} else if v := contextString(d.AgentContext, "server", "repo"); v != "" {
+			d.Project = &v
+		} else if v := contextString(d.AgentContext, "client", "repo"); v != "" {
+			d.Project = &v
+		} else if v := contextString(d.AgentContext, "repo"); v != "" {
+			d.Project = &v
+		}
+	}
+}
+
+func contextString(ctx map[string]any, path ...string) string {
+	var cur any = ctx
+	for _, key := range path {
+		m, ok := cur.(map[string]any)
+		if !ok {
+			return ""
+		}
+		cur, ok = m[key]
+		if !ok {
+			return ""
+		}
+	}
+	v, _ := cur.(string)
+	return v
+}
+
 func createTraceInTx(ctx context.Context, tx *sql.Tx, p storage.CreateTraceParams) (model.AgentRun, model.Decision, error) {
 	now := time.Now().UTC()
 	d := p.Decision
@@ -279,6 +332,7 @@ func createTraceInTx(ctx context.Context, tx *sql.Tx, p storage.CreateTraceParam
 	if d.AgentContext == nil {
 		d.AgentContext = map[string]any{}
 	}
+	fillAttributionColumnsFromContext(&d)
 	if d.Metadata == nil {
 		d.Metadata = map[string]any{}
 	}

--- a/internal/storage/sqlite/schema.sql
+++ b/internal/storage/sqlite/schema.sql
@@ -297,6 +297,7 @@ CREATE TABLE IF NOT EXISTS conflict_groups (
     agent_b           TEXT NOT NULL,
     conflict_kind     TEXT NOT NULL DEFAULT 'cross_agent',
     decision_type     TEXT NOT NULL DEFAULT '',
+    group_topic       TEXT,
     first_detected_at TEXT NOT NULL DEFAULT (datetime('now')),
     last_detected_at  TEXT NOT NULL DEFAULT (datetime('now')),
     UNIQUE(org_id, agent_a, agent_b, conflict_kind, decision_type)

--- a/internal/storage/sqlite/sqlite_test.go
+++ b/internal/storage/sqlite/sqlite_test.go
@@ -5649,6 +5649,91 @@ func TestCreateTraceTx_WithToolModelProject(t *testing.T) {
 	_ = dec
 }
 
+func TestCreateTraceTx_DerivesAttributionColumnsFromAgentContext(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	require.NoError(t, db.EnsureDefaultOrg(ctx))
+	orgID := uuid.Nil
+
+	_, err := db.CreateAgent(ctx, model.Agent{
+		AgentID: "context-attribution-agent", OrgID: orgID, Name: "CA", Role: model.RoleAgent,
+		Tags: []string{}, Metadata: map[string]any{},
+		CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+
+	_, dec, err := db.CreateTraceTx(ctx, storage.CreateTraceParams{
+		AgentID:  "context-attribution-agent",
+		OrgID:    orgID,
+		Metadata: map[string]any{},
+		AgentContext: map[string]any{
+			"server": map[string]any{
+				"tool":    "akashi_trace",
+				"model":   "server-model",
+				"project": "server-project",
+			},
+			"client": map[string]any{
+				"model":   "client-model",
+				"project": "client-project",
+			},
+		},
+		Decision: model.Decision{
+			DecisionType: "implementation", Outcome: "derive attribution columns from context",
+			Confidence: 0.9, Metadata: map[string]any{},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, dec.Tool)
+	require.NotNil(t, dec.Model)
+	require.NotNil(t, dec.Project)
+	assert.Equal(t, "akashi_trace", *dec.Tool)
+	assert.Equal(t, "client-model", *dec.Model)
+	assert.Equal(t, "client-project", *dec.Project)
+
+	decisions, _, err := db.QueryDecisions(ctx, orgID, model.QueryRequest{
+		Limit:   1,
+		Filters: model.QueryFilters{AgentIDs: []string{"context-attribution-agent"}},
+	})
+	require.NoError(t, err)
+	require.Len(t, decisions, 1)
+	require.NotNil(t, decisions[0].Tool)
+	require.NotNil(t, decisions[0].Model)
+	require.NotNil(t, decisions[0].Project)
+	assert.Equal(t, "akashi_trace", *decisions[0].Tool)
+	assert.Equal(t, "client-model", *decisions[0].Model)
+	assert.Equal(t, "client-project", *decisions[0].Project)
+}
+
+func TestCreateTraceTx_DerivesProjectFromLegacyRepoContext(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	require.NoError(t, db.EnsureDefaultOrg(ctx))
+	orgID := uuid.Nil
+
+	_, err := db.CreateAgent(ctx, model.Agent{
+		AgentID: "legacy-repo-agent", OrgID: orgID, Name: "LR", Role: model.RoleAgent,
+		Tags: []string{}, Metadata: map[string]any{},
+		CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+
+	_, dec, err := db.CreateTraceTx(ctx, storage.CreateTraceParams{
+		AgentID:  "legacy-repo-agent",
+		OrgID:    orgID,
+		Metadata: map[string]any{},
+		AgentContext: map[string]any{
+			"client": map[string]any{"repo": "legacy-repo"},
+		},
+		Decision: model.Decision{
+			DecisionType: "implementation", Outcome: "derive project from legacy repo context",
+			Confidence: 0.9, Metadata: map[string]any{},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, dec.Project)
+	assert.Equal(t, "legacy-repo", *dec.Project)
+}
+
 // ---------------------------------------------------------------------------
 // SearchDecisionsByText with all filter types
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #714 for the lite/MCP-stdio path. The cloud Scorer already enforces strict project equality (#372, 2026-03-08) across all three CandidateFinder backends, with opt-in cross-project comparison via `project_links`. The lite scorer at `internal/conflicts/lite_scorer.go:177-181` was the remaining leak:

```go
// before
if src.project != nil {
    q += ` AND (project = ? OR project IS NULL)`   // matches every untagged row
    args = append(args, *src.project)
}
// when src.project == nil → no project filter at all → matches the entire org
```

Replaced with the same 3-way contract used by `internal/search/local.go:163-181`:

- `src.project != nil` → `AND project = ?`
- `src.project == nil` → `AND project IS NULL`

Lite mode has no `project_links` table, so there is no opt-in mechanism here — cross-project comparison stays a cloud-only feature served by `storage.LinkedProjects`.

## What this changes wrt the field report

This closes the bullet `Cross-project tag contamination` for lite mode. It does **not** move:
- The 76% FP rate (those are same-project shared-vocabulary false positives — different mechanism).
- Mis-tagged decisions (e.g., mono filed as akashi via cross-repo sessions — that's an ingest-side problem, and strict scoping actually makes it more visible because mis-tagged decisions now confidently match their wrong project's pool).
- The confidence-parsing 0.4 default, the minimum decision bar, or the assessment loop. Separate tickets.

## Tests

Six new cases in `lite_scorer_test.go`, all `Equal`-based (no more `LessOrEqual` slack):

- `DifferentProjects` — tagged↔tagged with different projects → 0 conflicts
- `TaggedSourceUntaggedCandidate` — the dominant pre-fix leak path → 0 conflicts
- `UntaggedSourceTaggedCandidate` — the most aggressive pre-fix leak (no filter at all) → 0 conflicts
- `SameProjectStillConflicts` — negative control, must still produce 1 conflict
- `BothUntaggedStillConflicts` — negative control for the `IS NULL` branch
- `MixedPoolPicksOnlySameProject` — four-decision pool, scorer must pick the one same-project candidate and ignore the other three

The previous `TestLiteScorer_ProjectScoping` is replaced (its `LessOrEqual(count, 1)` documented the leaky behavior it was meant to detect).

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./internal/conflicts/...` clean
- [x] `atlas migrate validate --dir file://migrations` clean
- [x] `go test -race -count=1 ./...` full unit suite green
- [x] All 17 `TestLiteScorer*` cases pass, including the 6 new project-scoping tests

> Stones speak true visions
> Even across sundered realms —
> Eyes betray the seer