### PR TITLE
fix(trace): reject missing/unparseable confidence at HTTP and MCP boundaries

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -4246,6 +4246,16 @@ components:
           format: float
           minimum: 0
           maximum: 1
+          description: |
+            Stated confidence in the decision, in [0, 1]. The field is
+            required: requests that omit it or send null are rejected with
+            HTTP 400 (and the MCP equivalent surfaces an error result).
+            Values outside [0, 1] are rejected with the same status.
+
+            The server never substitutes a default for a missing or
+            unparseable value — every stored confidence reflects what the
+            caller actually claimed, so aggregate metrics
+            (`avg_confidence`, calibration buckets) remain trustworthy.
         reasoning:
           type: string
         alternatives:

--- a/internal/mcp/parse_confidence_test.go
+++ b/internal/mcp/parse_confidence_test.go
@@ -1,0 +1,135 @@
+package mcp
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// makeRequest builds a CallToolRequest carrying the given arguments map.
+func makeRequest(args map[string]any) mcplib.CallToolRequest {
+	return mcplib.CallToolRequest{
+		Params: mcplib.CallToolParams{
+			Name:      "akashi_trace",
+			Arguments: args,
+		},
+	}
+}
+
+// TestParseTraceConfidence_Accepts covers shapes a real MCP client may
+// produce — JSON numbers (decoded as float64), ints, json.Number, and
+// stringified floats — all of which should yield the expected float32.
+func TestParseTraceConfidence_Accepts(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  any
+		want float32
+	}{
+		{"float64 mid", float64(0.85), 0.85},
+		{"float64 zero", float64(0), 0},
+		{"float64 one", float64(1), 1},
+		{"float32", float32(0.42), 0.42},
+		{"int", int(1), 1},
+		{"int64", int64(0), 0},
+		{"json.Number", json.Number("0.75"), 0.75},
+		{"stringified float", "0.6", 0.6},
+		{"stringified zero", "0", 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseTraceConfidence(makeRequest(map[string]any{"confidence": tc.raw}))
+			require.NoError(t, err)
+			assert.InDelta(t, tc.want, got, 1e-6)
+		})
+	}
+}
+
+// TestParseTraceConfidence_Rejects covers everything the old GetFloat path
+// collapsed onto the silent 0.4 default. Each case must surface a
+// descriptive error rather than fall through to a fabricated value.
+func TestParseTraceConfidence_Rejects(t *testing.T) {
+	cases := []struct {
+		name    string
+		args    map[string]any
+		wantSub string
+	}{
+		{
+			name:    "missing key",
+			args:    map[string]any{},
+			wantSub: "confidence is required",
+		},
+		{
+			name:    "explicit nil",
+			args:    map[string]any{"confidence": nil},
+			wantSub: "confidence is required",
+		},
+		{
+			name:    "unparseable string",
+			args:    map[string]any{"confidence": "high"},
+			wantSub: "not a valid number",
+		},
+		{
+			name:    "bool",
+			args:    map[string]any{"confidence": true},
+			wantSub: "must be a number",
+		},
+		{
+			name:    "map",
+			args:    map[string]any{"confidence": map[string]any{"value": 0.5}},
+			wantSub: "must be a number",
+		},
+		{
+			name:    "slice",
+			args:    map[string]any{"confidence": []any{0.5}},
+			wantSub: "must be a number",
+		},
+		{
+			name:    "NaN",
+			args:    map[string]any{"confidence": math.NaN()},
+			wantSub: "finite number",
+		},
+		{
+			name:    "positive infinity",
+			args:    map[string]any{"confidence": math.Inf(1)},
+			wantSub: "finite number",
+		},
+		{
+			name:    "negative infinity",
+			args:    map[string]any{"confidence": math.Inf(-1)},
+			wantSub: "finite number",
+		},
+		{
+			name:    "below zero",
+			args:    map[string]any{"confidence": -0.01},
+			wantSub: "between 0 and 1",
+		},
+		{
+			name:    "above one",
+			args:    map[string]any{"confidence": 1.01},
+			wantSub: "between 0 and 1",
+		},
+		{
+			name:    "string above one",
+			args:    map[string]any{"confidence": "1.5"},
+			wantSub: "between 0 and 1",
+		},
+		{
+			name:    "bad json.Number",
+			args:    map[string]any{"confidence": json.Number("not-a-number")},
+			wantSub: "not a valid number",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseTraceConfidence(makeRequest(tc.args))
+			require.Error(t, err, "case %s must reject the input", tc.name)
+			assert.Equal(t, float32(0), got, "must not leak a fabricated value")
+			assert.Contains(t, err.Error(), tc.wantSub,
+				"error message should describe why the input is invalid")
+		})
+	}
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -7,6 +7,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
+	"strconv"
 	"strings"
 	"time"
 
@@ -732,6 +734,59 @@ func (s *Server) handleCheck(ctx context.Context, request mcplib.CallToolRequest
 	}, nil
 }
 
+// parseTraceConfidence extracts the "confidence" argument from an MCP trace
+// request with strict typing: it rejects missing, null, unparseable,
+// wrong-type, NaN/Inf, and out-of-range values rather than silently
+// defaulting them.
+//
+// This replaces request.GetFloat("confidence", 0.4), whose default behaviour
+// collapsed every parse failure — missing key, unparseable string, wrong
+// type — onto the same valid-looking 0.4 value. That made roughly 26 of 40
+// recently sampled traces store synthetic 0.4 confidence, indistinguishable
+// from a caller's explicit 0.4 choice, and corrupted every downstream
+// confidence aggregate (avg_confidence, calibration buckets, the
+// over/under-confident percentages in akashi_stats).
+//
+// See ashita-ai/akashi#713.
+func parseTraceConfidence(request mcplib.CallToolRequest) (float32, error) {
+	raw, ok := request.GetArguments()["confidence"]
+	if !ok || raw == nil {
+		return 0, fmt.Errorf("confidence is required (must be a number between 0 and 1)")
+	}
+	var f float64
+	switch v := raw.(type) {
+	case float64:
+		f = v
+	case float32:
+		f = float64(v)
+	case int:
+		f = float64(v)
+	case int64:
+		f = float64(v)
+	case json.Number:
+		parsed, err := v.Float64()
+		if err != nil {
+			return 0, fmt.Errorf("confidence is not a valid number: %v", v)
+		}
+		f = parsed
+	case string:
+		parsed, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			return 0, fmt.Errorf("confidence is not a valid number: %q", v)
+		}
+		f = parsed
+	default:
+		return 0, fmt.Errorf("confidence must be a number, got %T", raw)
+	}
+	if math.IsNaN(f) || math.IsInf(f, 0) {
+		return 0, fmt.Errorf("confidence must be a finite number between 0 and 1")
+	}
+	if f < 0 || f > 1 {
+		return 0, fmt.Errorf("confidence must be between 0 and 1, got %g", f)
+	}
+	return float32(f), nil
+}
+
 func (s *Server) handleTrace(ctx context.Context, request mcplib.CallToolRequest) (toolResult *mcplib.CallToolResult, err error) {
 	orgID := ctxutil.OrgIDFromContext(ctx)
 	claims := ctxutil.ClaimsFromContext(ctx)
@@ -762,7 +817,10 @@ func (s *Server) handleTrace(ctx context.Context, request mcplib.CallToolRequest
 	// idempotency hash matches regardless of casing.
 	decisionType := strings.ToLower(strings.TrimSpace(request.GetString("decision_type", "")))
 	outcome := request.GetString("outcome", "")
-	confidence := float32(request.GetFloat("confidence", 0.4))
+	confidence, confErr := parseTraceConfidence(request)
+	if confErr != nil {
+		return errorResult(confErr.Error()), nil
+	}
 	reasoning := request.GetString("reasoning", "")
 
 	// Default agent_id to the caller's authenticated identity.

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -119,11 +119,9 @@ WHEN TO USE: After you make any non-trivial decision — choosing a model,
 selecting an approach, picking a data source, resolving an ambiguity,
 or committing to a course of action.
 
-TWO REQUIRED FIELDS — everything else is optional:
+THREE REQUIRED FIELDS — everything else is optional:
 - decision_type: A short category (see enum for standard types)
 - outcome: What you decided, stated as a fact ("chose gpt-4o for summarization")
-
-OPTIONAL FIELDS (each improves completeness score and future usefulness):
 - confidence: How certain you are (0.0-1.0). Use this calibration guide:
     0.3-0.4 = educated guess, limited information, could easily be wrong
     0.5-0.6 = reasonable choice but real uncertainty remains
@@ -132,6 +130,8 @@ OPTIONAL FIELDS (each improves completeness score and future usefulness):
     0.9+     = near-certain, would be surprised if this is wrong
   Most decisions should land between 0.4 and 0.8. If you find yourself
   always above 0.8, you are probably not being honest about uncertainty.
+
+OPTIONAL FIELDS (each improves completeness score and future usefulness):
 - reasoning: Your chain of thought. Why this choice over alternatives?
   More detail = higher completeness score. Aim for >100 characters.
 - alternatives: JSON array of options you considered and rejected.
@@ -182,9 +182,10 @@ SKIP: formatting, typo fixes, running tests, reading code, asking questions.`),
 				mcplib.Required(),
 			),
 			mcplib.WithNumber("confidence",
-				mcplib.Description("How certain you are (0.0-1.0). Most decisions should be 0.4-0.8. See calibration guide above. Defaults to 0.4 if omitted."),
+				mcplib.Description("How certain you are (0.0-1.0). Required; missing or null values are rejected so stored confidence reflects the caller's actual claim."),
 				mcplib.Min(0),
 				mcplib.Max(1),
+				mcplib.Required(),
 			),
 			mcplib.WithString("reasoning",
 				mcplib.Description("Your chain of thought. Why this choice? What trade-offs did you consider?"),

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -233,6 +233,69 @@ func TestHandleTrace_InvalidAgentID(t *testing.T) {
 	assert.Contains(t, parseToolText(t, result), "invalid agent_id")
 }
 
+// TestHandleTrace_InvalidConfidence guards the ashita-ai/akashi#713 fix at the
+// MCP boundary. Each case is a value the old GetFloat path would have
+// collapsed onto a silent 0.4 default; all must now be rejected with a
+// descriptive error and no row written.
+func TestHandleTrace_InvalidConfidence(t *testing.T) {
+	ctx := adminCtx()
+
+	base := func() map[string]any {
+		return map[string]any{
+			"agent_id":      "trace-bad-conf",
+			"decision_type": "architecture",
+			"outcome":       "x",
+		}
+	}
+
+	cases := []struct {
+		name    string
+		mutate  func(map[string]any)
+		wantSub string
+	}{
+		{
+			name:    "confidence omitted",
+			mutate:  func(args map[string]any) {},
+			wantSub: "confidence is required",
+		},
+		{
+			name:    "confidence null",
+			mutate:  func(args map[string]any) { args["confidence"] = nil },
+			wantSub: "confidence is required",
+		},
+		{
+			name:    "unparseable string",
+			mutate:  func(args map[string]any) { args["confidence"] = "high" },
+			wantSub: "not a valid number",
+		},
+		{
+			name:    "boolean",
+			mutate:  func(args map[string]any) { args["confidence"] = true },
+			wantSub: "must be a number",
+		},
+		{
+			name:    "negative",
+			mutate:  func(args map[string]any) { args["confidence"] = -0.1 },
+			wantSub: "between 0 and 1",
+		},
+		{
+			name:    "above one",
+			mutate:  func(args map[string]any) { args["confidence"] = 1.5 },
+			wantSub: "between 0 and 1",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			args := base()
+			tc.mutate(args)
+			result, err := testServer.handleTrace(ctx, traceRequest(args))
+			require.NoError(t, err, "handler returns tool error, not go error")
+			require.True(t, result.IsError, "expected tool error for %s", tc.name)
+			assert.Contains(t, parseToolText(t, result), tc.wantSub)
+		})
+	}
+}
+
 func TestHandleTrace_DefaultsAgentIDFromClaims(t *testing.T) {
 	ctx := adminCtx()
 

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -843,6 +843,28 @@ func TestRegisterTools(t *testing.T) {
 	assert.NotNil(t, testServer.MCPServer(), "MCPServer() accessor should work")
 }
 
+func TestRegisterTools_TraceConfidenceRequired(t *testing.T) {
+	tools := testServer.MCPServer().ListTools()
+	require.NotNil(t, tools)
+	traceTool, ok := tools["akashi_trace"]
+	require.True(t, ok, "akashi_trace should be registered")
+
+	assert.Contains(t, traceTool.Tool.InputSchema.Required, "decision_type")
+	assert.Contains(t, traceTool.Tool.InputSchema.Required, "outcome")
+	assert.Contains(t, traceTool.Tool.InputSchema.Required, "confidence")
+
+	assert.Contains(t, traceTool.Tool.Description, "THREE REQUIRED FIELDS")
+	assert.NotContains(t, traceTool.Tool.Description, "Defaults to 0.4")
+	assert.NotContains(t, traceTool.Tool.Description, "TWO REQUIRED FIELDS")
+
+	confProp, ok := traceTool.Tool.InputSchema.Properties["confidence"].(map[string]any)
+	require.True(t, ok, "confidence property should be a JSON schema object")
+	desc, ok := confProp["description"].(string)
+	require.True(t, ok, "confidence property should include a description")
+	assert.Contains(t, desc, "Required")
+	assert.NotContains(t, desc, "Defaults to 0.4")
+}
+
 func TestHandleTrace_WithPrecedentRef(t *testing.T) {
 	ctx := adminCtx()
 	agentID := "precedent-ref-agent-" + uuid.New().String()[:8]

--- a/internal/model/api.go
+++ b/internal/model/api.go
@@ -268,6 +268,15 @@ type TraceRequest struct {
 }
 
 // TraceDecision is the decision portion of a trace convenience request.
+//
+// confidencePresent tracks whether the "confidence" key was present in the
+// JSON payload. HandleTrace gates on it to reject inputs that omit the field,
+// which would otherwise unmarshal to 0.0 and be indistinguishable from a
+// caller's explicit 0.0 choice. Internal callers that construct TraceDecision
+// programmatically are unaffected — they set Confidence directly, and the
+// flag stays false because no boundary check runs in that path.
+//
+// See ashita-ai/akashi#713.
 type TraceDecision struct {
 	DecisionType string             `json:"decision_type"`
 	Outcome      string             `json:"outcome"`
@@ -275,6 +284,41 @@ type TraceDecision struct {
 	Reasoning    *string            `json:"reasoning,omitempty"`
 	Alternatives []TraceAlternative `json:"alternatives,omitempty"`
 	Evidence     []TraceEvidence    `json:"evidence,omitempty"`
+
+	confidencePresent bool
+}
+
+// ConfidencePresent reports whether the "confidence" JSON key was present
+// in the request body that produced this TraceDecision.
+func (d TraceDecision) ConfidencePresent() bool {
+	return d.confidencePresent
+}
+
+// UnmarshalJSON decodes a TraceDecision and records whether the caller
+// supplied a confidence value, distinguishing "omitted" from "explicitly 0".
+func (d *TraceDecision) UnmarshalJSON(data []byte) error {
+	type rawDecision struct {
+		DecisionType string             `json:"decision_type"`
+		Outcome      string             `json:"outcome"`
+		Confidence   *float32           `json:"confidence"`
+		Reasoning    *string            `json:"reasoning,omitempty"`
+		Alternatives []TraceAlternative `json:"alternatives,omitempty"`
+		Evidence     []TraceEvidence    `json:"evidence,omitempty"`
+	}
+	var raw rawDecision
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	d.DecisionType = raw.DecisionType
+	d.Outcome = raw.Outcome
+	d.Reasoning = raw.Reasoning
+	d.Alternatives = raw.Alternatives
+	d.Evidence = raw.Evidence
+	if raw.Confidence != nil {
+		d.Confidence = *raw.Confidence
+		d.confidencePresent = true
+	}
+	return nil
 }
 
 // TraceAlternative is an alternative in a trace convenience request.

--- a/internal/model/api.go
+++ b/internal/model/api.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -297,6 +298,7 @@ func (d TraceDecision) ConfidencePresent() bool {
 // UnmarshalJSON decodes a TraceDecision and records whether the caller
 // supplied a confidence value, distinguishing "omitted" from "explicitly 0".
 func (d *TraceDecision) UnmarshalJSON(data []byte) error {
+	*d = TraceDecision{}
 	type rawDecision struct {
 		DecisionType string             `json:"decision_type"`
 		Outcome      string             `json:"outcome"`
@@ -306,7 +308,9 @@ func (d *TraceDecision) UnmarshalJSON(data []byte) error {
 		Evidence     []TraceEvidence    `json:"evidence,omitempty"`
 	}
 	var raw rawDecision
-	if err := json.Unmarshal(data, &raw); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&raw); err != nil {
 		return err
 	}
 	d.DecisionType = raw.DecisionType

--- a/internal/model/api_test.go
+++ b/internal/model/api_test.go
@@ -1,6 +1,7 @@
 package model_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -492,4 +493,73 @@ func TestHighConfidenceWarnings_CustomThreshold(t *testing.T) {
 	warnings := model.HighConfidenceWarnings(0.7, 0, 0.6)
 	require.Len(t, warnings, 1)
 	assert.Contains(t, warnings[0], "0.7")
+}
+
+// ---- TraceDecision JSON wire semantics (ashita-ai/akashi#713) -----------
+
+func TestTraceDecisionUnmarshalJSON_ConfidencePresent(t *testing.T) {
+	cases := []struct {
+		name        string
+		body        string
+		wantPresent bool
+		wantValue   float32
+	}{
+		{
+			name:        "explicit value",
+			body:        `{"decision_type":"architecture","outcome":"x","confidence":0.85}`,
+			wantPresent: true,
+			wantValue:   0.85,
+		},
+		{
+			name:        "explicit zero is still a present, valid claim",
+			body:        `{"decision_type":"architecture","outcome":"x","confidence":0}`,
+			wantPresent: true,
+			wantValue:   0,
+		},
+		{
+			name:        "omitted",
+			body:        `{"decision_type":"architecture","outcome":"x"}`,
+			wantPresent: false,
+			wantValue:   0,
+		},
+		{
+			name:        "explicit null",
+			body:        `{"decision_type":"architecture","outcome":"x","confidence":null}`,
+			wantPresent: false,
+			wantValue:   0,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var d model.TraceDecision
+			require.NoError(t, json.Unmarshal([]byte(tc.body), &d))
+			assert.Equal(t, tc.wantPresent, d.ConfidencePresent())
+			assert.InDelta(t, tc.wantValue, d.Confidence, 1e-6)
+		})
+	}
+}
+
+// TestTraceDecisionUnmarshalJSON_PreservesOtherFields guards against the
+// custom UnmarshalJSON accidentally dropping any sibling field.
+func TestTraceDecisionUnmarshalJSON_PreservesOtherFields(t *testing.T) {
+	body := `{
+		"decision_type":"security",
+		"outcome":"rotate keys",
+		"confidence":0.6,
+		"reasoning":"credential exposure",
+		"alternatives":[{"label":"do nothing","rejection_reason":"unsafe"}],
+		"evidence":[{"source_type":"document","content":"audit report"}]
+	}`
+	var d model.TraceDecision
+	require.NoError(t, json.Unmarshal([]byte(body), &d))
+	assert.Equal(t, "security", d.DecisionType)
+	assert.Equal(t, "rotate keys", d.Outcome)
+	assert.True(t, d.ConfidencePresent())
+	assert.InDelta(t, 0.6, d.Confidence, 1e-6)
+	require.NotNil(t, d.Reasoning)
+	assert.Equal(t, "credential exposure", *d.Reasoning)
+	require.Len(t, d.Alternatives, 1)
+	assert.Equal(t, "do nothing", d.Alternatives[0].Label)
+	require.Len(t, d.Evidence, 1)
+	assert.Equal(t, "document", d.Evidence[0].SourceType)
 }

--- a/internal/model/api_test.go
+++ b/internal/model/api_test.go
@@ -539,6 +539,30 @@ func TestTraceDecisionUnmarshalJSON_ConfidencePresent(t *testing.T) {
 	}
 }
 
+func TestTraceDecisionUnmarshalJSON_RejectsUnknownField(t *testing.T) {
+	body := `{"decision_type":"architecture","outcome":"x","confidence":0.85,"unexpected":"oops"}`
+
+	var d model.TraceDecision
+	err := json.Unmarshal([]byte(body), &d)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown field")
+}
+
+func TestTraceDecisionUnmarshalJSON_ResetsReceiver(t *testing.T) {
+	var d model.TraceDecision
+	require.NoError(t, json.Unmarshal([]byte(
+		`{"decision_type":"architecture","outcome":"x","confidence":0.85}`,
+	), &d))
+	require.True(t, d.ConfidencePresent())
+	require.InDelta(t, 0.85, d.Confidence, 1e-6)
+
+	require.NoError(t, json.Unmarshal([]byte(
+		`{"decision_type":"architecture","outcome":"x"}`,
+	), &d))
+	assert.False(t, d.ConfidencePresent())
+	assert.Zero(t, d.Confidence)
+}
+
 // TestTraceDecisionUnmarshalJSON_PreservesOtherFields guards against the
 // custom UnmarshalJSON accidentally dropping any sibling field.
 func TestTraceDecisionUnmarshalJSON_PreservesOtherFields(t *testing.T) {

--- a/internal/server/handlers_decisions.go
+++ b/internal/server/handlers_decisions.go
@@ -46,6 +46,14 @@ func (h *Handlers) HandleTrace(w http.ResponseWriter, r *http.Request) {
 		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "decision.outcome is required")
 		return
 	}
+	if !req.Decision.ConfidencePresent() {
+		// Reject explicitly rather than fall through to a silent default —
+		// see ashita-ai/akashi#713. A missing field was previously stored as
+		// 0.0, indistinguishable from a caller's deliberate 0.0 choice.
+		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput,
+			"decision.confidence is required (must be a number between 0 and 1)")
+		return
+	}
 	if req.Decision.Confidence < 0 || req.Decision.Confidence > 1 {
 		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "decision.confidence must be between 0 and 1")
 		return

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1550,6 +1550,56 @@ func TestHandleTrace_InvalidConfidence(t *testing.T) {
 	})
 }
 
+// TestHandleTrace_MissingOrNullConfidence guards the fix for ashita-ai/akashi#713.
+// Before this fix, a request that omitted the "confidence" key (or sent null)
+// would unmarshal to 0.0 and be silently accepted, indistinguishable from a
+// caller's explicit 0.0 stance. Both cases must now return 400.
+func TestHandleTrace_MissingOrNullConfidence(t *testing.T) {
+	cases := []struct {
+		name string
+		body map[string]any
+	}{
+		{
+			name: "confidence key omitted",
+			body: map[string]any{
+				"agent_id": "test-agent",
+				"decision": map[string]any{
+					"decision_type": "test_type",
+					"outcome":       "some-outcome",
+				},
+				"context": map[string]any{"project": "test-project"},
+			},
+		},
+		{
+			name: "confidence explicitly null",
+			body: map[string]any{
+				"agent_id": "test-agent",
+				"decision": map[string]any{
+					"decision_type": "test_type",
+					"outcome":       "some-outcome",
+					"confidence":    nil,
+				},
+				"context": map[string]any{"project": "test-project"},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := authedRequest("POST", testSrv.URL+"/v1/trace", agentToken, tc.body)
+			require.NoError(t, err)
+			defer func() { _ = resp.Body.Close() }()
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+			var errResp model.APIError
+			data, _ := io.ReadAll(resp.Body)
+			_ = json.Unmarshal(data, &errResp)
+			assert.Equal(t, model.ErrCodeInvalidInput, errResp.Error.Code)
+			assert.Contains(t, errResp.Error.Message, "confidence")
+			assert.Contains(t, errResp.Error.Message, "required")
+		})
+	}
+}
+
 func TestHandleTrace_InvalidAgentID(t *testing.T) {
 	resp, err := authedRequest("POST", testSrv.URL+"/v1/trace", adminToken,
 		model.TraceRequest{

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1600,6 +1600,28 @@ func TestHandleTrace_MissingOrNullConfidence(t *testing.T) {
 	}
 }
 
+func TestHandleTrace_RejectsUnknownDecisionField(t *testing.T) {
+	resp, err := authedRequest("POST", testSrv.URL+"/v1/trace", agentToken, map[string]any{
+		"agent_id": "test-agent",
+		"decision": map[string]any{
+			"decision_type": "test_type",
+			"outcome":       "some-outcome",
+			"confidence":    0.5,
+			"unexpected":    "oops",
+		},
+		"context": map[string]any{"project": "test-project"},
+	})
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	var errResp model.APIError
+	data, _ := io.ReadAll(resp.Body)
+	_ = json.Unmarshal(data, &errResp)
+	assert.Equal(t, model.ErrCodeInvalidInput, errResp.Error.Code)
+	assert.Contains(t, errResp.Error.Message, "invalid request body")
+}
+
 func TestHandleTrace_InvalidAgentID(t *testing.T) {
 	resp, err := authedRequest("POST", testSrv.URL+"/v1/trace", adminToken,
 		model.TraceRequest{


### PR DESCRIPTION
## Summary

- Confidence parse failures (missing key, unparseable string, wrong type, NaN/Inf, out-of-range) used to collapse onto silent defaults — `0.4` at the MCP boundary, `0.0` at the HTTP boundary — both indistinguishable from a caller's deliberate value. Roughly 26 of the 40 most recent traces in the May field-assessment sample sat at the synthetic 0.4, contaminating every confidence aggregate (`avg_confidence`, calibration buckets, the over/under-confident percentages in `akashi_stats`).
- `model.TraceDecision` now records JSON-key presence via custom `UnmarshalJSON`; `HandleTrace` rejects missing/null with a descriptive 400 before the range check. Internal callers that construct `TraceDecision` via struct literal are unaffected — no `*float32` ripple through ~25 test files.
- `mcp.parseTraceConfidence` replaces `request.GetFloat(\"confidence\", 0.4)`. Accepts every legitimate numeric shape (float64/int/json.Number/stringified float). Rejects missing/null/unparseable/wrong-type/NaN/Inf/out-of-range with a per-mode error.
- OpenAPI already declared `confidence` required and `[0,1]`; only the implementation diverged. Added a description block that nails down the no-default contract.

## What does *not* change

- No DB migration. `decisions.confidence` stays `NOT NULL REAL CHECK (0..1)`.
- No aggregate-query SQL changes. They keep averaging over real values.
- No SDK type changes. Every shipping SDK already sends an explicit float.
- Historical contamination is not rewritten. The trail is append-only and there is no marker to distinguish a synthetic 0.4 from a real one retroactively. Rolling-window dashboards become trustworthy as new traces accumulate; all-time aggregates carry the historical noise.

## What this addresses in the field assessment

Closes item #1 of the five must-fix items in the May 2026 field assessment (\"Confidence parsing is broken — fix it\"). Indirectly enables item #5 (assessment loop / calibration) because stated confidence will be a real signal going forward — calibration plots (stated confidence vs. assessed-correct rate) become meaningful only after this lands. Does not touch items #2 (cross-project tag enforcement), #3 (minimum decision bar at ingest), or #4 (conflict detector FP rate); those are separate work.

## Test plan

- [x] \`go mod tidy\` — no drift
- [x] \`go build ./...\` — clean
- [x] \`go vet ./...\` — clean
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] \`atlas migrate validate\` — pass
- [x] \`go test -race -count=1 ./...\` — all pass
- [x] \`go test -race -count=1 -tags integration ./...\` — all pass (full testcontainers suite)
- New tests cover, at the model layer: omitted, explicit-null, explicit-zero, and explicit-value cases all round-trip with the correct \`ConfidencePresent()\` flag and value preservation across all sibling fields.
- New tests cover, at the MCP layer (\`parseTraceConfidence\` unit + integration): every numeric shape a real client may produce is accepted; every silent-fallback case the old \`GetFloat\` path swallowed is rejected with a descriptive error and no fabricated value.
- New tests cover, at the HTTP layer: \`POST /v1/trace\` returns 400 with a message containing \`confidence\` and \`required\` for both the omitted-key and explicit-null cases; existing range tests (\`-0.1\`, \`1.5\`) keep passing.

Closes #713.

> Treebeard takes long council before he speaks, and longer still before
> he acts — but a hasty word in the Entmoot is worse than no word at
> all. A stored 0.4 that means \"I was rushed and did not look\" must
> never be written down as \"my judgment, weighed and offered.\" The
> bookkeeping has to know which is which.