### PR TITLE
Improve conflict resolution feedback

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1637,6 +1637,10 @@ paths:
       description: |
         Transition a conflict to a new lifecycle state (resolved,
         false_positive). Resolution requires `agent` role or higher.
+        When `winning_decision_id` is provided with status `resolved`, the
+        conflict is automatically labeled `genuine` for scorer evaluation.
+        When status is `false_positive`, the conflict is automatically labeled
+        using `false_positive_label`.
       parameters:
         - name: id
           in: path
@@ -1729,7 +1733,10 @@ paths:
       description: |
         Resolves all open conflicts in a conflict group at once.
         When `winning_agent` is provided with status "resolved", each conflict's
-        `winning_decision_id` is set to the decision from that agent.
+        `winning_decision_id` is set to the decision from that agent and each
+        updated conflict is automatically labeled `genuine` for scorer
+        evaluation. False-positive group resolutions are automatically labeled
+        using `false_positive_label`.
         Requires `agent` role or higher.
       parameters:
         - name: id
@@ -1890,6 +1897,42 @@ paths:
       responses:
         "204":
           description: Label deleted.
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /v1/admin/conflicts/{id}/resolution-note:
+    patch:
+      operationId: amendConflictResolutionNote
+      tags: [Admin]
+      summary: Amend a resolved conflict's resolution note
+      description: |
+        Updates the resolution note for a terminal conflict (`resolved` or
+        `false_positive`) and records the amendment in the mutation audit log.
+        Open conflicts cannot have resolution notes amended through this route.
+        Requires `admin` role or higher.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: The scored conflict ID.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ConflictResolutionNoteUpdate"
+      responses:
+        "200":
+          description: Updated conflict.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/APIResponse_DecisionConflict"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "404":
           $ref: "#/components/responses/NotFound"
 
@@ -4171,6 +4214,16 @@ components:
             Optional. The decision judged to be correct. Must be decision_a_id or
             decision_b_id of the conflict. Only valid when status is "resolved".
             When omitted, the conflict is resolved without declaring a winner.
+            When present, the conflict is automatically labeled `genuine` for
+            scorer evaluation.
+
+    ConflictResolutionNoteUpdate:
+      type: object
+      required: [resolution_note]
+      properties:
+        resolution_note:
+          type: string
+          description: Corrected explanation of how/why the conflict was resolved.
 
     ConflictGroupResolveRequest:
       type: object
@@ -4189,6 +4242,14 @@ components:
             Optional. Resolve all conflicts in favor of decisions from this agent.
             Only valid when status is "resolved". Each conflict's winning_decision_id
             is set to the decision from this agent (decision_a or decision_b).
+            When present, updated conflicts are automatically labeled `genuine`
+            for scorer evaluation.
+        false_positive_label:
+          type: string
+          enum: [unrelated_false_positive, related_not_contradicting]
+          description: |
+            Label for false positive ground truth. Defaults to unrelated_false_positive
+            when status is false_positive.
 
     ConflictGroupResolveResult:
       type: object

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -665,6 +665,10 @@ Every detected conflict (in `scored_conflicts`) can be labeled with one of three
 | `related_not_contradicting` | Same topic but not actually contradictory (e.g. paraphrases) | False positive |
 | `unrelated_false_positive` | Different topics entirely — should not have been flagged | False positive |
 
+Resolution endpoints also create labels automatically: resolving with a declared
+winner labels the conflict `genuine`, while marking a conflict `false_positive`
+labels it with `false_positive_label` (default `unrelated_false_positive`).
+
 ### Labeling Conflicts via API
 
 All label endpoints require admin authentication.
@@ -702,6 +706,35 @@ curl -s http://localhost:8081/v1/admin/conflict-labels \
 curl -X DELETE http://localhost:8081/v1/admin/conflicts/{id}/label \
   -H "Authorization: Bearer $TOKEN"
 ```
+
+### Amending Resolution Notes
+
+If a terminal conflict has a mis-keyed resolution note, amend the note through
+the admin route instead of reopening the conflict:
+
+```sh
+curl -X PATCH http://localhost:8081/v1/admin/conflicts/{id}/resolution-note \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"resolution_note": "corrected rationale for this conflict"}'
+```
+
+Open conflicts return `400`; resolve or mark them false-positive first.
+
+### Reducing False Positives
+
+For a noisy deployment, switch to the high-precision profile and force one
+rescore:
+
+```sh
+export AKASHI_CONFLICT_PROFILE=high_precision
+export AKASHI_FORCE_CONFLICT_RESCORE=true
+```
+
+Restart once with both variables set, wait for rescore to complete, then remove
+`AKASHI_FORCE_CONFLICT_RESCORE` so future restarts do not clear and rebuild the
+conflict table again. Keep `AKASHI_CONFLICT_PROFILE=high_precision` if the
+deployment favors reviewer time over marginal recall.
 
 ### Running Scorer Eval (Precision from Labels)
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -2170,15 +2170,15 @@ func (s *Server) handleResolve(ctx context.Context, request mcplib.CallToolReque
 
 	actorRole := string(claims.Role)
 
-	// Compute false_positive label once — passed to both resolution paths.
+	// Compute the ground-truth label once — passed to both resolution paths.
 	rawFPLabel := request.GetString("false_positive_label", "")
-	fpLabel := storage.ComputeFPLabel(status, &rawFPLabel)
+	resolutionLabel := storage.ComputeResolutionLabel(status, winningDecisionID, &rawFPLabel)
 
 	// Attempt single-conflict resolution first. UpdateConflictStatusWithAudit
 	// uses SELECT ... FOR UPDATE inside its transaction, so there is no
 	// read-then-write race. If the ID doesn't match a scored_conflict, fall
 	// back to group resolution.
-	singleResult, singleErr := s.resolveSingleConflict(ctx, conflictID, orgID, status, resolvedBy, actorRole, resolutionNote, winningDecisionID, fpLabel)
+	singleResult, singleErr := s.resolveSingleConflict(ctx, conflictID, orgID, status, resolvedBy, actorRole, resolutionNote, winningDecisionID, resolutionLabel)
 	if singleErr != nil {
 		return nil, singleErr
 	}
@@ -2187,7 +2187,7 @@ func (s *Server) handleResolve(ctx context.Context, request mcplib.CallToolReque
 	}
 
 	// Not a scored_conflict ID — try resolving as a conflict_group ID.
-	return s.resolveGroup(ctx, conflictID, orgID, status, resolvedBy, actorRole, resolutionNote, winningDecisionID, fpLabel)
+	return s.resolveGroup(ctx, conflictID, orgID, status, resolvedBy, actorRole, resolutionNote, winningDecisionID, resolutionLabel)
 }
 
 func (s *Server) handleReconcile(ctx context.Context, request mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
@@ -2332,7 +2332,7 @@ func (s *Server) resolveSingleConflict(
 	status, resolvedBy, actorRole string,
 	resolutionNote *string,
 	winningDecisionID *uuid.UUID,
-	fpLabel *string,
+	resolutionLabel *string,
 ) (*mcplib.CallToolResult, error) {
 	audit := storage.MutationAuditEntry{
 		OrgID:        orgID,
@@ -2345,7 +2345,7 @@ func (s *Server) resolveSingleConflict(
 		Metadata:     map[string]any{"new_status": status, "resolved_by": resolvedBy},
 	}
 
-	oldStatus, err := s.db.UpdateConflictStatusWithAudit(ctx, conflictID, orgID, status, resolvedBy, resolutionNote, winningDecisionID, fpLabel, audit)
+	oldStatus, err := s.db.UpdateConflictStatusWithAudit(ctx, conflictID, orgID, status, resolvedBy, resolutionNote, winningDecisionID, resolutionLabel, audit)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
 			// Not a scored_conflict — return nil to signal fallback to group path.
@@ -2427,7 +2427,7 @@ func (s *Server) resolveGroup(
 	status, resolvedBy, actorRole string,
 	resolutionNote *string,
 	winningDecisionID *uuid.UUID,
-	fpLabel *string,
+	resolutionLabel *string,
 ) (*mcplib.CallToolResult, error) {
 	// Convert winning_decision_id → winning agent. The storage method resolves
 	// per-conflict winners atomically via SQL CASE on agent_a/agent_b, which is
@@ -2443,6 +2443,7 @@ func (s *Server) resolveGroup(
 			return errorResult("winning_decision_id not found"), nil
 		}
 		winningAgent = &dec.AgentID
+		resolutionLabel = storage.ComputeGroupResolutionLabel(status, winningAgent, nil)
 	}
 
 	audit := storage.MutationAuditEntry{
@@ -2456,7 +2457,7 @@ func (s *Server) resolveGroup(
 		Metadata:     map[string]any{"new_status": status, "resolved_by": resolvedBy},
 	}
 
-	affected, err := s.db.ResolveConflictGroup(ctx, groupID, orgID, status, resolvedBy, resolutionNote, winningAgent, fpLabel, audit)
+	affected, err := s.db.ResolveConflictGroup(ctx, groupID, orgID, status, resolvedBy, resolutionNote, winningAgent, resolutionLabel, audit)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
 			return errorResult("conflict not found (no scored_conflict or conflict_group matches this ID)"), nil

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -2926,6 +2926,10 @@ func TestHandleResolve_WithWinner(t *testing.T) {
 	assert.Equal(t, "open", resp.OldStatus)
 	assert.Equal(t, "resolved", resp.NewStatus)
 	assert.Equal(t, testAdminID, resp.ResolvedBy)
+
+	label, labelErr := testDB.GetConflictLabel(ctx, conflictID, uuid.Nil)
+	require.NoError(t, labelErr)
+	assert.Equal(t, "genuine", label.Label)
 }
 
 func TestHandleReconcile_Success(t *testing.T) {
@@ -3811,6 +3815,12 @@ func TestHandleResolve_GroupID_ResolvedWithWinner(t *testing.T) {
 	require.NotNil(t, c2After.WinningDecisionID, "conflict 2 should have a winner")
 	assert.True(t, agentADecisions[*c2After.WinningDecisionID],
 		"conflict 2 winner %s should be one of agentA's decisions", c2After.WinningDecisionID)
+
+	for _, cid := range []uuid.UUID{conflictID1, conflictID2} {
+		label, labelErr := testDB.GetConflictLabel(ctx, cid, uuid.Nil)
+		require.NoError(t, labelErr)
+		assert.Equal(t, "genuine", label.Label)
+	}
 }
 
 func TestHandleResolve_GroupID_NotFound(t *testing.T) {

--- a/internal/server/broker_test.go
+++ b/internal/server/broker_test.go
@@ -541,6 +541,7 @@ func TestNewBroker(t *testing.T) {
 
 	if broker == nil {
 		t.Fatal("NewBroker returned nil")
+		return
 	}
 	if broker.logger != logger {
 		t.Error("NewBroker did not set logger")

--- a/internal/server/handlers_conflicts.go
+++ b/internal/server/handlers_conflicts.go
@@ -165,14 +165,14 @@ func (h *Handlers) HandlePatchConflict(w http.ResponseWriter, r *http.Request) {
 
 	resolvedBy := claims.ActorID()
 
-	fpLabel := storage.ComputeFPLabel(req.Status, req.FalsePositiveLabel)
+	resolutionLabel := storage.ComputeResolutionLabel(req.Status, req.WinningDecisionID, req.FalsePositiveLabel)
 
 	audit := h.buildAuditEntry(r, orgID,
 		"conflict_status_changed", "conflict", id.String(),
 		nil, nil,
 		map[string]any{"new_status": req.Status, "resolved_by": resolvedBy},
 	)
-	if _, err := h.db.UpdateConflictStatusWithAudit(r.Context(), id, orgID, req.Status, resolvedBy, req.ResolutionNote, req.WinningDecisionID, fpLabel, audit); err != nil {
+	if _, err := h.db.UpdateConflictStatusWithAudit(r.Context(), id, orgID, req.Status, resolvedBy, req.ResolutionNote, req.WinningDecisionID, resolutionLabel, audit); err != nil {
 		if isNotFoundError(err) {
 			writeError(w, r, http.StatusNotFound, model.ErrCodeNotFound, "conflict not found")
 			return
@@ -204,6 +204,58 @@ func (h *Handlers) HandlePatchConflict(w http.ResponseWriter, r *http.Request) {
 		h.executeCascadeResolution(r, orgID, *conflict, *req.WinningDecisionID)
 	}
 
+	writeJSON(w, r, http.StatusOK, conflict)
+}
+
+type conflictResolutionNoteUpdate struct {
+	ResolutionNote *string `json:"resolution_note"`
+}
+
+// HandleAmendConflictResolutionNote handles PATCH /v1/admin/conflicts/{id}/resolution-note.
+func (h *Handlers) HandleAmendConflictResolutionNote(w http.ResponseWriter, r *http.Request) {
+	claims := ClaimsFromContext(r.Context())
+	orgID := OrgIDFromContext(r.Context())
+
+	id, err := parsePathUUID(r, "id")
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "invalid conflict id")
+		return
+	}
+
+	var req conflictResolutionNoteUpdate
+	if err := decodeJSON(w, r, &req, h.maxRequestBodyBytes); err != nil {
+		handleDecodeError(w, r, err)
+		return
+	}
+	if req.ResolutionNote == nil {
+		writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "resolution_note is required")
+		return
+	}
+
+	amendedBy := claims.ActorID()
+	audit := h.buildAuditEntry(r, orgID,
+		"conflict_resolution_note_amended", "conflict", id.String(),
+		nil, nil,
+		map[string]any{"amended_by": amendedBy},
+	)
+	if err := h.db.UpdateConflictResolutionNoteWithAudit(r.Context(), id, orgID, req.ResolutionNote, amendedBy, audit); err != nil {
+		if isNotFoundError(err) {
+			writeError(w, r, http.StatusNotFound, model.ErrCodeNotFound, "conflict not found")
+			return
+		}
+		if errors.Is(err, storage.ErrConflictOpen) {
+			writeError(w, r, http.StatusBadRequest, model.ErrCodeInvalidInput, "resolution_note can only be amended after a conflict is resolved")
+			return
+		}
+		h.writeInternalError(w, r, "failed to amend conflict resolution note", err)
+		return
+	}
+
+	conflict, err := h.db.GetConflict(r.Context(), id, orgID)
+	if err != nil || conflict == nil {
+		h.writeInternalError(w, r, "failed to fetch updated conflict", err)
+		return
+	}
 	writeJSON(w, r, http.StatusOK, conflict)
 }
 
@@ -245,9 +297,9 @@ func (h *Handlers) HandleResolveConflictGroup(w http.ResponseWriter, r *http.Req
 		map[string]any{"new_status": req.Status, "resolved_by": resolvedBy},
 	)
 
-	fpLabel := storage.ComputeFPLabel(req.Status, req.FalsePositiveLabel)
+	resolutionLabel := storage.ComputeGroupResolutionLabel(req.Status, req.WinningAgent, req.FalsePositiveLabel)
 
-	affected, err := h.db.ResolveConflictGroup(r.Context(), groupID, orgID, req.Status, resolvedBy, req.ResolutionNote, req.WinningAgent, fpLabel, audit)
+	affected, err := h.db.ResolveConflictGroup(r.Context(), groupID, orgID, req.Status, resolvedBy, req.ResolutionNote, req.WinningAgent, resolutionLabel, audit)
 	if err != nil {
 		if isNotFoundError(err) {
 			writeError(w, r, http.StatusNotFound, model.ErrCodeNotFound, "conflict group not found")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -266,6 +266,7 @@ func New(cfg ServerConfig) *Server {
 	mux.Handle("PUT /v1/admin/conflicts/{id}/label", adminOnly(http.HandlerFunc(h.HandleUpsertConflictLabel)))
 	mux.Handle("GET /v1/admin/conflicts/{id}/label", adminOnly(http.HandlerFunc(h.HandleGetConflictLabel)))
 	mux.Handle("DELETE /v1/admin/conflicts/{id}/label", adminOnly(http.HandlerFunc(h.HandleDeleteConflictLabel)))
+	mux.Handle("PATCH /v1/admin/conflicts/{id}/resolution-note", adminOnly(http.HandlerFunc(h.HandleAmendConflictResolutionNote)))
 	mux.Handle("GET /v1/admin/conflict-labels", adminOnly(http.HandlerFunc(h.HandleListConflictLabels)))
 	mux.Handle("POST /v1/admin/scorer-eval", adminOnly(http.HandlerFunc(h.HandleScorerEval)))
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -3259,6 +3259,10 @@ func TestHandlePatchConflict_WinningDecisionID(t *testing.T) {
 		assert.Equal(t, "resolved", result.Status)
 		require.NotNil(t, result.WinningDecisionID)
 		assert.Equal(t, decisionAID, *result.WinningDecisionID)
+
+		label, labelErr := testDB.GetConflictLabel(context.Background(), conflictID, uuid.Nil)
+		require.NoError(t, labelErr)
+		assert.Equal(t, "genuine", label.Label)
 	})
 
 	t.Run("resolved without winning_decision_id leaves winner nil", func(t *testing.T) {
@@ -3286,6 +3290,44 @@ func TestHandlePatchConflict_WinningDecisionID(t *testing.T) {
 	// Silence unused variable warning: decisionBID is set by seedConflict
 	// and exists to make conflict-side validation meaningful.
 	_ = decisionBID
+}
+
+func TestHandleAmendConflictResolutionNote(t *testing.T) {
+	decisionAID, _, conflictID := seedConflict(t)
+
+	note := "initial note"
+	resp, err := authedRequest("PATCH", testSrv.URL+"/v1/conflicts/"+conflictID.String(), adminToken,
+		model.ConflictStatusUpdate{Status: "resolved", ResolutionNote: &note, WinningDecisionID: &decisionAID})
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	amended := "corrected resolution note"
+	resp, err = authedRequest("PATCH", testSrv.URL+"/v1/admin/conflicts/"+conflictID.String()+"/resolution-note", adminToken,
+		map[string]any{"resolution_note": amended})
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var envelope struct {
+		Data struct {
+			ResolutionNote *string `json:"resolution_note"`
+		} `json:"data"`
+	}
+	body, _ := io.ReadAll(resp.Body)
+	require.NoError(t, json.Unmarshal(body, &envelope))
+	require.NotNil(t, envelope.Data.ResolutionNote)
+	assert.Equal(t, amended, *envelope.Data.ResolutionNote)
+}
+
+func TestHandleAmendConflictResolutionNote_OpenConflict(t *testing.T) {
+	_, _, conflictID := seedConflict(t)
+
+	resp, err := authedRequest("PATCH", testSrv.URL+"/v1/admin/conflicts/"+conflictID.String()+"/resolution-note", adminToken,
+		map[string]any{"resolution_note": "too early"})
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 }
 
 // ---- HandlePatchDecision --------------------------------------------------
@@ -3658,6 +3700,9 @@ func TestHandleResolveConflictGroup(t *testing.T) {
 			require.NotNil(t, conflict)
 			assert.Equal(t, "resolved", conflict.Status)
 			require.NotNil(t, conflict.WinningDecisionID, "winning_decision_id should be set")
+			label, labelErr := testDB.GetConflictLabel(context.Background(), cid, uuid.Nil)
+			require.NoError(t, labelErr)
+			assert.Equal(t, "genuine", label.Label)
 		}
 	})
 

--- a/internal/service/autoresolve/service.go
+++ b/internal/service/autoresolve/service.go
@@ -88,6 +88,13 @@ func (s *Service) processOrg(ctx context.Context, org storage.OrgAutoResolveConf
 			},
 		}
 
+		// Auto-resolution is a policy/timeout decision, not a deliberate
+		// adjudication, so it must not write a ground-truth label (nil). These
+		// conflicts had their review window expire without human review and may
+		// include false positives; labeling them "genuine" would let the
+		// system's own resolutions inflate the scorer precision metric. The
+		// auto-resolution remains fully recorded in scored_conflicts and the
+		// mutation audit log.
 		_, err := s.db.UpdateConflictStatusWithAudit(ctx, c.ID, org.OrgID,
 			"resolved", "system:auto_resolve", &note, winner, nil, audit)
 		if err != nil {

--- a/internal/storage/conflicts.go
+++ b/internal/storage/conflicts.go
@@ -406,9 +406,10 @@ func (db *DB) GetConflict(ctx context.Context, id, orgID uuid.UUID) (*model.Deci
 // UpdateConflictStatusWithAudit transitions a conflict to a new lifecycle
 // state and inserts a mutation audit entry, atomically in a single transaction.
 // winningDecisionID is optional; when provided it is written only for "resolved" transitions.
-// fpLabel is optional; when non-nil and status is "false_positive", a ground-truth
-// label is inserted atomically within the same transaction.
-func (db *DB) UpdateConflictStatusWithAudit(ctx context.Context, id, orgID uuid.UUID, status, resolvedBy string, resolutionNote *string, winningDecisionID *uuid.UUID, fpLabel *string, audit MutationAuditEntry) (oldStatus string, err error) {
+// resolutionLabel is optional; when non-nil and the transition implies ground
+// truth (false_positive, or resolved with a declared winner), a label is
+// inserted atomically within the same transaction.
+func (db *DB) UpdateConflictStatusWithAudit(ctx context.Context, id, orgID uuid.UUID, status, resolvedBy string, resolutionNote *string, winningDecisionID *uuid.UUID, resolutionLabel *string, audit MutationAuditEntry) (oldStatus string, err error) {
 	txErr := db.WithTx(ctx, func(ctx context.Context, tx pgx.Tx) error {
 		// Read old status and decision pair for audit before_data and winner validation.
 		var decisionAID, decisionBID uuid.UUID
@@ -453,10 +454,10 @@ func (db *DB) UpdateConflictStatusWithAudit(ctx context.Context, id, orgID uuid.
 			return fmt.Errorf("storage: conflict: %w", ErrNotFound)
 		}
 
-		// Atomically label the conflict as a false positive for ground-truth
-		// training. Inserted in the same tx so a crash between status update
-		// and label insert can never leave an unlabeled false_positive.
-		if fpLabel != nil && status == "false_positive" {
+		// Atomically label the conflict for ground-truth training. Inserted in
+		// the same tx so a crash between status update and label insert can
+		// never leave an unlabeled terminal resolution.
+		if resolutionLabel != nil && (status == "false_positive" || (status == "resolved" && winningDecisionID != nil)) {
 			_, err = tx.Exec(ctx,
 				`INSERT INTO conflict_labels (scored_conflict_id, org_id, label, labeled_by, labeled_at)
 				 VALUES ($1, $2, $3, $4, now())
@@ -465,9 +466,9 @@ func (db *DB) UpdateConflictStatusWithAudit(ctx context.Context, id, orgID uuid.
 				   labeled_by = excluded.labeled_by,
 				   labeled_at = excluded.labeled_at
 				 WHERE conflict_labels.org_id = excluded.org_id`,
-				id, orgID, *fpLabel, resolvedBy)
+				id, orgID, *resolutionLabel, resolvedBy)
 			if err != nil {
-				return fmt.Errorf("storage: label false positive in conflict status tx: %w", err)
+				return fmt.Errorf("storage: label conflict in status tx: %w", err)
 			}
 		}
 
@@ -476,8 +477,8 @@ func (db *DB) UpdateConflictStatusWithAudit(ctx context.Context, id, orgID uuid.
 		if winningDecisionID != nil && status == "resolved" {
 			afterData["winning_decision_id"] = winningDecisionID.String()
 		}
-		if fpLabel != nil {
-			afterData["fp_label"] = *fpLabel
+		if resolutionLabel != nil {
+			afterData["resolution_label"] = *resolutionLabel
 		}
 		audit.AfterData = afterData
 		if err := InsertMutationAuditTx(ctx, tx, audit); err != nil {
@@ -489,6 +490,49 @@ func (db *DB) UpdateConflictStatusWithAudit(ctx context.Context, id, orgID uuid.
 		return "", txErr
 	}
 	return oldStatus, nil
+}
+
+// UpdateConflictResolutionNoteWithAudit amends the resolution note for a
+// terminal conflict and records the change in the mutation audit log.
+func (db *DB) UpdateConflictResolutionNoteWithAudit(ctx context.Context, id, orgID uuid.UUID, resolutionNote *string, amendedBy string, audit MutationAuditEntry) error {
+	return db.WithTx(ctx, func(ctx context.Context, tx pgx.Tx) error {
+		var oldStatus string
+		var oldNote *string
+		if err := tx.QueryRow(ctx,
+			`SELECT status, resolution_note FROM scored_conflicts WHERE id = $1 AND org_id = $2 FOR UPDATE`,
+			id, orgID).Scan(&oldStatus, &oldNote); err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return fmt.Errorf("storage: conflict: %w", ErrNotFound)
+			}
+			return fmt.Errorf("storage: get conflict resolution note: %w", err)
+		}
+		if oldStatus == "open" {
+			return ErrConflictOpen
+		}
+
+		tag, err := tx.Exec(ctx,
+			`UPDATE scored_conflicts
+			 SET resolution_note = $1
+			 WHERE id = $2 AND org_id = $3`,
+			resolutionNote, id, orgID)
+		if err != nil {
+			return fmt.Errorf("storage: update conflict resolution note: %w", err)
+		}
+		if tag.RowsAffected() == 0 {
+			return fmt.Errorf("storage: conflict: %w", ErrNotFound)
+		}
+
+		audit.BeforeData = map[string]any{"status": oldStatus, "resolution_note": oldNote}
+		audit.AfterData = map[string]any{
+			"status":          oldStatus,
+			"resolution_note": resolutionNote,
+			"amended_by":      amendedBy,
+		}
+		if err := InsertMutationAuditTx(ctx, tx, audit); err != nil {
+			return fmt.Errorf("storage: audit conflict resolution note amendment: %w", err)
+		}
+		return nil
+	})
 }
 
 // InsertScoredConflict inserts a semantic conflict into scored_conflicts.
@@ -1269,16 +1313,16 @@ func (db *DB) ListConflictGroups(ctx context.Context, orgID uuid.UUID, f Conflic
 // decision_b_id when agent_b matches). Returns ErrWinningAgentNotInGroup if
 // winningAgent does not match agent_a or agent_b in the group.
 //
-// When fpLabel is non-nil (status must be "false_positive"), ground truth
-// labels are inserted atomically within the same transaction — preventing
-// partial-label states on crash. Returns the number of conflicts updated.
+// When resolutionLabel is non-nil, ground truth labels are inserted atomically
+// within the same transaction — preventing partial-label states on crash.
+// Returns the number of conflicts updated.
 func (db *DB) ResolveConflictGroup(
 	ctx context.Context,
 	groupID, orgID uuid.UUID,
 	status, resolvedBy string,
 	resolutionNote *string,
 	winningAgent *string,
-	fpLabel *string,
+	resolutionLabel *string,
 	audit MutationAuditEntry,
 ) (int, error) {
 	tx, err := db.pool.Begin(ctx)
@@ -1401,7 +1445,7 @@ func (db *DB) ResolveConflictGroup(
 	// Atomically label the exact rows we just updated. Using the RETURNING IDs
 	// eliminates the fragile pattern of re-querying by status + resolved_by
 	// (which could accidentally match rows from concurrent transactions).
-	if fpLabel != nil && status == "false_positive" && affected > 0 {
+	if resolutionLabel != nil && (status == "false_positive" || (status == "resolved" && winningAgent != nil)) && affected > 0 {
 		_, err = tx.Exec(ctx,
 			`INSERT INTO conflict_labels (scored_conflict_id, org_id, label, labeled_by, labeled_at)
 			 SELECT unnest($1::uuid[]), $2, $3, $4, now()
@@ -1410,9 +1454,9 @@ func (db *DB) ResolveConflictGroup(
 			   labeled_by = excluded.labeled_by,
 			   labeled_at = excluded.labeled_at
 			 WHERE conflict_labels.org_id = excluded.org_id`,
-			updatedIDs, orgID, *fpLabel, resolvedBy)
+			updatedIDs, orgID, *resolutionLabel, resolvedBy)
 		if err != nil {
-			return 0, fmt.Errorf("storage: label false positives in resolve group tx: %w", err)
+			return 0, fmt.Errorf("storage: label conflicts in resolve group tx: %w", err)
 		}
 	}
 
@@ -1421,8 +1465,8 @@ func (db *DB) ResolveConflictGroup(
 	if winningAgent != nil {
 		afterData["winning_agent"] = *winningAgent
 	}
-	if fpLabel != nil {
-		afterData["fp_label"] = *fpLabel
+	if resolutionLabel != nil {
+		afterData["resolution_label"] = *resolutionLabel
 	}
 	audit.AfterData = afterData
 	if err := InsertMutationAuditTx(ctx, tx, audit); err != nil {

--- a/internal/storage/errors.go
+++ b/internal/storage/errors.go
@@ -16,6 +16,10 @@ var ErrWinningAgentNotInGroup = errors.New("storage: winning agent is not a part
 // does not match either decision_a_id or decision_b_id of the conflict.
 var ErrWinningDecisionNotInConflict = errors.New("storage: winning decision is not a participant in this conflict")
 
+// ErrConflictOpen is returned when an operation requires a terminal conflict
+// status but the target conflict is still open.
+var ErrConflictOpen = errors.New("storage: conflict is still open")
+
 // ErrSupersededDecisionNotInConflict is returned when adjudication tries to
 // supersede a decision that is not one of the target conflict's two sides.
 var ErrSupersededDecisionNotInConflict = errors.New("storage: superseded decision is not a participant in this conflict")

--- a/internal/storage/labels.go
+++ b/internal/storage/labels.go
@@ -1,5 +1,7 @@
 package storage
 
+import "github.com/google/uuid"
+
 // ComputeFPLabel returns the ground truth label for a false_positive resolution.
 // Returns nil when status is not "false_positive". When rawLabel is
 // "related_not_contradicting" it is used; otherwise defaults to
@@ -13,4 +15,31 @@ func ComputeFPLabel(status string, rawLabel *string) *string {
 		label = *rawLabel
 	}
 	return &label
+}
+
+// ComputeResolutionLabel returns the ground truth label implied by a deliberate
+// conflict adjudication. False positives preserve their explicit FP subtype; a
+// resolved conflict only becomes training data when a winner is declared.
+//
+// Only deliberate adjudications (an actor resolving through the API or MCP) may
+// use this. Automated paths — autoresolve (policy/timeout) and cascade
+// (embedding similarity) — must pass a nil label, because counting the system's
+// own resolutions as ground truth biases the scorer precision metric upward.
+func ComputeResolutionLabel(status string, winningDecisionID *uuid.UUID, rawFPLabel *string) *string {
+	if status == "resolved" && winningDecisionID != nil {
+		label := "genuine"
+		return &label
+	}
+	return ComputeFPLabel(status, rawFPLabel)
+}
+
+// ComputeGroupResolutionLabel is the group-resolution equivalent of
+// ComputeResolutionLabel. A winning agent means each updated conflict gets a
+// concrete winning_decision_id during the storage transaction.
+func ComputeGroupResolutionLabel(status string, winningAgent *string, rawFPLabel *string) *string {
+	if status == "resolved" && winningAgent != nil {
+		label := "genuine"
+		return &label
+	}
+	return ComputeFPLabel(status, rawFPLabel)
 }

--- a/internal/storage/labels_test.go
+++ b/internal/storage/labels_test.go
@@ -1,0 +1,101 @@
+package storage_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ashita-ai/akashi/internal/storage"
+)
+
+func ptr[T any](v T) *T { return &v }
+
+func TestComputeFPLabel(t *testing.T) {
+	relatedNotContradicting := "related_not_contradicting"
+	garbage := "not_a_real_label"
+
+	cases := []struct {
+		name     string
+		status   string
+		rawLabel *string
+		want     *string
+	}{
+		{"non-fp status yields no label", "resolved", &relatedNotContradicting, nil},
+		{"open status yields no label", "open", nil, nil},
+		{"fp with nil raw defaults to unrelated", "false_positive", nil, ptr("unrelated_false_positive")},
+		{"fp with empty raw defaults to unrelated", "false_positive", ptr(""), ptr("unrelated_false_positive")},
+		{"fp honors related_not_contradicting", "false_positive", &relatedNotContradicting, ptr("related_not_contradicting")},
+		{"fp ignores unrecognized raw and defaults", "false_positive", &garbage, ptr("unrelated_false_positive")},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := storage.ComputeFPLabel(tc.status, tc.rawLabel)
+			assertLabelEqual(t, tc.want, got)
+		})
+	}
+}
+
+func TestComputeResolutionLabel(t *testing.T) {
+	winner := ptr(uuid.New())
+	relatedNotContradicting := "related_not_contradicting"
+
+	cases := []struct {
+		name      string
+		status    string
+		winningID *uuid.UUID
+		rawFP     *string
+		want      *string
+	}{
+		{"resolved with winner is genuine", "resolved", winner, nil, ptr("genuine")},
+		{"resolved without winner has no label", "resolved", nil, nil, nil},
+		{"false_positive falls through to FP label", "false_positive", nil, nil, ptr("unrelated_false_positive")},
+		{"false_positive honors subtype even with no winner", "false_positive", nil, &relatedNotContradicting, ptr("related_not_contradicting")},
+		{"open has no label", "open", nil, nil, nil},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := storage.ComputeResolutionLabel(tc.status, tc.winningID, tc.rawFP)
+			assertLabelEqual(t, tc.want, got)
+		})
+	}
+}
+
+func TestComputeGroupResolutionLabel(t *testing.T) {
+	winningAgent := ptr("agent-a")
+	relatedNotContradicting := "related_not_contradicting"
+
+	cases := []struct {
+		name         string
+		status       string
+		winningAgent *string
+		rawFP        *string
+		want         *string
+	}{
+		{"resolved with winning agent is genuine", "resolved", winningAgent, nil, ptr("genuine")},
+		{"resolved without winning agent has no label", "resolved", nil, nil, nil},
+		{"false_positive falls through to FP label", "false_positive", nil, nil, ptr("unrelated_false_positive")},
+		{"false_positive honors subtype", "false_positive", nil, &relatedNotContradicting, ptr("related_not_contradicting")},
+		{"open has no label", "open", nil, nil, nil},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := storage.ComputeGroupResolutionLabel(tc.status, tc.winningAgent, tc.rawFP)
+			assertLabelEqual(t, tc.want, got)
+		})
+	}
+}
+
+func assertLabelEqual(t *testing.T, want, got *string) {
+	t.Helper()
+	if want == nil {
+		assert.Nil(t, got)
+		return
+	}
+	if assert.NotNil(t, got) {
+		assert.Equal(t, *want, *got)
+	}
+}

--- a/internal/storage/sqlite/conflicts.go
+++ b/internal/storage/sqlite/conflicts.go
@@ -421,9 +421,9 @@ func (l *LiteDB) GetConflict(ctx context.Context, id, orgID uuid.UUID) (*model.D
 }
 
 // UpdateConflictStatusWithAudit transitions a conflict to a new lifecycle state.
-// When fpLabel is non-nil and status is "false_positive", a ground-truth label
-// is inserted atomically within the same transaction.
-func (l *LiteDB) UpdateConflictStatusWithAudit(ctx context.Context, id, orgID uuid.UUID, status, resolvedBy string, resolutionNote *string, winningDecisionID *uuid.UUID, fpLabel *string, audit storage.MutationAuditEntry) (string, error) {
+// When resolutionLabel is non-nil and the transition implies ground truth, a
+// label is inserted atomically within the same transaction.
+func (l *LiteDB) UpdateConflictStatusWithAudit(ctx context.Context, id, orgID uuid.UUID, status, resolvedBy string, resolutionNote *string, winningDecisionID *uuid.UUID, resolutionLabel *string, audit storage.MutationAuditEntry) (string, error) {
 	tx, err := l.db.BeginTx(ctx, nil)
 	if err != nil {
 		return "", fmt.Errorf("sqlite: begin conflict status tx: %w", err)
@@ -471,8 +471,8 @@ func (l *LiteDB) UpdateConflictStatusWithAudit(ctx context.Context, id, orgID uu
 		return "", fmt.Errorf("sqlite: update conflict status: %w", err)
 	}
 
-	// Atomically label the conflict as a false positive for ground-truth training.
-	if fpLabel != nil && status == "false_positive" {
+	// Atomically label the conflict for ground-truth training.
+	if resolutionLabel != nil && (status == "false_positive" || (status == "resolved" && winningDecisionID != nil)) {
 		_, err = tx.ExecContext(ctx,
 			`INSERT INTO conflict_labels (scored_conflict_id, org_id, label, labeled_by, labeled_at)
 			 VALUES (?, ?, ?, ?, datetime('now'))
@@ -481,10 +481,10 @@ func (l *LiteDB) UpdateConflictStatusWithAudit(ctx context.Context, id, orgID uu
 			   labeled_by = excluded.labeled_by,
 			   labeled_at = excluded.labeled_at
 			 WHERE conflict_labels.org_id = excluded.org_id`,
-			uuidStr(id), uuidStr(orgID), *fpLabel, resolvedBy,
+			uuidStr(id), uuidStr(orgID), *resolutionLabel, resolvedBy,
 		)
 		if err != nil {
-			return "", fmt.Errorf("sqlite: label false positive in conflict status tx: %w", err)
+			return "", fmt.Errorf("sqlite: label conflict in conflict status tx: %w", err)
 		}
 	}
 
@@ -493,8 +493,8 @@ func (l *LiteDB) UpdateConflictStatusWithAudit(ctx context.Context, id, orgID uu
 	if winningDecisionID != nil && status == "resolved" {
 		afterData["winning_decision_id"] = winningDecisionID.String()
 	}
-	if fpLabel != nil {
-		afterData["fp_label"] = *fpLabel
+	if resolutionLabel != nil {
+		afterData["resolution_label"] = *resolutionLabel
 	}
 	audit.AfterData = afterData
 	if err := insertAuditTx(ctx, tx, audit); err != nil {
@@ -507,11 +507,71 @@ func (l *LiteDB) UpdateConflictStatusWithAudit(ctx context.Context, id, orgID uu
 	return oldStatus, nil
 }
 
+// UpdateConflictResolutionNoteWithAudit amends the resolution note for a
+// terminal conflict and records the change in the mutation audit log.
+func (l *LiteDB) UpdateConflictResolutionNoteWithAudit(ctx context.Context, id, orgID uuid.UUID, resolutionNote *string, amendedBy string, audit storage.MutationAuditEntry) error {
+	tx, err := l.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("sqlite: begin resolution note tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	var oldStatus string
+	var oldNote sql.NullString
+	err = tx.QueryRowContext(ctx,
+		`SELECT status, resolution_note FROM scored_conflicts WHERE id = ? AND org_id = ?`,
+		uuidStr(id), uuidStr(orgID),
+	).Scan(&oldStatus, &oldNote)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("sqlite: conflict: %w", storage.ErrNotFound)
+		}
+		return fmt.Errorf("sqlite: get conflict resolution note: %w", err)
+	}
+	if oldStatus == "open" {
+		return storage.ErrConflictOpen
+	}
+
+	var noteVal any
+	if resolutionNote != nil {
+		noteVal = *resolutionNote
+	}
+	result, err := tx.ExecContext(ctx,
+		`UPDATE scored_conflicts SET resolution_note = ? WHERE id = ? AND org_id = ?`,
+		noteVal, uuidStr(id), uuidStr(orgID),
+	)
+	if err != nil {
+		return fmt.Errorf("sqlite: update conflict resolution note: %w", err)
+	}
+	if affected, _ := result.RowsAffected(); affected == 0 {
+		return fmt.Errorf("sqlite: conflict: %w", storage.ErrNotFound)
+	}
+
+	var oldNotePtr *string
+	if oldNote.Valid {
+		oldNotePtr = &oldNote.String
+	}
+	audit.BeforeData = map[string]any{"status": oldStatus, "resolution_note": oldNotePtr}
+	audit.AfterData = map[string]any{
+		"status":          oldStatus,
+		"resolution_note": resolutionNote,
+		"amended_by":      amendedBy,
+	}
+	if err := insertAuditTx(ctx, tx, audit); err != nil {
+		return fmt.Errorf("sqlite: audit conflict resolution note amendment: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("sqlite: commit resolution note tx: %w", err)
+	}
+	return nil
+}
+
 // ResolveConflictGroup atomically resolves all open conflicts in a group.
-// Validates winningAgent against the group's agent pair. When fpLabel is
-// non-nil (status must be "false_positive"), ground truth labels are inserted
-// atomically within the same transaction.
-func (l *LiteDB) ResolveConflictGroup(ctx context.Context, groupID, orgID uuid.UUID, status, resolvedBy string, resolutionNote *string, winningAgent *string, fpLabel *string, audit storage.MutationAuditEntry) (int, error) {
+// Validates winningAgent against the group's agent pair. When resolutionLabel
+// is non-nil, ground truth labels are inserted atomically within the same
+// transaction.
+func (l *LiteDB) ResolveConflictGroup(ctx context.Context, groupID, orgID uuid.UUID, status, resolvedBy string, resolutionNote *string, winningAgent *string, resolutionLabel *string, audit storage.MutationAuditEntry) (int, error) {
 	tx, err := l.db.BeginTx(ctx, nil)
 	if err != nil {
 		return 0, fmt.Errorf("sqlite: begin resolve group tx: %w", err)
@@ -610,28 +670,28 @@ func (l *LiteDB) ResolveConflictGroup(ctx context.Context, groupID, orgID uuid.U
 
 	affected, _ := result.RowsAffected()
 
-	// Atomically label all just-resolved conflicts as false positives for
-	// ground truth training. The WHERE clause uses resolved_at = datetime('now')
-	// (which returns a constant within a transaction) to precisely target
-	// only rows updated in THIS transaction, avoiding a resolved_by
-	// collision when the same actor resolves the same group twice.
-	if fpLabel != nil && status == "false_positive" && affected > 0 {
+	// Atomically label all just-resolved conflicts for ground truth training.
+	// The WHERE clause uses resolved_at = datetime('now') (which returns a
+	// constant within a transaction) to precisely target only rows updated in
+	// THIS transaction, avoiding a resolved_by collision when the same actor
+	// resolves the same group twice.
+	if resolutionLabel != nil && (status == "false_positive" || (status == "resolved" && winningAgent != nil)) && affected > 0 {
 		_, err = tx.ExecContext(ctx,
 			`INSERT INTO conflict_labels (scored_conflict_id, org_id, label, labeled_by, labeled_at)
 			 SELECT sc.id, sc.org_id, ?, ?, datetime('now')
 			 FROM scored_conflicts sc
 			 WHERE sc.group_id = ? AND sc.org_id = ?
-			   AND sc.status = 'false_positive'
+			   AND sc.status = ?
 			   AND sc.resolved_at = datetime('now')
 			 ON CONFLICT (scored_conflict_id) DO UPDATE SET
 			   label = excluded.label,
 			   labeled_by = excluded.labeled_by,
 			   labeled_at = excluded.labeled_at
 			 WHERE conflict_labels.org_id = excluded.org_id`,
-			*fpLabel, resolvedBy, uuidStr(groupID), uuidStr(orgID),
+			*resolutionLabel, resolvedBy, uuidStr(groupID), uuidStr(orgID), status,
 		)
 		if err != nil {
-			return 0, fmt.Errorf("sqlite: label false positives in resolve group tx: %w", err)
+			return 0, fmt.Errorf("sqlite: label conflicts in resolve group tx: %w", err)
 		}
 	}
 
@@ -640,8 +700,8 @@ func (l *LiteDB) ResolveConflictGroup(ctx context.Context, groupID, orgID uuid.U
 	if winningAgent != nil {
 		afterData["winning_agent"] = *winningAgent
 	}
-	if fpLabel != nil {
-		afterData["fp_label"] = *fpLabel
+	if resolutionLabel != nil {
+		afterData["resolution_label"] = *resolutionLabel
 	}
 	audit.AfterData = afterData
 	if err := insertAuditTx(ctx, tx, audit); err != nil {

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -4112,11 +4112,15 @@ func TestUpdateConflictStatusWithAudit(t *testing.T) {
 	require.NotNil(t, got.ResolvedBy)
 	assert.Equal(t, "admin-agent", *got.ResolvedBy)
 	assert.Nil(t, got.WinningDecisionID, "false_positive should not set winner")
+	fpGot, err := testDB.GetConflictLabel(ctx, conflictID, uuid.Nil)
+	require.NoError(t, err)
+	assert.Equal(t, "unrelated_false_positive", fpGot.Label)
 
 	// Transition to resolved with a winner (overriding false_positive).
+	genuineLabel := "genuine"
 	resNote := "Right approach is better."
 	oldStatus2, err := testDB.UpdateConflictStatusWithAudit(ctx, conflictID, uuid.Nil,
-		"resolved", "admin-agent", &resNote, &dB.ID, nil,
+		"resolved", "admin-agent", &resNote, &dB.ID, &genuineLabel,
 		storage.MutationAuditEntry{
 			RequestID: "resolve-" + suffix, OrgID: uuid.Nil,
 			ActorAgentID: "admin-agent", ActorRole: "admin",
@@ -4132,6 +4136,74 @@ func TestUpdateConflictStatusWithAudit(t *testing.T) {
 	assert.Equal(t, "admin-agent", *got2.ResolvedBy)
 	require.NotNil(t, got2.WinningDecisionID)
 	assert.Equal(t, dB.ID, *got2.WinningDecisionID)
+	genuineGot, err := testDB.GetConflictLabel(ctx, conflictID, uuid.Nil)
+	require.NoError(t, err)
+	assert.Equal(t, "genuine", genuineGot.Label)
+}
+
+func TestUpdateConflictResolutionNoteWithAudit(t *testing.T) {
+	ctx := context.Background()
+	suffix := uuid.New().String()[:8]
+
+	agentA := "note-a-" + suffix
+	agentB := "note-b-" + suffix
+	runA, err := testDB.CreateRun(ctx, model.CreateRunRequest{AgentID: agentA})
+	require.NoError(t, err)
+	runB, err := testDB.CreateRun(ctx, model.CreateRunRequest{AgentID: agentB})
+	require.NoError(t, err)
+	dA, err := testDB.CreateDecision(ctx, model.Decision{RunID: runA.ID, AgentID: agentA, DecisionType: "note_test", Outcome: "left", Confidence: 0.8})
+	require.NoError(t, err)
+	dB, err := testDB.CreateDecision(ctx, model.Decision{RunID: runB.ID, AgentID: agentB, DecisionType: "note_test", Outcome: "right", Confidence: 0.8})
+	require.NoError(t, err)
+
+	topicSim := 0.8
+	outcomeDiv := 0.7
+	sig := topicSim * outcomeDiv
+	conflictID, err := testDB.InsertScoredConflict(ctx, model.DecisionConflict{
+		ConflictKind: model.ConflictKindCrossAgent, DecisionAID: dA.ID, DecisionBID: dB.ID,
+		OrgID: uuid.Nil, AgentA: agentA, AgentB: agentB,
+		DecisionTypeA: "note_test", DecisionTypeB: "note_test",
+		OutcomeA: "left", OutcomeB: "right",
+		TopicSimilarity: &topicSim, OutcomeDivergence: &outcomeDiv,
+		Significance: &sig, ScoringMethod: "text",
+	})
+	require.NoError(t, err)
+
+	amended := "cannot amend while open"
+	err = testDB.UpdateConflictResolutionNoteWithAudit(ctx, conflictID, uuid.Nil, &amended, "admin-agent",
+		storage.MutationAuditEntry{
+			RequestID: uuid.New().String(), OrgID: uuid.Nil,
+			ActorAgentID: "admin-agent", ActorRole: "admin",
+			Operation: "amend_resolution_note", ResourceType: "conflict",
+			ResourceID: conflictID.String(),
+		})
+	require.ErrorIs(t, err, storage.ErrConflictOpen)
+
+	original := "wrong note"
+	_, err = testDB.UpdateConflictStatusWithAudit(ctx, conflictID, uuid.Nil,
+		"resolved", "admin-agent", &original, &dA.ID, storage.ComputeResolutionLabel("resolved", &dA.ID, nil),
+		storage.MutationAuditEntry{
+			RequestID: uuid.New().String(), OrgID: uuid.Nil,
+			ActorAgentID: "admin-agent", ActorRole: "admin",
+			Operation: "resolve_conflict", ResourceType: "conflict",
+			ResourceID: conflictID.String(),
+		})
+	require.NoError(t, err)
+
+	amended = "corrected note"
+	err = testDB.UpdateConflictResolutionNoteWithAudit(ctx, conflictID, uuid.Nil, &amended, "admin-agent",
+		storage.MutationAuditEntry{
+			RequestID: uuid.New().String(), OrgID: uuid.Nil,
+			ActorAgentID: "admin-agent", ActorRole: "admin",
+			Operation: "amend_resolution_note", ResourceType: "conflict",
+			ResourceID: conflictID.String(),
+		})
+	require.NoError(t, err)
+
+	got, err := testDB.GetConflict(ctx, conflictID, uuid.Nil)
+	require.NoError(t, err)
+	require.NotNil(t, got.ResolutionNote)
+	assert.Equal(t, "corrected note", *got.ResolutionNote)
 }
 
 // ---------------------------------------------------------------------------
@@ -6029,9 +6101,10 @@ func TestResolveConflictGroup_WithWinner(t *testing.T) {
 	require.NotNil(t, conflict.GroupID, "conflict should have a group_id")
 
 	resNote := "agent B had higher confidence"
+	genuineLabel := "genuine"
 	affected, err := testDB.ResolveConflictGroup(ctx,
 		*conflict.GroupID, uuid.Nil,
-		"resolved", "test-admin", &resNote, &agentB, nil,
+		"resolved", "test-admin", &resNote, &agentB, &genuineLabel,
 		storage.MutationAuditEntry{
 			RequestID:    uuid.New().String(),
 			OrgID:        uuid.Nil,
@@ -6057,6 +6130,9 @@ func TestResolveConflictGroup_WithWinner(t *testing.T) {
 		if c.ID == conflictID {
 			found = true
 			assert.Equal(t, "resolved", c.Status)
+			label, labelErr := testDB.GetConflictLabel(ctx, conflictID, uuid.Nil)
+			require.NoError(t, labelErr)
+			assert.Equal(t, "genuine", label.Label)
 			break
 		}
 	}

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -94,8 +94,9 @@ type Store interface {
 	GetConflictCount(ctx context.Context, decisionID, orgID uuid.UUID) (int, error)
 	GetConflictCountsBatch(ctx context.Context, ids []uuid.UUID, orgID uuid.UUID) (map[uuid.UUID]int, error)
 	GetResolvedConflictsByType(ctx context.Context, orgID uuid.UUID, decisionType string, limit int) ([]model.ConflictResolution, error)
-	UpdateConflictStatusWithAudit(ctx context.Context, id, orgID uuid.UUID, status, resolvedBy string, resolutionNote *string, winningDecisionID *uuid.UUID, fpLabel *string, audit MutationAuditEntry) (oldStatus string, err error)
-	ResolveConflictGroup(ctx context.Context, groupID, orgID uuid.UUID, status, resolvedBy string, resolutionNote *string, winningAgent *string, fpLabel *string, audit MutationAuditEntry) (int, error)
+	UpdateConflictStatusWithAudit(ctx context.Context, id, orgID uuid.UUID, status, resolvedBy string, resolutionNote *string, winningDecisionID *uuid.UUID, resolutionLabel *string, audit MutationAuditEntry) (oldStatus string, err error)
+	UpdateConflictResolutionNoteWithAudit(ctx context.Context, id, orgID uuid.UUID, resolutionNote *string, amendedBy string, audit MutationAuditEntry) error
+	ResolveConflictGroup(ctx context.Context, groupID, orgID uuid.UUID, status, resolvedBy string, resolutionNote *string, winningAgent *string, resolutionLabel *string, audit MutationAuditEntry) (int, error)
 	CascadeResolveByOutcome(ctx context.Context, orgID, groupID, winningDecisionID, triggerID uuid.UUID, threshold float64, audit MutationAuditEntry) (int, error)
 	UpsertConflictLabel(ctx context.Context, cl ConflictLabel) error
 

--- a/sdk/go/akashi/client_endpoints.go
+++ b/sdk/go/akashi/client_endpoints.go
@@ -198,6 +198,15 @@ func (c *Client) PatchConflict(ctx context.Context, conflictID uuid.UUID, req Co
 	return &resp, nil
 }
 
+// AmendConflictResolutionNote updates the resolution note for a terminal conflict.
+func (c *Client) AmendConflictResolutionNote(ctx context.Context, conflictID uuid.UUID, req ConflictResolutionNoteUpdate) (*DecisionConflict, error) {
+	var resp DecisionConflict
+	if err := c.patch(ctx, "/v1/admin/conflicts/"+conflictID.String()+"/resolution-note", req, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
 // ListConflictGroups retrieves groups of related conflicts.
 func (c *Client) ListConflictGroups(ctx context.Context, opts *ConflictGroupOptions) (*ConflictGroupsResponse, error) {
 	params := url.Values{}

--- a/sdk/go/akashi/types.go
+++ b/sdk/go/akashi/types.go
@@ -755,6 +755,11 @@ type ConflictStatusUpdate struct {
 	FalsePositiveLabel string     `json:"false_positive_label,omitempty"`
 }
 
+// ConflictResolutionNoteUpdate is the input for Client.AmendConflictResolutionNote.
+type ConflictResolutionNoteUpdate struct {
+	ResolutionNote string `json:"resolution_note"`
+}
+
 // ResolveConflictGroupRequest is the input for Client.ResolveConflictGroup.
 type ResolveConflictGroupRequest struct {
 	Status             string `json:"status"` // "resolved" or "false_positive"

--- a/sdk/python/src/akashi/__init__.py
+++ b/sdk/python/src/akashi/__init__.py
@@ -28,6 +28,7 @@ from akashi.types import (
     ConflictEvalResponse,
     ConflictFate,
     ConflictLabelRecord,
+    ConflictResolutionNoteUpdate,
     ConflictResolution,
     ConflictResolutionPolicy,
     CreateAgentRequest,
@@ -94,6 +95,7 @@ __all__ = [
     "AssessRequest",
     "ValidatePairRequest",
     "UpsertConflictLabelRequest",
+    "ConflictResolutionNoteUpdate",
     # Types — responses
     "TraceResponse",
     "CheckResponse",

--- a/sdk/python/src/akashi/client.py
+++ b/sdk/python/src/akashi/client.py
@@ -51,6 +51,7 @@ from akashi.types import (
     ConflictEvalResponse,
     ConflictGroup,
     ConflictLabelRecord,
+    ConflictResolutionNoteUpdate,
     ConflictStatusUpdate,
     CreateAgentRequest,
     CreateGrantRequest,
@@ -800,6 +801,18 @@ class AkashiClient:
         """Update a conflict's status (resolve or mark false positive)."""
         data = await self._patch(
             f"/v1/conflicts/{conflict_id}",
+            req.model_dump(exclude_none=True),
+        )
+        return DecisionConflict.model_validate(data)
+
+    async def amend_conflict_resolution_note(
+        self,
+        conflict_id: UUID,
+        req: ConflictResolutionNoteUpdate,
+    ) -> DecisionConflict:
+        """Amend the resolution note for a terminal conflict."""
+        data = await self._patch(
+            f"/v1/admin/conflicts/{conflict_id}/resolution-note",
             req.model_dump(exclude_none=True),
         )
         return DecisionConflict.model_validate(data)
@@ -1797,6 +1810,18 @@ class AkashiSyncClient:
         """Update a conflict's status (resolve or mark false positive)."""
         data = self._patch(
             f"/v1/conflicts/{conflict_id}",
+            req.model_dump(exclude_none=True),
+        )
+        return DecisionConflict.model_validate(data)
+
+    def amend_conflict_resolution_note(
+        self,
+        conflict_id: UUID,
+        req: ConflictResolutionNoteUpdate,
+    ) -> DecisionConflict:
+        """Amend the resolution note for a terminal conflict."""
+        data = self._patch(
+            f"/v1/admin/conflicts/{conflict_id}/resolution-note",
             req.model_dump(exclude_none=True),
         )
         return DecisionConflict.model_validate(data)

--- a/sdk/python/src/akashi/types.py
+++ b/sdk/python/src/akashi/types.py
@@ -576,6 +576,10 @@ class ConflictStatusUpdate(BaseModel):
     false_positive_label: str | None = None
 
 
+class ConflictResolutionNoteUpdate(BaseModel):
+    resolution_note: str
+
+
 class AdjudicateConflictRequest(BaseModel):
     outcome: str
     reasoning: str | None = None

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -26,6 +26,7 @@ import type {
   ConflictEvalResponse,
   ConflictGroup,
   ConflictLabelRecord,
+  ConflictResolutionNoteUpdate,
   ConflictStatusUpdate,
   CreateAgentRequest,
   CreateGrantRequest,
@@ -848,6 +849,14 @@ export class AkashiClient {
   async patchConflict(conflictId: string, req: ConflictStatusUpdate): Promise<DecisionConflict> {
     return this.patch<DecisionConflict>(
       `/v1/conflicts/${encodeURIComponent(conflictId)}`,
+      req,
+    );
+  }
+
+  /** Amend the resolution note for a terminal conflict. */
+  async amendConflictResolutionNote(conflictId: string, req: ConflictResolutionNoteUpdate): Promise<DecisionConflict> {
+    return this.patch<DecisionConflict>(
+      `/v1/admin/conflicts/${encodeURIComponent(conflictId)}/resolution-note`,
       req,
     );
   }

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -38,6 +38,7 @@ export type {
   ConflictGroup,
   ConflictKind,
   ConflictRecommendation,
+  ConflictResolutionNoteUpdate,
   ConflictResolution,
   ConflictResolutionPolicy,
   ConflictSeverityStats,

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -525,6 +525,10 @@ export interface ConflictStatusUpdate {
   false_positive_label?: string;
 }
 
+export interface ConflictResolutionNoteUpdate {
+  resolution_note: string;
+}
+
 export interface ResolveConflictGroupRequest {
   status: string;
   resolution_note?: string;


### PR DESCRIPTION
## Summary

- Auto-label deliberate resolved-with-winner conflicts as `genuine`, while keeping autoresolve/cascade out of ground-truth scoring
- Add an audited admin route and SDK helpers to amend terminal conflict resolution notes
- Update OpenAPI, runbook guidance, and tests for conflict feedback and noisy-detector rollout

## Verification

- [x] I ran relevant tests locally (`go test ./...` or targeted package tests).
- [x] I updated docs/openapi for any API or behavior changes.
- [x] If I changed config vars in `internal/config/config.go`, I also updated:
  - [x] `docs/configuration.md`
  - [x] `docs/runbook.md` (operational subset, if relevant)
  - [x] `.env.example` (if baseline local/dev defaults changed)
- [x] `python3 scripts/check_doc_config_consistency.py` passes.
- [x] `go test -race -count=1 ./...` passes.
- [x] `DOCKER_CONFIG=$PWD/.context/docker-empty-config go test -race -count=1 -tags integration ./...` passes.
- [x] `golangci-lint run ./...`, `go build ./...`, `go vet ./...`, and `atlas migrate validate --dir file://migrations` pass.

## Risk / Rollout Notes

- No migration; the new HTTP route is admin-only, and existing conflict resolution payloads remain backward compatible.

> Twin suns fade to gold
> A droid counts the quiet sands
> Hope hums under stars
