### PR TITLE
feat(trace): configurable completeness ingest gate (#715)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -304,6 +304,24 @@ AKASHI_HOOKS_API_KEY=
 # AKASHI_STANDARD_DECISION_TYPES=
 
 
+# ── Completeness Ingest Gate (issue #715) ────────────────────────────────────
+#
+# Optional structural-quality gate on POST /v1/trace, akashi_trace MCP tool,
+# and the IDE auto-trace hook. Consumes the existing completeness score —
+# no new scoring logic. Disabled by default.
+#
+# Mode: off (default), warn (accept + warn in response), reject (refuse with
+# HTTP 422 / MCP tool error).
+# AKASHI_MIN_COMPLETENESS_MODE=off
+#
+# Global minimum score in [0.0, 1.0]. 0 disables the global floor.
+# AKASHI_MIN_COMPLETENESS=0.0
+#
+# Per-type override. Keys are decision_type (lowercased on load). Pair with
+# AKASHI_MIN_COMPLETENESS=0 to enforce only the named types.
+# AKASHI_MIN_COMPLETENESS_BY_TYPE={"security":0.60,"architecture":0.55,"code_review":0.45}
+
+
 # ── Safety Gates ─────────────────────────────────────────────────────────────
 #
 # Destructive delete is disabled by default. Enable only for controlled GDPR

--- a/akashi.go
+++ b/akashi.go
@@ -310,6 +310,23 @@ func New(opts ...Option) (*App, error) {
 	assessor := autoassess.New(db, logger)
 	decisionSvc.SetAutoAssessor(assessor)
 
+	// Completeness ingest gate (#715). Disabled by default; operators opt in
+	// via AKASHI_MIN_COMPLETENESS_MODE=warn|reject. The mode string was
+	// validated at config load, so ParseGateMode cannot return an error here.
+	gateMode, _ := quality.ParseGateMode(cfg.MinCompletenessMode)
+	decisionSvc.SetCompletenessGate(quality.CompletenessGate{
+		Mode:      gateMode,
+		Threshold: cfg.MinCompleteness,
+		ByType:    cfg.MinCompletenessByType,
+	})
+	if gateMode != quality.GateModeOff {
+		logger.Info("completeness ingest gate enabled",
+			"mode", string(gateMode),
+			"threshold", cfg.MinCompleteness,
+			"by_type_count", len(cfg.MinCompletenessByType),
+		)
+	}
+
 	// Embedding backfills (non-fatal).
 	if n, err := decisionSvc.BackfillEmbeddings(context.Background(), 500); err != nil {
 		logger.Warn("embedding backfill failed", "error", err)

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -636,6 +636,29 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "403":
           $ref: "#/components/responses/Forbidden"
+        "422":
+          description: |
+            Decision was refused by the completeness ingest gate (issue #715).
+            The `error.code` is `COMPLETENESS_BELOW_THRESHOLD` and
+            `error.details` carries the structured fields below. Returned only
+            when `AKASHI_MIN_COMPLETENESS_MODE=reject` and the trace's
+            completeness score is strictly below the effective threshold for
+            its `decision_type`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/APIError"
+              example:
+                error:
+                  code: COMPLETENESS_BELOW_THRESHOLD
+                  message: "decision completeness below configured minimum threshold: score=0.15 threshold=0.30 decision_type=\"code_review\""
+                  details:
+                    decision_type: code_review
+                    completeness_score: 0.15
+                    required_min: 0.30
+                meta:
+                  request_id: "11223344-5566-7788-99aa-bbccddeeff00"
+                  timestamp: "2026-05-13T10:30:00Z"
 
   # ── Query ──────────────────────────────────────────────────────────
   /v1/query:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -3064,6 +3064,7 @@ components:
             - FORBIDDEN
             - NOT_FOUND
             - CONFLICT
+            - COMPLETENESS_BELOW_THRESHOLD
             - INTERNAL_ERROR
         message:
           type: string

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1636,6 +1636,27 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "404":
           $ref: "#/components/responses/NotFound"
+        "422":
+          description: |
+            Adjudication decision was refused by the completeness ingest gate.
+            Returned only when `AKASHI_MIN_COMPLETENESS_MODE=reject` and the
+            adjudication trace's completeness score is strictly below the
+            effective threshold for its `decision_type`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/APIError"
+              example:
+                error:
+                  code: COMPLETENESS_BELOW_THRESHOLD
+                  message: "decision completeness below configured minimum threshold: score=0.15 threshold=0.30 decision_type=\"adjudication\""
+                  details:
+                    decision_type: adjudication
+                    completeness_score: 0.15
+                    required_min: 0.30
+                meta:
+                  request_id: "11223344-5566-7788-99aa-bbccddeeff00"
+                  timestamp: "2026-05-13T10:30:00Z"
 
   /v1/conflict-groups/{id}/resolve:
     patch:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -260,6 +260,46 @@ Hook endpoints (`/hooks/session-start`, `/hooks/pre-tool-use`, `/hooks/post-tool
 |----------|---------|-------------|
 | `AKASHI_HIGH_CONFIDENCE_WARN_THRESHOLD` | `0.85` | Confidence above this with zero evidence items triggers a `warnings` array in the trace response. Set to `1.0` to disable |
 
+## Completeness ingest gate
+
+The completeness ingest gate (issue [#715](https://github.com/ashita-ai/akashi/issues/715)) lets operators refuse or warn on low-completeness traces at ingest time. The gate consumes the same structural completeness score that's already computed for every trace (see [quality-scoring.md](quality-scoring.md)) — no new scoring logic. Disabled by default.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `AKASHI_MIN_COMPLETENESS_MODE` | `off` | Gate behavior: `off` (default — never blocks), `warn` (accept and attach a warning to the response), or `reject` (refuse with HTTP 422 / MCP tool error). Aliases: `disabled`/`warning`/`block` |
+| `AKASHI_MIN_COMPLETENESS` | `0.0` | Global minimum completeness score in `[0.0, 1.0]`. Traces below this are gated according to mode. A non-positive value disables the global floor (the gate then only fires for types listed in `_BY_TYPE`) |
+| `AKASHI_MIN_COMPLETENESS_BY_TYPE` | _(empty)_ | JSON object mapping `decision_type` → per-type floor. Overrides the global floor for the named type. Keys are lowercased on load. Example: `{"security":0.60,"architecture":0.55,"code_review":0.45}` |
+
+**Examples.**
+
+Reject any trace that scores below 0.30:
+
+```sh
+AKASHI_MIN_COMPLETENESS_MODE=reject
+AKASHI_MIN_COMPLETENESS=0.30
+```
+
+Enforce a per-type bar for high-stakes decisions only, leaving everything else ungated:
+
+```sh
+AKASHI_MIN_COMPLETENESS_MODE=reject
+AKASHI_MIN_COMPLETENESS=0
+AKASHI_MIN_COMPLETENESS_BY_TYPE={"security":0.60,"architecture":0.55}
+```
+
+Warn-only mode for a soft rollout — agents see what would be blocked without breaking ingest:
+
+```sh
+AKASHI_MIN_COMPLETENESS_MODE=warn
+AKASHI_MIN_COMPLETENESS=0.30
+```
+
+**Response shape.**
+
+In `reject` mode the HTTP API returns `422 Unprocessable Entity` with the `COMPLETENESS_BELOW_THRESHOLD` error code and a `details` object carrying `decision_type`, `completeness_score`, and `required_min`. The MCP `akashi_trace` tool returns the same information in a tool-error message. In `warn` mode the trace is persisted (201) and a string is appended to the response `warnings` array. The gate exposes two OTel counters: `akashi.trace.completeness_gate_rejects` and `akashi.trace.completeness_gate_warns`, both labeled by `decision_type`.
+
+**Scope.** The gate fires for any caller of the trace pipeline — HTTP `POST /v1/trace`, the MCP `akashi_trace` tool, and the IDE auto-trace hook. The local-lite binary (`cmd/akashi-local`) ignores these variables and always runs with the gate off; it's intended for single-developer use where structural enforcement isn't useful.
+
 ## Data retention
 
 Akashi supports per-org data retention policies that automatically delete decisions older than a configured threshold. Policies are set via `PUT /v1/retention` (admin-only). Legal holds (`POST /v1/retention/hold`) exempt matching decisions from both automated and GDPR deletion. All deletion operations are recorded in the `deletion_log` table.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -296,7 +296,7 @@ AKASHI_MIN_COMPLETENESS=0.30
 
 **Response shape.**
 
-In `reject` mode the HTTP API returns `422 Unprocessable Entity` with the `COMPLETENESS_BELOW_THRESHOLD` error code and a `details` object carrying `decision_type`, `completeness_score`, and `required_min`. The MCP `akashi_trace` tool returns the same information in a tool-error message. In `warn` mode the trace is persisted (201) and a string is appended to the response `warnings` array. The gate exposes two OTel counters: `akashi.trace.completeness_gate_rejects` and `akashi.trace.completeness_gate_warns`, both labeled by `decision_type`.
+In `reject` mode the HTTP API returns `422 Unprocessable Entity` with the `COMPLETENESS_BELOW_THRESHOLD` error code and a `details` object carrying `decision_type`, `completeness_score`, and `required_min`. The MCP `akashi_trace` tool returns the same information in a tool-error message. Rejected trace attempts are recorded in `mutation_audit_log` with operation `trace_decision_rejected` before the 422/tool error is returned. In `warn` mode the trace is persisted (201) and a string is appended to the response `warnings` array. The gate exposes two OTel counters: `akashi.trace.completeness_gate_rejects` and `akashi.trace.completeness_gate_warns`, both labeled by `decision_type`.
 
 **Scope.** The gate fires for any caller of the trace pipeline — HTTP `POST /v1/trace`, the MCP `akashi_trace` tool, and the IDE auto-trace hook. The local-lite binary (`cmd/akashi-local`) ignores these variables and always runs with the gate off; it's intended for single-developer use where structural enforcement isn't useful.
 

--- a/docs/quality-scoring.md
+++ b/docs/quality-scoring.md
@@ -108,7 +108,7 @@ the score above, no new logic — and is disabled by default.
 |------|-----------------------------------|
 | `off` (default) | No effect; pre-#715 behavior preserved |
 | `warn` | Trace is persisted; a string is appended to the response `warnings` array |
-| `reject` | Trace is refused; HTTP `422 Unprocessable Entity` with `COMPLETENESS_BELOW_THRESHOLD` error code and `details` carrying score/threshold/type. The MCP `akashi_trace` tool returns the same information as a tool-error message |
+| `reject` | Trace is refused; HTTP `422 Unprocessable Entity` with `COMPLETENESS_BELOW_THRESHOLD` error code and `details` carrying score/threshold/type. The MCP `akashi_trace` tool returns the same information as a tool-error message. The rejected attempt is recorded in `mutation_audit_log` with operation `trace_decision_rejected` |
 
 Per-type overrides take precedence over the global floor. Configure via
 `AKASHI_MIN_COMPLETENESS`, `AKASHI_MIN_COMPLETENESS_MODE`, and

--- a/docs/quality-scoring.md
+++ b/docs/quality-scoring.md
@@ -97,6 +97,28 @@ All weights are currently uncalibrated — chosen by hand without empirical basi
 iteration will fit weights against assessed decision data. See the factor table as a
 guide to what Akashi values in a decision trace, not as a precise quality metric.
 
+## Ingest gate (#715)
+
+The completeness score also feeds an optional ingest gate. When enabled, the
+gate refuses or warns on traces whose score falls below a configured
+threshold for their decision type. The gate is purely structural — it consumes
+the score above, no new logic — and is disabled by default.
+
+| Mode | Behavior on score below threshold |
+|------|-----------------------------------|
+| `off` (default) | No effect; pre-#715 behavior preserved |
+| `warn` | Trace is persisted; a string is appended to the response `warnings` array |
+| `reject` | Trace is refused; HTTP `422 Unprocessable Entity` with `COMPLETENESS_BELOW_THRESHOLD` error code and `details` carrying score/threshold/type. The MCP `akashi_trace` tool returns the same information as a tool-error message |
+
+Per-type overrides take precedence over the global floor. Configure via
+`AKASHI_MIN_COMPLETENESS`, `AKASHI_MIN_COMPLETENESS_MODE`, and
+`AKASHI_MIN_COMPLETENESS_BY_TYPE` — see [configuration.md](configuration.md#completeness-ingest-gate).
+
+Gate activity is observable via two OTel counters labeled by `decision_type`:
+
+- `akashi.trace.completeness_gate_rejects`
+- `akashi.trace.completeness_gate_warns`
+
 ## Outcome score
 
 The outcome score (0.0–1.0, or `null`) measures how correct a decision turned out to be

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@
 package config
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -159,6 +160,30 @@ type Config struct {
 	// When set, replaces the built-in 12 defaults. Example:
 	//   "architecture,security,data_pipeline,access_control"
 	StandardDecisionTypes []string
+
+	// Completeness ingest gate (issue #715).
+	// MinCompleteness is the global floor in [0.0, 1.0]. A trace whose
+	// completeness score (from quality.Score) is strictly below the
+	// effective floor for its decision_type is gated according to
+	// MinCompletenessMode. The gate is structural — it consumes the
+	// existing score that already weighs reasoning, alternatives, evidence,
+	// outcome, and precedent_ref. There is no new scoring logic.
+	//
+	// Default is 0.0 with mode "off" — pre-#715 behavior preserved.
+	MinCompleteness float32
+
+	// MinCompletenessMode selects the gate behavior: "off" (default),
+	// "warn" (accept and attach a warning to the response), or "reject"
+	// (refuse with HTTP 422 / MCP tool error). See quality.GateMode.
+	MinCompletenessMode string
+
+	// MinCompletenessByType is a JSON object mapping decision_type to a
+	// per-type floor that overrides MinCompleteness for that type. Keys
+	// are lowercased on load. Example:
+	//   {"security":0.60,"architecture":0.55,"code_review":0.45}
+	// Pair with MinCompleteness=0 to enforce only the named types and
+	// leave everything else ungated.
+	MinCompletenessByType map[string]float32
 }
 
 // Load reads configuration from environment variables with sensible defaults.
@@ -192,6 +217,7 @@ func Load() (Config, error) {
 		HooksAPIKey:              Secret(envStr("AKASHI_HOOKS_API_KEY", "")),
 		CompletenessProfilesJSON: envStr("AKASHI_COMPLETENESS_PROFILES", ""),
 		StandardDecisionTypes:    envStrSlice("AKASHI_STANDARD_DECISION_TYPES", nil),
+		MinCompletenessMode:      envStr("AKASHI_MIN_COMPLETENESS_MODE", "off"),
 	}
 
 	// Integer fields.
@@ -260,6 +286,20 @@ func Load() (Config, error) {
 	var highConfThreshF64 float64
 	highConfThreshF64, errs = collectFloat64(errs, "AKASHI_HIGH_CONFIDENCE_WARN_THRESHOLD", 0.85)
 	cfg.HighConfidenceWarnThreshold = float32(highConfThreshF64)
+
+	var minCompletenessF64 float64
+	minCompletenessF64, errs = collectFloat64(errs, "AKASHI_MIN_COMPLETENESS", 0.0)
+	cfg.MinCompleteness = float32(minCompletenessF64)
+
+	byTypeJSON := envStr("AKASHI_MIN_COMPLETENESS_BY_TYPE", "")
+	if byTypeJSON != "" {
+		parsed, err := parseMinCompletenessByType(byTypeJSON)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("config: AKASHI_MIN_COMPLETENESS_BY_TYPE: %w", err))
+		} else {
+			cfg.MinCompletenessByType = parsed
+		}
+	}
 
 	// Boolean fields.
 	cfg.RateLimitEnabled, errs = collectBool(errs, "AKASHI_RATE_LIMIT_ENABLED", true)
@@ -462,6 +502,14 @@ func (c Config) Validate() error {
 	}
 	if c.ConflictOutcomeSimFloor < 0 || c.ConflictOutcomeSimFloor > 1 {
 		errs = append(errs, errors.New("config: AKASHI_CONFLICT_OUTCOME_SIM_FLOOR must be between 0.0 and 1.0 (0 disables)"))
+	}
+	if c.MinCompleteness < 0 || c.MinCompleteness > 1 {
+		errs = append(errs, errors.New("config: AKASHI_MIN_COMPLETENESS must be between 0.0 and 1.0"))
+	}
+	// Validate mode by parsing through the canonical parser so the set of
+	// accepted spellings stays in lockstep with quality.ParseGateMode.
+	if _, modeErr := parseGateModeForValidation(c.MinCompletenessMode); modeErr != nil {
+		errs = append(errs, fmt.Errorf("config: AKASHI_MIN_COMPLETENESS_MODE: %w", modeErr))
 	}
 
 	// WAL fail-safe: refuse to start without WAL unless explicitly disabled.
@@ -719,6 +767,51 @@ func conflictProfileDefaults(profile string, embeddingModel string) conflictProf
 		outcomeSimFloor:       adj.outcomeSimFloor,
 		crossEncoderThreshold: adj.crossEncoderThreshold,
 	}
+}
+
+// parseGateModeForValidation validates AKASHI_MIN_COMPLETENESS_MODE without
+// importing the quality package (which would risk an import cycle and break
+// the convention that config has no internal/* dependencies). The accepted
+// strings must stay in lockstep with quality.ParseGateMode.
+func parseGateModeForValidation(s string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", "off", "disabled":
+		return "off", nil
+	case "warn", "warning":
+		return "warn", nil
+	case "reject", "block":
+		return "reject", nil
+	default:
+		return "", fmt.Errorf("%q is not a valid mode (want off|warn|reject)", s)
+	}
+}
+
+// parseMinCompletenessByType parses the AKASHI_MIN_COMPLETENESS_BY_TYPE JSON
+// at load time. The parsing logic mirrors quality.ParseGateByType but lives
+// here so config remains free of internal/service dependencies. Keys are
+// lowercased and trimmed to match the canonical decision_type form used by
+// the trace pipeline.
+func parseMinCompletenessByType(raw string) (map[string]float32, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+	var parsed map[string]float64
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+		return nil, fmt.Errorf("invalid JSON: %w", err)
+	}
+	out := make(map[string]float32, len(parsed))
+	for k, v := range parsed {
+		key := strings.ToLower(strings.TrimSpace(k))
+		if key == "" {
+			return nil, errors.New("empty decision_type key")
+		}
+		if v < 0 || v > 1 {
+			return nil, fmt.Errorf("%q=%.4f out of range [0.0, 1.0]", k, v)
+		}
+		out[key] = float32(v)
+	}
+	return out, nil
 }
 
 func envStrSlice(key string, fallback []string) []string {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1235,6 +1235,15 @@ func (s *Server) handleTrace(ctx context.Context, request mcplib.CallToolRequest
 		if idemOwned {
 			_ = s.db.ClearInProgressIdempotency(ctx, orgID, agentID, "MCP:akashi_trace", idemKey)
 		}
+		// Surface a structured message for completeness-gate rejections (#715)
+		// so the agent can fix the trace and retry rather than guessing at why
+		// the server refused it.
+		if rej := decisions.AsCompletenessRejection(err); rej != nil {
+			return errorResult(fmt.Sprintf(
+				"decision rejected by completeness gate: score %.2f for decision_type=%q is below the configured minimum of %.2f — add reasoning, alternatives with rejection reasons, evidence, or a precedent_ref before retrying",
+				rej.Score, rej.DecisionType, rej.Threshold,
+			)), nil
+		}
 		return errorResult(fmt.Sprintf("failed to record decision: %v", err)), nil
 	}
 
@@ -1290,7 +1299,12 @@ func (s *Server) handleTrace(ctx context.Context, request mcplib.CallToolRequest
 	if len(missing) > 0 {
 		responseMap["completeness_tips"] = missing
 	}
-	if warnings := model.HighConfidenceWarnings(confidence, len(evidence), s.highConfidenceWarnThreshold); len(warnings) > 0 {
+	warnings := model.HighConfidenceWarnings(confidence, len(evidence), s.highConfidenceWarnThreshold)
+	// Append any warn-mode messages produced by the completeness gate (#715).
+	if len(result.Warnings) > 0 {
+		warnings = append(warnings, result.Warnings...)
+	}
+	if len(warnings) > 0 {
 		responseMap["warnings"] = warnings
 	}
 	if checkHadResults {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -2081,6 +2081,12 @@ func (s *Server) handleReconcile(ctx context.Context, request mcplib.CallToolReq
 		Relationship:  "reconciles",
 	})
 	if err != nil {
+		if rej := decisions.AsCompletenessRejection(err); rej != nil {
+			return errorResult(fmt.Sprintf(
+				"decision rejected by completeness gate: score %.2f for decision_type=%q is below the configured minimum of %.2f — add reasoning, alternatives with rejection reasons, evidence, or a precedent_ref before retrying",
+				rej.Score, rej.DecisionType, rej.Threshold,
+			)), nil
+		}
 		if errors.Is(err, storage.ErrNotFound) {
 			return errorResult("conflict not found"), nil
 		}

--- a/internal/model/api.go
+++ b/internal/model/api.go
@@ -217,15 +217,16 @@ type ErrorDetail struct {
 
 // ErrorCode constants for standard API error codes.
 const (
-	ErrCodeInvalidInput       = "INVALID_INPUT"
-	ErrCodeUnauthorized       = "UNAUTHORIZED"
-	ErrCodeForbidden          = "FORBIDDEN"
-	ErrCodeNotFound           = "NOT_FOUND"
-	ErrCodeConflict           = "CONFLICT"
-	ErrCodeInternalError      = "INTERNAL_ERROR"
-	ErrCodeRateLimited        = "RATE_LIMITED"
-	ErrCodeNotImplemented     = "NOT_IMPLEMENTED"
-	ErrCodeServiceUnavailable = "SERVICE_UNAVAILABLE"
+	ErrCodeInvalidInput               = "INVALID_INPUT"
+	ErrCodeUnauthorized               = "UNAUTHORIZED"
+	ErrCodeForbidden                  = "FORBIDDEN"
+	ErrCodeNotFound                   = "NOT_FOUND"
+	ErrCodeConflict                   = "CONFLICT"
+	ErrCodeInternalError              = "INTERNAL_ERROR"
+	ErrCodeRateLimited                = "RATE_LIMITED"
+	ErrCodeNotImplemented             = "NOT_IMPLEMENTED"
+	ErrCodeServiceUnavailable         = "SERVICE_UNAVAILABLE"
+	ErrCodeCompletenessBelowThreshold = "COMPLETENESS_BELOW_THRESHOLD" // 422 — trace rejected by the ingest gate (#715)
 )
 
 // CreateRunRequest is the request body for POST /v1/runs.

--- a/internal/server/handlers_completeness_gate_test.go
+++ b/internal/server/handlers_completeness_gate_test.go
@@ -1,0 +1,158 @@
+//go:build integration
+
+package server_test
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ashita-ai/akashi/internal/auth"
+	"github.com/ashita-ai/akashi/internal/model"
+	"github.com/ashita-ai/akashi/internal/server"
+	"github.com/ashita-ai/akashi/internal/service/decisions"
+	"github.com/ashita-ai/akashi/internal/service/embedding"
+	"github.com/ashita-ai/akashi/internal/service/quality"
+	"github.com/ashita-ai/akashi/internal/service/trace"
+)
+
+// gateTestServer builds an isolated httptest.Server whose decision service has
+// the supplied completeness gate configured. The server reuses the shared
+// testDB (so the "admin" agent and its API key seeded by TestMain are visible),
+// but uses its own JWT manager and decision service so the gate cannot leak
+// into other tests' servers.
+func gateTestServer(t *testing.T, gate quality.CompletenessGate) (*httptest.Server, string, string) {
+	t.Helper()
+
+	jwtMgr, err := auth.NewJWTManager("", "", 24*time.Hour)
+	require.NoError(t, err)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	embedder := embedding.NewNoopProvider(1024)
+	decisionSvc := decisions.New(testDB, embedder, nil, logger, nil)
+	decisionSvc.SetCompletenessGate(gate)
+	buf := trace.NewBuffer(testDB, logger, 1000, 50*time.Millisecond, nil)
+
+	srv := server.New(server.ServerConfig{
+		DB:                  testDB,
+		JWTMgr:              jwtMgr,
+		DecisionSvc:         decisionSvc,
+		Buffer:              buf,
+		Logger:              logger,
+		ReadTimeout:         30 * time.Second,
+		WriteTimeout:        30 * time.Second,
+		Version:             "test",
+		MaxRequestBodyBytes: 1 * 1024 * 1024,
+	})
+
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+
+	// Reuse the admin agent already seeded by TestMain in server_test.go.
+	// The DB row exists with the hashed "test-admin-key"; we just need a
+	// fresh JWT against this server's JWT manager.
+	adminTok := getToken(ts.URL, "admin", "test-admin-key")
+
+	// Create a per-test agent so concurrent test runs don't collide on agent_id.
+	agentID := "gate-handler-" + uuid.New().String()[:8]
+	agentKey := "gate-handler-key-" + uuid.New().String()[:8]
+	createAgent(ts.URL, adminTok, agentID, "Gate Test Agent", "agent", agentKey)
+	agentTok := getToken(ts.URL, agentID, agentKey)
+	return ts, agentTok, agentID
+}
+
+func TestTraceHandler_CompletenessGateReject_Returns422(t *testing.T) {
+	ts, agentTok, agentID := gateTestServer(t, quality.CompletenessGate{
+		Mode:      quality.GateModeReject,
+		Threshold: 0.50, // high enough that a terse trace fails
+	})
+
+	resp, err := authedRequest("POST", ts.URL+"/v1/trace", agentTok, model.TraceRequest{
+		AgentID: agentID,
+		Decision: model.TraceDecision{
+			DecisionType: "code_review",
+			Outcome:      "approved",
+			Confidence:   0.5,
+		},
+		Context: map[string]any{"project": "test-project"},
+	})
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode,
+		"reject mode must surface as 422 Unprocessable Entity")
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var envelope struct {
+		Error struct {
+			Code    string         `json:"code"`
+			Message string         `json:"message"`
+			Details map[string]any `json:"details"`
+		} `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(body, &envelope))
+	assert.Equal(t, model.ErrCodeCompletenessBelowThreshold, envelope.Error.Code)
+	require.NotNil(t, envelope.Error.Details, "details must surface threshold/score/type for actionable client errors")
+	assert.Equal(t, "code_review", envelope.Error.Details["decision_type"])
+	// JSON numbers decode to float64. Threshold should match the configured 0.50.
+	if v, ok := envelope.Error.Details["required_min"].(float64); assert.True(t, ok, "required_min must be a number") {
+		assert.InDelta(t, 0.50, v, 0.001)
+	}
+}
+
+func TestTraceHandler_CompletenessGateWarn_Returns201WithWarning(t *testing.T) {
+	ts, agentTok, agentID := gateTestServer(t, quality.CompletenessGate{
+		Mode:      quality.GateModeWarn,
+		Threshold: 0.50,
+	})
+
+	resp, err := authedRequest("POST", ts.URL+"/v1/trace", agentTok, model.TraceRequest{
+		AgentID: agentID,
+		Decision: model.TraceDecision{
+			DecisionType: "code_review",
+			Outcome:      "approved",
+			Confidence:   0.5,
+		},
+		Context: map[string]any{"project": "test-project"},
+	})
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusCreated, resp.StatusCode,
+		"warn mode must still accept the trace (201 Created)")
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var envelope struct {
+		Data struct {
+			DecisionID uuid.UUID `json:"decision_id"`
+			Warnings   []string  `json:"warnings"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(body, &envelope))
+	assert.NotEqual(t, uuid.Nil, envelope.Data.DecisionID, "decision must be persisted in warn mode")
+	require.NotEmpty(t, envelope.Data.Warnings, "warn mode must attach a warning to the response")
+
+	// The completeness warning must appear (HighConfidenceWarnings is also possible
+	// but with confidence=0.5 it won't fire). Verify the gate's wording reached the client.
+	foundGateWarning := false
+	for _, w := range envelope.Data.Warnings {
+		if strings.HasPrefix(w, "completeness") {
+			foundGateWarning = true
+			break
+		}
+	}
+	assert.True(t, foundGateWarning, "gate warning must be surfaced via the response Warnings array")
+}

--- a/internal/server/handlers_conflicts.go
+++ b/internal/server/handlers_conflicts.go
@@ -382,6 +382,17 @@ func (h *Handlers) HandleAdjudicateConflict(w http.ResponseWriter, r *http.Reque
 		Relationship:      "reconciles",
 	})
 	if err != nil {
+		if rej := decisions.AsCompletenessRejection(err); rej != nil {
+			writeErrorWithDetails(w, r, http.StatusUnprocessableEntity, model.ErrCodeCompletenessBelowThreshold,
+				rej.Error(),
+				map[string]any{
+					"decision_type":      rej.DecisionType,
+					"completeness_score": rej.Score,
+					"required_min":       rej.Threshold,
+				},
+			)
+			return
+		}
 		if isNotFoundError(err) {
 			writeError(w, r, http.StatusNotFound, model.ErrCodeNotFound, "conflict not found")
 			return

--- a/internal/server/handlers_decisions.go
+++ b/internal/server/handlers_decisions.go
@@ -160,6 +160,20 @@ func (h *Handlers) HandleTrace(w http.ResponseWriter, r *http.Request) {
 	})
 	if err != nil {
 		h.clearIdempotentWrite(r, orgID, idem)
+		if rej := decisions.AsCompletenessRejection(err); rej != nil {
+			// 422 Unprocessable Entity: the request was syntactically valid
+			// but failed the structural-quality gate configured by the operator.
+			// Details carry the score/threshold/type so the agent can self-correct.
+			writeErrorWithDetails(w, r, http.StatusUnprocessableEntity, model.ErrCodeCompletenessBelowThreshold,
+				rej.Error(),
+				map[string]any{
+					"decision_type":      rej.DecisionType,
+					"completeness_score": rej.Score,
+					"required_min":       rej.Threshold,
+				},
+			)
+			return
+		}
 		if req.SupersedesID != nil && (errors.Is(err, storage.ErrNotFound) || isForeignKeyViolation(err)) {
 			writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput,
 				"superseded decision not found or already superseded")
@@ -194,6 +208,12 @@ func (h *Handlers) HandleTrace(w http.ResponseWriter, r *http.Request) {
 	}
 	if warnings := model.HighConfidenceWarnings(req.Decision.Confidence, len(req.Decision.Evidence), h.highConfidenceWarnThreshold); len(warnings) > 0 {
 		resp.Warnings = warnings
+	}
+	// Append any service-produced warnings (currently the completeness gate
+	// in warn mode, #715). Done after the high-confidence pass so the order
+	// is stable: confidence warnings first, completeness warnings second.
+	if len(result.Warnings) > 0 {
+		resp.Warnings = append(resp.Warnings, result.Warnings...)
 	}
 	reasoningLen := 0
 	if req.Decision.Reasoning != nil {

--- a/internal/server/handlers_hooks.go
+++ b/internal/server/handlers_hooks.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/ashita-ai/akashi/internal/ctxutil"
 	"github.com/ashita-ai/akashi/internal/model"
 	"github.com/ashita-ai/akashi/internal/service/decisions"
 	"github.com/ashita-ai/akashi/internal/storage"
@@ -482,6 +483,14 @@ func (h *Handlers) autoTraceCommit(input hookPostToolUseInput, commitMsg string)
 			Evidence:     evidence,
 		},
 		AgentContext: agentCtx,
+		AuditMeta: &ctxutil.AuditMeta{
+			RequestID:    uuid.NewString(),
+			OrgID:        orgID,
+			ActorAgentID: agentID,
+			ActorRole:    string(model.RoleAdmin),
+			HTTPMethod:   "HOOK",
+			Endpoint:     "hooks/post-tool-use:auto-trace",
+		},
 	}
 
 	if _, err := h.decisionSvc.Trace(ctx, orgID, traceInput); err != nil {

--- a/internal/server/handlers_hooks.go
+++ b/internal/server/handlers_hooks.go
@@ -485,7 +485,19 @@ func (h *Handlers) autoTraceCommit(input hookPostToolUseInput, commitMsg string)
 	}
 
 	if _, err := h.decisionSvc.Trace(ctx, orgID, traceInput); err != nil {
-		h.logger.Warn("auto-trace failed", "error", err, "commit", truncateHook(commitMsg, 60))
+		// A completeness-gate rejection (#715) is operator policy working as
+		// intended, not a failure. Log it at info so it shows up but doesn't
+		// look like infra distress in the noisy auto-trace path.
+		if rej := decisions.AsCompletenessRejection(err); rej != nil {
+			h.logger.Info("auto-trace skipped by completeness gate",
+				"score", rej.Score,
+				"threshold", rej.Threshold,
+				"decision_type", rej.DecisionType,
+				"commit", truncateHook(commitMsg, 60),
+			)
+		} else {
+			h.logger.Warn("auto-trace failed", "error", err, "commit", truncateHook(commitMsg, 60))
+		}
 	} else {
 		h.hookChecks.ClearProjectEmpty(project)
 	}

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -567,10 +567,18 @@ func writeJSON(w http.ResponseWriter, r *http.Request, status int, data any) {
 
 // writeError writes a JSON error response with the standard envelope.
 func writeError(w http.ResponseWriter, r *http.Request, status int, code, message string) {
+	writeErrorWithDetails(w, r, status, code, message, nil)
+}
+
+// writeErrorWithDetails writes a JSON error response with structured details
+// attached under the `details` field. Used when the caller needs to surface
+// actionable fields (e.g. completeness score and threshold for the #715 gate)
+// alongside the human-readable message.
+func writeErrorWithDetails(w http.ResponseWriter, r *http.Request, status int, code, message string, details any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	if err := json.NewEncoder(w).Encode(model.APIError{
-		Error: model.ErrorDetail{Code: code, Message: message},
+		Error: model.ErrorDetail{Code: code, Message: message, Details: details},
 		Meta: model.ResponseMeta{
 			RequestID: RequestIDFromContext(r.Context()),
 			Timestamp: time.Now().UTC(),

--- a/internal/service/decisions/gate_integration_test.go
+++ b/internal/service/decisions/gate_integration_test.go
@@ -1,0 +1,161 @@
+//go:build integration
+
+package decisions_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ashita-ai/akashi/internal/model"
+	"github.com/ashita-ai/akashi/internal/service/decisions"
+	"github.com/ashita-ai/akashi/internal/service/embedding"
+	"github.com/ashita-ai/akashi/internal/service/quality"
+	"github.com/ashita-ai/akashi/internal/testutil"
+)
+
+// newGatedSvc returns a fresh Service with the supplied gate configured.
+// We create per-test services so gate state never leaks between tests; the
+// shared testSvc keeps its default (off) gate for unrelated suites.
+func newGatedSvc(g quality.CompletenessGate) *decisions.Service {
+	logger := testutil.TestLogger()
+	embedder := embedding.NewNoopProvider(1024)
+	svc := decisions.New(testDB, embedder, nil, logger, nil)
+	svc.SetCompletenessGate(g)
+	return svc
+}
+
+// terseDecision returns the kind of trace that scores low against quality.Score:
+// short reasoning, no alternatives, no evidence. Under the default factors this
+// scores ~0.15 — enough to fail a 0.30 floor but not enough to be inherently
+// broken.
+func terseDecision() model.TraceDecision {
+	short := "small"
+	return model.TraceDecision{
+		DecisionType: "code_review",
+		Outcome:      "approved the change",
+		Confidence:   0.5,
+		Reasoning:    &short,
+	}
+}
+
+func TestCompletenessGate_OffMode_AcceptsTerseTrace(t *testing.T) {
+	ctx := context.Background()
+	svc := newGatedSvc(quality.CompletenessGate{Mode: quality.GateModeOff, Threshold: 0.90})
+	agentID := "gate-off-" + uuid.New().String()[:8]
+	createAgent(t, agentID)
+
+	result, err := svc.Trace(ctx, uuid.Nil, decisions.TraceInput{
+		AgentID:  agentID,
+		Decision: terseDecision(),
+	})
+	require.NoError(t, err)
+	assert.NotEqual(t, uuid.Nil, result.DecisionID)
+	assert.Empty(t, result.Warnings, "off mode must never produce gate warnings")
+}
+
+func TestCompletenessGate_RejectMode_BlocksTerseTrace(t *testing.T) {
+	ctx := context.Background()
+	svc := newGatedSvc(quality.CompletenessGate{Mode: quality.GateModeReject, Threshold: 0.30})
+	agentID := "gate-reject-" + uuid.New().String()[:8]
+	createAgent(t, agentID)
+
+	_, err := svc.Trace(ctx, uuid.Nil, decisions.TraceInput{
+		AgentID:  agentID,
+		Decision: terseDecision(),
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, decisions.ErrCompletenessBelowThreshold),
+		"err must wrap ErrCompletenessBelowThreshold so callers can detect it with errors.Is")
+
+	rej := decisions.AsCompletenessRejection(err)
+	require.NotNil(t, rej, "AsCompletenessRejection must extract the structured rejection")
+	assert.Equal(t, "code_review", rej.DecisionType)
+	assert.InDelta(t, 0.30, rej.Threshold, 0.0001)
+	assert.Less(t, rej.Score, float32(0.30), "score should be below threshold")
+}
+
+func TestCompletenessGate_WarnMode_AcceptsAndWarns(t *testing.T) {
+	ctx := context.Background()
+	svc := newGatedSvc(quality.CompletenessGate{Mode: quality.GateModeWarn, Threshold: 0.30})
+	agentID := "gate-warn-" + uuid.New().String()[:8]
+	createAgent(t, agentID)
+
+	result, err := svc.Trace(ctx, uuid.Nil, decisions.TraceInput{
+		AgentID:  agentID,
+		Decision: terseDecision(),
+	})
+	require.NoError(t, err)
+	assert.NotEqual(t, uuid.Nil, result.DecisionID, "warn mode must still persist the decision")
+	require.Len(t, result.Warnings, 1, "warn mode must produce exactly one gate warning")
+	assert.Contains(t, result.Warnings[0], "code_review")
+	assert.Contains(t, result.Warnings[0], "0.30")
+}
+
+func TestCompletenessGate_PerTypeOverride_BlocksOnlySpecificType(t *testing.T) {
+	ctx := context.Background()
+	// Global floor 0; security has a stricter per-type floor. Architecture and
+	// code_review must pass freely while security is blocked.
+	svc := newGatedSvc(quality.CompletenessGate{
+		Mode:      quality.GateModeReject,
+		Threshold: 0,
+		ByType:    map[string]float32{"security": 0.60},
+	})
+	agentID := "gate-pertype-" + uuid.New().String()[:8]
+	createAgent(t, agentID)
+
+	// Architecture trace with low completeness passes (no global floor).
+	archDec := terseDecision()
+	archDec.DecisionType = "architecture"
+	_, err := svc.Trace(ctx, uuid.Nil, decisions.TraceInput{
+		AgentID:  agentID,
+		Decision: archDec,
+	})
+	require.NoError(t, err, "architecture must pass — no global floor and no per-type override")
+
+	// Security trace with the same content is blocked.
+	secDec := terseDecision()
+	secDec.DecisionType = "security"
+	_, err = svc.Trace(ctx, uuid.Nil, decisions.TraceInput{
+		AgentID:  agentID,
+		Decision: secDec,
+	})
+	require.Error(t, err)
+	rej := decisions.AsCompletenessRejection(err)
+	require.NotNil(t, rej)
+	assert.Equal(t, "security", rej.DecisionType)
+	assert.InDelta(t, 0.60, rej.Threshold, 0.0001)
+}
+
+func TestCompletenessGate_RejectMode_PassesCompleteTrace(t *testing.T) {
+	// A trace that meets the bar must pass even in reject mode.
+	ctx := context.Background()
+	svc := newGatedSvc(quality.CompletenessGate{Mode: quality.GateModeReject, Threshold: 0.50})
+	agentID := "gate-passes-" + uuid.New().String()[:8]
+	createAgent(t, agentID)
+
+	longReasoning := "We chose Redis over Memcached because we need pub/sub and the operational overhead of running Redis matches existing infrastructure. Memcached lacks pub/sub and would require a second service to be added to the production stack."
+	rejectionA := "no pub/sub support, which we need for the notification fan-out"
+	rejectionB := "extra ops surface area for a feature subset we already get from Redis"
+	_, err := svc.Trace(ctx, uuid.Nil, decisions.TraceInput{
+		AgentID: agentID,
+		Decision: model.TraceDecision{
+			DecisionType: "trade_off",
+			Outcome:      "chose Redis over Memcached for cache + pub/sub",
+			Confidence:   0.7,
+			Reasoning:    &longReasoning,
+			Alternatives: []model.TraceAlternative{
+				{Label: "Memcached", RejectionReason: &rejectionA},
+				{Label: "DragonflyDB", RejectionReason: &rejectionB},
+			},
+			Evidence: []model.TraceEvidence{
+				{SourceType: "document", Content: "Redis is already operated in production for the session store"},
+			},
+		},
+	})
+	require.NoError(t, err, "a substantive trace must pass the gate even with threshold=0.50")
+}

--- a/internal/service/decisions/helpers_test.go
+++ b/internal/service/decisions/helpers_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ashita-ai/akashi/internal/model"
 	"github.com/ashita-ai/akashi/internal/search"
 	"github.com/ashita-ai/akashi/internal/service/embedding"
+	"github.com/ashita-ai/akashi/internal/service/quality"
 	"github.com/ashita-ai/akashi/internal/storage"
 )
 
@@ -967,6 +968,31 @@ func (f fakeEmbedder) EmbedBatch(_ context.Context, texts []string) ([]pgvector.
 }
 
 func (f fakeEmbedder) Dimensions() int { return f.dims }
+
+type countingEmbedder struct {
+	dims  int
+	calls atomic.Int64
+}
+
+func (c *countingEmbedder) Embed(_ context.Context, _ string) (pgvector.Vector, error) {
+	c.calls.Add(1)
+	v := make([]float32, c.dims)
+	v[0] = 1.0
+	return pgvector.NewVector(v), nil
+}
+
+func (c *countingEmbedder) EmbedBatch(_ context.Context, texts []string) ([]pgvector.Vector, error) {
+	c.calls.Add(int64(len(texts)))
+	vecs := make([]pgvector.Vector, len(texts))
+	for i := range texts {
+		v := make([]float32, c.dims)
+		v[0] = 1.0
+		vecs[i] = pgvector.NewVector(v)
+	}
+	return vecs, nil
+}
+
+func (c *countingEmbedder) Dimensions() int { return c.dims }
 
 // ---------------------------------------------------------------------------
 // isDuplicateKey (Service method — delegates to db.IsDuplicateKey)
@@ -2249,6 +2275,28 @@ func TestTrace_TxError(t *testing.T) {
 // ---------------------------------------------------------------------------
 // prepareTrace — edge cases
 // ---------------------------------------------------------------------------
+
+func TestPrepareTrace_CompletenessRejectSkipsEmbedding(t *testing.T) {
+	t.Parallel()
+	embedder := &countingEmbedder{dims: 3}
+	svc := New(&traceStore{}, embedder, nil, testLogger(), nil)
+	svc.SetCompletenessGate(quality.CompletenessGate{
+		Mode:      quality.GateModeReject,
+		Threshold: 0.30,
+	})
+
+	_, err := svc.Trace(context.Background(), uuid.Nil, TraceInput{
+		AgentID: "test-agent",
+		Decision: model.TraceDecision{
+			DecisionType: "code_review",
+			Outcome:      "short",
+			Confidence:   0.5,
+		},
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrCompletenessBelowThreshold)
+	assert.Equal(t, int64(0), embedder.calls.Load(), "reject mode should gate before embedding work")
+}
 
 func TestPrepareTrace_EvidenceEmbeddingDimMismatch(t *testing.T) {
 	t.Parallel()

--- a/internal/service/decisions/helpers_test.go
+++ b/internal/service/decisions/helpers_test.go
@@ -457,18 +457,42 @@ type mockStore struct {
 	insertClaimsErr    error
 	markFailedErr      error
 	clearFailureErr    error
+	insertAuditErr     error
 
 	// Tracking calls.
-	markFailedCalls   []uuid.UUID
-	clearFailureCalls []uuid.UUID
-	insertClaimsCalls int
+	markFailedCalls              []uuid.UUID
+	clearFailureCalls            []uuid.UUID
+	insertClaimsCalls            int
+	createDecisionTypeAliasCalls []decisionTypeAliasCall
+	insertAuditCalls             []storage.MutationAuditEntry
+}
+
+type decisionTypeAliasCall struct {
+	OrgID     uuid.UUID
+	Alias     string
+	Canonical string
+	CreatedBy string
 }
 
 func (m *mockStore) ResolveDecisionTypeAlias(_ context.Context, _ uuid.UUID, _ string) (string, error) {
 	return "", nil
 }
 
-func (m *mockStore) CreateDecisionTypeAlias(_ context.Context, _ uuid.UUID, _, _, _ string) error {
+func (m *mockStore) CreateDecisionTypeAlias(_ context.Context, orgID uuid.UUID, alias, canonical, createdBy string) error {
+	m.createDecisionTypeAliasCalls = append(m.createDecisionTypeAliasCalls, decisionTypeAliasCall{
+		OrgID:     orgID,
+		Alias:     alias,
+		Canonical: canonical,
+		CreatedBy: createdBy,
+	})
+	return nil
+}
+
+func (m *mockStore) InsertMutationAudit(_ context.Context, entry storage.MutationAuditEntry) error {
+	if m.insertAuditErr != nil {
+		return m.insertAuditErr
+	}
+	m.insertAuditCalls = append(m.insertAuditCalls, entry)
 	return nil
 }
 
@@ -2296,6 +2320,77 @@ func TestPrepareTrace_CompletenessRejectSkipsEmbedding(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrCompletenessBelowThreshold)
 	assert.Equal(t, int64(0), embedder.calls.Load(), "reject mode should gate before embedding work")
+}
+
+func TestPrepareTrace_CompletenessRejectDoesNotCreateAlias(t *testing.T) {
+	t.Parallel()
+	ms := &traceStore{}
+	svc := New(ms, fakeEmbedder{dims: 3}, nil, testLogger(), nil)
+	svc.SetCompletenessGate(quality.CompletenessGate{
+		Mode:      quality.GateModeReject,
+		Threshold: 0.30,
+	})
+
+	_, err := svc.Trace(context.Background(), uuid.Nil, TraceInput{
+		AgentID: "test-agent",
+		Decision: model.TraceDecision{
+			DecisionType: "code_reveiw", // Levenshtein typo for code_review.
+			Outcome:      "short",
+			Confidence:   0.5,
+		},
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrCompletenessBelowThreshold)
+	assert.Empty(t, ms.createDecisionTypeAliasCalls,
+		"rejected traces must not persist auto-created aliases")
+}
+
+func TestPrepareTrace_CompletenessRejectWritesAudit(t *testing.T) {
+	t.Parallel()
+	ms := &traceStore{}
+	svc := New(ms, fakeEmbedder{dims: 3}, nil, testLogger(), nil)
+	svc.SetCompletenessGate(quality.CompletenessGate{
+		Mode:      quality.GateModeReject,
+		Threshold: 0.30,
+	})
+	orgID := uuid.New()
+	apiKeyID := uuid.New()
+
+	_, err := svc.Trace(context.Background(), orgID, TraceInput{
+		AgentID:  "test-agent",
+		APIKeyID: &apiKeyID,
+		AuditMeta: &ctxutil.AuditMeta{
+			RequestID:    "req-rejected",
+			OrgID:        orgID,
+			ActorAgentID: "caller-agent",
+			ActorRole:    "agent",
+			HTTPMethod:   "MCP",
+			Endpoint:     "akashi_trace",
+		},
+		Decision: model.TraceDecision{
+			DecisionType: "code_review",
+			Outcome:      "short",
+			Confidence:   0.5,
+		},
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrCompletenessBelowThreshold)
+	require.Len(t, ms.insertAuditCalls, 1, "rejected traces need a durable audit row")
+
+	audit := ms.insertAuditCalls[0]
+	assert.Equal(t, "req-rejected", audit.RequestID)
+	assert.Equal(t, orgID, audit.OrgID)
+	assert.Equal(t, "caller-agent", audit.ActorAgentID)
+	assert.Equal(t, "trace_decision_rejected", audit.Operation)
+	assert.Equal(t, "decision_trace", audit.ResourceType)
+	assert.Equal(t, "code_review", audit.Metadata["decision_type"])
+	assert.InDelta(t, 0.30, audit.Metadata["required_min"], 0.0001)
+
+	after, ok := audit.AfterData.(map[string]any)
+	require.True(t, ok, "after_data should capture the rejected trace summary")
+	assert.Equal(t, "rejected", after["status"])
+	assert.Equal(t, "short", after["outcome"])
+	assert.Equal(t, &apiKeyID, after["api_key_id"])
 }
 
 func TestPrepareTrace_EvidenceEmbeddingDimMismatch(t *testing.T) {

--- a/internal/service/decisions/service.go
+++ b/internal/service/decisions/service.go
@@ -37,6 +37,45 @@ import (
 // ErrEmbeddingDimMismatch is returned when an embedding vector has the wrong number of dimensions.
 var ErrEmbeddingDimMismatch = errors.New("embedding dimension mismatch")
 
+// ErrCompletenessBelowThreshold is returned by Trace when the configured
+// completeness gate is in reject mode and the trace's score falls strictly
+// below the effective threshold for its decision_type. Callers use
+// errors.Is to detect this and AsCompletenessRejection to unpack the
+// score, threshold, and decision_type that triggered the rejection.
+var ErrCompletenessBelowThreshold = errors.New("decision completeness below configured minimum threshold")
+
+// CompletenessRejection carries the structured details of a gate rejection
+// so HTTP and MCP layers can emit useful error messages without re-parsing
+// the wrapped error string. The error wraps ErrCompletenessBelowThreshold so
+// errors.Is keeps working.
+type CompletenessRejection struct {
+	DecisionType string
+	Score        float32
+	Threshold    float32
+}
+
+// Error implements error.
+func (r *CompletenessRejection) Error() string {
+	return fmt.Sprintf(
+		"%s: score=%.2f threshold=%.2f decision_type=%q",
+		ErrCompletenessBelowThreshold.Error(), r.Score, r.Threshold, r.DecisionType,
+	)
+}
+
+// Unwrap lets errors.Is(err, ErrCompletenessBelowThreshold) work.
+func (r *CompletenessRejection) Unwrap() error { return ErrCompletenessBelowThreshold }
+
+// AsCompletenessRejection extracts the structured rejection from an error
+// chain. Returns nil when err is not a completeness rejection. This is the
+// preferred way for HTTP/MCP layers to read the score, threshold, and type.
+func AsCompletenessRejection(err error) *CompletenessRejection {
+	var rej *CompletenessRejection
+	if errors.As(err, &rej) {
+		return rej
+	}
+	return nil
+}
+
 // ConflictScorer scores semantic conflicts for new decisions.
 type ConflictScorer interface {
 	ScoreForDecision(ctx context.Context, decisionID, orgID uuid.UUID)
@@ -56,10 +95,21 @@ type Service struct {
 	claimEmbeddingFailures metric.Int64Counter
 	embeddingSkips         metric.Int64Counter
 
-	percentileCache *search.PercentileCache // nil = use log fallback in ReScore.
-	rescoreMetrics  *search.ReScoreMetrics  // nil = skip signal contribution recording.
-	standardTypes   map[string]bool         // nil = use quality.DefaultStandardDecisionTypes.
-	autoAssessor    AutoAssessor            // nil = skip auto-assessment.
+	// completenessGateRejects counts traces refused by the ingest gate
+	// (issue #715). Labeled with decision_type so operators can see which
+	// types are most often blocked and tune the threshold accordingly.
+	completenessGateRejects metric.Int64Counter
+
+	// completenessGateWarns counts traces that fell below the gate floor
+	// when running in warn mode. Labeled the same way as rejects so the
+	// two counters together describe gate activity.
+	completenessGateWarns metric.Int64Counter
+
+	percentileCache  *search.PercentileCache  // nil = use log fallback in ReScore.
+	rescoreMetrics   *search.ReScoreMetrics   // nil = skip signal contribution recording.
+	standardTypes    map[string]bool          // nil = use quality.DefaultStandardDecisionTypes.
+	autoAssessor     AutoAssessor             // nil = skip auto-assessment.
+	completenessGate quality.CompletenessGate // zero value = gate disabled.
 
 	// asyncWg tracks in-flight post-trace goroutines (claim generation,
 	// conflict scoring) so Shutdown can wait for them before closing the DB.
@@ -88,6 +138,12 @@ type AutoAssessor interface {
 // SetAutoAssessor configures automatic assessment generation from
 // supersession, citation, and conflict resolution signals.
 func (s *Service) SetAutoAssessor(a AutoAssessor) { s.autoAssessor = a }
+
+// SetCompletenessGate configures the ingest gate that refuses or warns on
+// low-completeness traces (issue #715). Pass quality.CompletenessGate{} to
+// disable. Safe to call before Run(); reading the gate is not synchronized
+// because it's expected to be set once at startup, never reconfigured.
+func (s *Service) SetCompletenessGate(g quality.CompletenessGate) { s.completenessGate = g }
 
 // AssessConflictResolution delegates to the auto-assessor to record outcome
 // assessments for conflict winners and losers. No-op when auto-assessor is nil.
@@ -192,19 +248,27 @@ func New(db storage.Store, embedder embedding.Provider, searcher search.Searcher
 	embSkips, _ := meter.Int64Counter("akashi.embedding.skips",
 		metric.WithDescription("Decisions traced without embedding (provider unavailable or errored)"),
 	)
+	gateRejects, _ := meter.Int64Counter("akashi.trace.completeness_gate_rejects",
+		metric.WithDescription("Traces rejected by the completeness ingest gate (#715)"),
+	)
+	gateWarns, _ := meter.Int64Counter("akashi.trace.completeness_gate_warns",
+		metric.WithDescription("Traces accepted with a completeness warning by the ingest gate (#715)"),
+	)
 	shutdownCtx, shutdownStop := context.WithCancel(context.Background())
 	return &Service{
-		db:                     db,
-		embedder:               embedder,
-		searcher:               searcher,
-		conflictScorer:         conflictScorer,
-		logger:                 logger,
-		embeddingDuration:      embDur,
-		searchDuration:         searchDur,
-		claimEmbeddingFailures: claimFail,
-		embeddingSkips:         embSkips,
-		shutdownCtx:            shutdownCtx,
-		shutdownStop:           shutdownStop,
+		db:                      db,
+		embedder:                embedder,
+		searcher:                searcher,
+		conflictScorer:          conflictScorer,
+		logger:                  logger,
+		embeddingDuration:       embDur,
+		searchDuration:          searchDur,
+		claimEmbeddingFailures:  claimFail,
+		embeddingSkips:          embSkips,
+		completenessGateRejects: gateRejects,
+		completenessGateWarns:   gateWarns,
+		shutdownCtx:             shutdownCtx,
+		shutdownStop:            shutdownStop,
 	}
 }
 
@@ -240,13 +304,18 @@ type TraceResult struct {
 	// returned an error. Conflict detection and semantic search may be degraded
 	// for this decision.
 	EmbeddingSkipped bool
+	// Warnings are non-fatal advisories produced during prepareTrace —
+	// currently the completeness gate (#715) in warn mode. Callers append
+	// these to the user-visible response so agents see them alongside
+	// existing warnings (high-confidence-no-evidence, etc).
+	Warnings []string
 }
 
 // Trace records a complete decision with its alternatives and evidence.
 // Embeddings and quality scores are computed first, then all database writes
 // happen atomically within a single transaction. Notification is sent after commit.
 func (s *Service) Trace(ctx context.Context, orgID uuid.UUID, input TraceInput) (TraceResult, error) {
-	params, err := s.prepareTrace(ctx, orgID, input)
+	params, warnings, err := s.prepareTrace(ctx, orgID, input)
 	if err != nil {
 		return TraceResult{}, err
 	}
@@ -269,6 +338,7 @@ func (s *Service) Trace(ctx context.Context, orgID uuid.UUID, input TraceInput) 
 		EventCount:       len(params.Alternatives) + len(params.Evidence) + 1,
 		Decision:         decision,
 		EmbeddingSkipped: decision.Embedding == nil,
+		Warnings:         warnings,
 	}, nil
 }
 
@@ -277,7 +347,7 @@ func (s *Service) Trace(ctx context.Context, orgID uuid.UUID, input TraceInput) 
 // an adjudication decision is created but the conflict remains unresolved due to
 // a crash between two separate transactions.
 func (s *Service) AdjudicateConflictWithTrace(ctx context.Context, orgID uuid.UUID, input TraceInput, conflictParams storage.AdjudicateConflictInTraceParams) (TraceResult, error) {
-	params, err := s.prepareTrace(ctx, orgID, input)
+	params, warnings, err := s.prepareTrace(ctx, orgID, input)
 	if err != nil {
 		return TraceResult{}, err
 	}
@@ -300,13 +370,18 @@ func (s *Service) AdjudicateConflictWithTrace(ctx context.Context, orgID uuid.UU
 		EventCount:       len(params.Alternatives) + len(params.Evidence) + 1,
 		Decision:         decision,
 		EmbeddingSkipped: decision.Embedding == nil,
+		Warnings:         warnings,
 	}, nil
 }
 
 // prepareTrace handles all pre-transaction work: OTEL span, embeddings, quality
 // scoring, alternatives, evidence, and audit entry construction. Returns the
-// fully-prepared CreateTraceParams ready for a transactional write.
-func (s *Service) prepareTrace(ctx context.Context, orgID uuid.UUID, input TraceInput) (storage.CreateTraceParams, error) {
+// fully-prepared CreateTraceParams, any non-fatal warnings produced during
+// preparation (currently from the completeness gate in warn mode), and an
+// error if the trace must be refused (currently CompletenessRejection when
+// the gate is in reject mode and the score is below the threshold).
+func (s *Service) prepareTrace(ctx context.Context, orgID uuid.UUID, input TraceInput) (storage.CreateTraceParams, []string, error) {
+	var warnings []string
 	if input.SupersedesID == nil && len(input.SupersedesIDs) > 0 {
 		primary := input.SupersedesIDs[0]
 		input.SupersedesID = &primary
@@ -381,7 +456,7 @@ func (s *Service) prepareTrace(ctx context.Context, orgID uuid.UUID, input Trace
 	}()
 	embWg.Wait()
 	if decEmbErr != nil {
-		return storage.CreateTraceParams{}, decEmbErr
+		return storage.CreateTraceParams{}, nil, decEmbErr
 	}
 	if decisionEmb == nil {
 		s.embeddingSkips.Add(ctx, 1)
@@ -394,7 +469,39 @@ func (s *Service) prepareTrace(ctx context.Context, orgID uuid.UUID, input Trace
 	// 2. Compute quality score.
 	qualityScore := quality.Score(input.Decision, input.PrecedentRef != nil)
 
-	// 2a. Adjust confidence based on evidence, alternatives, and reasoning.
+	// 2a. Completeness ingest gate (#715). Runs against the freshly-computed
+	// score before AdjustConfidence so the gate sees what the agent submitted,
+	// not what we deflated it to. Reject mode short-circuits before any
+	// downstream work (no extra embedding, no DB write). Warn mode lets the
+	// trace through and surfaces a warning via TraceResult.
+	if gateResult := s.completenessGate.Evaluate(qualityScore, input.Decision.DecisionType); gateResult.Below {
+		switch gateResult.Mode {
+		case quality.GateModeReject:
+			s.completenessGateRejects.Add(ctx, 1,
+				metric.WithAttributes(attribute.String("decision_type", input.Decision.DecisionType)),
+			)
+			s.logger.Info("trace: rejected by completeness gate",
+				"agent_id", input.AgentID,
+				"decision_type", input.Decision.DecisionType,
+				"score", qualityScore,
+				"threshold", gateResult.Threshold,
+			)
+			return storage.CreateTraceParams{}, nil, &CompletenessRejection{
+				DecisionType: input.Decision.DecisionType,
+				Score:        qualityScore,
+				Threshold:    gateResult.Threshold,
+			}
+		case quality.GateModeWarn:
+			s.completenessGateWarns.Add(ctx, 1,
+				metric.WithAttributes(attribute.String("decision_type", input.Decision.DecisionType)),
+			)
+			if msg := gateResult.WarningMessage(input.Decision.DecisionType); msg != "" {
+				warnings = append(warnings, msg)
+			}
+		}
+	}
+
+	// 2b. Adjust confidence based on evidence, alternatives, and reasoning.
 	// This deflates self-reported confidence that isn't supported by substance.
 	reasoningLen := 0
 	if input.Decision.Reasoning != nil {
@@ -415,7 +522,7 @@ func (s *Service) prepareTrace(ctx context.Context, orgID uuid.UUID, input Trace
 		input.Metadata["confidence_adjustment_reasons"] = confAdj.Reasons
 	}
 
-	// 2b. Bootstrap metadata from agent_context when agent-supplied metadata
+	// 2c. Bootstrap metadata from agent_context when agent-supplied metadata
 	// is empty. This makes tool/model/session queryable via the metadata JSONB
 	// column without requiring agents to populate it explicitly.
 	bootstrapMetadata(&input)
@@ -461,7 +568,7 @@ func (s *Service) prepareTrace(ctx context.Context, orgID uuid.UUID, input Trace
 		// Check for dimension validation errors (hard failure).
 		for _, err := range errs {
 			if err != nil && errors.Is(err, ErrEmbeddingDimMismatch) {
-				return storage.CreateTraceParams{}, err
+				return storage.CreateTraceParams{}, nil, err
 			}
 		}
 
@@ -519,7 +626,7 @@ func (s *Service) prepareTrace(ctx context.Context, orgID uuid.UUID, input Trace
 		SessionID:    input.SessionID,
 		AgentContext: input.AgentContext,
 		AuditEntry:   auditEntry,
-	}, nil
+	}, warnings, nil
 }
 
 // postTraceAsync handles post-commit work: subscriber notification and

--- a/internal/service/decisions/service.go
+++ b/internal/service/decisions/service.go
@@ -76,6 +76,15 @@ func AsCompletenessRejection(err error) *CompletenessRejection {
 	return nil
 }
 
+type mutationAuditWriter interface {
+	InsertMutationAudit(context.Context, storage.MutationAuditEntry) error
+}
+
+type decisionTypeAliasCandidate struct {
+	Alias     string
+	Canonical string
+}
+
 // ConflictScorer scores semantic conflicts for new decisions.
 type ConflictScorer interface {
 	ScoreForDecision(ctx context.Context, decisionID, orgID uuid.UUID)
@@ -315,7 +324,7 @@ type TraceResult struct {
 // Embeddings and quality scores are computed first, then all database writes
 // happen atomically within a single transaction. Notification is sent after commit.
 func (s *Service) Trace(ctx context.Context, orgID uuid.UUID, input TraceInput) (TraceResult, error) {
-	params, warnings, err := s.prepareTrace(ctx, orgID, input)
+	params, warnings, aliasCandidate, err := s.prepareTrace(ctx, orgID, input)
 	if err != nil {
 		return TraceResult{}, err
 	}
@@ -331,6 +340,7 @@ func (s *Service) Trace(ctx context.Context, orgID uuid.UUID, input TraceInput) 
 		return TraceResult{}, fmt.Errorf("trace: %w", err)
 	}
 
+	s.createDecisionTypeAliasAfterCommit(ctx, orgID, aliasCandidate)
 	s.postTraceAsync(ctx, orgID, input, decision)
 	return TraceResult{
 		RunID:            run.ID,
@@ -347,7 +357,7 @@ func (s *Service) Trace(ctx context.Context, orgID uuid.UUID, input TraceInput) 
 // an adjudication decision is created but the conflict remains unresolved due to
 // a crash between two separate transactions.
 func (s *Service) AdjudicateConflictWithTrace(ctx context.Context, orgID uuid.UUID, input TraceInput, conflictParams storage.AdjudicateConflictInTraceParams) (TraceResult, error) {
-	params, warnings, err := s.prepareTrace(ctx, orgID, input)
+	params, warnings, aliasCandidate, err := s.prepareTrace(ctx, orgID, input)
 	if err != nil {
 		return TraceResult{}, err
 	}
@@ -363,6 +373,7 @@ func (s *Service) AdjudicateConflictWithTrace(ctx context.Context, orgID uuid.UU
 		return TraceResult{}, fmt.Errorf("trace+adjudicate: %w", err)
 	}
 
+	s.createDecisionTypeAliasAfterCommit(ctx, orgID, aliasCandidate)
 	s.postTraceAsync(ctx, orgID, input, decision)
 	return TraceResult{
 		RunID:            run.ID,
@@ -380,8 +391,9 @@ func (s *Service) AdjudicateConflictWithTrace(ctx context.Context, orgID uuid.UU
 // preparation (currently from the completeness gate in warn mode), and an
 // error if the trace must be refused (currently CompletenessRejection when
 // the gate is in reject mode and the score is below the threshold).
-func (s *Service) prepareTrace(ctx context.Context, orgID uuid.UUID, input TraceInput) (storage.CreateTraceParams, []string, error) {
+func (s *Service) prepareTrace(ctx context.Context, orgID uuid.UUID, input TraceInput) (storage.CreateTraceParams, []string, *decisionTypeAliasCandidate, error) {
 	var warnings []string
+	var aliasCandidate *decisionTypeAliasCandidate
 	if input.SupersedesID == nil && len(input.SupersedesIDs) > 0 {
 		primary := input.SupersedesIDs[0]
 		input.SupersedesID = &primary
@@ -401,10 +413,12 @@ func (s *Service) prepareTrace(ctx context.Context, orgID uuid.UUID, input Trace
 		input.Metadata["original_decision_type"] = input.Decision.DecisionType
 		input.Decision.DecisionType = canonical
 	} else if suggested := quality.SuggestStandardType(input.Decision.DecisionType, s.effectiveStandardTypes(), 2); suggested != "" {
-		// Close Levenshtein match found — auto-create alias for future lookups.
-		if aliasErr := s.db.CreateDecisionTypeAlias(ctx, orgID, input.Decision.DecisionType, suggested, "system:levenshtein-auto"); aliasErr != nil {
-			s.logger.Warn("trace: failed to auto-create decision type alias",
-				"alias", input.Decision.DecisionType, "canonical", suggested, "error", aliasErr)
+		// Close Levenshtein match found. Canonicalize this trace immediately,
+		// but defer durable alias creation until after the trace commits so a
+		// rejected/failed trace cannot leave alias side effects behind.
+		aliasCandidate = &decisionTypeAliasCandidate{
+			Alias:     input.Decision.DecisionType,
+			Canonical: suggested,
 		}
 		if input.Metadata == nil {
 			input.Metadata = make(map[string]any)
@@ -443,11 +457,15 @@ func (s *Service) prepareTrace(ctx context.Context, orgID uuid.UUID, input Trace
 				"score", qualityScore,
 				"threshold", gateResult.Threshold,
 			)
-			return storage.CreateTraceParams{}, nil, &CompletenessRejection{
+			rej := &CompletenessRejection{
 				DecisionType: input.Decision.DecisionType,
 				Score:        qualityScore,
 				Threshold:    gateResult.Threshold,
 			}
+			if err := s.recordCompletenessRejectionAudit(ctx, orgID, input, rej); err != nil {
+				return storage.CreateTraceParams{}, nil, nil, fmt.Errorf("trace: audit completeness rejection: %w", err)
+			}
+			return storage.CreateTraceParams{}, nil, nil, rej
 		case quality.GateModeWarn:
 			s.completenessGateWarns.Add(ctx, 1,
 				metric.WithAttributes(attribute.String("decision_type", input.Decision.DecisionType)),
@@ -491,7 +509,7 @@ func (s *Service) prepareTrace(ctx context.Context, orgID uuid.UUID, input Trace
 	}()
 	embWg.Wait()
 	if decEmbErr != nil {
-		return storage.CreateTraceParams{}, nil, decEmbErr
+		return storage.CreateTraceParams{}, nil, nil, decEmbErr
 	}
 	if decisionEmb == nil {
 		s.embeddingSkips.Add(ctx, 1)
@@ -568,7 +586,7 @@ func (s *Service) prepareTrace(ctx context.Context, orgID uuid.UUID, input Trace
 		// Check for dimension validation errors (hard failure).
 		for _, err := range errs {
 			if err != nil && errors.Is(err, ErrEmbeddingDimMismatch) {
-				return storage.CreateTraceParams{}, nil, err
+				return storage.CreateTraceParams{}, nil, nil, err
 			}
 		}
 
@@ -626,7 +644,74 @@ func (s *Service) prepareTrace(ctx context.Context, orgID uuid.UUID, input Trace
 		SessionID:    input.SessionID,
 		AgentContext: input.AgentContext,
 		AuditEntry:   auditEntry,
-	}, warnings, nil
+	}, warnings, aliasCandidate, nil
+}
+
+func (s *Service) createDecisionTypeAliasAfterCommit(ctx context.Context, orgID uuid.UUID, alias *decisionTypeAliasCandidate) {
+	if alias == nil {
+		return
+	}
+	if err := s.db.CreateDecisionTypeAlias(ctx, orgID, alias.Alias, alias.Canonical, "system:levenshtein-auto"); err != nil {
+		s.logger.Warn("trace: failed to auto-create decision type alias",
+			"alias", alias.Alias, "canonical", alias.Canonical, "error", err)
+	}
+}
+
+func (s *Service) recordCompletenessRejectionAudit(ctx context.Context, orgID uuid.UUID, input TraceInput, rej *CompletenessRejection) error {
+	auditor, ok := s.db.(mutationAuditWriter)
+	if !ok {
+		s.logger.Warn("trace: completeness rejection audit unavailable for storage backend",
+			"agent_id", input.AgentID,
+			"decision_type", rej.DecisionType,
+			"score", rej.Score,
+			"threshold", rej.Threshold,
+		)
+		return nil
+	}
+
+	audit := storage.MutationAuditEntry{
+		OrgID:        orgID,
+		ActorAgentID: input.AgentID,
+		ActorRole:    "agent",
+		HTTPMethod:   "service",
+		Endpoint:     "trace",
+		Operation:    "trace_decision_rejected",
+		ResourceType: "decision_trace",
+		Metadata: map[string]any{
+			"agent_id":           input.AgentID,
+			"decision_type":      rej.DecisionType,
+			"completeness_score": rej.Score,
+			"required_min":       rej.Threshold,
+			"reason":             ErrCompletenessBelowThreshold.Error(),
+		},
+		AfterData: map[string]any{
+			"status":             "rejected",
+			"decision_type":      input.Decision.DecisionType,
+			"outcome":            input.Decision.Outcome,
+			"confidence":         input.Decision.Confidence,
+			"reasoning":          input.Decision.Reasoning,
+			"alternatives":       input.Decision.Alternatives,
+			"evidence":           input.Decision.Evidence,
+			"precedent_ref":      input.PrecedentRef,
+			"precedent_reason":   input.PrecedentReason,
+			"supersedes_id":      input.SupersedesID,
+			"session_id":         input.SessionID,
+			"api_key_id":         input.APIKeyID,
+			"agent_context":      input.AgentContext,
+			"metadata":           input.Metadata,
+			"completeness_score": rej.Score,
+			"required_min":       rej.Threshold,
+		},
+	}
+	if input.AuditMeta != nil {
+		audit.RequestID = input.AuditMeta.RequestID
+		audit.OrgID = input.AuditMeta.OrgID
+		audit.ActorAgentID = input.AuditMeta.ActorAgentID
+		audit.ActorRole = input.AuditMeta.ActorRole
+		audit.HTTPMethod = input.AuditMeta.HTTPMethod
+		audit.Endpoint = input.AuditMeta.Endpoint
+	}
+	return auditor.InsertMutationAudit(ctx, audit)
 }
 
 // postTraceAsync handles post-commit work: subscriber notification and

--- a/internal/service/decisions/service.go
+++ b/internal/service/decisions/service.go
@@ -423,7 +423,42 @@ func (s *Service) prepareTrace(ctx context.Context, orgID uuid.UUID, input Trace
 		span.SetAttributes(attribute.String("akashi.trace_id", *input.TraceID))
 	}
 
-	// 1. Generate decision embedding (full) and outcome embedding concurrently.
+	// 1. Compute quality score.
+	qualityScore := quality.Score(input.Decision, input.PrecedentRef != nil)
+
+	// 1a. Completeness ingest gate (#715). Runs against the freshly-computed
+	// score before any embedding work or AdjustConfidence so reject mode can
+	// refuse low-completeness traces without spending embedding latency/quota,
+	// and so the gate sees what the agent submitted, not what we deflated it to.
+	// Warn mode lets the trace through and surfaces a warning via TraceResult.
+	if gateResult := s.completenessGate.Evaluate(qualityScore, input.Decision.DecisionType); gateResult.Below {
+		switch gateResult.Mode {
+		case quality.GateModeReject:
+			s.completenessGateRejects.Add(ctx, 1,
+				metric.WithAttributes(attribute.String("decision_type", input.Decision.DecisionType)),
+			)
+			s.logger.Info("trace: rejected by completeness gate",
+				"agent_id", input.AgentID,
+				"decision_type", input.Decision.DecisionType,
+				"score", qualityScore,
+				"threshold", gateResult.Threshold,
+			)
+			return storage.CreateTraceParams{}, nil, &CompletenessRejection{
+				DecisionType: input.Decision.DecisionType,
+				Score:        qualityScore,
+				Threshold:    gateResult.Threshold,
+			}
+		case quality.GateModeWarn:
+			s.completenessGateWarns.Add(ctx, 1,
+				metric.WithAttributes(attribute.String("decision_type", input.Decision.DecisionType)),
+			)
+			if msg := gateResult.WarningMessage(input.Decision.DecisionType); msg != "" {
+				warnings = append(warnings, msg)
+			}
+		}
+	}
+
+	// 2. Generate decision embedding (full) and outcome embedding concurrently.
 	embText := input.Decision.DecisionType + ": " + input.Decision.Outcome
 	if input.Decision.Reasoning != nil {
 		embText += " " + *input.Decision.Reasoning
@@ -466,42 +501,7 @@ func (s *Service) prepareTrace(ctx context.Context, orgID uuid.UUID, input Trace
 		)
 	}
 
-	// 2. Compute quality score.
-	qualityScore := quality.Score(input.Decision, input.PrecedentRef != nil)
-
-	// 2a. Completeness ingest gate (#715). Runs against the freshly-computed
-	// score before AdjustConfidence so the gate sees what the agent submitted,
-	// not what we deflated it to. Reject mode short-circuits before any
-	// downstream work (no extra embedding, no DB write). Warn mode lets the
-	// trace through and surfaces a warning via TraceResult.
-	if gateResult := s.completenessGate.Evaluate(qualityScore, input.Decision.DecisionType); gateResult.Below {
-		switch gateResult.Mode {
-		case quality.GateModeReject:
-			s.completenessGateRejects.Add(ctx, 1,
-				metric.WithAttributes(attribute.String("decision_type", input.Decision.DecisionType)),
-			)
-			s.logger.Info("trace: rejected by completeness gate",
-				"agent_id", input.AgentID,
-				"decision_type", input.Decision.DecisionType,
-				"score", qualityScore,
-				"threshold", gateResult.Threshold,
-			)
-			return storage.CreateTraceParams{}, nil, &CompletenessRejection{
-				DecisionType: input.Decision.DecisionType,
-				Score:        qualityScore,
-				Threshold:    gateResult.Threshold,
-			}
-		case quality.GateModeWarn:
-			s.completenessGateWarns.Add(ctx, 1,
-				metric.WithAttributes(attribute.String("decision_type", input.Decision.DecisionType)),
-			)
-			if msg := gateResult.WarningMessage(input.Decision.DecisionType); msg != "" {
-				warnings = append(warnings, msg)
-			}
-		}
-	}
-
-	// 2b. Adjust confidence based on evidence, alternatives, and reasoning.
+	// 3. Adjust confidence based on evidence, alternatives, and reasoning.
 	// This deflates self-reported confidence that isn't supported by substance.
 	reasoningLen := 0
 	if input.Decision.Reasoning != nil {
@@ -522,12 +522,12 @@ func (s *Service) prepareTrace(ctx context.Context, orgID uuid.UUID, input Trace
 		input.Metadata["confidence_adjustment_reasons"] = confAdj.Reasons
 	}
 
-	// 2c. Bootstrap metadata from agent_context when agent-supplied metadata
+	// 3a. Bootstrap metadata from agent_context when agent-supplied metadata
 	// is empty. This makes tool/model/session queryable via the metadata JSONB
 	// column without requiring agents to populate it explicitly.
 	bootstrapMetadata(&input)
 
-	// 3. Build alternatives.
+	// 4. Build alternatives.
 	alts := make([]model.Alternative, len(input.Decision.Alternatives))
 	for i, a := range input.Decision.Alternatives {
 		alts[i] = model.Alternative{
@@ -536,7 +536,7 @@ func (s *Service) prepareTrace(ctx context.Context, orgID uuid.UUID, input Trace
 		}
 	}
 
-	// 4. Build evidence with embeddings (outside tx — may call external API).
+	// 5. Build evidence with embeddings (outside tx — may call external API).
 	// Parallelize embedding calls since each is an independent API request.
 	evs := make([]model.Evidence, len(input.Decision.Evidence))
 	if len(input.Decision.Evidence) > 0 {
@@ -585,7 +585,7 @@ func (s *Service) prepareTrace(ctx context.Context, orgID uuid.UUID, input Trace
 		}
 	}
 
-	// 5. Build optional audit entry for atomic insertion.
+	// 6. Build optional audit entry for atomic insertion.
 	var auditEntry *storage.MutationAuditEntry
 	if input.AuditMeta != nil {
 		auditEntry = &storage.MutationAuditEntry{

--- a/internal/service/quality/gate.go
+++ b/internal/service/quality/gate.go
@@ -1,0 +1,169 @@
+package quality
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// GateMode controls how the completeness gate reacts to a trace whose
+// completeness score falls below the configured threshold.
+type GateMode string
+
+const (
+	// GateModeOff disables the gate. Traces are accepted regardless of score.
+	// This is the default and preserves pre-#715 behavior.
+	GateModeOff GateMode = "off"
+
+	// GateModeWarn accepts low-completeness traces but attaches a warning to
+	// the response so the caller can surface it to the agent or operator.
+	GateModeWarn GateMode = "warn"
+
+	// GateModeReject refuses to store low-completeness traces; the trace
+	// endpoint returns a 4xx error with a descriptive code.
+	GateModeReject GateMode = "reject"
+)
+
+// ParseGateMode normalizes the input string to a known GateMode.
+// The empty string maps to GateModeOff to keep zero-value behavior safe.
+// Unrecognized values return an error so misconfiguration is surfaced loudly
+// at startup rather than silently disabling the gate.
+func ParseGateMode(s string) (GateMode, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", "off", "disabled":
+		return GateModeOff, nil
+	case "warn", "warning":
+		return GateModeWarn, nil
+	case "reject", "block":
+		return GateModeReject, nil
+	default:
+		return "", fmt.Errorf("invalid completeness gate mode %q (want off|warn|reject)", s)
+	}
+}
+
+// CompletenessGate is the operator-configurable structural-quality gate for
+// trace ingest. A new trace is gated by the threshold for its decision_type
+// (per-type override if set, otherwise the global Threshold).
+//
+// The zero value is safe: Mode defaults to GateModeOff which short-circuits
+// every evaluation as a pass, so service code that hasn't been wired to the
+// gate yet behaves exactly as before.
+type CompletenessGate struct {
+	// Mode selects between off (default), warn, and reject behavior.
+	Mode GateMode
+
+	// Threshold is the global minimum completeness score. Decisions whose
+	// type does not appear in ByType are evaluated against this value.
+	// Range: [0.0, 1.0]. Zero is treated as "no global floor" — the gate
+	// then only fires for types listed in ByType.
+	Threshold float32
+
+	// ByType is an optional per-decision-type floor that overrides Threshold
+	// for the named type. Keys must be lowercase canonical decision_type
+	// values (e.g. "security", "architecture"). Use this to set a stricter
+	// bar for high-stakes types without raising the global floor.
+	ByType map[string]float32
+}
+
+// ThresholdFor returns the effective threshold for a decision_type.
+// Per-type overrides take precedence over the global threshold. The lookup is
+// case-sensitive against lowercase keys, since decision types are normalized
+// to lowercase before reaching the gate.
+func (g CompletenessGate) ThresholdFor(decisionType string) float32 {
+	if t, ok := g.ByType[decisionType]; ok {
+		return t
+	}
+	return g.Threshold
+}
+
+// GateResult is the outcome of evaluating a single trace against the gate.
+// Below is true only when the gate is active (Mode != off), the threshold is
+// positive, AND the score falls strictly below the threshold. A score that
+// exactly equals the threshold passes — this matches the convention used for
+// the rest of the codebase's threshold comparisons (e.g. confidence factor
+// uses strict inequalities at boundaries).
+type GateResult struct {
+	// Mode is the gate mode at evaluation time. Carried on the result so the
+	// caller can decide between rejecting, warning, or emitting telemetry
+	// without re-reading service state.
+	Mode GateMode
+
+	// Threshold is the effective threshold the score was compared against.
+	Threshold float32
+
+	// Score is the score that was evaluated, returned for telemetry and
+	// human-readable error/warning messages.
+	Score float32
+
+	// Below indicates the score fell strictly below the threshold AND the
+	// gate is active. When false, no action should be taken regardless of mode.
+	Below bool
+}
+
+// Evaluate compares score against the threshold for decisionType and returns
+// a structured result. The function is pure; callers translate the result
+// into errors (reject), warnings (warn), or no-ops (off, or above threshold).
+//
+// A non-positive threshold disables evaluation for that type regardless of
+// mode. This lets operators turn the gate on globally while exempting a
+// specific type by mapping it to 0 in ByType.
+func (g CompletenessGate) Evaluate(score float32, decisionType string) GateResult {
+	threshold := g.ThresholdFor(decisionType)
+	result := GateResult{
+		Mode:      g.Mode,
+		Threshold: threshold,
+		Score:     score,
+	}
+	if g.Mode == GateModeOff || g.Mode == "" {
+		return result
+	}
+	if threshold <= 0 {
+		return result
+	}
+	if score < threshold {
+		result.Below = true
+	}
+	return result
+}
+
+// WarningMessage returns a stable, human-readable string for warn-mode
+// responses. Format is deliberately consistent so downstream tooling can
+// parse it. Returns empty string when the result did not trip the gate.
+func (r GateResult) WarningMessage(decisionType string) string {
+	if !r.Below {
+		return ""
+	}
+	return fmt.Sprintf(
+		"completeness score %.2f for decision_type=%q is below the configured minimum of %.2f; this decision may be filtered from quality-sensitive queries",
+		r.Score, decisionType, r.Threshold,
+	)
+}
+
+// ParseGateByType parses a JSON object mapping decision_type strings to
+// float thresholds. Returns an empty (non-nil) map for empty input so
+// downstream lookups never panic on nil. Keys are normalized to lowercase
+// and trimmed; values must be in [0.0, 1.0]. Out-of-range values return an
+// error rather than being silently clamped — silent clamping would mask
+// operator typos like "0.85" written as "85".
+func ParseGateByType(raw string) (map[string]float32, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+	var parsed map[string]float64
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+		return nil, fmt.Errorf("invalid completeness-by-type JSON: %w", err)
+	}
+	out := make(map[string]float32, len(parsed))
+	for k, v := range parsed {
+		key := strings.ToLower(strings.TrimSpace(k))
+		if key == "" {
+			return nil, fmt.Errorf("completeness-by-type contains empty decision_type key")
+		}
+		if v < 0 || v > 1 {
+			return nil, fmt.Errorf("completeness-by-type[%q]=%.4f out of range [0.0, 1.0]", k, v)
+		}
+		out[key] = float32(v)
+	}
+	return out, nil
+}

--- a/internal/service/quality/gate_test.go
+++ b/internal/service/quality/gate_test.go
@@ -1,0 +1,176 @@
+package quality_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ashita-ai/akashi/internal/service/quality"
+)
+
+func TestParseGateMode(t *testing.T) {
+	cases := []struct {
+		input string
+		want  quality.GateMode
+		err   bool
+	}{
+		{"", quality.GateModeOff, false},
+		{"off", quality.GateModeOff, false},
+		{"OFF", quality.GateModeOff, false},
+		{"disabled", quality.GateModeOff, false},
+		{"  warn  ", quality.GateModeWarn, false},
+		{"warning", quality.GateModeWarn, false},
+		{"reject", quality.GateModeReject, false},
+		{"block", quality.GateModeReject, false},
+		{"strict", "", true},
+		{"true", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			got, err := quality.ParseGateMode(tc.input)
+			if tc.err {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestCompletenessGate_OffMode_AlwaysPasses(t *testing.T) {
+	g := quality.CompletenessGate{Mode: quality.GateModeOff, Threshold: 0.9}
+	r := g.Evaluate(0.05, "code_review")
+	assert.False(t, r.Below, "off mode must never trip the gate even on very low scores")
+	assert.Empty(t, r.WarningMessage("code_review"))
+}
+
+func TestCompletenessGate_ZeroValue_AlwaysPasses(t *testing.T) {
+	// The zero value of CompletenessGate is the safe default — service code
+	// not yet wired to operator config must behave exactly as pre-#715.
+	var g quality.CompletenessGate
+	r := g.Evaluate(0.01, "architecture")
+	assert.False(t, r.Below)
+	assert.Equal(t, quality.GateMode(""), r.Mode)
+}
+
+func TestCompletenessGate_RejectMode_BelowThresholdFires(t *testing.T) {
+	g := quality.CompletenessGate{Mode: quality.GateModeReject, Threshold: 0.30}
+	r := g.Evaluate(0.20, "code_review")
+	assert.True(t, r.Below)
+	assert.InDelta(t, 0.30, r.Threshold, 0.0001)
+	assert.InDelta(t, 0.20, r.Score, 0.0001)
+}
+
+func TestCompletenessGate_ExactThresholdPasses(t *testing.T) {
+	// Exact equality must pass. Strict-below semantics avoid surprising
+	// rejections caused by floating-point round-off at threshold boundaries.
+	g := quality.CompletenessGate{Mode: quality.GateModeReject, Threshold: 0.30}
+	r := g.Evaluate(0.30, "code_review")
+	assert.False(t, r.Below)
+}
+
+func TestCompletenessGate_PerTypeOverridesGlobal(t *testing.T) {
+	g := quality.CompletenessGate{
+		Mode:      quality.GateModeReject,
+		Threshold: 0.30,
+		ByType: map[string]float32{
+			"security":     0.60,
+			"architecture": 0.55,
+		},
+	}
+	// Score 0.45 passes the global 0.30 but fails the per-type override for
+	// security and architecture.
+	assert.True(t, g.Evaluate(0.45, "security").Below)
+	assert.True(t, g.Evaluate(0.45, "architecture").Below)
+	assert.False(t, g.Evaluate(0.45, "code_review").Below)
+	assert.False(t, g.Evaluate(0.45, "investigation").Below)
+}
+
+func TestCompletenessGate_PerTypeZeroDisablesGate(t *testing.T) {
+	// Mapping a type to 0 in ByType exempts it from the global floor —
+	// useful when operators want strict security/architecture bars but
+	// want to allow brief investigation traces unconditionally.
+	g := quality.CompletenessGate{
+		Mode:      quality.GateModeReject,
+		Threshold: 0.40,
+		ByType:    map[string]float32{"investigation": 0},
+	}
+	assert.False(t, g.Evaluate(0.01, "investigation").Below)
+	assert.True(t, g.Evaluate(0.01, "code_review").Below)
+}
+
+func TestCompletenessGate_GlobalZero_OnlyTypedGateFires(t *testing.T) {
+	// Threshold 0 with ByType set means "no global floor, but enforce these
+	// specific types." Used to opt only the high-stakes types into a bar.
+	g := quality.CompletenessGate{
+		Mode:      quality.GateModeReject,
+		Threshold: 0,
+		ByType:    map[string]float32{"security": 0.60},
+	}
+	assert.True(t, g.Evaluate(0.30, "security").Below)
+	assert.False(t, g.Evaluate(0.30, "code_review").Below)
+	assert.False(t, g.Evaluate(0.30, "investigation").Below)
+}
+
+func TestCompletenessGate_WarningMessageStable(t *testing.T) {
+	g := quality.CompletenessGate{Mode: quality.GateModeWarn, Threshold: 0.50}
+	r := g.Evaluate(0.25, "code_review")
+	msg := r.WarningMessage("code_review")
+	require.NotEmpty(t, msg)
+	// The message must contain the score, threshold, and decision type so
+	// operators can act on it without correlating against other logs.
+	assert.Contains(t, msg, "0.25")
+	assert.Contains(t, msg, "0.50")
+	assert.Contains(t, msg, "code_review")
+}
+
+func TestCompletenessGate_WarningMessageEmptyWhenPassing(t *testing.T) {
+	g := quality.CompletenessGate{Mode: quality.GateModeWarn, Threshold: 0.50}
+	r := g.Evaluate(0.80, "code_review")
+	assert.Empty(t, r.WarningMessage("code_review"))
+}
+
+func TestParseGateByType_EmptyReturnsNil(t *testing.T) {
+	m, err := quality.ParseGateByType("")
+	require.NoError(t, err)
+	assert.Nil(t, m)
+
+	m, err = quality.ParseGateByType("   ")
+	require.NoError(t, err)
+	assert.Nil(t, m)
+}
+
+func TestParseGateByType_NormalizesKeysToLowercase(t *testing.T) {
+	m, err := quality.ParseGateByType(`{"Security": 0.6, "ARCHITECTURE": 0.55}`)
+	require.NoError(t, err)
+	assert.InDelta(t, 0.60, m["security"], 0.0001)
+	assert.InDelta(t, 0.55, m["architecture"], 0.0001)
+	// Original-case keys must NOT be present — that would cause silent
+	// misses when the trace pipeline normalizes types to lowercase first.
+	_, hasUpper := m["Security"]
+	assert.False(t, hasUpper)
+}
+
+func TestParseGateByType_RejectsOutOfRange(t *testing.T) {
+	_, err := quality.ParseGateByType(`{"security": 1.5}`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "out of range")
+
+	_, err = quality.ParseGateByType(`{"security": -0.1}`)
+	require.Error(t, err)
+}
+
+func TestParseGateByType_RejectsEmptyKey(t *testing.T) {
+	_, err := quality.ParseGateByType(`{"": 0.5}`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty")
+}
+
+func TestParseGateByType_RejectsInvalidJSON(t *testing.T) {
+	_, err := quality.ParseGateByType(`{not json}`)
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "invalid"))
+}


### PR DESCRIPTION
## Summary

- Adds an optional operator-configurable gate that refuses or warns on low-completeness traces at ingest. Consumes the existing completeness score — no new scoring logic. Disabled by default; behavior is unchanged unless an operator opts in.
- Three new env vars: `AKASHI_MIN_COMPLETENESS_MODE` (`off` | `warn` | `reject`), `AKASHI_MIN_COMPLETENESS` (global floor), `AKASHI_MIN_COMPLETENESS_BY_TYPE` (per-type JSON override).
- Gate lives in the service layer so it fires uniformly on HTTP `POST /v1/trace`, the MCP `akashi_trace` tool, and the IDE auto-trace hook, and short-circuits before any storage write in reject mode.

## Behavior

- **`off`** (default): no effect.
- **`warn`**: trace is persisted; a string is appended to the response `warnings` array.
- **`reject`**: HTTP `422 Unprocessable Entity` with `COMPLETENESS_BELOW_THRESHOLD` error code; `error.details` carries `decision_type`, `completeness_score`, and `required_min`. The MCP tool returns the same information in a tool-error message.

Per-type overrides take precedence over the global threshold so operators can enforce a strict bar on high-stakes types (security, architecture) while leaving terse investigations ungated. Mapping a type to `0` in `_BY_TYPE` exempts it from the global floor.

## Telemetry

Two OTel counters labeled by `decision_type` for tuning:

- `akashi.trace.completeness_gate_rejects`
- `akashi.trace.completeness_gate_warns`

## Field-report context

This is item #3 of the five operational fixes called out in the May 2026 field assessment (\"the minimum decision bar does not exist — define it and enforce it at ingest\"). The score-threshold approach in issue #715 is a softer version of the field-report's literal prescription (a hard structural rule on `code_review` with no trade-off / precedent_ref / ticket ref). The gate is structural in spirit because the score itself weighs structural signals (alternatives, evidence, precedent_ref). This unblocks the harder structural-rule version later.

The other four items (confidence parsing default, project-tag enforcement, conflict-detector FP rate, assessment loop) are not in scope for this PR.

## Test plan

- [x] Unit tests for the gate: `internal/service/quality/gate_test.go` (mode parsing, threshold semantics, per-type override, warning message stability, JSON parser edge cases)
- [x] Integration tests for the service: `internal/service/decisions/gate_integration_test.go` (off/warn/reject behavior end-to-end through `Trace`, per-type override, complete traces pass under reject mode)
- [x] Integration tests for the handler: `internal/server/handlers_completeness_gate_test.go` (422 envelope shape + details, 201 with warning in warn mode)
- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`golangci-lint run ./...\`: 0 issues
- [x] \`atlas migrate validate\`: passes (no migrations)
- [x] \`go test -race -count=1 ./...\` (unit): all green
- [x] \`go test -race -count=1 -tags integration ./...\` (full): all green

> The Twins were sundered before time itself was named. Ungoliant fed on the Light, leaving Telperion and Laurelin barren — but the Valar saved a single silver fruit and one golden, and from those, the Moon and the Sun were lifted into the heavens. The audit trail is exactly this: most of the light has already passed and cannot be recovered, but a single preserved seed of structured reasoning, recorded at the right moment, can illuminate every decision that comes after.