### PR TITLE
Persist ticket context on conflicts

### DIFF
--- a/internal/conflicts/scorer.go
+++ b/internal/conflicts/scorer.go
@@ -719,6 +719,8 @@ func (s *Scorer) scoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 		examined++
 
 		cand := sc.cand
+		ticketRefsA := extractTicketRefs(d)
+		ticketRefsB := extractTicketRefs(cand)
 
 		// Cross-encoder reranking: pre-filter before expensive LLM validation.
 		// Only applies to the built-in LLM path — skipped when using the
@@ -818,6 +820,8 @@ func (s *Scorer) scoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 				FullOutcomeB:      cand.Outcome,
 				BranchA:           nestedContextString(d.AgentContext, "git_branch"),
 				BranchB:           nestedContextString(cand.AgentContext, "git_branch"),
+				TicketRefsA:       ticketRefsA,
+				TicketRefsB:       ticketRefsB,
 				TopicSimilarity:   sc.topicSim,
 				PrecedentLinked:   isPrecedentLinked(d, cand),
 				OutcomeSimilarity: sc.outcomeSim,
@@ -942,6 +946,14 @@ func (s *Scorer) scoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 		branchB := nestedContextString(cand.AgentContext, "git_branch")
 		if branchA != "" && branchB != "" && branchA != branchB {
 			note := fmt.Sprintf(" [Branch context: Decision A on %q, Decision B on %q — consider whether this represents parallel work.]", branchA, branchB)
+			if c.Explanation != nil {
+				annotated := *c.Explanation + note
+				c.Explanation = &annotated
+			} else {
+				c.Explanation = &note
+			}
+		}
+		if note := ticketContextNote(ticketRefsA, ticketRefsB); note != "" {
 			if c.Explanation != nil {
 				annotated := *c.Explanation + note
 				c.Explanation = &annotated
@@ -1754,6 +1766,18 @@ var refinementKeywords = []string{
 	"resolved",
 	"completed",
 	"addressed",
+}
+
+func ticketContextNote(a, b []string) string {
+	if len(a) == 0 || len(b) == 0 {
+		return ""
+	}
+	refsA := strings.Join(a, ", ")
+	refsB := strings.Join(b, ", ")
+	if ticketRefsOverlap(a, b) {
+		return fmt.Sprintf(" [Ticket context: Decision A references %s; Decision B references %s. Shared ticket references were available during validation.]", refsA, refsB)
+	}
+	return fmt.Sprintf(" [Ticket context: Decision A references %s; Decision B references %s. Non-overlapping ticket references were available during validation; the conflict was retained because validation found the same design question or an explicit supersession/rejection.]", refsA, refsB)
 }
 
 func derefString(s *string) string {

--- a/internal/conflicts/scorer_test.go
+++ b/internal/conflicts/scorer_test.go
@@ -3240,6 +3240,86 @@ func TestScoreForDecision_SameAgentSameTicketSuggestion(t *testing.T) {
 	assert.Contains(t, suggestions[0].Reason, agentID)
 }
 
+func TestScoreForDecision_ConfirmedConflictPersistsTicketContext(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	orgID := uuid.Nil
+
+	suffix := uuid.New().String()[:8]
+	agentA := "ticket-context-a-" + suffix
+	agentB := "ticket-context-b-" + suffix
+	for _, agentID := range []string{agentA, agentB} {
+		_, err := testDB.CreateAgent(ctx, model.Agent{
+			AgentID: agentID, OrgID: orgID, Name: agentID, Role: model.RoleAgent,
+		})
+		require.NoError(t, err)
+	}
+
+	runA := createRun(t, agentA, orgID)
+	runB := createRun(t, agentB, orgID)
+	project := "ticket-context-project-" + suffix
+	topicEmb := makeEmbedding(940, 1.0)
+	outcomeEmbA := makeEmbedding(941, 1.0)
+	outcomeEmbB := makeEmbedding(942, 1.0)
+
+	dA, err := testDB.CreateDecision(ctx, model.Decision{
+		RunID:        runA.ID,
+		AgentID:      agentA,
+		OrgID:        orgID,
+		DecisionType: "architecture",
+		Outcome:      "ARD-1429 keeps pgstream snapshot/WAL parity at schema-level only",
+		Confidence:   0.9,
+		Embedding:    &topicEmb, OutcomeEmbedding: &outcomeEmbA,
+		Project: &project,
+	})
+	require.NoError(t, err)
+
+	dB, err := testDB.CreateDecision(ctx, model.Decision{
+		RunID:        runB.ID,
+		AgentID:      agentB,
+		OrgID:        orgID,
+		DecisionType: "architecture",
+		Outcome:      "ARD-1430 moves pgstream snapshot/WAL parity to table-level patterns",
+		Confidence:   0.9,
+		Embedding:    &topicEmb, OutcomeEmbedding: &outcomeEmbB,
+		Project: &project,
+	})
+	require.NoError(t, err)
+
+	validator := &scorerMockValidator{
+		result: ValidationResult{
+			Relationship: "contradiction",
+			Category:     "strategic",
+			Severity:     "high",
+			Explanation:  "The two agents chose incompatible parity scopes for the same mechanism.",
+		},
+	}
+	scorer := NewScorer(testDB, logger, 0.1, validator, 0, 0)
+	scorer = scorer.WithCandidateFinder(storage.NewPgCandidateFinder(testDB))
+	scorer.ScoreForDecision(ctx, dB.ID, orgID)
+
+	assert.Greater(t, validator.calls, 0, "disjoint-ticket same-question pairs must reach validation")
+
+	conflicts, err := testDB.ListConflicts(ctx, orgID, storage.ConflictFilters{}, 1000, 0)
+	require.NoError(t, err)
+	var found bool
+	for _, c := range conflicts {
+		aMatch := c.DecisionAID == dA.ID || c.DecisionBID == dA.ID
+		bMatch := c.DecisionAID == dB.ID || c.DecisionBID == dB.ID
+		if aMatch && bMatch {
+			found = true
+			require.NotNil(t, c.Explanation)
+			assert.Contains(t, *c.Explanation, "The two agents chose incompatible parity scopes")
+			assert.Contains(t, *c.Explanation, "Ticket context")
+			assert.Contains(t, *c.Explanation, "ARD-1429")
+			assert.Contains(t, *c.Explanation, "ARD-1430")
+			assert.Contains(t, *c.Explanation, "Non-overlapping ticket references")
+			break
+		}
+	}
+	assert.True(t, found, "validator-confirmed conflict should retain a durable conflict record")
+}
+
 func TestScoreForDecision_SameBranchCrossAgentMechanicalReachesValidator(t *testing.T) {
 	ctx := context.Background()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))

--- a/internal/conflicts/validator.go
+++ b/internal/conflicts/validator.go
@@ -37,6 +37,8 @@ type ValidateInput struct {
 	FullOutcomeB      string
 	BranchA           string // git branch from agent_context
 	BranchB           string
+	TicketRefsA       []string
+	TicketRefsB       []string
 	TopicSimilarity   float64 // decision-level embedding similarity (0–1); 0 means unavailable
 	PrecedentLinked   bool    // true when one decision cites the other via precedent_ref
 	OutcomeSimilarity float64 // outcome embedding similarity (0–1); 0 means unavailable
@@ -157,6 +159,22 @@ func formatPrompt(input ValidateInput) string {
 		fmt.Fprintf(&b, "Task (%s): %s\n", input.AgentB, compact.Truncate(input.TaskB, 100))
 	}
 
+	// --- Ticket context (#717 follow-up: disjoint-ticket false positives) ---
+	if len(input.TicketRefsA) > 0 && len(input.TicketRefsB) > 0 {
+		refsA := strings.Join(input.TicketRefsA, ", ")
+		refsB := strings.Join(input.TicketRefsB, ", ")
+		if ticketRefsOverlap(input.TicketRefsA, input.TicketRefsB) {
+			fmt.Fprintf(&b, "Shared ticket context: %s vs %s. Shared ticket references are evidence these decisions may address the same work item.\n",
+				refsA, refsB)
+		} else {
+			fmt.Fprintf(&b, "DIFFERENT TICKETS: %q's decision references %s; %q's decision references %s. "+
+				"Non-overlapping ticket references usually mean separate work items, even inside the same repository or component. "+
+				"Classify as UNRELATED or COMPLEMENTARY unless both decisions explicitly address the same specific design question, "+
+				"or one decision explicitly says it supersedes/rejects the other.\n",
+				input.AgentA, refsA, input.AgentB, refsB)
+		}
+	}
+
 	// --- Session context (#170: temporal refinement) ---
 	if input.SessionIDA != "" && input.SessionIDB != "" && input.SessionIDA == input.SessionIDB {
 		b.WriteString("SAME SESSION: Both decisions were recorded in the same work session. Sequential decisions are typically REFINEMENT or COMPLEMENTARY, not contradictions.\n")
@@ -258,6 +276,22 @@ SEVERITY: critical, high, medium, or low
 EXPLANATION: one sentence using agent names (not "Decision A" or "Decision B")`)
 
 	return b.String()
+}
+
+func ticketRefsOverlap(a, b []string) bool {
+	if len(a) == 0 || len(b) == 0 {
+		return false
+	}
+	seen := make(map[string]struct{}, len(a))
+	for _, ref := range a {
+		seen[ref] = struct{}{}
+	}
+	for _, ref := range b {
+		if _, ok := seen[ref]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 // workflowPairs maps decision type pairs that represent sequential workflows

--- a/internal/conflicts/validator_test.go
+++ b/internal/conflicts/validator_test.go
@@ -589,6 +589,75 @@ func TestFormatPrompt_NullRepoSameAgent(t *testing.T) {
 	assert.NotContains(t, prompt, "DIFFERENT PROJECTS")
 }
 
+func TestFormatPrompt_DifferentTicketRefs(t *testing.T) {
+	now := time.Now()
+	prompt := formatPrompt(ValidateInput{
+		OutcomeA:    "Ported ARD-1429 Terraform/runbook changes onto a clean branch",
+		OutcomeB:    "Cleaned ARD-1117 PR branch history by cherry-picking rollout commits",
+		TypeA:       "trade_off",
+		TypeB:       "trade_off",
+		AgentA:      "codex-mcp-client",
+		AgentB:      "codex-coder",
+		CreatedA:    now,
+		CreatedB:    now.Add(time.Hour),
+		TicketRefsA: []string{"ARD-1429"},
+		TicketRefsB: []string{"ARD-1117"},
+	})
+
+	assert.Contains(t, prompt, "DIFFERENT TICKETS")
+	assert.Contains(t, prompt, "ARD-1429")
+	assert.Contains(t, prompt, "ARD-1117")
+	assert.Contains(t, prompt, "separate work items")
+	assert.Contains(t, prompt, "same specific design question")
+}
+
+func TestFormatPrompt_DifferentTicketRefsSameDesignQuestionCanStillConflict(t *testing.T) {
+	now := time.Now()
+	prompt := formatPrompt(ValidateInput{
+		OutcomeA:        "ARD-1429 requires pgstream snapshot/WAL parity to stay schema-level only",
+		OutcomeB:        "ARD-1430 requires pgstream snapshot/WAL parity to move to table-level patterns",
+		TypeA:           "architecture",
+		TypeB:           "architecture",
+		AgentA:          "planner-a",
+		AgentB:          "planner-b",
+		CreatedA:        now,
+		CreatedB:        now.Add(time.Hour),
+		TicketRefsA:     []string{"ARD-1429"},
+		TicketRefsB:     []string{"ARD-1430"},
+		TopicSimilarity: 0.82,
+	})
+
+	assert.Contains(t, prompt, "DIFFERENT TICKETS")
+	assert.Contains(t, prompt, "same specific design question")
+	assert.Contains(t, prompt, "Two agents recommending DIFFERENT approaches to the SAME design question ARE contradictions")
+	assert.Contains(t, prompt, "OPPOSITE STANCES")
+}
+
+func TestFormatPrompt_SharedTicketRefs(t *testing.T) {
+	now := time.Now()
+	prompt := formatPrompt(ValidateInput{
+		OutcomeA:    "ARD-958 uses Redis for session cache",
+		OutcomeB:    "ARD-958 uses Memcached for session cache",
+		TypeA:       "architecture",
+		TypeB:       "architecture",
+		AgentA:      "planner-a",
+		AgentB:      "planner-b",
+		CreatedA:    now,
+		CreatedB:    now.Add(time.Hour),
+		TicketRefsA: []string{"ARD-958"},
+		TicketRefsB: []string{"ARD-958", "ARD-960"},
+	})
+
+	assert.Contains(t, prompt, "Shared ticket context")
+	assert.NotContains(t, prompt, "DIFFERENT TICKETS")
+}
+
+func TestTicketRefsOverlap(t *testing.T) {
+	assert.True(t, ticketRefsOverlap([]string{"ARD-958"}, []string{"ARD-960", "ARD-958"}))
+	assert.False(t, ticketRefsOverlap([]string{"ARD-958"}, []string{"ARD-960"}))
+	assert.False(t, ticketRefsOverlap(nil, []string{"ARD-960"}))
+}
+
 func TestIsWorkflowPair(t *testing.T) {
 	// Positive cases: review/analysis types followed by fix/implementation types.
 	assert.True(t, isWorkflowPair("code_review", "bug_fix"))


### PR DESCRIPTION
## Summary

- Add ticket-reference context to conflict validation and persist it on confirmed conflict explanations for auditability.
- Keep disjoint-ticket pairs eligible for conflict records when validation finds the same design question or an explicit supersession/rejection.

## Verification

- [x] I ran relevant tests locally (`go test ./...` or targeted package tests): `go test -race -count=1 ./...`, `go test -race -count=1 -tags integration ./...`, and targeted conflict package tests.
- [x] No docs/openapi updates needed; this does not change public API behavior.
- [x] No config vars changed in `internal/config/config.go`.
- [ ] `python3 scripts/check_doc_config_consistency.py` passes. Not run; no config docs changed.

## Risk / Rollout Notes

- No migrations, schema changes, or backward-incompatible behavior; this only enriches validation context and newly stored conflict explanations.

> Starlight on the Shire
> A ring bends two roads inward
> Dawn keeps the ledger
