### PR TITLE
feat(conflicts): structural pre-filters to reduce FP rate (#717)

### DIFF
--- a/internal/conflicts/branch_filters_test.go
+++ b/internal/conflicts/branch_filters_test.go
@@ -37,6 +37,11 @@ func TestIsMechanicalOperation(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "migration strategy is not housekeeping",
+			outcome:  "Chose pg_dump migration strategy for ARD-958",
+			expected: false,
+		},
+		{
 			name:     "architecture decision — not mechanical",
 			outcome:  "Chose Redis with 5min TTL for session cache to handle expected QPS",
 			expected: false,

--- a/internal/conflicts/issue_717_filters_test.go
+++ b/internal/conflicts/issue_717_filters_test.go
@@ -11,7 +11,6 @@ import (
 // Tests for the issue #717 structural updates:
 //   - supersession keyword expansion (walk-back vocabulary)
 //   - extractTicketRefs (multi-ticket extraction)
-//   - isSameBranchMechanicalHousekeeping (narrow cross-agent same-branch housekeeping)
 
 func TestContainsSupersessionKeyword_WalkbackVocabulary(t *testing.T) {
 	// Coverage for the keyword extension added by #717. These are the exact
@@ -119,108 +118,4 @@ func TestExtractTicketRef_WrapsExtractTicketRefs(t *testing.T) {
 	// API contract) even after the refactor to multi-ticket extraction.
 	d := model.Decision{Outcome: "Touches ARD-958 and ARD-960"}
 	assert.Equal(t, "ARD-958", extractTicketRef(d))
-}
-
-func TestIsSameBranchMechanicalHousekeeping(t *testing.T) {
-	branchCtx := func(branch string) map[string]any {
-		return map[string]any{"client": map[string]any{"git_branch": branch}}
-	}
-
-	tests := []struct {
-		name     string
-		d        model.Decision
-		cand     model.Decision
-		expected bool
-	}{
-		{
-			name: "cross-agent same branch, both mechanical → suppressed (the #717 same-branch FP shape)",
-			d: model.Decision{
-				AgentID: "claude-code", AgentContext: branchCtx("evanvolgas/fix-sse-heartbeat"),
-				Outcome: "Merged origin/main into evanvolgas/fix-sse-heartbeat, renumbering migration 097→098",
-			},
-			cand: model.Decision{
-				AgentID: "reviewer", AgentContext: branchCtx("evanvolgas/fix-sse-heartbeat"),
-				Outcome: "Resolved 9 merge conflicts after rebasing onto main",
-			},
-			expected: true,
-		},
-		{
-			name: "same agent same branch → not suppressed (self-correction filter owns this case)",
-			d: model.Decision{
-				AgentID: "claude-code", AgentContext: branchCtx("evanvolgas/fix-sse-heartbeat"),
-				Outcome: "Renumbered migration 097→098",
-			},
-			cand: model.Decision{
-				AgentID: "claude-code", AgentContext: branchCtx("evanvolgas/fix-sse-heartbeat"),
-				Outcome: "Renumbered migration 098→099",
-			},
-			expected: false,
-		},
-		{
-			name: "cross-agent different branches → not suppressed (cross-branch filter owns that case)",
-			d: model.Decision{
-				AgentID: "claude-code", AgentContext: branchCtx("branch-a"),
-				Outcome: "Renumbered migration 097→098",
-			},
-			cand: model.Decision{
-				AgentID: "reviewer", AgentContext: branchCtx("branch-b"),
-				Outcome: "Renumbered migration 099→100",
-			},
-			expected: false,
-		},
-		{
-			name: "cross-agent same branch, only one mechanical → not suppressed",
-			d: model.Decision{
-				AgentID: "claude-code", AgentContext: branchCtx("feature/x"),
-				Outcome: "Renumbered migration 097→098",
-			},
-			cand: model.Decision{
-				AgentID: "reviewer", AgentContext: branchCtx("feature/x"),
-				Outcome: "Chose Redis with 5min TTL for session cache",
-			},
-			expected: false,
-		},
-		{
-			name: "cross-agent same branch, neither mechanical → not suppressed",
-			d: model.Decision{
-				AgentID: "claude-code", AgentContext: branchCtx("feature/x"),
-				Outcome: "Chose Redis for caching",
-			},
-			cand: model.Decision{
-				AgentID: "reviewer", AgentContext: branchCtx("feature/x"),
-				Outcome: "Chose Memcached for caching",
-			},
-			expected: false,
-		},
-		{
-			name: "cross-agent same branch, migration strategy only → not suppressed",
-			d: model.Decision{
-				AgentID: "claude-code", AgentContext: branchCtx("feature/x"),
-				Outcome: "Chose pg_dump migration strategy for ARD-958",
-			},
-			cand: model.Decision{
-				AgentID: "reviewer", AgentContext: branchCtx("feature/x"),
-				Outcome: "Rejected pg_dump migration strategy; use logical replication",
-			},
-			expected: false,
-		},
-		{
-			name: "missing branch on one side → not suppressed",
-			d: model.Decision{
-				AgentID: "claude-code", AgentContext: branchCtx("feature/x"),
-				Outcome: "Renumbered migration 097→098",
-			},
-			cand: model.Decision{
-				AgentID: "reviewer", AgentContext: map[string]any{},
-				Outcome: "Renumbered migration 099→100",
-			},
-			expected: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, isSameBranchMechanicalHousekeeping(tt.d, tt.cand))
-		})
-	}
 }

--- a/internal/conflicts/issue_717_filters_test.go
+++ b/internal/conflicts/issue_717_filters_test.go
@@ -1,0 +1,531 @@
+package conflicts
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ashita-ai/akashi/internal/model"
+)
+
+// Tests for the issue #717 structural pre-filters:
+//   - supersession keyword expansion (walk-back vocabulary)
+//   - extractTicketRefs (multi-ticket extraction)
+//   - layer marker extraction
+//   - isPRSeriesLayerRefinement (cross-agent same-ticket PR-series)
+//   - isDisjointTicketReviewPair (cross-agent reviews on disjoint tickets)
+//   - isSameBranchMechanicalHousekeeping (cross-agent same-branch housekeeping)
+
+func TestContainsSupersessionKeyword_WalkbackVocabulary(t *testing.T) {
+	// Coverage for the keyword extension added by #717. These are the exact
+	// phrasings the FP audit found in self_contradiction / cross_agent FPs
+	// that should have classified as supersession instead of contradiction.
+	walkBacks := []string{
+		"Shelved Observable Post-conditions draft (PR #28 closed without merge)",
+		"Dropped the 2026-05-12 publish slot",
+		"pivoting 2026-05-12 slot to a broader-audience essay",
+		"Walked back over-critical take on ARD-720",
+		"Rewrote ARD-952 ticket framing from scratch",
+		"Scrapped the disk-spill buffer design (design A)",
+		"Discarded the prior approach after empirical verification",
+		"Retracted the recommendation in light of new evidence",
+		"Tabled the migration until Q3 planning",
+		"Parked the K8s RBAC change pending security review",
+		"Deprecated this design in favour of B",
+	}
+	for _, outcome := range walkBacks {
+		t.Run(outcome, func(t *testing.T) {
+			assert.True(t, containsSupersessionKeyword(outcome),
+				"#717 walk-back vocabulary should be recognised as supersession")
+		})
+	}
+
+	// Negatives — none of these contain a walk-back signal.
+	nonWalkBacks := []string{
+		"Implemented the planned validator",
+		"Reviewed PR #942 and approved",
+		"Found one bug in the connection pool sizing",
+		"",
+	}
+	for _, outcome := range nonWalkBacks {
+		t.Run("not_walkback_"+outcome, func(t *testing.T) {
+			assert.False(t, containsSupersessionKeyword(outcome),
+				"non-reversal outcome should not trip supersession keyword check")
+		})
+	}
+}
+
+func TestExtractTicketRefs(t *testing.T) {
+	tests := []struct {
+		name     string
+		decision model.Decision
+		expected []string
+	}{
+		{
+			name: "single ticket in task field",
+			decision: model.Decision{
+				AgentContext: map[string]any{"client": map[string]any{"task": "ARD-958 PR-1"}},
+			},
+			expected: []string{"ARD-958"},
+		},
+		{
+			name: "multiple tickets across task and outcome are deduplicated and ordered",
+			decision: model.Decision{
+				AgentContext: map[string]any{"client": map[string]any{"task": "ARD-958 followup"}},
+				Outcome:      "Implements ARD-958, also touches ARD-960 and ARD-958 again",
+			},
+			expected: []string{"ARD-958", "ARD-960"},
+		},
+		{
+			name: "co-mention captured (regression for #717 first-match blindspot)",
+			decision: model.Decision{
+				Outcome: "Reviewed ARD-957 vs ARD-958 designs; both rejected in favour of design C",
+			},
+			expected: []string{"ARD-957", "ARD-958"},
+		},
+		{
+			name: "branch + outcome with disjoint tickets returns both",
+			decision: model.Decision{
+				AgentContext: map[string]any{"client": map[string]any{"git_branch": "evanvolgas/ard-958-stream-wal"}},
+				Outcome:      "Plumbing for ARD-960 verified",
+			},
+			expected: []string{"ARD-958", "ARD-960"},
+		},
+		{
+			name: "lowercase canonicalised",
+			decision: model.Decision{
+				Outcome: "fixed ard-958 and ARD-960 in a single pass",
+			},
+			expected: []string{"ARD-958", "ARD-960"},
+		},
+		{
+			name:     "no tickets extractable",
+			decision: model.Decision{Outcome: "Refactored storage layer"},
+			expected: nil,
+		},
+		{
+			name:     "nil agent_context, empty outcome",
+			decision: model.Decision{},
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, extractTicketRefs(tt.decision))
+		})
+	}
+}
+
+func TestExtractTicketRef_WrapsExtractTicketRefs(t *testing.T) {
+	// extractTicketRef must continue to return the first ticket (the prior
+	// API contract) even after the refactor to multi-ticket extraction.
+	d := model.Decision{Outcome: "Touches ARD-958 and ARD-960"}
+	assert.Equal(t, "ARD-958", extractTicketRef(d))
+}
+
+func TestExtractLayerMarker(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"Reviewed ARD-958 S1 PR (return consistent_point LSN)", "s1"},
+		{"ARD-958 S2 implemented in branch", "s2"},
+		{"Reviewed ARD-844 layer 3 PR", "layer 3"},
+		{"ARD-844 layer-2 done", "layer 2"},
+		{"phase 1 of the migration", "phase 1"},
+		{"step-2 implementation", "step 2"},
+		{"stage 4 complete", "stage 4"},
+		{"PR-2 merged", "pr 2"},
+		{"PR_2 review", "pr 2"},
+		{"PR 2 of the series", "pr 2"},
+		{"S-1 typo case", ""}, // hyphen between S and digit not matched
+		{"prefix S1Z", ""},    // not a word boundary
+		{"version 1.2.3", ""}, // unrelated digits
+		{"refactor", ""},      // no marker
+		{"", ""},              // empty
+		{"step 12", ""},       // multi-digit deliberately rejected
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.expected, extractLayerMarker(tt.input))
+		})
+	}
+}
+
+func TestShareAny(t *testing.T) {
+	assert.True(t, shareAny([]string{"A", "B"}, []string{"B", "C"}))
+	assert.False(t, shareAny([]string{"A"}, []string{"B"}))
+	assert.False(t, shareAny(nil, []string{"A"}))
+	assert.False(t, shareAny([]string{"A"}, nil))
+	assert.False(t, shareAny(nil, nil))
+}
+
+func TestTicketSetsDisjoint(t *testing.T) {
+	assert.True(t, ticketSetsDisjoint([]string{"ARD-957"}, []string{"ARD-958"}))
+	assert.False(t, ticketSetsDisjoint([]string{"ARD-958"}, []string{"ARD-958"}))
+	assert.False(t, ticketSetsDisjoint([]string{"ARD-957", "ARD-958"}, []string{"ARD-958"}))
+	assert.False(t, ticketSetsDisjoint(nil, []string{"ARD-957"}),
+		"empty side treated as not-disjoint so callers don't suppress no-ticket pairs")
+	assert.False(t, ticketSetsDisjoint([]string{"ARD-957"}, nil))
+	assert.False(t, ticketSetsDisjoint(nil, nil))
+}
+
+func TestIsPRSeriesLayerRefinement(t *testing.T) {
+	now := time.Date(2026, 5, 8, 23, 0, 0, 0, time.UTC)
+	idA := uuid.New()
+	idB := uuid.New()
+
+	taskCtx := func(task string) map[string]any {
+		return map[string]any{"client": map[string]any{"task": task}}
+	}
+
+	tests := []struct {
+		name     string
+		d        model.Decision
+		cand     model.Decision
+		expected bool
+	}{
+		{
+			name: "cross-agent same-ticket, S1 vs S2 → suppressed (the dominant #717 FP shape)",
+			d: model.Decision{
+				ID: idA, AgentID: "claude-code", AgentContext: taskCtx("ARD-958"),
+				Outcome: "Reviewed ARD-958 S1 PR (return consistent_point LSN)", ValidFrom: now,
+			},
+			cand: model.Decision{
+				ID: idB, AgentID: "reviewer", AgentContext: taskCtx("ARD-958"),
+				Outcome: "Reviewed ARD-958 S2 PR (thread Init consistent_point)", ValidFrom: now.Add(time.Hour),
+			},
+			expected: true,
+		},
+		{
+			name: "cross-agent same-ticket, only one side has layer marker → suppressed",
+			d: model.Decision{
+				ID: idA, AgentID: "claude-code", AgentContext: taskCtx("ARD-844"),
+				Outcome: "Reviewed ARD-844 layer 3 PR (5 commits, ~1.2k lines)", ValidFrom: now,
+			},
+			cand: model.Decision{
+				ID: idB, AgentID: "reviewer", AgentContext: taskCtx("ARD-844"),
+				Outcome: "ARD-844 ticket assessed: structurally correct diagnosis", ValidFrom: now.Add(time.Hour),
+			},
+			expected: true,
+		},
+		{
+			name: "same agent → not suppressed (#711 handles same-agent)",
+			d: model.Decision{
+				ID: idA, AgentID: "claude-code", AgentContext: taskCtx("ARD-958"),
+				Outcome: "ARD-958 S1 implemented", ValidFrom: now,
+			},
+			cand: model.Decision{
+				ID: idB, AgentID: "claude-code", AgentContext: taskCtx("ARD-958"),
+				Outcome: "ARD-958 S2 implemented", ValidFrom: now.Add(time.Hour),
+			},
+			expected: false,
+		},
+		{
+			name: "cross-agent same ticket but identical layer markers → not suppressed (duplicate review, not chain)",
+			d: model.Decision{
+				ID: idA, AgentID: "claude-code", AgentContext: taskCtx("ARD-958"),
+				Outcome: "Reviewed ARD-958 S2 PR — approved", ValidFrom: now,
+			},
+			cand: model.Decision{
+				ID: idB, AgentID: "reviewer", AgentContext: taskCtx("ARD-958"),
+				Outcome: "Reviewed ARD-958 S2 PR — rejected", ValidFrom: now.Add(time.Hour),
+			},
+			expected: false,
+		},
+		{
+			name: "cross-agent same ticket but no layer marker on either side → not suppressed",
+			d: model.Decision{
+				ID: idA, AgentID: "claude-code", AgentContext: taskCtx("ARD-958"),
+				Outcome: "ARD-958 deployed", ValidFrom: now,
+			},
+			cand: model.Decision{
+				ID: idB, AgentID: "reviewer", AgentContext: taskCtx("ARD-958"),
+				Outcome: "ARD-958 rolled back", ValidFrom: now.Add(time.Hour),
+			},
+			expected: false,
+		},
+		{
+			name: "cross-agent disjoint tickets → not suppressed (this filter is same-ticket)",
+			d: model.Decision{
+				ID: idA, AgentID: "claude-code", AgentContext: taskCtx("ARD-957"),
+				Outcome: "Reviewed ARD-957 S1", ValidFrom: now,
+			},
+			cand: model.Decision{
+				ID: idB, AgentID: "reviewer", AgentContext: taskCtx("ARD-958"),
+				Outcome: "Reviewed ARD-958 S2", ValidFrom: now.Add(time.Hour),
+			},
+			expected: false,
+		},
+		{
+			name: "cross-agent same ticket but later outcome reverses prior → not suppressed (let LLM judge)",
+			d: model.Decision{
+				ID: idA, AgentID: "claude-code", AgentContext: taskCtx("ARD-958"),
+				Outcome: "Reviewed ARD-958 S1 — approved", ValidFrom: now,
+			},
+			cand: model.Decision{
+				ID: idB, AgentID: "reviewer", AgentContext: taskCtx("ARD-958"),
+				Outcome: "Walked back ARD-958 S1 approval; design B preferred", ValidFrom: now.Add(time.Hour),
+			},
+			expected: false,
+		},
+		{
+			name: "cross-agent same ticket but precedent-linked → not suppressed",
+			d: model.Decision{
+				ID: idA, AgentID: "claude-code", AgentContext: taskCtx("ARD-958"),
+				Outcome: "ARD-958 S2 implemented", ValidFrom: now, PrecedentRef: &idB,
+			},
+			cand: model.Decision{
+				ID: idB, AgentID: "reviewer", AgentContext: taskCtx("ARD-958"),
+				Outcome: "Reviewed ARD-958 S1", ValidFrom: now.Add(-time.Hour),
+			},
+			expected: false,
+		},
+		{
+			name: "cross-agent missing ticket → not suppressed",
+			d: model.Decision{
+				ID: idA, AgentID: "claude-code",
+				Outcome: "Reviewed S1 PR", ValidFrom: now,
+			},
+			cand: model.Decision{
+				ID: idB, AgentID: "reviewer",
+				Outcome: "Reviewed S2 PR", ValidFrom: now.Add(time.Hour),
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isPRSeriesLayerRefinement(tt.d, tt.cand))
+		})
+	}
+}
+
+func TestIsDisjointTicketReviewPair(t *testing.T) {
+	now := time.Date(2026, 5, 8, 23, 0, 0, 0, time.UTC)
+	idA := uuid.New()
+	idB := uuid.New()
+
+	taskCtx := func(task string) map[string]any {
+		return map[string]any{"client": map[string]any{"task": task}}
+	}
+
+	tests := []struct {
+		name     string
+		d        model.Decision
+		cand     model.Decision
+		expected bool
+	}{
+		{
+			name: "cross-agent code_review on different tickets → suppressed (10/71 FP signature)",
+			d: model.Decision{
+				ID: idA, AgentID: "claude-code", DecisionType: "code_review",
+				AgentContext: taskCtx("ARD-950"),
+				Outcome:      "Reviewed ARD-950 (statement_timeout killing slot creation)", ValidFrom: now,
+			},
+			cand: model.Decision{
+				ID: idB, AgentID: "reviewer", DecisionType: "code_review",
+				AgentContext: taskCtx("ARD-958"),
+				Outcome:      "Reviewed ARD-958 S1 PR (consistent_point LSN)", ValidFrom: now.Add(time.Hour),
+			},
+			expected: true,
+		},
+		{
+			name: "cross-agent assessment vs investigation, disjoint tickets → suppressed",
+			d: model.Decision{
+				ID: idA, AgentID: "claude-code", DecisionType: "investigation",
+				AgentContext: taskCtx("ARD-870"),
+				Outcome:      "ARD-870 homework verified", ValidFrom: now,
+			},
+			cand: model.Decision{
+				ID: idB, AgentID: "reviewer", DecisionType: "assessment",
+				AgentContext: taskCtx("ARD-964"),
+				Outcome:      "Reviewed ARD-964 (SP BYOC pg_dump fast-path)", ValidFrom: now.Add(time.Hour),
+			},
+			expected: true,
+		},
+		{
+			name: "shared ticket → not suppressed (other filters handle same-ticket)",
+			d: model.Decision{
+				ID: idA, AgentID: "claude-code", DecisionType: "code_review",
+				AgentContext: taskCtx("ARD-958"),
+				Outcome:      "Reviewed ARD-958 design", ValidFrom: now,
+			},
+			cand: model.Decision{
+				ID: idB, AgentID: "reviewer", DecisionType: "code_review",
+				AgentContext: taskCtx("ARD-958"),
+				Outcome:      "Reviewed ARD-958 S2", ValidFrom: now.Add(time.Hour),
+			},
+			expected: false,
+		},
+		{
+			name: "same agent, disjoint tickets → not suppressed (deliberate cross-ticket analysis preserved)",
+			d: model.Decision{
+				ID: idA, AgentID: "claude-code", DecisionType: "code_review",
+				AgentContext: taskCtx("ARD-957"),
+				Outcome:      "Reviewed ARD-957 design", ValidFrom: now,
+			},
+			cand: model.Decision{
+				ID: idB, AgentID: "claude-code", DecisionType: "code_review",
+				AgentContext: taskCtx("ARD-958"),
+				Outcome:      "Reviewed ARD-958 design", ValidFrom: now.Add(time.Hour),
+			},
+			expected: false,
+		},
+		{
+			name: "cross-agent but non-review types → not suppressed (architecture can span tickets)",
+			d: model.Decision{
+				ID: idA, AgentID: "claude-code", DecisionType: "architecture",
+				AgentContext: taskCtx("ARD-957"),
+				Outcome:      "Adopted shadow Neon mirror for ARD-957", ValidFrom: now,
+			},
+			cand: model.Decision{
+				ID: idB, AgentID: "design-architect", DecisionType: "architecture",
+				AgentContext: taskCtx("ARD-958"),
+				Outcome:      "Migration flow design for ARD-958", ValidFrom: now.Add(time.Hour),
+			},
+			expected: false,
+		},
+		{
+			name: "cross-agent precedent-linked → not suppressed",
+			d: model.Decision{
+				ID: idA, AgentID: "claude-code", DecisionType: "code_review",
+				AgentContext: taskCtx("ARD-957"),
+				Outcome:      "Reviewed ARD-957", ValidFrom: now, PrecedentRef: &idB,
+			},
+			cand: model.Decision{
+				ID: idB, AgentID: "reviewer", DecisionType: "code_review",
+				AgentContext: taskCtx("ARD-958"),
+				Outcome:      "Reviewed ARD-958", ValidFrom: now.Add(-time.Hour),
+			},
+			expected: false,
+		},
+		{
+			name: "cross-agent review, one side has no ticket → not suppressed (no join key)",
+			d: model.Decision{
+				ID: idA, AgentID: "claude-code", DecisionType: "code_review",
+				AgentContext: taskCtx("ARD-957"),
+				Outcome:      "Reviewed ARD-957", ValidFrom: now,
+			},
+			cand: model.Decision{
+				ID: idB, AgentID: "reviewer", DecisionType: "code_review",
+				Outcome: "Reviewed the storage layer refactor", ValidFrom: now.Add(time.Hour),
+			},
+			expected: false,
+		},
+		{
+			name: "case-insensitive review type match",
+			d: model.Decision{
+				ID: idA, AgentID: "claude-code", DecisionType: "CODE_REVIEW",
+				AgentContext: taskCtx("ARD-950"), Outcome: "Reviewed ARD-950", ValidFrom: now,
+			},
+			cand: model.Decision{
+				ID: idB, AgentID: "reviewer", DecisionType: "Assessment",
+				AgentContext: taskCtx("ARD-958"), Outcome: "Assessed ARD-958", ValidFrom: now.Add(time.Hour),
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isDisjointTicketReviewPair(tt.d, tt.cand))
+		})
+	}
+}
+
+func TestIsSameBranchMechanicalHousekeeping(t *testing.T) {
+	branchCtx := func(branch string) map[string]any {
+		return map[string]any{"client": map[string]any{"git_branch": branch}}
+	}
+
+	tests := []struct {
+		name     string
+		d        model.Decision
+		cand     model.Decision
+		expected bool
+	}{
+		{
+			name: "cross-agent same branch, both mechanical → suppressed (the #717 same-branch FP shape)",
+			d: model.Decision{
+				AgentID: "claude-code", AgentContext: branchCtx("evanvolgas/fix-sse-heartbeat"),
+				Outcome: "Merged origin/main into evanvolgas/fix-sse-heartbeat, renumbering migration 097→098",
+			},
+			cand: model.Decision{
+				AgentID: "reviewer", AgentContext: branchCtx("evanvolgas/fix-sse-heartbeat"),
+				Outcome: "Resolved 9 merge conflicts after rebasing onto main",
+			},
+			expected: true,
+		},
+		{
+			name: "same agent same branch → not suppressed (self-correction filter owns this case)",
+			d: model.Decision{
+				AgentID: "claude-code", AgentContext: branchCtx("evanvolgas/fix-sse-heartbeat"),
+				Outcome: "Renumbered migration 097→098",
+			},
+			cand: model.Decision{
+				AgentID: "claude-code", AgentContext: branchCtx("evanvolgas/fix-sse-heartbeat"),
+				Outcome: "Renumbered migration 098→099",
+			},
+			expected: false,
+		},
+		{
+			name: "cross-agent different branches → not suppressed (cross-branch filter owns that case)",
+			d: model.Decision{
+				AgentID: "claude-code", AgentContext: branchCtx("branch-a"),
+				Outcome: "Renumbered migration 097→098",
+			},
+			cand: model.Decision{
+				AgentID: "reviewer", AgentContext: branchCtx("branch-b"),
+				Outcome: "Renumbered migration 099→100",
+			},
+			expected: false,
+		},
+		{
+			name: "cross-agent same branch, only one mechanical → not suppressed",
+			d: model.Decision{
+				AgentID: "claude-code", AgentContext: branchCtx("feature/x"),
+				Outcome: "Renumbered migration 097→098",
+			},
+			cand: model.Decision{
+				AgentID: "reviewer", AgentContext: branchCtx("feature/x"),
+				Outcome: "Chose Redis with 5min TTL for session cache",
+			},
+			expected: false,
+		},
+		{
+			name: "cross-agent same branch, neither mechanical → not suppressed",
+			d: model.Decision{
+				AgentID: "claude-code", AgentContext: branchCtx("feature/x"),
+				Outcome: "Chose Redis for caching",
+			},
+			cand: model.Decision{
+				AgentID: "reviewer", AgentContext: branchCtx("feature/x"),
+				Outcome: "Chose Memcached for caching",
+			},
+			expected: false,
+		},
+		{
+			name: "missing branch on one side → not suppressed",
+			d: model.Decision{
+				AgentID: "claude-code", AgentContext: branchCtx("feature/x"),
+				Outcome: "Renumbered migration 097→098",
+			},
+			cand: model.Decision{
+				AgentID: "reviewer", AgentContext: map[string]any{},
+				Outcome: "Renumbered migration 099→100",
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isSameBranchMechanicalHousekeeping(tt.d, tt.cand))
+		})
+	}
+}

--- a/internal/conflicts/issue_717_filters_test.go
+++ b/internal/conflicts/issue_717_filters_test.go
@@ -2,21 +2,16 @@ package conflicts
 
 import (
 	"testing"
-	"time"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/ashita-ai/akashi/internal/model"
 )
 
-// Tests for the issue #717 structural pre-filters:
+// Tests for the issue #717 structural updates:
 //   - supersession keyword expansion (walk-back vocabulary)
 //   - extractTicketRefs (multi-ticket extraction)
-//   - layer marker extraction
-//   - isPRSeriesLayerRefinement (cross-agent same-ticket PR-series)
-//   - isDisjointTicketReviewPair (cross-agent reviews on disjoint tickets)
-//   - isSameBranchMechanicalHousekeeping (cross-agent same-branch housekeeping)
+//   - isSameBranchMechanicalHousekeeping (narrow cross-agent same-branch housekeeping)
 
 func TestContainsSupersessionKeyword_WalkbackVocabulary(t *testing.T) {
 	// Coverage for the keyword extension added by #717. These are the exact
@@ -126,318 +121,6 @@ func TestExtractTicketRef_WrapsExtractTicketRefs(t *testing.T) {
 	assert.Equal(t, "ARD-958", extractTicketRef(d))
 }
 
-func TestExtractLayerMarker(t *testing.T) {
-	tests := []struct {
-		input    string
-		expected string
-	}{
-		{"Reviewed ARD-958 S1 PR (return consistent_point LSN)", "s1"},
-		{"ARD-958 S2 implemented in branch", "s2"},
-		{"Reviewed ARD-844 layer 3 PR", "layer 3"},
-		{"ARD-844 layer-2 done", "layer 2"},
-		{"phase 1 of the migration", "phase 1"},
-		{"step-2 implementation", "step 2"},
-		{"stage 4 complete", "stage 4"},
-		{"PR-2 merged", "pr 2"},
-		{"PR_2 review", "pr 2"},
-		{"PR 2 of the series", "pr 2"},
-		{"S-1 typo case", ""}, // hyphen between S and digit not matched
-		{"prefix S1Z", ""},    // not a word boundary
-		{"version 1.2.3", ""}, // unrelated digits
-		{"refactor", ""},      // no marker
-		{"", ""},              // empty
-		{"step 12", ""},       // multi-digit deliberately rejected
-	}
-	for _, tt := range tests {
-		t.Run(tt.input, func(t *testing.T) {
-			assert.Equal(t, tt.expected, extractLayerMarker(tt.input))
-		})
-	}
-}
-
-func TestShareAny(t *testing.T) {
-	assert.True(t, shareAny([]string{"A", "B"}, []string{"B", "C"}))
-	assert.False(t, shareAny([]string{"A"}, []string{"B"}))
-	assert.False(t, shareAny(nil, []string{"A"}))
-	assert.False(t, shareAny([]string{"A"}, nil))
-	assert.False(t, shareAny(nil, nil))
-}
-
-func TestTicketSetsDisjoint(t *testing.T) {
-	assert.True(t, ticketSetsDisjoint([]string{"ARD-957"}, []string{"ARD-958"}))
-	assert.False(t, ticketSetsDisjoint([]string{"ARD-958"}, []string{"ARD-958"}))
-	assert.False(t, ticketSetsDisjoint([]string{"ARD-957", "ARD-958"}, []string{"ARD-958"}))
-	assert.False(t, ticketSetsDisjoint(nil, []string{"ARD-957"}),
-		"empty side treated as not-disjoint so callers don't suppress no-ticket pairs")
-	assert.False(t, ticketSetsDisjoint([]string{"ARD-957"}, nil))
-	assert.False(t, ticketSetsDisjoint(nil, nil))
-}
-
-func TestIsPRSeriesLayerRefinement(t *testing.T) {
-	now := time.Date(2026, 5, 8, 23, 0, 0, 0, time.UTC)
-	idA := uuid.New()
-	idB := uuid.New()
-
-	taskCtx := func(task string) map[string]any {
-		return map[string]any{"client": map[string]any{"task": task}}
-	}
-
-	tests := []struct {
-		name     string
-		d        model.Decision
-		cand     model.Decision
-		expected bool
-	}{
-		{
-			name: "cross-agent same-ticket, S1 vs S2 → suppressed (the dominant #717 FP shape)",
-			d: model.Decision{
-				ID: idA, AgentID: "claude-code", AgentContext: taskCtx("ARD-958"),
-				Outcome: "Reviewed ARD-958 S1 PR (return consistent_point LSN)", ValidFrom: now,
-			},
-			cand: model.Decision{
-				ID: idB, AgentID: "reviewer", AgentContext: taskCtx("ARD-958"),
-				Outcome: "Reviewed ARD-958 S2 PR (thread Init consistent_point)", ValidFrom: now.Add(time.Hour),
-			},
-			expected: true,
-		},
-		{
-			name: "cross-agent same-ticket, only one side has layer marker → suppressed",
-			d: model.Decision{
-				ID: idA, AgentID: "claude-code", AgentContext: taskCtx("ARD-844"),
-				Outcome: "Reviewed ARD-844 layer 3 PR (5 commits, ~1.2k lines)", ValidFrom: now,
-			},
-			cand: model.Decision{
-				ID: idB, AgentID: "reviewer", AgentContext: taskCtx("ARD-844"),
-				Outcome: "ARD-844 ticket assessed: structurally correct diagnosis", ValidFrom: now.Add(time.Hour),
-			},
-			expected: true,
-		},
-		{
-			name: "same agent → not suppressed (#711 handles same-agent)",
-			d: model.Decision{
-				ID: idA, AgentID: "claude-code", AgentContext: taskCtx("ARD-958"),
-				Outcome: "ARD-958 S1 implemented", ValidFrom: now,
-			},
-			cand: model.Decision{
-				ID: idB, AgentID: "claude-code", AgentContext: taskCtx("ARD-958"),
-				Outcome: "ARD-958 S2 implemented", ValidFrom: now.Add(time.Hour),
-			},
-			expected: false,
-		},
-		{
-			name: "cross-agent same ticket but identical layer markers → not suppressed (duplicate review, not chain)",
-			d: model.Decision{
-				ID: idA, AgentID: "claude-code", AgentContext: taskCtx("ARD-958"),
-				Outcome: "Reviewed ARD-958 S2 PR — approved", ValidFrom: now,
-			},
-			cand: model.Decision{
-				ID: idB, AgentID: "reviewer", AgentContext: taskCtx("ARD-958"),
-				Outcome: "Reviewed ARD-958 S2 PR — rejected", ValidFrom: now.Add(time.Hour),
-			},
-			expected: false,
-		},
-		{
-			name: "cross-agent same ticket but no layer marker on either side → not suppressed",
-			d: model.Decision{
-				ID: idA, AgentID: "claude-code", AgentContext: taskCtx("ARD-958"),
-				Outcome: "ARD-958 deployed", ValidFrom: now,
-			},
-			cand: model.Decision{
-				ID: idB, AgentID: "reviewer", AgentContext: taskCtx("ARD-958"),
-				Outcome: "ARD-958 rolled back", ValidFrom: now.Add(time.Hour),
-			},
-			expected: false,
-		},
-		{
-			name: "cross-agent disjoint tickets → not suppressed (this filter is same-ticket)",
-			d: model.Decision{
-				ID: idA, AgentID: "claude-code", AgentContext: taskCtx("ARD-957"),
-				Outcome: "Reviewed ARD-957 S1", ValidFrom: now,
-			},
-			cand: model.Decision{
-				ID: idB, AgentID: "reviewer", AgentContext: taskCtx("ARD-958"),
-				Outcome: "Reviewed ARD-958 S2", ValidFrom: now.Add(time.Hour),
-			},
-			expected: false,
-		},
-		{
-			name: "cross-agent same ticket but later outcome reverses prior → not suppressed (let LLM judge)",
-			d: model.Decision{
-				ID: idA, AgentID: "claude-code", AgentContext: taskCtx("ARD-958"),
-				Outcome: "Reviewed ARD-958 S1 — approved", ValidFrom: now,
-			},
-			cand: model.Decision{
-				ID: idB, AgentID: "reviewer", AgentContext: taskCtx("ARD-958"),
-				Outcome: "Walked back ARD-958 S1 approval; design B preferred", ValidFrom: now.Add(time.Hour),
-			},
-			expected: false,
-		},
-		{
-			name: "cross-agent same ticket but precedent-linked → not suppressed",
-			d: model.Decision{
-				ID: idA, AgentID: "claude-code", AgentContext: taskCtx("ARD-958"),
-				Outcome: "ARD-958 S2 implemented", ValidFrom: now, PrecedentRef: &idB,
-			},
-			cand: model.Decision{
-				ID: idB, AgentID: "reviewer", AgentContext: taskCtx("ARD-958"),
-				Outcome: "Reviewed ARD-958 S1", ValidFrom: now.Add(-time.Hour),
-			},
-			expected: false,
-		},
-		{
-			name: "cross-agent missing ticket → not suppressed",
-			d: model.Decision{
-				ID: idA, AgentID: "claude-code",
-				Outcome: "Reviewed S1 PR", ValidFrom: now,
-			},
-			cand: model.Decision{
-				ID: idB, AgentID: "reviewer",
-				Outcome: "Reviewed S2 PR", ValidFrom: now.Add(time.Hour),
-			},
-			expected: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, isPRSeriesLayerRefinement(tt.d, tt.cand))
-		})
-	}
-}
-
-func TestIsDisjointTicketReviewPair(t *testing.T) {
-	now := time.Date(2026, 5, 8, 23, 0, 0, 0, time.UTC)
-	idA := uuid.New()
-	idB := uuid.New()
-
-	taskCtx := func(task string) map[string]any {
-		return map[string]any{"client": map[string]any{"task": task}}
-	}
-
-	tests := []struct {
-		name     string
-		d        model.Decision
-		cand     model.Decision
-		expected bool
-	}{
-		{
-			name: "cross-agent code_review on different tickets → suppressed (10/71 FP signature)",
-			d: model.Decision{
-				ID: idA, AgentID: "claude-code", DecisionType: "code_review",
-				AgentContext: taskCtx("ARD-950"),
-				Outcome:      "Reviewed ARD-950 (statement_timeout killing slot creation)", ValidFrom: now,
-			},
-			cand: model.Decision{
-				ID: idB, AgentID: "reviewer", DecisionType: "code_review",
-				AgentContext: taskCtx("ARD-958"),
-				Outcome:      "Reviewed ARD-958 S1 PR (consistent_point LSN)", ValidFrom: now.Add(time.Hour),
-			},
-			expected: true,
-		},
-		{
-			name: "cross-agent assessment vs investigation, disjoint tickets → suppressed",
-			d: model.Decision{
-				ID: idA, AgentID: "claude-code", DecisionType: "investigation",
-				AgentContext: taskCtx("ARD-870"),
-				Outcome:      "ARD-870 homework verified", ValidFrom: now,
-			},
-			cand: model.Decision{
-				ID: idB, AgentID: "reviewer", DecisionType: "assessment",
-				AgentContext: taskCtx("ARD-964"),
-				Outcome:      "Reviewed ARD-964 (SP BYOC pg_dump fast-path)", ValidFrom: now.Add(time.Hour),
-			},
-			expected: true,
-		},
-		{
-			name: "shared ticket → not suppressed (other filters handle same-ticket)",
-			d: model.Decision{
-				ID: idA, AgentID: "claude-code", DecisionType: "code_review",
-				AgentContext: taskCtx("ARD-958"),
-				Outcome:      "Reviewed ARD-958 design", ValidFrom: now,
-			},
-			cand: model.Decision{
-				ID: idB, AgentID: "reviewer", DecisionType: "code_review",
-				AgentContext: taskCtx("ARD-958"),
-				Outcome:      "Reviewed ARD-958 S2", ValidFrom: now.Add(time.Hour),
-			},
-			expected: false,
-		},
-		{
-			name: "same agent, disjoint tickets → not suppressed (deliberate cross-ticket analysis preserved)",
-			d: model.Decision{
-				ID: idA, AgentID: "claude-code", DecisionType: "code_review",
-				AgentContext: taskCtx("ARD-957"),
-				Outcome:      "Reviewed ARD-957 design", ValidFrom: now,
-			},
-			cand: model.Decision{
-				ID: idB, AgentID: "claude-code", DecisionType: "code_review",
-				AgentContext: taskCtx("ARD-958"),
-				Outcome:      "Reviewed ARD-958 design", ValidFrom: now.Add(time.Hour),
-			},
-			expected: false,
-		},
-		{
-			name: "cross-agent but non-review types → not suppressed (architecture can span tickets)",
-			d: model.Decision{
-				ID: idA, AgentID: "claude-code", DecisionType: "architecture",
-				AgentContext: taskCtx("ARD-957"),
-				Outcome:      "Adopted shadow Neon mirror for ARD-957", ValidFrom: now,
-			},
-			cand: model.Decision{
-				ID: idB, AgentID: "design-architect", DecisionType: "architecture",
-				AgentContext: taskCtx("ARD-958"),
-				Outcome:      "Migration flow design for ARD-958", ValidFrom: now.Add(time.Hour),
-			},
-			expected: false,
-		},
-		{
-			name: "cross-agent precedent-linked → not suppressed",
-			d: model.Decision{
-				ID: idA, AgentID: "claude-code", DecisionType: "code_review",
-				AgentContext: taskCtx("ARD-957"),
-				Outcome:      "Reviewed ARD-957", ValidFrom: now, PrecedentRef: &idB,
-			},
-			cand: model.Decision{
-				ID: idB, AgentID: "reviewer", DecisionType: "code_review",
-				AgentContext: taskCtx("ARD-958"),
-				Outcome:      "Reviewed ARD-958", ValidFrom: now.Add(-time.Hour),
-			},
-			expected: false,
-		},
-		{
-			name: "cross-agent review, one side has no ticket → not suppressed (no join key)",
-			d: model.Decision{
-				ID: idA, AgentID: "claude-code", DecisionType: "code_review",
-				AgentContext: taskCtx("ARD-957"),
-				Outcome:      "Reviewed ARD-957", ValidFrom: now,
-			},
-			cand: model.Decision{
-				ID: idB, AgentID: "reviewer", DecisionType: "code_review",
-				Outcome: "Reviewed the storage layer refactor", ValidFrom: now.Add(time.Hour),
-			},
-			expected: false,
-		},
-		{
-			name: "case-insensitive review type match",
-			d: model.Decision{
-				ID: idA, AgentID: "claude-code", DecisionType: "CODE_REVIEW",
-				AgentContext: taskCtx("ARD-950"), Outcome: "Reviewed ARD-950", ValidFrom: now,
-			},
-			cand: model.Decision{
-				ID: idB, AgentID: "reviewer", DecisionType: "Assessment",
-				AgentContext: taskCtx("ARD-958"), Outcome: "Assessed ARD-958", ValidFrom: now.Add(time.Hour),
-			},
-			expected: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, isDisjointTicketReviewPair(tt.d, tt.cand))
-		})
-	}
-}
-
 func TestIsSameBranchMechanicalHousekeeping(t *testing.T) {
 	branchCtx := func(branch string) map[string]any {
 		return map[string]any{"client": map[string]any{"git_branch": branch}}
@@ -506,6 +189,18 @@ func TestIsSameBranchMechanicalHousekeeping(t *testing.T) {
 			cand: model.Decision{
 				AgentID: "reviewer", AgentContext: branchCtx("feature/x"),
 				Outcome: "Chose Memcached for caching",
+			},
+			expected: false,
+		},
+		{
+			name: "cross-agent same branch, migration strategy only → not suppressed",
+			d: model.Decision{
+				AgentID: "claude-code", AgentContext: branchCtx("feature/x"),
+				Outcome: "Chose pg_dump migration strategy for ARD-958",
+			},
+			cand: model.Decision{
+				AgentID: "reviewer", AgentContext: branchCtx("feature/x"),
+				Outcome: "Rejected pg_dump migration strategy; use logical replication",
 			},
 			expected: false,
 		},

--- a/internal/conflicts/metrics.go
+++ b/internal/conflicts/metrics.go
@@ -31,6 +31,9 @@ type Metrics struct {
 	fpPatternFiltered            metric.Int64Counter
 	temporalReassessmentFiltered metric.Int64Counter
 	supersedesCandidateFiltered  metric.Int64Counter
+	prSeriesLayerFiltered        metric.Int64Counter
+	disjointTicketReviewFiltered metric.Int64Counter
+	sameBranchMechanicalFiltered metric.Int64Counter
 
 	scoringDuration    metric.Float64Histogram
 	llmCallDuration    metric.Float64Histogram
@@ -203,6 +206,30 @@ func (s *Scorer) registerMetrics() {
 	if err != nil {
 		s.logger.Warn("conflicts: failed to create akashi.conflicts.supersedes_candidate_filtered metric", "error", err)
 		s.metrics.supersedesCandidateFiltered, _ = meter.Int64Counter("akashi.conflicts.supersedes_candidate_filtered.fallback")
+	}
+
+	s.metrics.prSeriesLayerFiltered, err = meter.Int64Counter("akashi.conflicts.pr_series_layer_filtered",
+		metric.WithDescription("Candidate pairs suppressed as cross-agent same-ticket PR-series layer refinements (S1/S2, layer N, phase N, step N, stage N, PR-N) — issue #717"),
+	)
+	if err != nil {
+		s.logger.Warn("conflicts: failed to create akashi.conflicts.pr_series_layer_filtered metric", "error", err)
+		s.metrics.prSeriesLayerFiltered, _ = meter.Int64Counter("akashi.conflicts.pr_series_layer_filtered.fallback")
+	}
+
+	s.metrics.disjointTicketReviewFiltered, err = meter.Int64Counter("akashi.conflicts.disjoint_ticket_review_filtered",
+		metric.WithDescription("Candidate pairs suppressed as cross-agent review-type decisions on disjoint ticket sets (different tickets in the same product) — issue #717"),
+	)
+	if err != nil {
+		s.logger.Warn("conflicts: failed to create akashi.conflicts.disjoint_ticket_review_filtered metric", "error", err)
+		s.metrics.disjointTicketReviewFiltered, _ = meter.Int64Counter("akashi.conflicts.disjoint_ticket_review_filtered.fallback")
+	}
+
+	s.metrics.sameBranchMechanicalFiltered, err = meter.Int64Counter("akashi.conflicts.same_branch_mechanical_filtered",
+		metric.WithDescription("Candidate pairs suppressed as cross-agent same-branch housekeeping (rebase/renumber/merge resolution) — issue #717"),
+	)
+	if err != nil {
+		s.logger.Warn("conflicts: failed to create akashi.conflicts.same_branch_mechanical_filtered metric", "error", err)
+		s.metrics.sameBranchMechanicalFiltered, _ = meter.Int64Counter("akashi.conflicts.same_branch_mechanical_filtered.fallback")
 	}
 
 	// --- Histograms ---

--- a/internal/conflicts/metrics.go
+++ b/internal/conflicts/metrics.go
@@ -31,7 +31,6 @@ type Metrics struct {
 	fpPatternFiltered            metric.Int64Counter
 	temporalReassessmentFiltered metric.Int64Counter
 	supersedesCandidateFiltered  metric.Int64Counter
-	sameBranchMechanicalFiltered metric.Int64Counter
 
 	scoringDuration    metric.Float64Histogram
 	llmCallDuration    metric.Float64Histogram
@@ -204,14 +203,6 @@ func (s *Scorer) registerMetrics() {
 	if err != nil {
 		s.logger.Warn("conflicts: failed to create akashi.conflicts.supersedes_candidate_filtered metric", "error", err)
 		s.metrics.supersedesCandidateFiltered, _ = meter.Int64Counter("akashi.conflicts.supersedes_candidate_filtered.fallback")
-	}
-
-	s.metrics.sameBranchMechanicalFiltered, err = meter.Int64Counter("akashi.conflicts.same_branch_mechanical_filtered",
-		metric.WithDescription("Candidate pairs suppressed as cross-agent same-branch housekeeping (rebase/renumber/merge resolution) — issue #717"),
-	)
-	if err != nil {
-		s.logger.Warn("conflicts: failed to create akashi.conflicts.same_branch_mechanical_filtered metric", "error", err)
-		s.metrics.sameBranchMechanicalFiltered, _ = meter.Int64Counter("akashi.conflicts.same_branch_mechanical_filtered.fallback")
 	}
 
 	// --- Histograms ---

--- a/internal/conflicts/metrics.go
+++ b/internal/conflicts/metrics.go
@@ -31,8 +31,6 @@ type Metrics struct {
 	fpPatternFiltered            metric.Int64Counter
 	temporalReassessmentFiltered metric.Int64Counter
 	supersedesCandidateFiltered  metric.Int64Counter
-	prSeriesLayerFiltered        metric.Int64Counter
-	disjointTicketReviewFiltered metric.Int64Counter
 	sameBranchMechanicalFiltered metric.Int64Counter
 
 	scoringDuration    metric.Float64Histogram
@@ -206,22 +204,6 @@ func (s *Scorer) registerMetrics() {
 	if err != nil {
 		s.logger.Warn("conflicts: failed to create akashi.conflicts.supersedes_candidate_filtered metric", "error", err)
 		s.metrics.supersedesCandidateFiltered, _ = meter.Int64Counter("akashi.conflicts.supersedes_candidate_filtered.fallback")
-	}
-
-	s.metrics.prSeriesLayerFiltered, err = meter.Int64Counter("akashi.conflicts.pr_series_layer_filtered",
-		metric.WithDescription("Candidate pairs suppressed as cross-agent same-ticket PR-series layer refinements (S1/S2, layer N, phase N, step N, stage N, PR-N) — issue #717"),
-	)
-	if err != nil {
-		s.logger.Warn("conflicts: failed to create akashi.conflicts.pr_series_layer_filtered metric", "error", err)
-		s.metrics.prSeriesLayerFiltered, _ = meter.Int64Counter("akashi.conflicts.pr_series_layer_filtered.fallback")
-	}
-
-	s.metrics.disjointTicketReviewFiltered, err = meter.Int64Counter("akashi.conflicts.disjoint_ticket_review_filtered",
-		metric.WithDescription("Candidate pairs suppressed as cross-agent review-type decisions on disjoint ticket sets (different tickets in the same product) — issue #717"),
-	)
-	if err != nil {
-		s.logger.Warn("conflicts: failed to create akashi.conflicts.disjoint_ticket_review_filtered metric", "error", err)
-		s.metrics.disjointTicketReviewFiltered, _ = meter.Int64Counter("akashi.conflicts.disjoint_ticket_review_filtered.fallback")
 	}
 
 	s.metrics.sameBranchMechanicalFiltered, err = meter.Int64Counter("akashi.conflicts.same_branch_mechanical_filtered",

--- a/internal/conflicts/scorer.go
+++ b/internal/conflicts/scorer.go
@@ -641,22 +641,6 @@ func (s *Scorer) scoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 			continue
 		}
 
-		// Same-branch mechanical housekeeping filter: when two DIFFERENT
-		// agents both operate on the same branch and both outcomes describe
-		// pure mechanical operations (renumber/rebase/merge resolution/
-		// version bump), the pair is a handoff on the same housekeeping
-		// task, not disagreement. Complement to isCrossBranchMechanical
-		// (which requires different branches) and isSameBranchSelfCorrection
-		// (which requires the same agent). See issue #717 FP audit.
-		if isSameBranchMechanicalHousekeeping(d, sc.cand) {
-			s.metrics.sameBranchMechanicalFiltered.Add(ctx, 1)
-			s.logger.Debug("conflict scorer: same-branch mechanical housekeeping suppressed pair",
-				"decision_a", decisionID, "decision_b", sc.cand.ID,
-				"agent_a", d.AgentID, "agent_b", sc.cand.AgentID,
-				"branch", nestedContextString(d.AgentContext, "git_branch"))
-			continue
-		}
-
 		// Same-agent same-ticket refinement filter: when the same agent
 		// traces a refinement of their own prior decision on the same ticket
 		// without setting supersedes_id, treat it as a missed-link refinement
@@ -1589,43 +1573,6 @@ func isTemporalReassessment(d, cand model.Decision) bool {
 		delta = -delta
 	}
 	return delta >= temporalReassessmentWindow
-}
-
-// isSameBranchMechanicalHousekeeping returns true when two decisions are
-// authored by *different* agents on the *same* git branch and both
-// outcomes describe pure mechanical operations (migration renumbering,
-// rebase, merge conflict resolution, version bump).
-//
-// Complement to isCrossBranchMechanical and isSameBranchSelfCorrection:
-//   - isCrossBranchMechanical: different branches + both mechanical
-//     (parallel housekeeping resolved by merge order)
-//   - isSameBranchSelfCorrection: same agent + same branch (iterative
-//     self-correction regardless of outcome content)
-//   - isSameBranchMechanicalHousekeeping (this filter): same branch +
-//     different agents + both mechanical (handoff/help on the same
-//     housekeeping task, e.g. one agent rebases, another renumbers
-//     migrations on the same branch)
-//
-// The #717 audit found ~6 FPs in this exact shape — outcomes like
-// "Merged origin/main into evanvolgas/fix-sse-heartbeat, renumbering
-// migration 097→098" paired across agents on the SAME branch. The
-// existing cross-branch filter required different branches, so these
-// slipped through.
-//
-// Recall risk: low. Two genuinely contradictory architecture decisions on
-// the same branch by different agents are very unlikely to both phrase
-// themselves as pure mechanical operations (the mechanical keyword check
-// is strict: renumber/migration/rebase/merge conflict/version bump).
-func isSameBranchMechanicalHousekeeping(d, cand model.Decision) bool {
-	if d.AgentID == cand.AgentID {
-		return false
-	}
-	branchA := nestedContextString(d.AgentContext, "git_branch")
-	branchB := nestedContextString(cand.AgentContext, "git_branch")
-	if branchA == "" || branchB == "" || branchA != branchB {
-		return false
-	}
-	return isMechanicalOperation(d.Outcome) && isMechanicalOperation(cand.Outcome)
 }
 
 // isPrecedentLinked returns true if either decision cites the other via

--- a/internal/conflicts/scorer.go
+++ b/internal/conflicts/scorer.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
-	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -677,23 +676,6 @@ func (s *Scorer) scoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 			continue
 		}
 
-		// PR-series layer marker filter: when two CROSS-agent decisions
-		// reference the same ticket and at least one outcome carries a
-		// PR-series layer marker (S1/S2/layer N/phase N/step N/stage N/
-		// PR-N), the pair is a sequential delivery of that ticket — one
-		// agent reviews the S1 PR, another agent ships the S2 PR. Sibling
-		// of isSameAgentSameTicketRefinement that handles the cross-agent
-		// case. See issue #717 FP audit.
-		if isPRSeriesLayerRefinement(d, sc.cand) {
-			s.metrics.prSeriesLayerFiltered.Add(ctx, 1)
-			s.logger.Debug("conflict scorer: PR-series layer refinement suppressed pair",
-				"decision_a", decisionID, "decision_b", sc.cand.ID,
-				"agent_a", d.AgentID, "agent_b", sc.cand.AgentID,
-				"marker_a", extractLayerMarker(d.Outcome),
-				"marker_b", extractLayerMarker(sc.cand.Outcome))
-			continue
-		}
-
 		// Temporal re-assessment filter: two review-type decisions on the
 		// same project, recorded sufficiently far apart with no precedent
 		// link, are re-measurements rather than contradictions. Quantitative
@@ -706,22 +688,6 @@ func (s *Scorer) scoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 				"type_a", d.DecisionType, "type_b", sc.cand.DecisionType,
 				"project", derefString(d.Project),
 				"delta", d.ValidFrom.Sub(sc.cand.ValidFrom).Abs())
-			continue
-		}
-
-		// Disjoint-ticket review filter: two CROSS-agent review-type
-		// decisions whose ticket sets are entirely disjoint cannot be
-		// contradictions — they are reviewing different problems. Gated
-		// on review-types and cross-agent to preserve recall on
-		// deliberate same-agent cross-ticket architectural comparisons.
-		// See issue #717 FP audit (10/71 FPs matched this pattern).
-		if isDisjointTicketReviewPair(d, sc.cand) {
-			s.metrics.disjointTicketReviewFiltered.Add(ctx, 1)
-			s.logger.Debug("conflict scorer: disjoint-ticket review pair suppressed",
-				"decision_a", decisionID, "decision_b", sc.cand.ID,
-				"agent_a", d.AgentID, "agent_b", sc.cand.AgentID,
-				"tickets_a", extractTicketRefs(d),
-				"tickets_b", extractTicketRefs(sc.cand))
 			continue
 		}
 
@@ -1439,7 +1405,6 @@ var mechanicalKeywords = []string{
 	"renumber",
 	"renumbering",
 	"renumbered",
-	"migration",
 	"rebase",
 	"rebasing",
 	"rebased",
@@ -1624,162 +1589,6 @@ func isTemporalReassessment(d, cand model.Decision) bool {
 		delta = -delta
 	}
 	return delta >= temporalReassessmentWindow
-}
-
-// layerMarkerPattern matches PR-series delivery markers like "S1", "S2",
-// "layer 3", "phase 2", "step 4", "stage 1", "PR-2". These appear in outcome
-// text when an agent delivers a single ticket as a sequence of PRs
-// ("Reviewed ARD-958 S1 PR", "ARD-958 S2 implemented on branch...").
-//
-// The pattern is deliberately conservative: it accepts the canonical labels
-// and a single digit (1-9). Multi-digit indices (S10, layer 12) are rare in
-// practice and admitting them risks colliding with version strings or
-// migration numbers. If wider matching becomes necessary, prefer extending
-// the alternation to specific labels rather than relaxing the digit class.
-var layerMarkerPattern = regexp.MustCompile(`(?i)\b(?:S[1-9]|layer[\s_-]*[1-9]|phase[\s_-]*[1-9]|step[\s_-]*[1-9]|stage[\s_-]*[1-9]|PR[\s_-]*[1-9])\b`)
-
-// extractLayerMarker returns the canonical lowercased+space-normalised layer
-// marker found in s, or "" if none is present. "PR-2", "PR 2", and "PR_2"
-// all canonicalise to "pr 2"; "S1" stays "s1". Used by
-// isPRSeriesLayerRefinement to detect when two outcomes are different
-// stages of the same delivery rather than competing positions.
-func extractLayerMarker(s string) string {
-	if s == "" {
-		return ""
-	}
-	m := layerMarkerPattern.FindString(s)
-	if m == "" {
-		return ""
-	}
-	lower := strings.ToLower(m)
-	// Collapse "-" and "_" to spaces so "PR-2" / "PR_2" / "PR 2" all hash to
-	// the same canonical form for cross-outcome comparison.
-	lower = strings.ReplaceAll(lower, "-", " ")
-	lower = strings.ReplaceAll(lower, "_", " ")
-	// Squash any internal whitespace runs to a single space.
-	return strings.Join(strings.Fields(lower), " ")
-}
-
-// isPRSeriesLayerRefinement returns true when two cross-agent decisions
-// reference the same ticket and at least one outcome carries a PR-series
-// layer marker ("S1", "layer 3", "phase 2", "PR-2"). The pair is then a
-// sequential delivery of one ticket — reviewer reviews S1, implementer
-// ships S2 — not a contradiction.
-//
-// Sibling of isSameAgentSameTicketRefinement (#711): that filter handles
-// the same-agent variant. This one handles the cross-agent variant
-// surfaced by the issue #717 FP audit (claude-code reviews ARD-958 S1,
-// reviewer reviews ARD-958 S2; both code_review; topical overlap fools
-// the embedder into flagging contradiction).
-//
-// Excluded:
-//   - same agent (caught upstream by #711)
-//   - precedent-linked pairs (an explicit lineage signal already exists)
-//   - neither outcome has a layer marker (no PR-series evidence)
-//   - both outcomes share the same marker (probable duplicate review of
-//     the same layer, not a chain)
-//   - the later outcome contains an explicit supersession keyword (the
-//     reversal is stated, let the LLM read it)
-//
-// Recall risk: low. Same-ticket cross-agent disagreement WITHOUT layer
-// markers still flows to the LLM. Same-ticket cross-agent disagreement
-// WITH layer markers but where the agent intends to contradict (rather
-// than ship the next stage) would have to phrase the contradiction without
-// any of the supersession verbs — uncommon in practice.
-func isPRSeriesLayerRefinement(d, cand model.Decision) bool {
-	if d.AgentID == cand.AgentID {
-		return false
-	}
-	if isPrecedentLinked(d, cand) {
-		return false
-	}
-	refsA := extractTicketRefs(d)
-	if len(refsA) == 0 {
-		return false
-	}
-	refsB := extractTicketRefs(cand)
-	if !shareAny(refsA, refsB) {
-		return false
-	}
-	markerA := extractLayerMarker(d.Outcome)
-	markerB := extractLayerMarker(cand.Outcome)
-	if markerA == "" && markerB == "" {
-		return false
-	}
-	if markerA != "" && markerB != "" && markerA == markerB {
-		return false
-	}
-	later := d
-	if cand.ValidFrom.After(d.ValidFrom) {
-		later = cand
-	}
-	if containsSupersessionKeyword(later.Outcome) {
-		return false
-	}
-	return true
-}
-
-// shareAny returns true when slices a and b share at least one element.
-// Both slices are expected to be small (typical ticket count per decision
-// is 1-3), so the nested loop is fine.
-func shareAny(a, b []string) bool {
-	for _, x := range a {
-		for _, y := range b {
-			if x == y {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-// isDisjointTicketReviewPair returns true when two cross-agent review-type
-// decisions reference *non-overlapping* sets of tickets. Two reviewers
-// looking at different tickets in the same product produce embeddings
-// close enough to trip the scorer ("pgstream slot drain bug" vs "pgstream
-// snapshot validator design") even though they cannot contradict — they
-// are about different problems.
-//
-// The cross-agent gate is the recall safety belt: a single agent
-// deliberately comparing ARD-957 and ARD-958 designs in one decision is
-// authoring exactly the cross-ticket judgement we DO want to preserve;
-// suppressing same-agent disjoint pairs would erase that signal. The
-// observed FPs in the #717 audit were unanimously cross-agent
-// (claude-code | reviewer the dominant pair).
-//
-// Excluded:
-//   - either decision is not a review-type (architecture decisions can
-//     legitimately span multiple tickets; let the LLM read them)
-//   - same agent (deliberate cross-ticket comparison, keep recall)
-//   - precedent-linked pairs (lineage already declared)
-//   - either side has no extractable ticket (no join key — the existing
-//     ticket-blind filters above already handled the no-ticket case)
-//   - any shared ticket between the two decisions (handled by other
-//     same-ticket filters; not this filter's job)
-//
-// Recall risk: medium. Genuine cross-agent cross-ticket architectural
-// contradictions exist (agent A on ARD-957 picked design X for the
-// subsystem; agent B on ARD-958 picked incompatible design Y for the
-// same subsystem). The cross-encoder pass downstream provides a soft
-// second gate. We accept this trade because the observed FP rate of this
-// pattern (10/71 ≈ 14%) is the dominant remaining noise source and the
-// suppressed pairs are debug-logged for retrospective audit.
-func isDisjointTicketReviewPair(d, cand model.Decision) bool {
-	if !reviewTypes[strings.ToLower(d.DecisionType)] {
-		return false
-	}
-	if !reviewTypes[strings.ToLower(cand.DecisionType)] {
-		return false
-	}
-	if d.AgentID == cand.AgentID {
-		return false
-	}
-	if isPrecedentLinked(d, cand) {
-		return false
-	}
-	refsA := extractTicketRefs(d)
-	refsB := extractTicketRefs(cand)
-	return ticketSetsDisjoint(refsA, refsB)
 }
 
 // isSameBranchMechanicalHousekeeping returns true when two decisions are

--- a/internal/conflicts/scorer.go
+++ b/internal/conflicts/scorer.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -641,6 +642,22 @@ func (s *Scorer) scoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 			continue
 		}
 
+		// Same-branch mechanical housekeeping filter: when two DIFFERENT
+		// agents both operate on the same branch and both outcomes describe
+		// pure mechanical operations (renumber/rebase/merge resolution/
+		// version bump), the pair is a handoff on the same housekeeping
+		// task, not disagreement. Complement to isCrossBranchMechanical
+		// (which requires different branches) and isSameBranchSelfCorrection
+		// (which requires the same agent). See issue #717 FP audit.
+		if isSameBranchMechanicalHousekeeping(d, sc.cand) {
+			s.metrics.sameBranchMechanicalFiltered.Add(ctx, 1)
+			s.logger.Debug("conflict scorer: same-branch mechanical housekeeping suppressed pair",
+				"decision_a", decisionID, "decision_b", sc.cand.ID,
+				"agent_a", d.AgentID, "agent_b", sc.cand.AgentID,
+				"branch", nestedContextString(d.AgentContext, "git_branch"))
+			continue
+		}
+
 		// Same-agent same-ticket refinement filter: when the same agent
 		// traces a refinement of their own prior decision on the same ticket
 		// without setting supersedes_id, treat it as a missed-link refinement
@@ -660,6 +677,23 @@ func (s *Scorer) scoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 			continue
 		}
 
+		// PR-series layer marker filter: when two CROSS-agent decisions
+		// reference the same ticket and at least one outcome carries a
+		// PR-series layer marker (S1/S2/layer N/phase N/step N/stage N/
+		// PR-N), the pair is a sequential delivery of that ticket — one
+		// agent reviews the S1 PR, another agent ships the S2 PR. Sibling
+		// of isSameAgentSameTicketRefinement that handles the cross-agent
+		// case. See issue #717 FP audit.
+		if isPRSeriesLayerRefinement(d, sc.cand) {
+			s.metrics.prSeriesLayerFiltered.Add(ctx, 1)
+			s.logger.Debug("conflict scorer: PR-series layer refinement suppressed pair",
+				"decision_a", decisionID, "decision_b", sc.cand.ID,
+				"agent_a", d.AgentID, "agent_b", sc.cand.AgentID,
+				"marker_a", extractLayerMarker(d.Outcome),
+				"marker_b", extractLayerMarker(sc.cand.Outcome))
+			continue
+		}
+
 		// Temporal re-assessment filter: two review-type decisions on the
 		// same project, recorded sufficiently far apart with no precedent
 		// link, are re-measurements rather than contradictions. Quantitative
@@ -672,6 +706,22 @@ func (s *Scorer) scoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 				"type_a", d.DecisionType, "type_b", sc.cand.DecisionType,
 				"project", derefString(d.Project),
 				"delta", d.ValidFrom.Sub(sc.cand.ValidFrom).Abs())
+			continue
+		}
+
+		// Disjoint-ticket review filter: two CROSS-agent review-type
+		// decisions whose ticket sets are entirely disjoint cannot be
+		// contradictions — they are reviewing different problems. Gated
+		// on review-types and cross-agent to preserve recall on
+		// deliberate same-agent cross-ticket architectural comparisons.
+		// See issue #717 FP audit (10/71 FPs matched this pattern).
+		if isDisjointTicketReviewPair(d, sc.cand) {
+			s.metrics.disjointTicketReviewFiltered.Add(ctx, 1)
+			s.logger.Debug("conflict scorer: disjoint-ticket review pair suppressed",
+				"decision_a", decisionID, "decision_b", sc.cand.ID,
+				"agent_a", d.AgentID, "agent_b", sc.cand.AgentID,
+				"tickets_a", extractTicketRefs(d),
+				"tickets_b", extractTicketRefs(sc.cand))
 			continue
 		}
 
@@ -1576,6 +1626,199 @@ func isTemporalReassessment(d, cand model.Decision) bool {
 	return delta >= temporalReassessmentWindow
 }
 
+// layerMarkerPattern matches PR-series delivery markers like "S1", "S2",
+// "layer 3", "phase 2", "step 4", "stage 1", "PR-2". These appear in outcome
+// text when an agent delivers a single ticket as a sequence of PRs
+// ("Reviewed ARD-958 S1 PR", "ARD-958 S2 implemented on branch...").
+//
+// The pattern is deliberately conservative: it accepts the canonical labels
+// and a single digit (1-9). Multi-digit indices (S10, layer 12) are rare in
+// practice and admitting them risks colliding with version strings or
+// migration numbers. If wider matching becomes necessary, prefer extending
+// the alternation to specific labels rather than relaxing the digit class.
+var layerMarkerPattern = regexp.MustCompile(`(?i)\b(?:S[1-9]|layer[\s_-]*[1-9]|phase[\s_-]*[1-9]|step[\s_-]*[1-9]|stage[\s_-]*[1-9]|PR[\s_-]*[1-9])\b`)
+
+// extractLayerMarker returns the canonical lowercased+space-normalised layer
+// marker found in s, or "" if none is present. "PR-2", "PR 2", and "PR_2"
+// all canonicalise to "pr 2"; "S1" stays "s1". Used by
+// isPRSeriesLayerRefinement to detect when two outcomes are different
+// stages of the same delivery rather than competing positions.
+func extractLayerMarker(s string) string {
+	if s == "" {
+		return ""
+	}
+	m := layerMarkerPattern.FindString(s)
+	if m == "" {
+		return ""
+	}
+	lower := strings.ToLower(m)
+	// Collapse "-" and "_" to spaces so "PR-2" / "PR_2" / "PR 2" all hash to
+	// the same canonical form for cross-outcome comparison.
+	lower = strings.ReplaceAll(lower, "-", " ")
+	lower = strings.ReplaceAll(lower, "_", " ")
+	// Squash any internal whitespace runs to a single space.
+	return strings.Join(strings.Fields(lower), " ")
+}
+
+// isPRSeriesLayerRefinement returns true when two cross-agent decisions
+// reference the same ticket and at least one outcome carries a PR-series
+// layer marker ("S1", "layer 3", "phase 2", "PR-2"). The pair is then a
+// sequential delivery of one ticket — reviewer reviews S1, implementer
+// ships S2 — not a contradiction.
+//
+// Sibling of isSameAgentSameTicketRefinement (#711): that filter handles
+// the same-agent variant. This one handles the cross-agent variant
+// surfaced by the issue #717 FP audit (claude-code reviews ARD-958 S1,
+// reviewer reviews ARD-958 S2; both code_review; topical overlap fools
+// the embedder into flagging contradiction).
+//
+// Excluded:
+//   - same agent (caught upstream by #711)
+//   - precedent-linked pairs (an explicit lineage signal already exists)
+//   - neither outcome has a layer marker (no PR-series evidence)
+//   - both outcomes share the same marker (probable duplicate review of
+//     the same layer, not a chain)
+//   - the later outcome contains an explicit supersession keyword (the
+//     reversal is stated, let the LLM read it)
+//
+// Recall risk: low. Same-ticket cross-agent disagreement WITHOUT layer
+// markers still flows to the LLM. Same-ticket cross-agent disagreement
+// WITH layer markers but where the agent intends to contradict (rather
+// than ship the next stage) would have to phrase the contradiction without
+// any of the supersession verbs — uncommon in practice.
+func isPRSeriesLayerRefinement(d, cand model.Decision) bool {
+	if d.AgentID == cand.AgentID {
+		return false
+	}
+	if isPrecedentLinked(d, cand) {
+		return false
+	}
+	refsA := extractTicketRefs(d)
+	if len(refsA) == 0 {
+		return false
+	}
+	refsB := extractTicketRefs(cand)
+	if !shareAny(refsA, refsB) {
+		return false
+	}
+	markerA := extractLayerMarker(d.Outcome)
+	markerB := extractLayerMarker(cand.Outcome)
+	if markerA == "" && markerB == "" {
+		return false
+	}
+	if markerA != "" && markerB != "" && markerA == markerB {
+		return false
+	}
+	later := d
+	if cand.ValidFrom.After(d.ValidFrom) {
+		later = cand
+	}
+	if containsSupersessionKeyword(later.Outcome) {
+		return false
+	}
+	return true
+}
+
+// shareAny returns true when slices a and b share at least one element.
+// Both slices are expected to be small (typical ticket count per decision
+// is 1-3), so the nested loop is fine.
+func shareAny(a, b []string) bool {
+	for _, x := range a {
+		for _, y := range b {
+			if x == y {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// isDisjointTicketReviewPair returns true when two cross-agent review-type
+// decisions reference *non-overlapping* sets of tickets. Two reviewers
+// looking at different tickets in the same product produce embeddings
+// close enough to trip the scorer ("pgstream slot drain bug" vs "pgstream
+// snapshot validator design") even though they cannot contradict — they
+// are about different problems.
+//
+// The cross-agent gate is the recall safety belt: a single agent
+// deliberately comparing ARD-957 and ARD-958 designs in one decision is
+// authoring exactly the cross-ticket judgement we DO want to preserve;
+// suppressing same-agent disjoint pairs would erase that signal. The
+// observed FPs in the #717 audit were unanimously cross-agent
+// (claude-code | reviewer the dominant pair).
+//
+// Excluded:
+//   - either decision is not a review-type (architecture decisions can
+//     legitimately span multiple tickets; let the LLM read them)
+//   - same agent (deliberate cross-ticket comparison, keep recall)
+//   - precedent-linked pairs (lineage already declared)
+//   - either side has no extractable ticket (no join key — the existing
+//     ticket-blind filters above already handled the no-ticket case)
+//   - any shared ticket between the two decisions (handled by other
+//     same-ticket filters; not this filter's job)
+//
+// Recall risk: medium. Genuine cross-agent cross-ticket architectural
+// contradictions exist (agent A on ARD-957 picked design X for the
+// subsystem; agent B on ARD-958 picked incompatible design Y for the
+// same subsystem). The cross-encoder pass downstream provides a soft
+// second gate. We accept this trade because the observed FP rate of this
+// pattern (10/71 ≈ 14%) is the dominant remaining noise source and the
+// suppressed pairs are debug-logged for retrospective audit.
+func isDisjointTicketReviewPair(d, cand model.Decision) bool {
+	if !reviewTypes[strings.ToLower(d.DecisionType)] {
+		return false
+	}
+	if !reviewTypes[strings.ToLower(cand.DecisionType)] {
+		return false
+	}
+	if d.AgentID == cand.AgentID {
+		return false
+	}
+	if isPrecedentLinked(d, cand) {
+		return false
+	}
+	refsA := extractTicketRefs(d)
+	refsB := extractTicketRefs(cand)
+	return ticketSetsDisjoint(refsA, refsB)
+}
+
+// isSameBranchMechanicalHousekeeping returns true when two decisions are
+// authored by *different* agents on the *same* git branch and both
+// outcomes describe pure mechanical operations (migration renumbering,
+// rebase, merge conflict resolution, version bump).
+//
+// Complement to isCrossBranchMechanical and isSameBranchSelfCorrection:
+//   - isCrossBranchMechanical: different branches + both mechanical
+//     (parallel housekeeping resolved by merge order)
+//   - isSameBranchSelfCorrection: same agent + same branch (iterative
+//     self-correction regardless of outcome content)
+//   - isSameBranchMechanicalHousekeeping (this filter): same branch +
+//     different agents + both mechanical (handoff/help on the same
+//     housekeeping task, e.g. one agent rebases, another renumbers
+//     migrations on the same branch)
+//
+// The #717 audit found ~6 FPs in this exact shape — outcomes like
+// "Merged origin/main into evanvolgas/fix-sse-heartbeat, renumbering
+// migration 097→098" paired across agents on the SAME branch. The
+// existing cross-branch filter required different branches, so these
+// slipped through.
+//
+// Recall risk: low. Two genuinely contradictory architecture decisions on
+// the same branch by different agents are very unlikely to both phrase
+// themselves as pure mechanical operations (the mechanical keyword check
+// is strict: renumber/migration/rebase/merge conflict/version bump).
+func isSameBranchMechanicalHousekeeping(d, cand model.Decision) bool {
+	if d.AgentID == cand.AgentID {
+		return false
+	}
+	branchA := nestedContextString(d.AgentContext, "git_branch")
+	branchB := nestedContextString(cand.AgentContext, "git_branch")
+	if branchA == "" || branchB == "" || branchA != branchB {
+		return false
+	}
+	return isMechanicalOperation(d.Outcome) && isMechanicalOperation(cand.Outcome)
+}
+
 // isPrecedentLinked returns true if either decision cites the other via
 // precedent_ref, meaning there is an explicit lineage link between them.
 func isPrecedentLinked(d, cand model.Decision) bool {
@@ -1590,6 +1833,12 @@ func isPrecedentLinked(d, cand model.Decision) bool {
 
 // supersessionKeywords are outcome substrings that indicate the decision
 // reverses or replaces a prior decision rather than refining it.
+//
+// The "walk-back" group (shelved, dropped, pivoting, …) was added after the
+// #717 FP audit observed agents stating their own reversal in plain English
+// — "Shelved the draft; pivoting to a different topic" — without the
+// existing same-agent same-ticket filter recognising the reversal because
+// the keyword list missed the verb.
 var supersessionKeywords = []string{
 	"switched",
 	"superseding",
@@ -1606,6 +1855,30 @@ var supersessionKeywords = []string{
 	"no longer",
 	"abandoned",
 	"abandoning",
+	// Walk-back / pivot vocabulary surfaced by issue #717 FP audit.
+	"shelved",
+	"shelving",
+	"dropped",
+	"dropping",
+	"pivoting",
+	"pivoted",
+	"walked back",
+	"walking back",
+	"rewrote",
+	"rewriting",
+	"rewritten",
+	"scrapped",
+	"scrapping",
+	"discarded",
+	"discarding",
+	"retracted",
+	"retracting",
+	"withdrew",
+	"withdrawing",
+	"tabled",
+	"parked",
+	"deprecated this",
+	"deprecating",
 }
 
 // containsSupersessionKeyword returns true if the outcome text contains any

--- a/internal/conflicts/scorer_test.go
+++ b/internal/conflicts/scorer_test.go
@@ -3239,3 +3239,75 @@ func TestScoreForDecision_SameAgentSameTicketSuggestion(t *testing.T) {
 	assert.Contains(t, suggestions[0].Reason, "ARD-958")
 	assert.Contains(t, suggestions[0].Reason, agentID)
 }
+
+func TestScoreForDecision_SameBranchCrossAgentMechanicalReachesValidator(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	orgID := uuid.Nil
+
+	suffix := uuid.New().String()[:8]
+	agentA := "same-branch-mech-a-" + suffix
+	agentB := "same-branch-mech-b-" + suffix
+	for _, agentID := range []string{agentA, agentB} {
+		_, err := testDB.CreateAgent(ctx, model.Agent{
+			AgentID: agentID, OrgID: orgID, Name: agentID, Role: model.RoleAgent,
+		})
+		require.NoError(t, err)
+	}
+
+	runA := createRun(t, agentA, orgID)
+	runB := createRun(t, agentB, orgID)
+	project := "same-branch-mechanical-" + suffix
+	branch := "feature/same-branch-mechanical-" + suffix
+	agentCtx := map[string]any{"client": map[string]any{"git_branch": branch}}
+
+	topicEmb := makeEmbedding(930, 1.0)
+	outcomeEmbA := makeEmbedding(931, 1.0)
+	outcomeEmbB := makeEmbedding(932, 1.0)
+
+	dA, err := testDB.CreateDecision(ctx, model.Decision{
+		RunID: runA.ID, AgentID: agentA, OrgID: orgID,
+		DecisionType: "bug_fix",
+		Outcome:      "Resolved merge conflicts by keeping migration 101 before 102",
+		Confidence:   0.9,
+		Embedding:    &topicEmb, OutcomeEmbedding: &outcomeEmbA,
+		AgentContext: agentCtx,
+		Project:      &project,
+	})
+	require.NoError(t, err)
+
+	dB, err := testDB.CreateDecision(ctx, model.Decision{
+		RunID: runB.ID, AgentID: agentB, OrgID: orgID,
+		DecisionType: "bug_fix",
+		Outcome:      "Resolved merge conflicts by keeping migration 102 before 101",
+		Confidence:   0.9,
+		Embedding:    &topicEmb, OutcomeEmbedding: &outcomeEmbB,
+		AgentContext: agentCtx,
+		Project:      &project,
+	})
+	require.NoError(t, err)
+
+	validator := &scorerMockValidator{
+		result: ValidationResult{Relationship: "contradiction", Severity: "high", Category: "factual"},
+	}
+	scorer := NewScorer(testDB, logger, 0.1, validator, 0, 0)
+	scorer = scorer.WithCandidateFinder(storage.NewPgCandidateFinder(testDB))
+	scorer.ScoreForDecision(ctx, dB.ID, orgID)
+
+	assert.Greater(t, validator.calls, 0,
+		"same-branch cross-agent mechanical pairs must reach validation, not a hard suppression")
+
+	conflicts, err := testDB.ListConflicts(ctx, orgID, storage.ConflictFilters{}, 1000, 0)
+	require.NoError(t, err)
+	var found bool
+	for _, c := range conflicts {
+		aMatch := c.DecisionAID == dA.ID || c.DecisionBID == dA.ID
+		bMatch := c.DecisionAID == dB.ID || c.DecisionBID == dB.ID
+		if aMatch && bMatch {
+			found = true
+			assert.Equal(t, "llm_v2", c.ScoringMethod)
+			break
+		}
+	}
+	assert.True(t, found, "validator-confirmed mechanical disagreement should retain a durable conflict record")
+}

--- a/internal/conflicts/ticket_extract.go
+++ b/internal/conflicts/ticket_extract.go
@@ -98,22 +98,3 @@ func matchTicketRef(s string) string {
 	}
 	return strings.ToUpper(m[1]) + "-" + m[2]
 }
-
-// ticketSetsDisjoint returns true when neither a nor b is empty and the two
-// slices share no element. Used by the disjoint-ticket pre-filter to verify
-// that two review-type decisions are operating on different ticket scopes.
-// O(len(a)*len(b)) is fine for the small slices these decisions produce
-// (typically 1-3 entries each).
-func ticketSetsDisjoint(a, b []string) bool {
-	if len(a) == 0 || len(b) == 0 {
-		return false
-	}
-	for _, x := range a {
-		for _, y := range b {
-			if x == y {
-				return false
-			}
-		}
-	}
-	return true
-}

--- a/internal/conflicts/ticket_extract.go
+++ b/internal/conflicts/ticket_extract.go
@@ -28,17 +28,66 @@ var ticketRefPattern = regexp.MustCompile(`(?i)\b([A-Z]{3,10})-(\d+)\b`)
 // contradictions when the same agent refines their own prior decision on the
 // same ticket without setting supersedes_id.
 func extractTicketRef(d model.Decision) string {
-	if ref := matchTicketRef(nestedContextString(d.AgentContext, "task")); ref != "" {
-		return ref
+	refs := extractTicketRefs(d)
+	if len(refs) == 0 {
+		return ""
 	}
-	if ref := matchTicketRef(nestedContextString(d.AgentContext, "git_branch")); ref != "" {
-		return ref
+	return refs[0]
+}
+
+// extractTicketRefs returns every canonical ticket reference visible in a
+// decision, deduplicated and ordered by source priority then occurrence.
+// Sources are walked in the same priority order as extractTicketRef
+// (task → branch → outcome); within a single source, references are returned
+// in the order they appear.
+//
+// Used by structural pre-filters that need to compare *sets* of tickets
+// across two decisions — e.g. the disjoint-ticket filter and the PR-series
+// layer-marker filter both need to recognise that a single outcome can
+// legitimately mention several tickets and we should not throw away the
+// non-primary ones.
+//
+// Returns nil when nothing is extractable from any source.
+func extractTicketRefs(d model.Decision) []string {
+	var out []string
+	seen := map[string]struct{}{}
+	add := func(s string) {
+		for _, m := range allTicketRefs(s) {
+			if _, dup := seen[m]; dup {
+				continue
+			}
+			seen[m] = struct{}{}
+			out = append(out, m)
+		}
 	}
-	return matchTicketRef(d.Outcome)
+	add(nestedContextString(d.AgentContext, "task"))
+	add(nestedContextString(d.AgentContext, "git_branch"))
+	add(d.Outcome)
+	return out
+}
+
+// allTicketRefs returns every canonical ticket reference found in s, in the
+// order they appear. Duplicates within a single string are preserved here —
+// callers that want set semantics should dedupe across sources.
+func allTicketRefs(s string) []string {
+	if s == "" {
+		return nil
+	}
+	matches := ticketRefPattern.FindAllStringSubmatch(s, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(matches))
+	for _, m := range matches {
+		out = append(out, strings.ToUpper(m[1])+"-"+m[2])
+	}
+	return out
 }
 
 // matchTicketRef applies ticketRefPattern to s and returns the canonical
 // uppercase ticket reference (e.g. "ARD-958"), or "" if none found.
+// Returns only the first match; callers that need every match should use
+// allTicketRefs.
 func matchTicketRef(s string) string {
 	if s == "" {
 		return ""
@@ -48,4 +97,23 @@ func matchTicketRef(s string) string {
 		return ""
 	}
 	return strings.ToUpper(m[1]) + "-" + m[2]
+}
+
+// ticketSetsDisjoint returns true when neither a nor b is empty and the two
+// slices share no element. Used by the disjoint-ticket pre-filter to verify
+// that two review-type decisions are operating on different ticket scopes.
+// O(len(a)*len(b)) is fine for the small slices these decisions produce
+// (typically 1-3 entries each).
+func ticketSetsDisjoint(a, b []string) bool {
+	if len(a) == 0 || len(b) == 0 {
+		return false
+	}
+	for _, x := range a {
+		for _, y := range b {
+			if x == y {
+				return false
+			}
+		}
+	}
+	return true
 }

--- a/internal/conflicts/ticket_extract_test.go
+++ b/internal/conflicts/ticket_extract_test.go
@@ -179,8 +179,8 @@ func TestIsSameAgentSameTicketRefinement(t *testing.T) {
 			},
 			cand: model.Decision{
 				ID: idB, AgentID: "claude-code",
-				AgentContext: taskCtx("", "evanvolgas/ard-958-rewrite"),
-				Outcome:      "Rewrote streaming layer", ValidFrom: now.Add(time.Hour),
+				AgentContext: taskCtx("", "evanvolgas/ard-958-followup"),
+				Outcome:      "Streaming layer refined further", ValidFrom: now.Add(time.Hour),
 			},
 			expected: true,
 		},


### PR DESCRIPTION
## Summary

The conflict detector has been running at an 87 % rolling-30-day false-positive rate. This PR ships four new structural pre-filters plus a keyword expansion, each independently revertible via its own OTel counter.

Closes #717.

## What this changes

- **Walk-back vocabulary expansion** in `supersessionKeywords` — adds ~15 verbs (`shelved`, `dropped`, `pivoting`, `rewrote`, `walked back`, `scrapped`, `discarded`, `retracted`, `tabled`, `parked`, `deprecated this`, …). Tips the existing same-agent same-ticket filter into firing on outcomes where agents stated their own reversal in plain English.
- **`isPRSeriesLayerRefinement`** — cross-agent same-ticket pairs where at least one outcome carries an `S\d` / `layer N` / `phase N` / `step N` / `stage N` / `PR-N` marker. Sibling of #711 (which handles the same-agent variant). Counter: `akashi.conflicts.pr_series_layer_filtered`.
- **`isDisjointTicketReviewPair`** — cross-agent review-type decisions whose extracted ticket sets are entirely disjoint. Cross-agent gate is the recall safety belt: same-agent disjoint pairs (deliberate cross-ticket comparison) pass through. Counter: `akashi.conflicts.disjoint_ticket_review_filtered`.
- **`isSameBranchMechanicalHousekeeping`** — cross-agent same-branch pairs where both outcomes are pure mechanical operations (renumber / rebase / merge resolution / version bump). Complement to the existing `isCrossBranchMechanical` (different branches) and `isSameBranchSelfCorrection` (same agent). Counter: `akashi.conflicts.same_branch_mechanical_filtered`.
- **`extractTicketRefs(d) []string`** — new multi-ticket API that returns every canonical ticket reference in source-priority order with deduplication. Fixes a latent first-match blindspot in the prior single-ticket extractor when one outcome co-mentions multiple tickets. `extractTicketRef` remains the single-ticket API.

## How I got here

Audited all 71 labelled FPs from the audit trail (subagent dumped the full set and clustered by surviving-filter pattern). Pattern frequencies:

| Pattern | FPs |
|---|---|
| PR-series layer markers (cross-agent same-ticket) | 13 |
| Walk-back vocabulary not in keyword list | 10–12 |
| Cross-agent disjoint-ticket review chains | 10 |
| Same-branch cross-agent mechanical housekeeping | 6 |

The hypothesised NULL-project leakage filter was dropped: zero FPs matched that pattern. Templated-review-boilerplate suppression (~18 more FPs) is excluded as a follow-up — phrase-prefix matching has higher recall risk and qualitatively differs from the deterministic predicates here.

## Expected impact

**30–40 of 71 labelled FPs suppressed (42–56 %).** Conservative — some FPs match multiple patterns.

## Recall risk

| Filter | Risk |
|---|---|
| Walk-back keywords | low |
| PR-series layer marker | low |
| Disjoint-ticket (cross-agent gated) | medium — genuine cross-agent cross-ticket architectural contradictions exist; mitigated by cross-agent gate + downstream cross-encoder; suppressions are debug-logged for retrospective audit |
| Same-branch mechanical (cross-agent gated) | low |

Each filter has its own counter so any single filter can be backed out without disturbing the others.

## Honest caveat (re: field-assessment-2026-05.md)

The field report recommended retraining or replacing the LLM validator. This PR commits to extending the structural pre-filter ladder instead, on the basis that the approach has a track record (PR #579 took FP from 51 % to <5 % on its measured slice) and is much cheaper than retraining. If the rolling FP rate does not drop materially within a release cycle, the field report's harder recommendation becomes load-bearing.

## Test plan

- [x] `go test -race -count=1 ./...` — all packages pass
- [x] `go test -race -count=1 -tags integration ./internal/conflicts/... ./internal/storage/... ./internal/server/...` — all green
- [x] `golangci-lint run ./...` — 0 issues
- [x] `atlas migrate validate` — clean
- [x] New unit tests in `internal/conflicts/issue_717_filters_test.go` cover positive case, negative case (different ticket / agent / linked), edge cases drawn from the actual FP dump
- [ ] Watch the new counters in Honeycomb for a release cycle; if disjoint-ticket suppressions show any pair the team disagrees with, back the disjoint filter out via its dedicated counter

> Tolkien edges Star Wars on the strength of small wisdom.
> Star Wars solves problems by destroying a Death Star;
> Tolkien solves them by deciding to walk a narrower road than you might have wanted.
> The Ring goes to Mount Doom, not to war.
> A pre-filter runs before the LLM, not in place of it.