### PR TITLE
feat(assess): pending-assessment prompt loop (#716)

### DIFF
--- a/akashi.go
+++ b/akashi.go
@@ -54,6 +54,7 @@ import (
 	"github.com/ashita-ai/akashi/internal/service/autoresolve"
 	"github.com/ashita-ai/akashi/internal/service/decisions"
 	"github.com/ashita-ai/akashi/internal/service/embedding"
+	"github.com/ashita-ai/akashi/internal/service/pendingassess"
 	"github.com/ashita-ai/akashi/internal/service/quality"
 	"github.com/ashita-ai/akashi/internal/service/trace"
 	"github.com/ashita-ai/akashi/internal/storage"
@@ -393,9 +394,13 @@ func New(opts ...Option) (*App, error) {
 	// Grant cache.
 	grantCache := authz.NewGrantCache(30 * time.Second)
 
+	// Outcome-assessment prompt service (issue #716).
+	pendingAssess := pendingassess.New(db, cfg.AssessmentWindows, cfg.AssessmentPromptLimit)
+
 	// MCP server.
 	mcpSrv := mcp.New(db, decisionSvc, grantCache, logger, version, cfg.HighConfidenceWarnThreshold, quality.BuildStandardTypes(cfg.StandardDecisionTypes))
 	mcpSrv.SetAutoAssessor(assessor)
+	mcpSrv.SetPendingAssessor(pendingAssess)
 
 	// SSE broker.
 	var broker *server.Broker
@@ -483,6 +488,7 @@ func New(opts ...Option) (*App, error) {
 		ConflictValidator:           conflictValidator,
 		HighConfidenceWarnThreshold: cfg.HighConfidenceWarnThreshold,
 		ExportPageSize:              cfg.ExportPageSize,
+		PendingAssessSvc:            pendingAssess,
 	})
 
 	// Wire akashi_check → IDE hook gate.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1178,6 +1178,69 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
+  /v1/decisions/pending-assessment:
+    get:
+      operationId: listPendingAssessments
+      tags: [Decisions]
+      summary: List decisions past their assessment window
+      description: |
+        Surface decisions that are older than their per-type
+        outcome-assessment window and have no recorded assessment from any
+        source (manual or auto). Use the returned `decision_id` values to
+        follow up via `POST /v1/decisions/{id}/assess`.
+
+        Default scope is the caller's own `agent_id`. Pass `agent_id=*`
+        to expand to all decisions the caller has access to (subject to
+        per-org grant filtering). A decision_type with no configured
+        window returns zero rows by design (opt-out).
+
+        Returns 404 when pending-assessment prompting is not configured
+        on this deployment.
+
+        Requires `reader` role or higher.
+      parameters:
+        - name: agent_id
+          in: query
+          description: |
+            `*` for all accessible agents; specific id to scope; omit to
+            default to the caller's own agent_id.
+          schema:
+            type: string
+        - name: decision_type
+          in: query
+          description: Optional. Narrow to a single decision type.
+          schema:
+            type: string
+        - name: project
+          in: query
+          description: Optional. Restrict to one project.
+          schema:
+            type: string
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+      responses:
+        "200":
+          description: Pending-assessment list.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: "#/components/schemas/PendingAssessmentListResponse"
+                  meta:
+                    $ref: "#/components/schemas/ResponseMeta"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
   /v1/decisions/{id}/assessments:
     get:
       operationId: listDecisionAssessments
@@ -3755,6 +3818,59 @@ components:
         incorrect:
           type: integer
         partially_correct:
+          type: integer
+
+    PendingAssessment:
+      type: object
+      description: |
+        A decision past its outcome-assessment window with no recorded
+        assessment from any source (manual or auto). Returned by
+        `GET /v1/decisions/pending-assessment` to prompt agents to follow
+        up via `akashi_assess`.
+      required:
+        - decision_id
+        - agent_id
+        - decision_type
+        - outcome
+        - confidence
+        - valid_from
+        - age_hours
+      properties:
+        decision_id:
+          type: string
+          format: uuid
+        agent_id:
+          type: string
+        decision_type:
+          type: string
+        outcome:
+          type: string
+          description: The decision's `outcome` text (not an assessment verdict).
+        confidence:
+          type: number
+          format: float
+        project:
+          type: string
+          nullable: true
+        valid_from:
+          type: string
+          format: date-time
+        age_hours:
+          type: number
+          format: double
+          description: Hours since `valid_from`, computed server-side at query time.
+
+    PendingAssessmentListResponse:
+      type: object
+      required:
+        - decisions
+        - count
+      properties:
+        decisions:
+          type: array
+          items:
+            $ref: "#/components/schemas/PendingAssessment"
+        count:
           type: integer
 
     DecisionAssessment:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -199,6 +199,8 @@ Existing deployments that set `AKASHI_WAL_DIR` explicitly will continue to work 
 | `AKASHI_SHUTDOWN_LOOP_DRAIN_TIMEOUT` | `10s` | Maximum time to wait for background loops (conflict backfill, retention, integrity audit, etc.) to exit during shutdown. `0` = wait indefinitely |
 | `AKASHI_PERCENTILE_REFRESH_INTERVAL` | `1h` | How often to refresh per-org signal percentile caches used for distribution-aware ReScore normalization. Set to `0` to disable |
 | `AKASHI_AUTO_RESOLVE_INTERVAL` | `1h` | How often the background auto-resolution worker runs to resolve eligible conflicts per org policy. Set to `0` to disable |
+| `AKASHI_ASSESSMENT_PROMPT_LIMIT` | `10` | Maximum decisions returned by `GET /v1/decisions/pending-assessment` and the `akashi_pending_assessments` MCP tool in a single call. Range: 1–100 |
+| `AKASHI_ASSESSMENT_WINDOW_<TYPE>` | _see below_ | Per-decision-type window (`time.Duration`) before an unassessed decision is surfaced for follow-up. `<TYPE>` is uppercased (e.g. `AKASHI_ASSESSMENT_WINDOW_ARCHITECTURE=72h`). The literal value `0` disables prompting for that type. Built-in defaults: `architecture`, `security`, `design`, `trade_off` = 168h (7d); `planning` = 720h (30d); all other types = disabled |
 
 ## Write Idempotency
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -159,6 +159,28 @@ type Config struct {
 	// When set, replaces the built-in 12 defaults. Example:
 	//   "architecture,security,data_pipeline,access_control"
 	StandardDecisionTypes []string
+
+	// Outcome assessment prompting.
+	//
+	// AssessmentWindows maps decision_type → minimum age before the decision is
+	// surfaced via GET /v1/decisions/pending-assessment (or akashi_pending_assessments).
+	// A zero duration disables prompting for that type — used to suppress noisy
+	// types (code_review, implementation, investigation) where follow-up assessment
+	// adds little value.
+	//
+	// Defaults (May 2026 field assessment, internal strategy doc):
+	//   architecture / security / design / trade_off:  168h  (7 days)
+	//   planning:                                       720h  (30 days)
+	//   everything else:                                  0   (disabled)
+	//
+	// Override per-type via env: AKASHI_ASSESSMENT_WINDOW_<TYPE>=<duration>
+	// (TYPE is uppercased; e.g. AKASHI_ASSESSMENT_WINDOW_ARCHITECTURE=72h).
+	// Setting the value to "0" opts a previously-enabled type out.
+	AssessmentWindows map[string]time.Duration
+
+	// AssessmentPromptLimit bounds the number of pending decisions surfaced
+	// to a single MCP/HTTP call. Default 10; AKASHI_ASSESSMENT_PROMPT_LIMIT.
+	AssessmentPromptLimit int
 }
 
 // Load reads configuration from environment variables with sensible defaults.
@@ -301,6 +323,10 @@ func Load() (Config, error) {
 	cfg.ClaimRetryInterval, errs = collectDuration(errs, "AKASHI_CLAIM_RETRY_INTERVAL", 2*time.Minute)
 	cfg.PercentileRefreshInterval, errs = collectDuration(errs, "AKASHI_PERCENTILE_REFRESH_INTERVAL", 1*time.Hour)
 	cfg.AutoResolveInterval, errs = collectDuration(errs, "AKASHI_AUTO_RESOLVE_INTERVAL", 1*time.Hour)
+
+	// Per-type outcome-assessment windows.
+	cfg.AssessmentWindows, errs = loadAssessmentWindows(errs)
+	cfg.AssessmentPromptLimit, errs = collectInt(errs, "AKASHI_ASSESSMENT_PROMPT_LIMIT", 10)
 
 	if len(errs) > 0 {
 		msgs := make([]string, len(errs))
@@ -463,6 +489,17 @@ func (c Config) Validate() error {
 	if c.ConflictOutcomeSimFloor < 0 || c.ConflictOutcomeSimFloor > 1 {
 		errs = append(errs, errors.New("config: AKASHI_CONFLICT_OUTCOME_SIM_FLOOR must be between 0.0 and 1.0 (0 disables)"))
 	}
+	// AssessmentPromptLimit: only reject explicitly-set out-of-range values.
+	// 0 is permitted (handlers fall back to the service default) so tests
+	// constructing partial Configs don't have to set every new field.
+	if c.AssessmentPromptLimit < 0 || c.AssessmentPromptLimit > 100 {
+		errs = append(errs, fmt.Errorf("config: AKASHI_ASSESSMENT_PROMPT_LIMIT must be between 1 and 100 (got %d)", c.AssessmentPromptLimit))
+	}
+	for t, d := range c.AssessmentWindows {
+		if d < 0 {
+			errs = append(errs, fmt.Errorf("config: AKASHI_ASSESSMENT_WINDOW_%s must be >= 0 (0 disables)", strings.ToUpper(t)))
+		}
+	}
 
 	// WAL fail-safe: refuse to start without WAL unless explicitly disabled.
 	// The envStr helper prevents AKASHI_WAL_DIR="" from clearing the default,
@@ -580,6 +617,59 @@ func envDuration(key string, fallback time.Duration) (time.Duration, error) {
 
 // envStrSlice reads a comma-separated env var into a string slice.
 // Returns fallback if the env var is empty or unset.
+
+// defaultAssessmentWindows returns the built-in per-type windows used when
+// no AKASHI_ASSESSMENT_WINDOW_* override is supplied for a type. Values are
+// drawn from the May 2026 field assessment: assessment loops are only useful
+// for decision types that carry forward constraints worth revisiting.
+//
+// Types not in this map default to 0 (assessment prompting disabled).
+func defaultAssessmentWindows() map[string]time.Duration {
+	return map[string]time.Duration{
+		"architecture": 7 * 24 * time.Hour,
+		"security":     7 * 24 * time.Hour,
+		"design":       7 * 24 * time.Hour,
+		"trade_off":    7 * 24 * time.Hour,
+		"planning":     30 * 24 * time.Hour,
+	}
+}
+
+// loadAssessmentWindows starts from the built-in defaults and applies any
+// AKASHI_ASSESSMENT_WINDOW_<TYPE> overrides found in the environment. An
+// override value of "0" disables a previously-enabled type; a positive
+// duration enables a type that defaulted to disabled.
+func loadAssessmentWindows(errs []error) (map[string]time.Duration, []error) {
+	windows := defaultAssessmentWindows()
+	const prefix = "AKASHI_ASSESSMENT_WINDOW_"
+	for _, kv := range os.Environ() {
+		eq := strings.IndexByte(kv, '=')
+		if eq < 0 {
+			continue
+		}
+		key := kv[:eq]
+		if !strings.HasPrefix(key, prefix) {
+			continue
+		}
+		typeName := strings.ToLower(strings.TrimPrefix(key, prefix))
+		if typeName == "" {
+			continue
+		}
+		raw := kv[eq+1:]
+		// "0" is treated as a literal disable signal rather than failing on
+		// time.ParseDuration's strict requirement for a unit suffix.
+		if raw == "0" {
+			windows[typeName] = 0
+			continue
+		}
+		d, err := time.ParseDuration(raw)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("%s=%q is not a valid duration", key, raw))
+			continue
+		}
+		windows[typeName] = d
+	}
+	return windows, errs
+}
 
 // conflictProfileValues holds the default threshold values for a conflict
 // detection profile. Individual env var overrides always take precedence.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -489,10 +489,7 @@ func (c Config) Validate() error {
 	if c.ConflictOutcomeSimFloor < 0 || c.ConflictOutcomeSimFloor > 1 {
 		errs = append(errs, errors.New("config: AKASHI_CONFLICT_OUTCOME_SIM_FLOOR must be between 0.0 and 1.0 (0 disables)"))
 	}
-	// AssessmentPromptLimit: only reject explicitly-set out-of-range values.
-	// 0 is permitted (handlers fall back to the service default) so tests
-	// constructing partial Configs don't have to set every new field.
-	if c.AssessmentPromptLimit < 0 || c.AssessmentPromptLimit > 100 {
+	if c.AssessmentPromptLimit < 1 || c.AssessmentPromptLimit > 100 {
 		errs = append(errs, fmt.Errorf("config: AKASHI_ASSESSMENT_PROMPT_LIMIT must be between 1 and 100 (got %d)", c.AssessmentPromptLimit))
 	}
 	for t, d := range c.AssessmentWindows {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -833,6 +833,7 @@ func validBaseConfig() Config {
 		RateLimitBurst:             200,
 		WALDir:                     "./data/wal",
 		ExportPageSize:             100,
+		AssessmentPromptLimit:      10,
 	}
 }
 
@@ -1420,5 +1421,16 @@ func TestLoad_AssessmentPromptLimitOverride(t *testing.T) {
 	}
 	if cfg.AssessmentPromptLimit != 25 {
 		t.Fatalf("got %d, want 25", cfg.AssessmentPromptLimit)
+	}
+}
+
+func TestLoad_AssessmentPromptLimitRejectsZero(t *testing.T) {
+	t.Setenv("AKASHI_ASSESSMENT_PROMPT_LIMIT", "0")
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected Load to fail when prompt limit is zero")
+	}
+	if !contains(err.Error(), "AKASHI_ASSESSMENT_PROMPT_LIMIT") {
+		t.Fatalf("error should mention AKASHI_ASSESSMENT_PROMPT_LIMIT, got: %s", err.Error())
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1358,3 +1358,67 @@ func TestLoad_ExportPageSizeBoundaries(t *testing.T) {
 		}
 	})
 }
+
+func TestLoad_AssessmentWindowsDefaults(t *testing.T) {
+	// With no env overrides, defaults from defaultAssessmentWindows() apply.
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got, want := cfg.AssessmentWindows["architecture"], 7*24*time.Hour; got != want {
+		t.Fatalf("architecture: got %v, want %v", got, want)
+	}
+	if got, want := cfg.AssessmentWindows["security"], 7*24*time.Hour; got != want {
+		t.Fatalf("security: got %v, want %v", got, want)
+	}
+	if got, want := cfg.AssessmentWindows["planning"], 30*24*time.Hour; got != want {
+		t.Fatalf("planning: got %v, want %v", got, want)
+	}
+	// Types not listed in defaults must be absent (i.e. opt-out by default).
+	if _, ok := cfg.AssessmentWindows["code_review"]; ok {
+		t.Fatalf("code_review must not appear in default windows; got entry")
+	}
+	if cfg.AssessmentPromptLimit != 10 {
+		t.Fatalf("AssessmentPromptLimit: got %d, want 10", cfg.AssessmentPromptLimit)
+	}
+}
+
+func TestLoad_AssessmentWindowsEnvOverride(t *testing.T) {
+	// Override a default, opt out a default, and opt in a new type.
+	t.Setenv("AKASHI_ASSESSMENT_WINDOW_ARCHITECTURE", "72h")
+	t.Setenv("AKASHI_ASSESSMENT_WINDOW_SECURITY", "0")
+	t.Setenv("AKASHI_ASSESSMENT_WINDOW_CODE_REVIEW", "48h")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got, want := cfg.AssessmentWindows["architecture"], 72*time.Hour; got != want {
+		t.Fatalf("architecture override: got %v, want %v", got, want)
+	}
+	if cfg.AssessmentWindows["security"] != 0 {
+		t.Fatalf("security 0-override: got %v, want 0 (disabled)", cfg.AssessmentWindows["security"])
+	}
+	if got, want := cfg.AssessmentWindows["code_review"], 48*time.Hour; got != want {
+		t.Fatalf("code_review opt-in: got %v, want %v", got, want)
+	}
+}
+
+func TestLoad_AssessmentWindowInvalidDuration(t *testing.T) {
+	t.Setenv("AKASHI_ASSESSMENT_WINDOW_ARCHITECTURE", "not-a-duration")
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected Load to fail on unparseable duration override")
+	}
+}
+
+func TestLoad_AssessmentPromptLimitOverride(t *testing.T) {
+	t.Setenv("AKASHI_ASSESSMENT_PROMPT_LIMIT", "25")
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.AssessmentPromptLimit != 25 {
+		t.Fatalf("got %d, want 25", cfg.AssessmentPromptLimit)
+	}
+}

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ashita-ai/akashi/internal/authz"
 	"github.com/ashita-ai/akashi/internal/service/autoassess"
 	"github.com/ashita-ai/akashi/internal/service/decisions"
+	"github.com/ashita-ai/akashi/internal/service/pendingassess"
 	"github.com/ashita-ai/akashi/internal/service/quality"
 	"github.com/ashita-ai/akashi/internal/storage"
 )
@@ -68,7 +69,8 @@ type Server struct {
 
 	highConfidenceWarnThreshold float32
 	standardTypes               map[string]bool
-	autoAssessor                *autoassess.Assessor // optional auto-assessor for conflict resolution signals
+	autoAssessor                *autoassess.Assessor   // optional auto-assessor for conflict resolution signals
+	pendingAssessor             *pendingassess.Service // optional outcome-assessment prompt source (issue #716)
 }
 
 // SetCheckNotify registers a callback that fires whenever akashi_check is called.
@@ -90,6 +92,14 @@ func (s *Server) SetTraceCompleteNotify(f func(agentID string, isError bool, err
 // SetAutoAssessor registers the auto-assessor for conflict resolution signals.
 func (s *Server) SetAutoAssessor(a *autoassess.Assessor) {
 	s.autoAssessor = a
+}
+
+// SetPendingAssessor wires the pending-assessment prompt service. When nil,
+// the akashi_pending_assessments tool returns an empty list with a hint
+// indicating the feature is not configured. Call once at startup; not
+// thread-safe with concurrent tool calls.
+func (s *Server) SetPendingAssessor(p *pendingassess.Service) {
+	s.pendingAssessor = p
 }
 
 // New creates and configures a new MCP server with all resources, tools, and prompts.

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -14,11 +14,13 @@ import (
 	mcplib "github.com/mark3labs/mcp-go/mcp"
 	mcpserver "github.com/mark3labs/mcp-go/server"
 
+	"github.com/ashita-ai/akashi/internal/auth"
 	"github.com/ashita-ai/akashi/internal/authz"
 	"github.com/ashita-ai/akashi/internal/ctxutil"
 	"github.com/ashita-ai/akashi/internal/model"
 	"github.com/ashita-ai/akashi/internal/projectsuggest"
 	"github.com/ashita-ai/akashi/internal/service/decisions"
+	"github.com/ashita-ai/akashi/internal/service/pendingassess"
 	"github.com/ashita-ai/akashi/internal/service/quality"
 	"github.com/ashita-ai/akashi/internal/service/tracehealth"
 	"github.com/ashita-ai/akashi/internal/storage"
@@ -502,6 +504,59 @@ edges for both sides, and invalidates both original decisions in one transaction
 			),
 		),
 		s.handleReconcile,
+	)
+
+	// akashi_pending_assessments — surface decisions past their assessment window
+	// that have no recorded assessment from any source (issue #716).
+	s.mcpServer.AddTool(
+		mcplib.NewTool("akashi_pending_assessments",
+			mcplib.WithDescription(`Find prior decisions that are past their outcome-assessment window
+and still have no recorded assessment from any source.
+
+WHEN TO USE: Call at session start (or when picking up a previous thread of
+work) to discover prior decisions you should evaluate via akashi_assess.
+Closing the assessment loop is what makes confidence calibration meaningful
+across agents — without it, "I'm 85% confident" never gets compared to
+ground truth.
+
+WHAT YOU GET BACK: a list of decisions older than the configured per-type
+window (default: 7 days for architecture/security/design/trade_off, 30 days
+for planning). Decisions auto-assessed by supersession, conflict resolution,
+or precedent-citation threshold are NOT returned — any-source assessment
+counts as already-assessed.
+
+DEFAULT SCOPE: decisions YOU traced (caller's agent_id). Pass agent_id="*"
+to see all decisions you have access to.
+
+NEXT STEP: for each returned decision_id, observe whether the choice held
+up in practice, then call akashi_assess with outcome of "correct",
+"partially_correct", or "incorrect" and a short notes field describing
+what you observed.`),
+			mcplib.WithReadOnlyHintAnnotation(true),
+			mcplib.WithIdempotentHintAnnotation(true),
+			mcplib.WithOpenWorldHintAnnotation(false),
+			mcplib.WithString("agent_id",
+				mcplib.Description(`Optional. Defaults to the caller's agent_id. Pass "*" to see all decisions the caller can access (subject to per-org grant filtering).`),
+			),
+			mcplib.WithString("decision_type",
+				mcplib.Description("Optional: narrow to a single decision_type (e.g. architecture, security). Returns empty if the type has no configured window."),
+			),
+			mcplib.WithString("project",
+				mcplib.Description(`Optional project filter. Auto-detected from MCP roots/cwd/repo_url if omitted; pass "*" to disable.`),
+			),
+			mcplib.WithString("cwd",
+				mcplib.Description("Absolute path to your current git working directory; used for project auto-detection."),
+			),
+			mcplib.WithString("repo_url",
+				mcplib.Description("Git remote URL; used for project auto-detection when cwd is unavailable."),
+			),
+			mcplib.WithNumber("limit",
+				mcplib.Description("Maximum decisions to return. Defaults to the server's configured prompt limit."),
+				mcplib.Min(1),
+				mcplib.Max(100),
+			),
+		),
+		s.handlePendingAssessments,
 	)
 }
 
@@ -1886,6 +1941,102 @@ func (s *Server) handleAssess(ctx context.Context, request mcplib.CallToolReques
 			mcplib.TextContent{Type: "text", Text: string(resultData)},
 		},
 	}, nil
+}
+
+// handlePendingAssessments implements the akashi_pending_assessments tool
+// (issue #716). Returns decisions past their per-type assessment window that
+// have no recorded assessment from any source, so the agent can follow up
+// via akashi_assess. Default scope is the caller's agent_id; agent_id="*"
+// expands to the full grant set.
+func (s *Server) handlePendingAssessments(ctx context.Context, request mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+	claims := ctxutil.ClaimsFromContext(ctx)
+	if claims == nil {
+		return errorResult("authentication required"), nil
+	}
+	orgID := ctxutil.OrgIDFromContext(ctx)
+
+	if s.pendingAssessor == nil {
+		// Tool is registered unconditionally so its description appears in
+		// tools/list, but ListPending requires the service to be wired up.
+		empty, _ := json.MarshalIndent(map[string]any{
+			"decisions": []any{},
+			"count":     0,
+			"hint":      "pending-assessment prompting is not configured on this server",
+		}, "", "  ")
+		return &mcplib.CallToolResult{
+			Content: []mcplib.Content{mcplib.TextContent{Type: "text", Text: string(empty)}},
+		}, nil
+	}
+
+	requested := request.GetString("agent_id", "")
+	decisionType := strings.ToLower(strings.TrimSpace(request.GetString("decision_type", "")))
+	limit := request.GetInt("limit", 0) // 0 = use service default
+
+	agentIDs, err := resolveAgentScopeForMCP(ctx, s.db, claims, s.grantCache, requested)
+	if err != nil {
+		return errorResult(fmt.Sprintf("authorization check failed: %v", err)), nil
+	}
+
+	in := pendingassess.ListInput{
+		AgentIDs:     agentIDs,
+		DecisionType: decisionType,
+		Limit:        limit,
+	}
+	if project := s.resolveProjectFilter(ctx, request); project != nil {
+		in.Project = project
+	}
+
+	rows, err := s.pendingAssessor.ListPending(ctx, orgID, in)
+	if err != nil {
+		return errorResult(fmt.Sprintf("pending-assessment lookup failed: %v", err)), nil
+	}
+	if rows == nil {
+		rows = []model.PendingAssessment{}
+	}
+
+	payload := map[string]any{
+		"decisions": rows,
+		"count":     len(rows),
+	}
+	if len(rows) > 0 {
+		payload["hint"] = "For each decision_id above, call akashi_assess with outcome=\"correct\"/\"partially_correct\"/\"incorrect\" and a short notes field describing what you observed."
+	}
+	data, _ := json.MarshalIndent(payload, "", "  ")
+	return &mcplib.CallToolResult{
+		Content: []mcplib.Content{mcplib.TextContent{Type: "text", Text: string(data)}},
+	}, nil
+}
+
+// resolveAgentScopeForMCP mirrors the HTTP handler's agent_id resolution:
+// empty → caller-only, "*" → full grant set (nil for admin), specific id →
+// allow if accessible, deny-all empty slice otherwise.
+func resolveAgentScopeForMCP(ctx context.Context, db storage.Store, claims *auth.Claims, cache *authz.GrantCache, requested string) ([]string, error) {
+	switch requested {
+	case "":
+		return []string{claims.AgentID}, nil
+	case "*":
+		granted, err := authz.LoadGrantedSet(ctx, db, claims, cache)
+		if err != nil {
+			return nil, err
+		}
+		if granted == nil {
+			return nil, nil
+		}
+		ids := make([]string, 0, len(granted))
+		for id := range granted {
+			ids = append(ids, id)
+		}
+		return ids, nil
+	default:
+		granted, err := authz.LoadGrantedSet(ctx, db, claims, cache)
+		if err != nil {
+			return nil, err
+		}
+		if granted == nil || granted[requested] {
+			return []string{requested}, nil
+		}
+		return []string{}, nil
+	}
 }
 
 // cascadeSimilarityThreshold is the minimum cosine similarity for cascade resolution.

--- a/internal/model/decision.go
+++ b/internal/model/decision.go
@@ -379,6 +379,29 @@ type AssessRequest struct {
 	Notes   *string           `json:"notes,omitempty"`
 }
 
+// PendingAssessment is a decision past its outcome-assessment window with no
+// recorded assessment from any source. Returned by GET /v1/decisions/pending-assessment
+// and the akashi_pending_assessments MCP tool to surface decisions that should
+// receive follow-up via akashi_assess. The 2.3% manual assessment rate observed
+// in May 2026 is the gap this list closes.
+type PendingAssessment struct {
+	DecisionID   uuid.UUID `json:"decision_id"`
+	AgentID      string    `json:"agent_id"`
+	DecisionType string    `json:"decision_type"`
+	Outcome      string    `json:"outcome"`
+	Confidence   float32   `json:"confidence"`
+	Project      *string   `json:"project,omitempty"`
+	ValidFrom    time.Time `json:"valid_from"`
+	AgeHours     float64   `json:"age_hours"`
+}
+
+// PendingAssessmentListResponse is the response body for
+// GET /v1/decisions/pending-assessment.
+type PendingAssessmentListResponse struct {
+	Decisions []PendingAssessment `json:"decisions"`
+	Count     int                 `json:"count"`
+}
+
 // DecisionErasure records that a decision's PII was scrubbed per GDPR Art. 17.
 // The original content hash is preserved for forensic verification that the
 // decision existed and was intentionally erased (vs. tampered with).

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ashita-ai/akashi/internal/ratelimit"
 	"github.com/ashita-ai/akashi/internal/search"
 	"github.com/ashita-ai/akashi/internal/service/decisions"
+	"github.com/ashita-ai/akashi/internal/service/pendingassess"
 	"github.com/ashita-ai/akashi/internal/service/trace"
 	"github.com/ashita-ai/akashi/internal/storage"
 )
@@ -63,6 +64,9 @@ type Handlers struct {
 	// exportPageSize is the batch size used by HandleExportDecisions when
 	// streaming NDJSON via keyset pagination. Validated at config load (1–10000).
 	exportPageSize int
+	// pendingAssessSvc resolves the per-type window list and queries pending
+	// outcome-assessments. Shared with the MCP tool path.
+	pendingAssessSvc *pendingassess.Service
 }
 
 // HandlersDeps holds all dependencies for constructing Handlers.
@@ -88,6 +92,7 @@ type HandlersDeps struct {
 	ConflictValidator           conflicts.Validator
 	HighConfidenceWarnThreshold float32
 	ExportPageSize              int
+	PendingAssessSvc            *pendingassess.Service
 }
 
 // NewHandlers creates a new Handlers with all dependencies.
@@ -115,6 +120,7 @@ func NewHandlers(d HandlersDeps) *Handlers {
 		conflictValidator:           d.ConflictValidator,
 		highConfidenceWarnThreshold: d.HighConfidenceWarnThreshold,
 		exportPageSize:              exportPageSizeOrDefault(d.ExportPageSize),
+		pendingAssessSvc:            d.PendingAssessSvc,
 	}
 }
 

--- a/internal/server/handlers_assessments.go
+++ b/internal/server/handlers_assessments.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"net/http"
+	"strings"
 
 	"github.com/google/uuid"
 
@@ -127,7 +128,7 @@ func (h *Handlers) HandleListPendingAssessments(w http.ResponseWriter, r *http.R
 
 	q := r.URL.Query()
 	requested := q.Get("agent_id")
-	decisionType := q.Get("decision_type")
+	decisionType := strings.ToLower(strings.TrimSpace(q.Get("decision_type")))
 	project := q.Get("project")
 	// Parse limit directly rather than via queryLimit: a missing param must
 	// flow through as 0 so the service applies its configured default. The

--- a/internal/server/handlers_assessments.go
+++ b/internal/server/handlers_assessments.go
@@ -1,11 +1,15 @@
 package server
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/google/uuid"
 
+	"github.com/ashita-ai/akashi/internal/auth"
+	"github.com/ashita-ai/akashi/internal/authz"
 	"github.com/ashita-ai/akashi/internal/model"
+	"github.com/ashita-ai/akashi/internal/service/pendingassess"
 	"github.com/ashita-ai/akashi/internal/service/quality"
 	"github.com/ashita-ai/akashi/internal/storage"
 )
@@ -94,6 +98,117 @@ func (h *Handlers) HandleAssessDecision(w http.ResponseWriter, r *http.Request) 
 		`{"source":"assess","decision_id":"`+decisionID.String()+`","org_id":"`+orgID.String()+`"}`)
 
 	writeJSON(w, r, http.StatusOK, result)
+}
+
+// HandleListPendingAssessments handles GET /v1/decisions/pending-assessment (reader+).
+//
+// Surfaces decisions that are past their per-type assessment window and have
+// no recorded assessment from any source (manual or auto). Default scope is
+// the caller's own agent_id — the issue #716 use case is "agents follow up
+// on decisions they traced." Pass agent_id=* to expand to all accessible
+// agents (subject to authz filtering).
+//
+// Query params:
+//   - agent_id      Optional. Defaults to caller. Pass "*" for org-wide
+//     (still filtered by the caller's grant set).
+//   - decision_type Optional. Narrows to a single type. Returns empty if
+//     the type has no configured window (i.e. opted out).
+//   - project       Optional. Restricts to one project.
+//   - limit         Optional. Clamped to [1, 100]; default from config.
+func (h *Handlers) HandleListPendingAssessments(w http.ResponseWriter, r *http.Request) {
+	if h.pendingAssessSvc == nil {
+		// Route should not be registered when the service is nil — defensive
+		// guard in case wiring changes in the future.
+		writeError(w, r, http.StatusNotFound, model.ErrCodeNotFound, "pending-assessment is not configured on this server")
+		return
+	}
+	claims := ClaimsFromContext(r.Context())
+	orgID := OrgIDFromContext(r.Context())
+
+	q := r.URL.Query()
+	requested := q.Get("agent_id")
+	decisionType := q.Get("decision_type")
+	project := q.Get("project")
+	// Parse limit directly rather than via queryLimit: a missing param must
+	// flow through as 0 so the service applies its configured default. The
+	// shared queryLimit helper clamps 0→1, which would silently cap MCP/HTTP
+	// callers at one result whenever they omit limit.
+	limit := queryInt(r, "limit", 0)
+	if limit < 0 {
+		limit = 0
+	}
+	if limit > 100 {
+		limit = 100
+	}
+
+	agentIDs, err := resolvePendingAssessAgentScope(r.Context(), h.db, claims, h.grantCache, requested)
+	if err != nil {
+		h.writeInternalError(w, r, "authorization check failed", err)
+		return
+	}
+
+	in := pendingassess.ListInput{
+		AgentIDs:     agentIDs,
+		DecisionType: decisionType,
+		Limit:        limit,
+	}
+	if project != "" {
+		in.Project = &project
+	}
+
+	rows, err := h.pendingAssessSvc.ListPending(r.Context(), orgID, in)
+	if err != nil {
+		h.writeInternalError(w, r, "failed to list pending assessments", err)
+		return
+	}
+	if rows == nil {
+		rows = []model.PendingAssessment{}
+	}
+	writeJSON(w, r, http.StatusOK, model.PendingAssessmentListResponse{
+		Decisions: rows,
+		Count:     len(rows),
+	})
+}
+
+// resolvePendingAssessAgentScope translates the agent_id query parameter into
+// the agent-set passed to storage.
+//
+// Behavior:
+//   - empty (default)   → caller's own agent_id only
+//   - "*"               → all agents the caller can access. For admin+ this
+//     returns nil (no filter); for others, the granted set
+//   - "<specific>"      → that agent if the caller can access it; empty slice
+//     otherwise (which yields zero rows without DB churn)
+//
+// Returning ([], nil) is the deny-all signal; returning (nil, nil) is the
+// unrestricted signal — same contract as authz.LoadGrantedSet.
+func resolvePendingAssessAgentScope(ctx context.Context, db storage.Store, claims *auth.Claims, cache *authz.GrantCache, requested string) ([]string, error) {
+	if claims == nil {
+		return []string{}, nil
+	}
+	if requested == "" {
+		return []string{claims.AgentID}, nil
+	}
+	// "*" and a specific id both require the grant set, so load once.
+	granted, err := authz.LoadGrantedSet(ctx, db, claims, cache)
+	if err != nil {
+		return nil, err
+	}
+	if requested == "*" {
+		if granted == nil {
+			return nil, nil // admin: unrestricted
+		}
+		ids := make([]string, 0, len(granted))
+		for id := range granted {
+			ids = append(ids, id)
+		}
+		return ids, nil
+	}
+	// Specific agent_id.
+	if granted == nil || granted[requested] {
+		return []string{requested}, nil
+	}
+	return []string{}, nil
 }
 
 // HandleListAssessments handles GET /v1/decisions/{id}/assessments (reader+).

--- a/internal/server/pending_assessments_test.go
+++ b/internal/server/pending_assessments_test.go
@@ -81,6 +81,27 @@ func TestPendingAssessment_Endpoint_AssessedAreHidden(t *testing.T) {
 	}
 }
 
+// TestPendingAssessment_Endpoint_NormalizesDecisionType verifies the HTTP
+// surface matches MCP/trace normalization. Operators and SDKs should not get
+// an empty prompt list just because they send display casing or surrounding
+// whitespace.
+func TestPendingAssessment_Endpoint_NormalizesDecisionType(t *testing.T) {
+	ctx := context.Background()
+	old := time.Now().UTC().Add(-30 * 24 * time.Hour)
+	d := seedPendingDecision(t, ctx, "test-agent", "architecture", old)
+
+	resp, err := authedRequest("GET",
+		testSrv.URL+"/v1/decisions/pending-assessment?decision_type=%20Architecture%20",
+		agentToken, nil)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body := decodePendingResponse(t, resp.Body)
+	assert.Contains(t, pendingDecisionIDs(body.Decisions), d,
+		"HTTP decision_type filter should normalize case and whitespace")
+}
+
 // TestPendingAssessment_Endpoint_OptedOutType verifies decision_type=code_review
 // (no configured window in the test harness) returns an empty list rather than
 // a 400. An opt-out type is invisible, not an error.

--- a/internal/server/pending_assessments_test.go
+++ b/internal/server/pending_assessments_test.go
@@ -1,0 +1,172 @@
+//go:build integration
+
+package server_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ashita-ai/akashi/internal/model"
+)
+
+// TestPendingAssessment_Endpoint_DefaultsToCallerAgent confirms that the
+// HTTP surface's "agents follow up on what they traced" UX works end-to-end:
+//   - admin sees nothing under their own agent_id (they didn't trace anything)
+//   - an agent sees decisions they traced (when older than the window)
+//   - the same agent does NOT see decisions traced by a different agent
+//     unless they pass agent_id=*
+//
+// This is the load-bearing path from issue #716: the prompt loop is only
+// useful if it surfaces the caller's own work by default.
+func TestPendingAssessment_Endpoint_DefaultsToCallerAgent(t *testing.T) {
+	ctx := context.Background()
+
+	// Seed two decisions older than the 7-day architecture window: one by
+	// test-agent, one by a fresh agent that no token here owns.
+	otherAgentID := "pending-other-" + uuid.New().String()[:8]
+	require.NoError(t, seedAgent(ctx, otherAgentID))
+
+	old := time.Now().UTC().Add(-30 * 24 * time.Hour)
+	myDecision := seedPendingDecision(t, ctx, "test-agent", "architecture", old)
+	_ = seedPendingDecision(t, ctx, otherAgentID, "architecture", old)
+
+	// Default scope: only the caller's own decision should appear.
+	resp, err := authedRequest("GET", testSrv.URL+"/v1/decisions/pending-assessment", agentToken, nil)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body := decodePendingResponse(t, resp.Body)
+	ids := pendingDecisionIDs(body.Decisions)
+	assert.Contains(t, ids, myDecision, "caller's decision should appear under default scope")
+	for _, p := range body.Decisions {
+		assert.Equal(t, "test-agent", p.AgentID,
+			"default scope must restrict to caller; saw %s", p.AgentID)
+	}
+}
+
+// TestPendingAssessment_Endpoint_AssessedAreHidden encodes the "any source
+// counts as assessed" rule. A decision with a manual assessment must not
+// reappear in the prompt list, even if it would otherwise be eligible.
+func TestPendingAssessment_Endpoint_AssessedAreHidden(t *testing.T) {
+	ctx := context.Background()
+	old := time.Now().UTC().Add(-30 * 24 * time.Hour)
+
+	d := seedPendingDecision(t, ctx, "test-agent", "architecture", old)
+	_, err := testDB.CreateAssessment(ctx, uuid.Nil, model.DecisionAssessment{
+		DecisionID:      d,
+		AssessorAgentID: "test-agent",
+		Outcome:         model.AssessmentCorrect,
+		Source:          model.AssessmentSourceManual,
+	})
+	require.NoError(t, err)
+
+	resp, err := authedRequest("GET", testSrv.URL+"/v1/decisions/pending-assessment", agentToken, nil)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body := decodePendingResponse(t, resp.Body)
+	for _, p := range body.Decisions {
+		assert.NotEqual(t, d, p.DecisionID,
+			"decision with an existing assessment must not be re-surfaced")
+	}
+}
+
+// TestPendingAssessment_Endpoint_OptedOutType verifies decision_type=code_review
+// (no configured window in the test harness) returns an empty list rather than
+// a 400. An opt-out type is invisible, not an error.
+func TestPendingAssessment_Endpoint_OptedOutType(t *testing.T) {
+	ctx := context.Background()
+	old := time.Now().UTC().Add(-30 * 24 * time.Hour)
+	_ = seedPendingDecision(t, ctx, "test-agent", "code_review", old)
+
+	resp, err := authedRequest("GET",
+		testSrv.URL+"/v1/decisions/pending-assessment?decision_type=code_review",
+		agentToken, nil)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body := decodePendingResponse(t, resp.Body)
+	assert.Equal(t, 0, body.Count)
+	assert.Empty(t, body.Decisions)
+}
+
+// TestPendingAssessment_Endpoint_AgentIDStar_AdminSeesAll: an admin caller
+// with agent_id=* must see decisions from any agent because LoadGrantedSet
+// returns nil (unrestricted) for admin+.
+func TestPendingAssessment_Endpoint_AgentIDStar_AdminSeesAll(t *testing.T) {
+	ctx := context.Background()
+	otherAgentID := "pending-star-" + uuid.New().String()[:8]
+	require.NoError(t, seedAgent(ctx, otherAgentID))
+
+	old := time.Now().UTC().Add(-30 * 24 * time.Hour)
+	d := seedPendingDecision(t, ctx, otherAgentID, "architecture", old)
+
+	resp, err := authedRequest("GET",
+		testSrv.URL+"/v1/decisions/pending-assessment?agent_id=*",
+		adminToken, nil)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body := decodePendingResponse(t, resp.Body)
+	assert.Contains(t, pendingDecisionIDs(body.Decisions), d,
+		"admin with agent_id=* should see decisions from any agent")
+}
+
+func seedAgent(ctx context.Context, agentID string) error {
+	_, err := testDB.CreateAgent(ctx, model.Agent{
+		AgentID: agentID,
+		Name:    agentID,
+		Role:    model.RoleAgent,
+	})
+	return err
+}
+
+func seedPendingDecision(t *testing.T, ctx context.Context, agentID, decisionType string, validFrom time.Time) uuid.UUID {
+	t.Helper()
+	run, err := testDB.CreateRun(ctx, model.CreateRunRequest{AgentID: agentID})
+	require.NoError(t, err)
+	d, err := testDB.CreateDecision(ctx, model.Decision{
+		RunID:        run.ID,
+		AgentID:      agentID,
+		DecisionType: decisionType,
+		Outcome:      "pending-fixture",
+		Confidence:   0.7,
+		ValidFrom:    validFrom,
+		Metadata:     map[string]any{},
+	})
+	require.NoError(t, err)
+	return d.ID
+}
+
+func decodePendingResponse(t *testing.T, r io.Reader) model.PendingAssessmentListResponse {
+	t.Helper()
+	// HTTP handlers wrap payloads in {data, meta}. Mirror that shape so we
+	// decode the inner PendingAssessmentListResponse correctly rather than
+	// passing through the envelope's structurally-similar but empty top
+	// level.
+	var envelope struct {
+		Data model.PendingAssessmentListResponse `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(r).Decode(&envelope))
+	return envelope.Data
+}
+
+func pendingDecisionIDs(rows []model.PendingAssessment) []uuid.UUID {
+	out := make([]uuid.UUID, len(rows))
+	for i, r := range rows {
+		out[i] = r.DecisionID
+	}
+	return out
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ashita-ai/akashi/internal/ratelimit"
 	"github.com/ashita-ai/akashi/internal/search"
 	"github.com/ashita-ai/akashi/internal/service/decisions"
+	"github.com/ashita-ai/akashi/internal/service/pendingassess"
 	"github.com/ashita-ai/akashi/internal/service/trace"
 	"github.com/ashita-ai/akashi/internal/storage"
 )
@@ -104,6 +105,11 @@ type ServerConfig struct {
 	// Page size for GET /v1/export/decisions NDJSON pagination. Zero = use
 	// the handler's default (100). Validated at config load (1–10000).
 	ExportPageSize int
+
+	// Outcome-assessment prompting service. Nil disables the
+	// GET /v1/decisions/pending-assessment route entirely (the route is not
+	// registered when nil — clients receive 404 rather than 500).
+	PendingAssessSvc *pendingassess.Service
 }
 
 // New creates a new HTTP server with all routes configured.
@@ -129,6 +135,7 @@ func New(cfg ServerConfig) *Server {
 		ConflictValidator:           cfg.ConflictValidator,
 		HighConfidenceWarnThreshold: cfg.HighConfidenceWarnThreshold,
 		ExportPageSize:              cfg.ExportPageSize,
+		PendingAssessSvc:            cfg.PendingAssessSvc,
 	})
 
 	mux := http.NewServeMux()
@@ -216,6 +223,14 @@ func New(cfg ServerConfig) *Server {
 	// Decision assessments: explicit outcome feedback (spec 29 / ADR-020 Tier 2).
 	mux.Handle("POST /v1/decisions/{id}/assess", writeRole(http.HandlerFunc(h.HandleAssessDecision)))
 	mux.Handle("GET /v1/decisions/{id}/assessments", readRole(http.HandlerFunc(h.HandleListAssessments)))
+
+	// Pending outcome-assessment list (issue #716). Only registered when a
+	// pending-assessment service is wired in — clients hit 404 otherwise,
+	// which is the correct signal that prompting is not configured for this
+	// deployment.
+	if cfg.PendingAssessSvc != nil {
+		mux.Handle("GET /v1/decisions/pending-assessment", readRole(http.HandlerFunc(h.HandleListPendingAssessments)))
+	}
 
 	// Session view (reader+).
 	mux.Handle("GET /v1/sessions/{session_id}", readRole(http.HandlerFunc(h.HandleSessionView)))

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ashita-ai/akashi/internal/server"
 	"github.com/ashita-ai/akashi/internal/service/decisions"
 	"github.com/ashita-ai/akashi/internal/service/embedding"
+	"github.com/ashita-ai/akashi/internal/service/pendingassess"
 	"github.com/ashita-ai/akashi/internal/service/trace"
 	"github.com/ashita-ai/akashi/internal/storage"
 	"github.com/ashita-ai/akashi/internal/testutil"
@@ -83,7 +84,12 @@ func TestMain(m *testing.M) {
 	buf.Start(ctx)
 	testBuf = buf
 
+	pendingAssess := pendingassess.New(db, map[string]time.Duration{
+		"architecture": 7 * 24 * time.Hour,
+		"security":     7 * 24 * time.Hour,
+	}, 10)
 	mcpSrv := mcp.New(db, decisionSvc, nil, logger, "test", 0.85, nil)
+	mcpSrv.SetPendingAssessor(pendingAssess)
 	srv := server.New(server.ServerConfig{
 		DB:                  db,
 		JWTMgr:              jwtMgr,
@@ -98,6 +104,7 @@ func TestMain(m *testing.M) {
 		// Explicitly enabled for tests that exercise GDPR delete behavior.
 		EnableDestructiveDelete:     true,
 		HighConfidenceWarnThreshold: 0.85,
+		PendingAssessSvc:            pendingAssess,
 	})
 
 	// Seed admin.
@@ -589,7 +596,7 @@ func TestMCPListTools(t *testing.T) {
 
 	toolsResult, err := c.ListTools(ctx, mcplib.ListToolsRequest{})
 	require.NoError(t, err)
-	assert.Len(t, toolsResult.Tools, 8)
+	assert.Len(t, toolsResult.Tools, 9)
 
 	toolNames := make(map[string]bool)
 	for _, tool := range toolsResult.Tools {
@@ -603,6 +610,7 @@ func TestMCPListTools(t *testing.T) {
 	assert.True(t, toolNames["akashi_reconcile"], "expected akashi_reconcile tool")
 	assert.True(t, toolNames["akashi_stats"], "expected akashi_stats tool")
 	assert.True(t, toolNames["akashi_assess"], "expected akashi_assess tool")
+	assert.True(t, toolNames["akashi_pending_assessments"], "expected akashi_pending_assessments tool")
 }
 
 func TestMCPListResources(t *testing.T) {

--- a/internal/service/pendingassess/service.go
+++ b/internal/service/pendingassess/service.go
@@ -1,0 +1,136 @@
+// Package pendingassess surfaces decisions that are past their per-type
+// outcome-assessment window and have no recorded assessment from any source.
+// It is the shared business-logic layer behind both
+// GET /v1/decisions/pending-assessment and the akashi_pending_assessments
+// MCP tool — both call ListPending to keep windowing and access-filter
+// behavior identical across surfaces.
+//
+// Design rationale (issue #716, May 2026 field assessment):
+//
+//   - Manual outcome-assessment coverage was 2.3% across 1,292 traced decisions.
+//     Without outcome labels, calibration metrics are meaningless. The fix is
+//     a prompt loop: surface decisions past a per-type window so agents can
+//     follow up via akashi_assess.
+//
+//   - "Any source counts as assessed" — supersession, conflict resolution, and
+//     citation-threshold auto-assessments already produce verdicts. Re-prompting
+//     would be redundant noise and risks the same dismissal pattern that hurt
+//     the conflict detector at 76% FP.
+//
+//   - Per-type windows are configured at boot (see config.AssessmentWindows).
+//     Types with window=0 are excluded from the surface entirely.
+package pendingassess
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/ashita-ai/akashi/internal/model"
+	"github.com/ashita-ai/akashi/internal/storage"
+)
+
+// Service computes pending-assessment lists from configured windows.
+type Service struct {
+	db           storage.Store
+	windows      map[string]time.Duration
+	defaultLimit int
+}
+
+// New constructs a Service. windows maps decision_type → minimum age before
+// a decision is eligible for prompting; entries with value 0 are ignored.
+// defaultLimit applies when the caller does not specify one.
+func New(db storage.Store, windows map[string]time.Duration, defaultLimit int) *Service {
+	if defaultLimit <= 0 {
+		defaultLimit = 10
+	}
+	return &Service{db: db, windows: windows, defaultLimit: defaultLimit}
+}
+
+// ListInput parameterizes a pending-assessment query.
+//
+// AgentIDs scopes results: nil means no agent-level filter (used by admin
+// callers); a populated slice restricts results to those agent IDs; an
+// explicit empty slice yields zero rows (caller has access to no agents).
+//
+// DecisionType, when non-empty, narrows to a single type. The type must
+// have a window configured; types with window=0 always return zero rows.
+//
+// Project, when non-nil, filters by project (cross-project hygiene).
+type ListInput struct {
+	AgentIDs     []string
+	DecisionType string
+	Project      *string
+	Limit        int
+}
+
+// ListPending returns pending-assessment rows visible to the caller.
+//
+// Returns (nil, nil) without hitting the DB when no configured windows match
+// the requested DecisionType (or when no types are configured at all). This
+// preserves the type opt-out semantics — an opted-out type is invisible, not
+// an error.
+func (s *Service) ListPending(ctx context.Context, orgID uuid.UUID, in ListInput) ([]model.PendingAssessment, error) {
+	now := time.Now().UTC()
+	windows := s.activeWindows(in.DecisionType, now)
+	if len(windows) == 0 {
+		return nil, nil
+	}
+
+	limit := in.Limit
+	if limit <= 0 {
+		limit = s.defaultLimit
+	}
+	if limit > 100 {
+		limit = 100
+	}
+
+	opts := storage.ListPendingAssessmentsOpts{
+		Windows:  windows,
+		AgentIDs: in.AgentIDs,
+		Project:  in.Project,
+		Limit:    limit,
+	}
+	out, err := s.db.ListPendingAssessments(ctx, orgID, opts)
+	if err != nil {
+		return nil, fmt.Errorf("pendingassess: list: %w", err)
+	}
+	return out, nil
+}
+
+// HasConfiguredType reports whether a decision_type has a non-zero configured
+// window. Used by handlers/tools that want to short-circuit a 400-style hint
+// before issuing the query.
+func (s *Service) HasConfiguredType(decisionType string) bool {
+	d, ok := s.windows[decisionType]
+	return ok && d > 0
+}
+
+// activeWindows derives the per-type cutoffs for the storage call. When
+// onlyType is empty, all configured types with window>0 are included.
+// Otherwise only that type is included (and only if its window is enabled).
+func (s *Service) activeWindows(onlyType string, now time.Time) []storage.PendingAssessmentWindow {
+	if onlyType != "" {
+		d, ok := s.windows[onlyType]
+		if !ok || d <= 0 {
+			return nil
+		}
+		return []storage.PendingAssessmentWindow{{
+			DecisionType: onlyType,
+			Cutoff:       now.Add(-d),
+		}}
+	}
+	out := make([]storage.PendingAssessmentWindow, 0, len(s.windows))
+	for t, d := range s.windows {
+		if d <= 0 {
+			continue
+		}
+		out = append(out, storage.PendingAssessmentWindow{
+			DecisionType: t,
+			Cutoff:       now.Add(-d),
+		})
+	}
+	return out
+}

--- a/internal/service/pendingassess/service_test.go
+++ b/internal/service/pendingassess/service_test.go
@@ -1,0 +1,163 @@
+package pendingassess_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/pgvector/pgvector-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ashita-ai/akashi/internal/model"
+	"github.com/ashita-ai/akashi/internal/service/pendingassess"
+	"github.com/ashita-ai/akashi/internal/storage"
+)
+
+// captureStore is a storage.Store stub that records what ListPendingAssessments
+// was called with so we can assert on the (decision_type, cutoff) windows the
+// service builds. Every other Store method panics — the service only depends
+// on ListPendingAssessments, and a misroute through an unrelated method should
+// fail loudly rather than silently.
+type captureStore struct {
+	storage.Store // panics for unused methods via embedded nil interface
+
+	gotOpts storage.ListPendingAssessmentsOpts
+	gotOrg  uuid.UUID
+	resp    []model.PendingAssessment
+	err     error
+}
+
+func (c *captureStore) ListPendingAssessments(_ context.Context, orgID uuid.UUID, opts storage.ListPendingAssessmentsOpts) ([]model.PendingAssessment, error) {
+	c.gotOrg = orgID
+	c.gotOpts = opts
+	return c.resp, c.err
+}
+
+// silence the unused-import warning for pgvector — the embedded storage.Store
+// pulls it transitively but go vet wants it referenced.
+var _ = pgvector.Vector{}
+
+func TestListPending_DerivesPerTypeCutoffs(t *testing.T) {
+	store := &captureStore{}
+	windows := map[string]time.Duration{
+		"architecture": 7 * 24 * time.Hour,
+		"security":     7 * 24 * time.Hour,
+		"code_review":  0, // disabled — must not appear in derived windows
+	}
+	svc := pendingassess.New(store, windows, 10)
+	org := uuid.New()
+
+	before := time.Now().UTC()
+	_, err := svc.ListPending(context.Background(), org, pendingassess.ListInput{
+		AgentIDs: []string{"agent-1"},
+	})
+	require.NoError(t, err)
+	after := time.Now().UTC()
+
+	assert.Equal(t, org, store.gotOrg)
+	require.Len(t, store.gotOpts.Windows, 2, "code_review (window=0) must not contribute a row")
+
+	// Each cutoff must equal now - window for its type. We don't know the
+	// exact `now` the service used so we bound it to [before-window, after-window].
+	expected := map[string]time.Duration{
+		"architecture": 7 * 24 * time.Hour,
+		"security":     7 * 24 * time.Hour,
+	}
+	for _, w := range store.gotOpts.Windows {
+		dur, ok := expected[w.DecisionType]
+		require.True(t, ok, "unexpected window for type %s", w.DecisionType)
+		assert.False(t, w.Cutoff.Before(before.Add(-dur)),
+			"cutoff for %s should not be earlier than before-window", w.DecisionType)
+		assert.False(t, w.Cutoff.After(after.Add(-dur)),
+			"cutoff for %s should not be later than after-window", w.DecisionType)
+	}
+}
+
+func TestListPending_DecisionTypeNarrowsToSingleWindow(t *testing.T) {
+	store := &captureStore{}
+	svc := pendingassess.New(store, map[string]time.Duration{
+		"architecture": 7 * 24 * time.Hour,
+		"security":     7 * 24 * time.Hour,
+	}, 10)
+
+	_, err := svc.ListPending(context.Background(), uuid.New(), pendingassess.ListInput{
+		DecisionType: "security",
+		AgentIDs:     []string{"agent-1"},
+	})
+	require.NoError(t, err)
+	require.Len(t, store.gotOpts.Windows, 1)
+	assert.Equal(t, "security", store.gotOpts.Windows[0].DecisionType)
+}
+
+func TestListPending_UnconfiguredTypeReturnsEmptyWithoutDB(t *testing.T) {
+	// A captureStore whose ListPendingAssessments would error if called.
+	// We assert no DB call by checking that gotOrg stays at uuid.Nil.
+	store := &captureStore{err: errors.New("DB MUST NOT BE CALLED")}
+	svc := pendingassess.New(store, map[string]time.Duration{
+		"architecture": 7 * 24 * time.Hour,
+	}, 10)
+
+	rows, err := svc.ListPending(context.Background(), uuid.New(), pendingassess.ListInput{
+		DecisionType: "code_review", // not in windows map
+	})
+	require.NoError(t, err)
+	assert.Nil(t, rows)
+	assert.Equal(t, uuid.Nil, store.gotOrg, "service must short-circuit before storage")
+}
+
+func TestListPending_LimitDefaultsAndClamp(t *testing.T) {
+	store := &captureStore{}
+	svc := pendingassess.New(store, map[string]time.Duration{
+		"architecture": 24 * time.Hour,
+	}, 5)
+
+	// Default fires when Limit <= 0.
+	_, err := svc.ListPending(context.Background(), uuid.New(), pendingassess.ListInput{
+		AgentIDs: []string{"a"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 5, store.gotOpts.Limit)
+
+	// Caller-supplied limit passes through verbatim within range.
+	_, err = svc.ListPending(context.Background(), uuid.New(), pendingassess.ListInput{
+		Limit:    25,
+		AgentIDs: []string{"a"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 25, store.gotOpts.Limit)
+
+	// Limit > 100 is clamped to 100 (defense in depth — handlers already clamp).
+	_, err = svc.ListPending(context.Background(), uuid.New(), pendingassess.ListInput{
+		Limit:    500,
+		AgentIDs: []string{"a"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 100, store.gotOpts.Limit)
+}
+
+func TestListPending_AllWindowsZero(t *testing.T) {
+	store := &captureStore{err: errors.New("DB MUST NOT BE CALLED")}
+	svc := pendingassess.New(store, map[string]time.Duration{
+		"architecture": 0,
+		"security":     0,
+	}, 10)
+
+	rows, err := svc.ListPending(context.Background(), uuid.New(), pendingassess.ListInput{
+		AgentIDs: []string{"a"},
+	})
+	require.NoError(t, err)
+	assert.Nil(t, rows)
+}
+
+func TestHasConfiguredType(t *testing.T) {
+	svc := pendingassess.New(&captureStore{}, map[string]time.Duration{
+		"architecture": 7 * 24 * time.Hour,
+		"code_review":  0,
+	}, 10)
+	assert.True(t, svc.HasConfiguredType("architecture"))
+	assert.False(t, svc.HasConfiguredType("code_review"))
+	assert.False(t, svc.HasConfiguredType("unknown_type"))
+}

--- a/internal/storage/assessments.go
+++ b/internal/storage/assessments.go
@@ -5,6 +5,7 @@ package storage
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -229,4 +230,86 @@ func (db *DB) HasAssessmentFromSource(ctx context.Context, orgID, decisionID uui
 		return false, fmt.Errorf("storage: has assessment from source: %w", err)
 	}
 	return exists, nil
+}
+
+// ListPendingAssessments returns active decisions whose valid_from is older
+// than their per-type assessment window AND have no recorded assessment from
+// any source (manual, supersession, conflict, or citation).
+//
+// Any-source counts as already-assessed: if auto-assessment via supersession,
+// conflict resolution, or citation threshold has already produced a verdict,
+// prompting the agent again would be redundant noise.
+//
+// Rows are ordered by valid_from ASC so the oldest unassessed decisions surface
+// first. Decisions are scoped to the org and to active rows (valid_to IS NULL).
+func (db *DB) ListPendingAssessments(ctx context.Context, orgID uuid.UUID, opts ListPendingAssessmentsOpts) ([]model.PendingAssessment, error) {
+	if len(opts.Windows) == 0 {
+		return nil, nil
+	}
+	if opts.AgentIDs != nil && len(opts.AgentIDs) == 0 {
+		// Caller passed an explicit empty access set — deny all rows without
+		// hitting the DB.
+		return nil, nil
+	}
+	if opts.Limit <= 0 {
+		opts.Limit = 10
+	}
+
+	types := make([]string, len(opts.Windows))
+	cutoffs := make([]time.Time, len(opts.Windows))
+	for i, w := range opts.Windows {
+		types[i] = w.DecisionType
+		cutoffs[i] = w.Cutoff
+	}
+
+	// Argument layout: $1 org_id, $2 type[], $3 cutoff[], then optional
+	// project ($4) and agent set; the index of agent_ids depends on whether
+	// project was added.
+	args := []any{orgID, types, cutoffs}
+	q := `WITH windows(decision_type, cutoff) AS (
+		SELECT * FROM unnest($2::text[], $3::timestamptz[])
+	)
+	SELECT d.id, d.agent_id, d.decision_type, d.outcome, d.confidence,
+	       d.project, d.valid_from
+	FROM decisions d
+	JOIN windows w ON w.decision_type = d.decision_type AND d.valid_from < w.cutoff
+	LEFT JOIN decision_assessments a
+	    ON a.decision_id = d.id AND a.org_id = d.org_id
+	WHERE d.org_id = $1
+	  AND d.valid_to IS NULL
+	  AND a.id IS NULL`
+	if opts.Project != nil {
+		args = append(args, *opts.Project)
+		q += fmt.Sprintf(" AND d.project = $%d", len(args))
+	}
+	if opts.AgentIDs != nil {
+		args = append(args, opts.AgentIDs)
+		q += fmt.Sprintf(" AND d.agent_id = ANY($%d::text[])", len(args))
+	}
+	args = append(args, opts.Limit)
+	q += fmt.Sprintf(" ORDER BY d.valid_from ASC LIMIT $%d", len(args))
+
+	rows, err := db.pool.Query(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("storage: list pending assessments: %w", err)
+	}
+	defer rows.Close()
+
+	now := time.Now().UTC()
+	out := make([]model.PendingAssessment, 0)
+	for rows.Next() {
+		var p model.PendingAssessment
+		if err := rows.Scan(
+			&p.DecisionID, &p.AgentID, &p.DecisionType, &p.Outcome,
+			&p.Confidence, &p.Project, &p.ValidFrom,
+		); err != nil {
+			return nil, fmt.Errorf("storage: list pending assessments: scan: %w", err)
+		}
+		p.AgeHours = now.Sub(p.ValidFrom).Hours()
+		out = append(out, p)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("storage: list pending assessments: rows: %w", err)
+	}
+	return out, nil
 }

--- a/internal/storage/pending_assessments_test.go
+++ b/internal/storage/pending_assessments_test.go
@@ -1,0 +1,176 @@
+//go:build !lite && integration
+
+package storage_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ashita-ai/akashi/internal/model"
+	"github.com/ashita-ai/akashi/internal/storage"
+)
+
+// makePendingFixture seeds a decision with a controlled valid_from so the
+// pending-assessment query can be exercised against deterministic ages.
+// suffix isolates fixtures across tests in the shared testDB.
+func makePendingFixture(t *testing.T, ctx context.Context, suffix, agentID, decisionType string, validFrom time.Time) model.Decision {
+	t.Helper()
+	run, err := testDB.CreateRun(ctx, model.CreateRunRequest{AgentID: agentID})
+	require.NoError(t, err)
+	d, err := testDB.CreateDecision(ctx, model.Decision{
+		RunID:        run.ID,
+		AgentID:      agentID,
+		DecisionType: decisionType,
+		Outcome:      "fixture-" + suffix,
+		Confidence:   0.7,
+		ValidFrom:    validFrom,
+		Metadata:     map[string]any{},
+	})
+	require.NoError(t, err)
+	return d
+}
+
+// TestListPendingAssessments_AgeAndAssessmentFilters covers the core
+// post-conditions that issue #716's prompt loop depends on:
+//   - decisions older than the cutoff are surfaced
+//   - decisions younger than the cutoff are not
+//   - decisions with any-source assessment are excluded
+//   - decisions whose decision_type has no window are invisible
+//
+// All four cases hit the same query, which means a regression in any single
+// branch silently breaks the prompt loop in production. They are exercised
+// together to keep that surface honest.
+func TestListPendingAssessments_AgeAndAssessmentFilters(t *testing.T) {
+	ctx := context.Background()
+	suffix := uuid.New().String()[:8]
+	agentID := "pending-agent-" + suffix
+	now := time.Now().UTC()
+
+	// Old + unassessed: should appear.
+	oldUnassessed := makePendingFixture(t, ctx, suffix+"-old-unassessed",
+		agentID, "architecture", now.Add(-30*24*time.Hour))
+
+	// Old + manually assessed: should be excluded.
+	oldManuallyAssessed := makePendingFixture(t, ctx, suffix+"-old-manual",
+		agentID, "architecture", now.Add(-30*24*time.Hour))
+	_, err := testDB.CreateAssessment(ctx, uuid.Nil, model.DecisionAssessment{
+		DecisionID:      oldManuallyAssessed.ID,
+		AssessorAgentID: agentID,
+		Outcome:         model.AssessmentCorrect,
+		Source:          model.AssessmentSourceManual,
+	})
+	require.NoError(t, err)
+
+	// Old + auto-assessed (citation): should also be excluded — auto counts
+	// as already-assessed per the design (avoid prompt-loop noise once an
+	// auto signal has produced a verdict).
+	oldAutoAssessed := makePendingFixture(t, ctx, suffix+"-old-auto",
+		agentID, "architecture", now.Add(-30*24*time.Hour))
+	_, err = testDB.CreateAssessment(ctx, uuid.Nil, model.DecisionAssessment{
+		DecisionID:      oldAutoAssessed.ID,
+		AssessorAgentID: "system:" + model.AssessmentSourceCitation,
+		Outcome:         model.AssessmentCorrect,
+		Source:          model.AssessmentSourceCitation,
+	})
+	require.NoError(t, err)
+
+	// Young + unassessed: should not appear (still within the window).
+	makePendingFixture(t, ctx, suffix+"-young",
+		agentID, "architecture", now.Add(-2*time.Hour))
+
+	// Wrong type (no window passed): should not appear.
+	makePendingFixture(t, ctx, suffix+"-wrong-type",
+		agentID, "code_review", now.Add(-30*24*time.Hour))
+
+	// Apply a 7-day window for "architecture" only. "code_review" is omitted
+	// to assert the opt-out semantics (a type with no entry in Windows is
+	// invisible to the surface).
+	rows, err := testDB.ListPendingAssessments(ctx, uuid.Nil, storage.ListPendingAssessmentsOpts{
+		Windows: []storage.PendingAssessmentWindow{
+			{DecisionType: "architecture", Cutoff: now.Add(-7 * 24 * time.Hour)},
+		},
+		AgentIDs: []string{agentID},
+		Limit:    50,
+	})
+	require.NoError(t, err)
+
+	ids := pendingIDs(rows)
+	assert.Contains(t, ids, oldUnassessed.ID, "old unassessed decision should surface")
+	assert.NotContains(t, ids, oldManuallyAssessed.ID, "manual assessment must exclude")
+	assert.NotContains(t, ids, oldAutoAssessed.ID, "auto assessment (any source) must exclude")
+	for _, r := range rows {
+		assert.NotEqual(t, "code_review", r.DecisionType,
+			"opt-out type must never appear in results")
+	}
+}
+
+// TestListPendingAssessments_AgentScope ensures the AgentIDs filter respects
+// the contract documented on ListPendingAssessmentsOpts: nil means no
+// agent-level restriction; populated means restrict; explicit empty means
+// deny-all without touching the DB.
+func TestListPendingAssessments_AgentScope(t *testing.T) {
+	ctx := context.Background()
+	suffix := uuid.New().String()[:8]
+	agentA := "scope-a-" + suffix
+	agentB := "scope-b-" + suffix
+	now := time.Now().UTC()
+
+	dA := makePendingFixture(t, ctx, suffix+"-a", agentA, "architecture", now.Add(-14*24*time.Hour))
+	dB := makePendingFixture(t, ctx, suffix+"-b", agentB, "architecture", now.Add(-14*24*time.Hour))
+
+	windows := []storage.PendingAssessmentWindow{
+		{DecisionType: "architecture", Cutoff: now.Add(-7 * 24 * time.Hour)},
+	}
+
+	// Scope to agentA only.
+	rows, err := testDB.ListPendingAssessments(ctx, uuid.Nil, storage.ListPendingAssessmentsOpts{
+		Windows: windows, AgentIDs: []string{agentA}, Limit: 50,
+	})
+	require.NoError(t, err)
+	ids := pendingIDs(rows)
+	assert.Contains(t, ids, dA.ID)
+	assert.NotContains(t, ids, dB.ID, "agentA scope must hide agentB's decisions")
+
+	// Explicit empty AgentIDs slice → deny-all, no DB error.
+	rows, err = testDB.ListPendingAssessments(ctx, uuid.Nil, storage.ListPendingAssessmentsOpts{
+		Windows: windows, AgentIDs: []string{}, Limit: 50,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, rows, "empty agent set must yield zero rows")
+
+	// Nil AgentIDs (admin path) → both agents visible.
+	rows, err = testDB.ListPendingAssessments(ctx, uuid.Nil, storage.ListPendingAssessmentsOpts{
+		Windows: windows, AgentIDs: nil, Limit: 50,
+	})
+	require.NoError(t, err)
+	ids = pendingIDs(rows)
+	assert.Contains(t, ids, dA.ID)
+	assert.Contains(t, ids, dB.ID)
+}
+
+// TestListPendingAssessments_NoWindows confirms the empty-Windows short-circuit.
+// This is the path used when every configured type has window=0 (assessment
+// prompting fully disabled) — we must not issue a query that scans the whole
+// decisions table.
+func TestListPendingAssessments_NoWindows(t *testing.T) {
+	ctx := context.Background()
+	rows, err := testDB.ListPendingAssessments(ctx, uuid.Nil, storage.ListPendingAssessmentsOpts{
+		Windows: nil,
+		Limit:   10,
+	})
+	require.NoError(t, err)
+	assert.Nil(t, rows)
+}
+
+func pendingIDs(rows []model.PendingAssessment) []uuid.UUID {
+	out := make([]uuid.UUID, len(rows))
+	for i, r := range rows {
+		out[i] = r.DecisionID
+	}
+	return out
+}

--- a/internal/storage/sqlite/assessments.go
+++ b/internal/storage/sqlite/assessments.go
@@ -3,11 +3,15 @@ package sqlite
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/google/uuid"
 
 	"github.com/ashita-ai/akashi/internal/model"
+	"github.com/ashita-ai/akashi/internal/storage"
 )
 
 // CreateAssessment records an outcome assessment for a decision.
@@ -312,6 +316,107 @@ func (l *LiteDB) GetPrecedentCitationCount(ctx context.Context, orgID uuid.UUID,
 		return 0, fmt.Errorf("sqlite: precedent citation count: %w", err)
 	}
 	return count, nil
+}
+
+// ListPendingAssessments returns active decisions whose valid_from is older
+// than their per-type assessment window AND have no recorded assessment from
+// any source. Mirrors the PostgreSQL implementation; see its doc comment for
+// the full design rationale.
+func (l *LiteDB) ListPendingAssessments(ctx context.Context, orgID uuid.UUID, opts storage.ListPendingAssessmentsOpts) ([]model.PendingAssessment, error) {
+	if len(opts.Windows) == 0 {
+		return nil, nil
+	}
+	if opts.AgentIDs != nil && len(opts.AgentIDs) == 0 {
+		return nil, nil
+	}
+	if opts.Limit <= 0 {
+		opts.Limit = 10
+	}
+
+	// Build dynamic VALUES (?, ?), (?, ?), ... for the windows CTE.
+	values := make([]string, len(opts.Windows))
+	args := make([]any, 0, len(opts.Windows)*2+4)
+	for i, w := range opts.Windows {
+		values[i] = "(?, ?)"
+		args = append(args, w.DecisionType, w.Cutoff.UTC().Format(time.RFC3339Nano))
+	}
+	args = append(args, uuidStr(orgID))
+
+	// The interpolated segment is literal "(?, ?)" placeholders only — never
+	// user-controlled text. Every (decision_type, cutoff) value goes through
+	// the parameterized args slice. SQLite has no array binding equivalent
+	// to Postgres' unnest(), so a dynamic VALUES list is the standard pattern.
+	q := `WITH windows(decision_type, cutoff) AS (VALUES ` + //nolint:gosec // G202: only "(?, ?)" placeholders are concatenated; values flow through args
+		strings.Join(values, ", ") + `)
+		SELECT d.id, d.agent_id, d.decision_type, d.outcome, d.confidence,
+		       d.project, d.valid_from
+		FROM decisions d
+		JOIN windows w ON w.decision_type = d.decision_type
+		             AND datetime(d.valid_from) < datetime(w.cutoff)
+		LEFT JOIN decision_assessments a
+		    ON a.decision_id = d.id AND a.org_id = d.org_id
+		WHERE d.org_id = ?
+		  AND d.valid_to IS NULL
+		  AND a.id IS NULL`
+
+	if opts.Project != nil {
+		q += " AND d.project = ?"
+		args = append(args, *opts.Project)
+	}
+	if opts.AgentIDs != nil {
+		// json_each is the standard SQLite pattern for IN (?,?,...) with a
+		// variable-length set — also used by GetAssessmentSummaryBatch and
+		// GetDecisionsByIDs in this package.
+		idsJSON, err := json.Marshal(opts.AgentIDs)
+		if err != nil {
+			return nil, fmt.Errorf("sqlite: list pending assessments: marshal agent_ids: %w", err)
+		}
+		q += " AND d.agent_id IN (SELECT value FROM json_each(?))"
+		args = append(args, string(idsJSON))
+	}
+	q += " ORDER BY datetime(d.valid_from) ASC LIMIT ?"
+	args = append(args, opts.Limit)
+
+	rows, err := l.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("sqlite: list pending assessments: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck
+
+	now := time.Now().UTC()
+	out := make([]model.PendingAssessment, 0)
+	for rows.Next() {
+		var (
+			idStr        string
+			agentID      string
+			decisionType string
+			outcome      string
+			confidence   float32
+			project      sql.NullString
+			validFromStr string
+		)
+		if err := rows.Scan(&idStr, &agentID, &decisionType, &outcome, &confidence, &project, &validFromStr); err != nil {
+			return nil, fmt.Errorf("sqlite: list pending assessments: scan: %w", err)
+		}
+		p := model.PendingAssessment{
+			DecisionID:   parseUUID(idStr),
+			AgentID:      agentID,
+			DecisionType: decisionType,
+			Outcome:      outcome,
+			Confidence:   confidence,
+			ValidFrom:    parseTime(validFromStr),
+		}
+		if project.Valid {
+			s := project.String
+			p.Project = &s
+		}
+		p.AgeHours = now.Sub(p.ValidFrom).Hours()
+		out = append(out, p)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("sqlite: list pending assessments: rows: %w", err)
+	}
+	return out, nil
 }
 
 // HasAssessmentFromSource returns true if an assessment from the given source

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -18,6 +18,31 @@ import (
 	"github.com/ashita-ai/akashi/internal/model"
 )
 
+// PendingAssessmentWindow expresses "decisions of this type whose valid_from
+// is strictly older than Cutoff are eligible for outcome-assessment prompting".
+type PendingAssessmentWindow struct {
+	DecisionType string
+	Cutoff       time.Time
+}
+
+// ListPendingAssessmentsOpts narrows ListPendingAssessments.
+//
+// Windows is required: callers compute (decision_type, now-window) cutoffs from
+// configured per-type windows and pass only the types that opt in (window > 0).
+// An empty Windows slice yields zero rows by definition.
+//
+// AgentIDs scopes results: nil means no agent-level filter (admin caller);
+// otherwise rows are restricted to AgentIDs. An explicit empty slice yields
+// zero rows (the caller has access to no agents).
+//
+// Project, when non-nil, scopes by project (used for cross-project hygiene).
+type ListPendingAssessmentsOpts struct {
+	Windows  []PendingAssessmentWindow
+	AgentIDs []string
+	Project  *string
+	Limit    int
+}
+
 // Store is the storage interface consumed by the MCP tool path.
 //
 // Every method on this interface is already implemented by *DB (PostgreSQL).
@@ -91,6 +116,7 @@ type Store interface {
 	UpdateOutcomeScore(ctx context.Context, orgID, decisionID uuid.UUID, score *float32) error
 	GetPrecedentCitationCount(ctx context.Context, orgID uuid.UUID, decisionID uuid.UUID) (int, error)
 	HasAssessmentFromSource(ctx context.Context, orgID, decisionID uuid.UUID, source string) (bool, error)
+	ListPendingAssessments(ctx context.Context, orgID uuid.UUID, opts ListPendingAssessmentsOpts) ([]model.PendingAssessment, error)
 
 	// ---- Claims ----
 


### PR DESCRIPTION
## Summary

Adds `GET /v1/decisions/pending-assessment` and the `akashi_pending_assessments` MCP tool, which surface decisions past a per-type assessment window with no recorded assessment from any source — closing the feedback loop that the May 2026 field assessment flagged as our biggest operational gap (2.3% manual assessment coverage across 1,292 decisions). Default scope is the caller's own `agent_id`; pass `agent_id=*` to expand to the full grant set. Per-type windows are configurable via `AKASHI_ASSESSMENT_WINDOW_<TYPE>` with sensible defaults (7d for architecture/security/design/trade_off, 30d for planning, disabled for noisy types like `code_review`); setting `0` opts a type out. This is the prerequisite for usable confidence calibration, not a fix for it — the broken `0.4`-default confidence parse remains the gating issue for meaningful `avg_confidence` numbers.

## Verification

- [x] I ran relevant tests locally (`go test ./...` or targeted package tests).
- [x] I updated docs/openapi for any API or behavior changes.
- [x] If I changed config vars in \`internal/config/config.go\`, I also updated:
  - [x] \`docs/configuration.md\`
  - [ ] \`docs/runbook.md\` (operational subset, if relevant) — not relevant; this is a read-only prompt surface with no ops impact
  - [ ] \`.env.example\` (if baseline local/dev defaults changed) — defaults are sensible; per-type windows are tuning knobs, not baseline config
- [x] \`python3 scripts/check_doc_config_consistency.py\` passes.

## Risk / Rollout Notes

No migrations, no schema changes. The new HTTP route is registered only when a pending-assessment service is wired in, so deployments that don't construct one get a clean 404 instead of a 500. \"Any source counts as already assessed\" is intentional — auto-assessments from supersession/conflict/citation already produce verdicts, so re-prompting would be redundant noise (the same dismissal failure mode that hurt the conflict detector at 76% FP).

> The Vorlon question for any decision trail is \"Who are you?\" and the Shadow question is \"What do you want?\" — Akashi keeps asking both, but until now it never came back a week later and asked the Vorlon's harder follow-up: \"And was that the truth?\"