### PR TITLE
feat(conflicts): suppress cross-agent precedent-linked refinements

### DIFF
--- a/internal/conflicts/cross_agent_precedent_test.go
+++ b/internal/conflicts/cross_agent_precedent_test.go
@@ -1,0 +1,254 @@
+package conflicts
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ashita-ai/akashi/internal/model"
+)
+
+// TestIsCrossAgentPrecedentRefinement exercises the cross-agent sibling of
+// isSameAgentSameTicketRefinement. The filter is intentionally narrower than
+// the same-agent variant: it requires an EXPLICIT precedent_ref between the
+// pair (no inference from shared metadata), so the table covers each
+// guardrail in isolation.
+//
+// Anchor cases drawn from the 2026-05-22 open conflict queue:
+//   - ARD-1173 (suppressed): codex's audit-trigger refinement cites claude's
+//     plan via precedent_ref, same ticket, no supersession keyword.
+//   - ARD-1168 (NOT suppressed): no direct precedent_ref between the two
+//     agents — preserves the genuine disagreement that resolved with codex
+//     winning at 18:39 today.
+func TestIsCrossAgentPrecedentRefinement(t *testing.T) {
+	now := time.Date(2026, 5, 22, 4, 36, 0, 0, time.UTC)
+	idA := uuid.New()
+	idB := uuid.New()
+	mono := "mono"
+	other := "other"
+
+	taskCtx := func(task string) map[string]any {
+		return map[string]any{"client": map[string]any{"task": task}}
+	}
+
+	tests := []struct {
+		name     string
+		d        model.Decision
+		cand     model.Decision
+		expected bool
+	}{
+		{
+			// ARD-1173 anchor: codex 41b52b01 → claude cb9ca435 ("Builds on ...").
+			name: "cross-agent same ticket, B precedent_ref → A, no supersession kw → suppressed",
+			d: model.Decision{
+				ID: idA, AgentID: "claude-code", Project: &mono,
+				AgentContext: taskCtx("ARD-1173: implementation plan"),
+				Outcome:      "ARD-1173 plan: add api_keys.last_used_at column + index + debounced RPC",
+				ValidFrom:    now,
+			},
+			cand: model.Decision{
+				ID: idB, AgentID: "codex-mcp-client", Project: &mono,
+				AgentContext: taskCtx("fix ARD-1173 review findings"),
+				Outcome:      "Fixed ARD-1173 review findings using an api_keys-specific audit trigger",
+				ValidFrom:    now.Add(time.Hour),
+				PrecedentRef: &idA,
+			},
+			expected: true,
+		},
+		{
+			name: "cross-agent same ticket, A precedent_ref → B (reverse direction), no supersession kw → suppressed",
+			d: model.Decision{
+				ID: idA, AgentID: "claude-code", Project: &mono,
+				AgentContext: taskCtx("ARD-1173 follow-up"),
+				Outcome:      "ARD-1173 follow-up: completed the audit-trigger refinement",
+				ValidFrom:    now.Add(time.Hour),
+				PrecedentRef: &idB,
+			},
+			cand: model.Decision{
+				ID: idB, AgentID: "codex-mcp-client", Project: &mono,
+				AgentContext: taskCtx("ARD-1173 initial"),
+				Outcome:      "ARD-1173 initial: api_keys.last_used_at column + RPC",
+				ValidFrom:    now,
+			},
+			expected: true,
+		},
+		{
+			// ARD-1168 anchor: real disagreement, no precedent_ref between them.
+			name: "cross-agent same ticket but no precedent link → NOT suppressed (preserves real disagreements)",
+			d: model.Decision{
+				ID: idA, AgentID: "claude-code", Project: &mono,
+				AgentContext: taskCtx("ARD-1168 shared env fallback"),
+				Outcome:      "ARD-1168: broad ardent_owned fallback for GET /v1/environments",
+				ValidFrom:    now,
+			},
+			cand: model.Decision{
+				ID: idB, AgentID: "codex-mcp-client", Project: &mono,
+				AgentContext: taskCtx("ARD-1168 narrower fallback"),
+				Outcome:      "ARD-1168: narrow env_ardent-cloud-only fallback",
+				ValidFrom:    now.Add(time.Hour),
+			},
+			expected: false,
+		},
+		{
+			name: "cross-agent same ticket, precedent linked, later outcome has supersession kw → NOT suppressed",
+			d: model.Decision{
+				ID: idA, AgentID: "claude-code", Project: &mono,
+				AgentContext: taskCtx("ARD-1173"),
+				Outcome:      "ARD-1173 plan",
+				ValidFrom:    now,
+			},
+			cand: model.Decision{
+				ID: idB, AgentID: "codex-mcp-client", Project: &mono,
+				AgentContext: taskCtx("ARD-1173 revisit"),
+				Outcome:      "Reverted ARD-1173 audit-trigger approach; switched to last_used_only table",
+				ValidFrom:    now.Add(time.Hour),
+				PrecedentRef: &idA,
+			},
+			expected: false,
+		},
+		{
+			name: "cross-agent same ticket, precedent linked, supersession kw on EARLIER outcome only → suppressed (only later is inspected)",
+			d: model.Decision{
+				ID: idA, AgentID: "claude-code", Project: &mono,
+				AgentContext: taskCtx("ARD-1173"),
+				Outcome:      "Reverted a prior unrelated ARD-1173 approach",
+				ValidFrom:    now,
+			},
+			cand: model.Decision{
+				ID: idB, AgentID: "codex-mcp-client", Project: &mono,
+				AgentContext: taskCtx("ARD-1173 refinement"),
+				Outcome:      "Refined ARD-1173 with audit-trigger approach",
+				ValidFrom:    now.Add(time.Hour),
+				PrecedentRef: &idA,
+			},
+			expected: true,
+		},
+		{
+			name: "cross-agent, precedent linked, different tickets → NOT suppressed",
+			d: model.Decision{
+				ID: idA, AgentID: "claude-code", Project: &mono,
+				AgentContext: taskCtx("ARD-1173"),
+				Outcome:      "ARD-1173 plan",
+				ValidFrom:    now,
+			},
+			cand: model.Decision{
+				ID: idB, AgentID: "codex-mcp-client", Project: &mono,
+				AgentContext: taskCtx("ARD-1174"),
+				Outcome:      "ARD-1174 implementation referencing the ARD-1173 architecture",
+				ValidFrom:    now.Add(time.Hour),
+				PrecedentRef: &idA,
+			},
+			expected: false,
+		},
+		{
+			name: "cross-agent, precedent linked, no ticket on either side → NOT suppressed (no shared join key)",
+			d: model.Decision{
+				ID: idA, AgentID: "claude-code", Project: &mono,
+				AgentContext: nil,
+				Outcome:      "Refactored storage layer",
+				ValidFrom:    now,
+			},
+			cand: model.Decision{
+				ID: idB, AgentID: "codex-mcp-client", Project: &mono,
+				AgentContext: nil,
+				Outcome:      "Refactored storage layer more",
+				ValidFrom:    now.Add(time.Hour),
+				PrecedentRef: &idA,
+			},
+			expected: false,
+		},
+		{
+			name: "cross-agent, precedent linked, ticket only on one side → NOT suppressed",
+			d: model.Decision{
+				ID: idA, AgentID: "claude-code", Project: &mono,
+				AgentContext: taskCtx("ARD-1173"),
+				Outcome:      "ARD-1173 plan",
+				ValidFrom:    now,
+			},
+			cand: model.Decision{
+				ID: idB, AgentID: "codex-mcp-client", Project: &mono,
+				AgentContext: nil,
+				Outcome:      "Refactored storage layer",
+				ValidFrom:    now.Add(time.Hour),
+				PrecedentRef: &idA,
+			},
+			expected: false,
+		},
+		{
+			name: "cross-agent, precedent linked, same ticket, DIFFERENT projects → NOT suppressed (defense)",
+			d: model.Decision{
+				ID: idA, AgentID: "claude-code", Project: &mono,
+				AgentContext: taskCtx("ARD-1173"),
+				Outcome:      "ARD-1173 plan",
+				ValidFrom:    now,
+			},
+			cand: model.Decision{
+				ID: idB, AgentID: "codex-mcp-client", Project: &other,
+				AgentContext: taskCtx("ARD-1173"),
+				Outcome:      "ARD-1173 in other project",
+				ValidFrom:    now.Add(time.Hour),
+				PrecedentRef: &idA,
+			},
+			expected: false,
+		},
+		{
+			name: "SAME agent, same ticket, precedent linked → NOT suppressed here (same-agent path handles it)",
+			d: model.Decision{
+				ID: idA, AgentID: "claude-code", Project: &mono,
+				AgentContext: taskCtx("ARD-1173"),
+				Outcome:      "ARD-1173 plan",
+				ValidFrom:    now,
+			},
+			cand: model.Decision{
+				ID: idB, AgentID: "claude-code", Project: &mono,
+				AgentContext: taskCtx("ARD-1173 refinement"),
+				Outcome:      "ARD-1173 refined",
+				ValidFrom:    now.Add(time.Hour),
+				PrecedentRef: &idA,
+			},
+			expected: false,
+		},
+		{
+			name: "cross-agent, same ticket from outcome regex on both sides, precedent linked → suppressed",
+			d: model.Decision{
+				ID: idA, AgentID: "claude-code", Project: &mono,
+				AgentContext: nil,
+				Outcome:      "ARD-958 S2 implemented",
+				ValidFrom:    now,
+			},
+			cand: model.Decision{
+				ID: idB, AgentID: "codex-mcp-client", Project: &mono,
+				AgentContext: nil,
+				Outcome:      "ARD-958 follow-up extending S2",
+				ValidFrom:    now.Add(time.Hour),
+				PrecedentRef: &idA,
+			},
+			expected: true,
+		},
+		{
+			name: "cross-agent, precedent linked but no project set on either side (nil == nil) → suppressed when ticket matches",
+			d: model.Decision{
+				ID: idA, AgentID: "claude-code",
+				AgentContext: taskCtx("ARD-1173"),
+				Outcome:      "ARD-1173 plan",
+				ValidFrom:    now,
+			},
+			cand: model.Decision{
+				ID: idB, AgentID: "codex-mcp-client",
+				AgentContext: taskCtx("ARD-1173"),
+				Outcome:      "ARD-1173 refinement",
+				ValidFrom:    now.Add(time.Hour),
+				PrecedentRef: &idA,
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isCrossAgentPrecedentRefinement(tt.d, tt.cand))
+		})
+	}
+}

--- a/internal/conflicts/metrics.go
+++ b/internal/conflicts/metrics.go
@@ -31,6 +31,7 @@ type Metrics struct {
 	fpPatternFiltered            metric.Int64Counter
 	temporalReassessmentFiltered metric.Int64Counter
 	supersedesCandidateFiltered  metric.Int64Counter
+	crossAgentPrecedentFiltered  metric.Int64Counter
 
 	scoringDuration    metric.Float64Histogram
 	llmCallDuration    metric.Float64Histogram
@@ -203,6 +204,14 @@ func (s *Scorer) registerMetrics() {
 	if err != nil {
 		s.logger.Warn("conflicts: failed to create akashi.conflicts.supersedes_candidate_filtered metric", "error", err)
 		s.metrics.supersedesCandidateFiltered, _ = meter.Int64Counter("akashi.conflicts.supersedes_candidate_filtered.fallback")
+	}
+
+	s.metrics.crossAgentPrecedentFiltered, err = meter.Int64Counter("akashi.conflicts.cross_agent_precedent_filtered",
+		metric.WithDescription("Candidate pairs suppressed as cross-agent precedent-linked refinements on the same ticket (sibling of supersedes_candidate_filtered for cross-agent work)"),
+	)
+	if err != nil {
+		s.logger.Warn("conflicts: failed to create akashi.conflicts.cross_agent_precedent_filtered metric", "error", err)
+		s.metrics.crossAgentPrecedentFiltered, _ = meter.Int64Counter("akashi.conflicts.cross_agent_precedent_filtered.fallback")
 	}
 
 	// --- Histograms ---

--- a/internal/conflicts/scorer.go
+++ b/internal/conflicts/scorer.go
@@ -660,6 +660,24 @@ func (s *Scorer) scoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 			continue
 		}
 
+		// Cross-agent precedent-linked refinement filter: when two different
+		// agents trace decisions on the same ticket and one explicitly cites
+		// the other via precedent_ref, the cite IS the declaration that the
+		// later decision builds on the earlier — even when the LLM validator
+		// (which already sees PrecedentLinked, see validator.go) classifies
+		// them as contradiction because the outcomes mention competing
+		// implementation details. The agent's explicit cite is a stronger
+		// signal than the LLM's inference. Bails on supersession keywords so
+		// declared reversals still reach the validator.
+		if isCrossAgentPrecedentRefinement(d, sc.cand) {
+			s.metrics.crossAgentPrecedentFiltered.Add(ctx, 1)
+			s.logger.Debug("conflict scorer: cross-agent precedent refinement suppressed pair",
+				"decision_a", decisionID, "decision_b", sc.cand.ID,
+				"agent_a", d.AgentID, "agent_b", sc.cand.AgentID,
+				"ticket_ref", extractTicketRef(d))
+			continue
+		}
+
 		// Temporal re-assessment filter: two review-type decisions on the
 		// same project, recorded sufficiently far apart with no precedent
 		// link, are re-measurements rather than contradictions. Quantitative
@@ -1515,6 +1533,58 @@ func isSameAgentSameTicketRefinement(d, cand model.Decision) bool {
 		return false
 	}
 	if isPrecedentLinked(d, cand) {
+		return false
+	}
+	later := d
+	if cand.ValidFrom.After(d.ValidFrom) {
+		later = cand
+	}
+	if containsSupersessionKeyword(later.Outcome) {
+		return false
+	}
+	refA := extractTicketRef(d)
+	if refA == "" {
+		return false
+	}
+	return refA == extractTicketRef(cand)
+}
+
+// isCrossAgentPrecedentRefinement returns true when two different agents
+// trace decisions on the same ticket, one explicitly cites the other via
+// precedent_ref, and the later outcome contains no supersession keywords.
+//
+// Cross-agent analogue of isSameAgentSameTicketRefinement: the same-agent
+// filter targets forgotten-supersedes within one agent's work; this filter
+// targets the case where agent B explicitly declares "I am building on A"
+// (by setting precedent_ref to A on the same ticket) yet the LLM validator
+// still classifies the pair as contradiction because the two outcomes
+// mention competing implementation details.
+//
+// Conservative by construction. Required signals:
+//   - different agents
+//   - precedent_ref explicit between the two decisions (either direction)
+//   - identical extracted ticket reference on both sides
+//   - same project (defense against pathological cross-project precedent_refs)
+//   - later outcome free of supersession keywords (so declared reversals
+//     and partial supersessions still reach the validator)
+//
+// Does NOT catch (deliberately):
+//   - same-ticket cross-agent pairs without precedent_ref — those may be
+//     genuine disagreements (e.g. ARD-1168 broad vs narrow shared-env
+//     fallback, which resolved with codex winning)
+//   - pairs sharing only a common-ancestor precedent_ref but not citing
+//     each other — shared ancestry is too weak a signal to suppress, in
+//     line with the 8f5124c8 reversal of bare same-branch suppression
+//
+// See sibling isSameAgentSameTicketRefinement for the same-agent variant.
+func isCrossAgentPrecedentRefinement(d, cand model.Decision) bool {
+	if d.AgentID == cand.AgentID {
+		return false
+	}
+	if !isPrecedentLinked(d, cand) {
+		return false
+	}
+	if derefString(d.Project) != derefString(cand.Project) {
 		return false
 	}
 	later := d

--- a/internal/conflicts/ticket_extract.go
+++ b/internal/conflicts/ticket_extract.go
@@ -24,9 +24,10 @@ var ticketRefPattern = regexp.MustCompile(`(?i)\b([A-Z]{3,10})-(\d+)\b`)
 // appear in the same source, returns the first match — agents conventionally
 // place the primary ticket first.
 //
-// Used by isSameAgentSameTicketRefinement to suppress false-positive
-// contradictions when the same agent refines their own prior decision on the
-// same ticket without setting supersedes_id.
+// Used by isSameAgentSameTicketRefinement and isCrossAgentPrecedentRefinement
+// to suppress false-positive contradictions when an agent refines a prior
+// decision on the same ticket — either implicitly (same-agent, no
+// supersedes_id link) or explicitly (cross-agent, precedent_ref set).
 func extractTicketRef(d model.Decision) string {
 	refs := extractTicketRefs(d)
 	if len(refs) == 0 {


### PR DESCRIPTION
## Summary

Adds `isCrossAgentPrecedentRefinement` as the cross-agent sibling of `isSameAgentSameTicketRefinement` (#711). Suppresses pairs where two different agents trace decisions on the same ticket, one explicitly cites the other via `precedent_ref`, both share the same project, and the later outcome contains no supersession keywords. Motivated by today's ARD-1173 open conflict (codex `41b52b01` cites claude `cb9ca435` with precedent_reason "refinement"; LLM validator still verdicts contradiction) — the agent's explicit cite is a stronger signal than the LLM's inference. Deliberately narrow: requires explicit precedent_ref rather than bare shared metadata, respecting the `8f5124c8` reversal lesson, so unlinked same-ticket pairs (e.g. ARD-1168) still reach the validator.

## Verification

- [x] I ran relevant tests locally (`go test -race -count=1 ./...` — all 28 packages green, 12 new table tests pass).
- [x] I updated docs/openapi for any API or behavior changes. *(N/A — internal filter, no API surface change.)*
- [x] If I changed config vars in `internal/config/config.go`, I also updated: *(N/A — no new config vars.)*
- [x] `python3 scripts/check_doc_config_consistency.py` passes.

Pre-commit gauntlet also clean: `go build`, `go vet`, `go mod tidy`, `golangci-lint run ./...` (0 issues), `atlas migrate validate`.

## Risk / Rollout Notes

- **Defaults**: filter is on for every Scorer instance, no config flag. Consistent with existing filter chain — opt-out would dilute the value.
- **FN risk**: a real cross-agent disagreement on the same ticket that nonetheless has a `precedent_ref` and no supersession verb in the later outcome would be silently suppressed. Mitigated by the four guardrails (precedent_ref required, same ticket, same project, supersession-keyword bail) and by the LLM still being available when the agent uses reversal vocabulary.
- **No migration, no API change, no operational risk**. New OTel counter `akashi.conflicts.cross_agent_precedent_filtered` is opt-in via dashboards.
- Verified against the live open queue: ARD-1173 suppresses (correctly); ARD-1168 does not fire (preserves the real disagreement that resolved with codex winning today).

> Among the towers of Minas Tirith, the loudest voice is rarely the most credible. Faramir, who declined the One Ring without a debate, understood that a clear declaration of intent — "I would not take this thing if it lay by the highway" — beats any later forensic reconstruction. This filter trusts the agent's own precedent_ref the way Denethor refused to trust his son: which is to say, the agent's declaration outranks the watcher's verdict.