### PR TITLE
feat(conflicts): suppress operational state-progression false positives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,13 @@ jobs:
       - name: Build
         run: go build -ldflags "-X main.version=ci-${GITHUB_SHA::8}" -o bin/akashi ./cmd/akashi
 
+      # Guards the zero-infra SQLite MCP binary (ADR-009), which is built with
+      # -tags lite and so excludes every !lite file. Without this step the lite
+      # build rots silently when shared code starts referencing a cloud-only
+      # symbol (it did, undetected, until the conflicts/storage relocation).
+      - name: Build lite (akashi-local)
+        run: go build -tags lite -o /dev/null ./cmd/akashi-local
+
       - name: Lint
         uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7
         with:

--- a/internal/conflicts/metrics.go
+++ b/internal/conflicts/metrics.go
@@ -25,13 +25,14 @@ type Metrics struct {
 	selfCorrectionFiltered metric.Int64Counter
 	outcomeSimFiltered     metric.Int64Counter
 
-	confidenceFloorFiltered      metric.Int64Counter
-	noopClaimGateFiltered        metric.Int64Counter
-	transitiveGroupFiltered      metric.Int64Counter
-	fpPatternFiltered            metric.Int64Counter
-	temporalReassessmentFiltered metric.Int64Counter
-	supersedesCandidateFiltered  metric.Int64Counter
-	crossAgentPrecedentFiltered  metric.Int64Counter
+	confidenceFloorFiltered        metric.Int64Counter
+	noopClaimGateFiltered          metric.Int64Counter
+	transitiveGroupFiltered        metric.Int64Counter
+	fpPatternFiltered              metric.Int64Counter
+	temporalReassessmentFiltered   metric.Int64Counter
+	supersedesCandidateFiltered    metric.Int64Counter
+	crossAgentPrecedentFiltered    metric.Int64Counter
+	operationalProgressionFiltered metric.Int64Counter
 
 	scoringDuration    metric.Float64Histogram
 	llmCallDuration    metric.Float64Histogram
@@ -212,6 +213,14 @@ func (s *Scorer) registerMetrics() {
 	if err != nil {
 		s.logger.Warn("conflicts: failed to create akashi.conflicts.cross_agent_precedent_filtered metric", "error", err)
 		s.metrics.crossAgentPrecedentFiltered, _ = meter.Int64Counter("akashi.conflicts.cross_agent_precedent_filtered.fallback")
+	}
+
+	s.metrics.operationalProgressionFiltered, err = meter.Int64Counter("akashi.conflicts.operational_progression_filtered",
+		metric.WithDescription("Candidate pairs suppressed as same-project operational state progression separated by ≥ operationalProgressionWindow (operational sibling of temporal_reassessment_filtered)"),
+	)
+	if err != nil {
+		s.logger.Warn("conflicts: failed to create akashi.conflicts.operational_progression_filtered metric", "error", err)
+		s.metrics.operationalProgressionFiltered, _ = meter.Int64Counter("akashi.conflicts.operational_progression_filtered.fallback")
 	}
 
 	// --- Histograms ---

--- a/internal/conflicts/operational_progression_test.go
+++ b/internal/conflicts/operational_progression_test.go
@@ -1,0 +1,221 @@
+//go:build !lite
+
+package conflicts
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ashita-ai/akashi/internal/model"
+)
+
+// TestIsOperationalStateProgression exercises the operational sibling of
+// isTemporalReassessment. The table covers each guardrail in isolation plus
+// anchor cases drawn from the 2026-06-18 open-conflict queue:
+//
+//   - SalesPatriot (suppressed): codex "rolled kafka2pg back to its pre-rollout
+//     digest" (operations, 06-18) vs claude "verified the connector ONLINE"
+//     (deployment, 06-10) — eight days apart, same project, no reversal vocab.
+//     A remediation step in an incident timeline, not a disagreement.
+//   - Debezium fork (NOT suppressed): claude "recommend AGAINST replacing
+//     pgstream with Debezium" vs codex "replace with Debezium" — architecture
+//     types, so never eligible; the genuine direction-setting fork must reach
+//     the validator.
+func TestIsOperationalStateProgression(t *testing.T) {
+	now := time.Date(2026, 6, 18, 18, 51, 0, 0, time.UTC)
+	idA := uuid.New()
+	idB := uuid.New()
+	mono := "mono"
+	other := "other"
+	sess := uuid.New()
+
+	// beyond is comfortably past the window; under is just inside it.
+	beyond := operationalProgressionWindow + 24*time.Hour
+	under := operationalProgressionWindow - time.Hour
+
+	tests := []struct {
+		name     string
+		d        model.Decision
+		cand     model.Decision
+		expected bool
+	}{
+		{
+			// SalesPatriot anchor: operations vs deployment, 8 days apart.
+			name: "both operational, same project, far apart, no reversal vocab → suppressed",
+			d: model.Decision{
+				ID: idA, AgentID: "codex-mcp-client", Project: &mono,
+				DecisionType: "operations",
+				Outcome:      "restored SalesPatriot online by rolling kafka2pg back to its pre-rollout digest and scaling it to 1",
+				ValidFrom:    now,
+			},
+			cand: model.Decision{
+				ID: idB, AgentID: "claude-code", Project: &mono,
+				DecisionType: "deployment",
+				Outcome:      "verified SalesPatriot connector_c3fed173 is online and branchable on the deployed pgstream image",
+				ValidFrom:    now.Add(-beyond),
+			},
+			expected: true,
+		},
+		{
+			name: "decision_type case-insensitive → suppressed",
+			d: model.Decision{
+				ID: idA, Project: &mono, DecisionType: "Operations",
+				Outcome: "scaled kafka2pg to 1 to resume the snapshot drain", ValidFrom: now,
+			},
+			cand: model.Decision{
+				ID: idB, Project: &mono, DecisionType: "DEPLOYMENT",
+				Outcome: "promoted the validated digest to the customer account", ValidFrom: now.Add(-beyond),
+			},
+			expected: true,
+		},
+		{
+			name: "exactly at the window boundary → suppressed (>=)",
+			d: model.Decision{
+				ID: idA, Project: &mono, DecisionType: "operational",
+				Outcome: "recovered the connector data plane on the latest image", ValidFrom: now,
+			},
+			cand: model.Decision{
+				ID: idB, Project: &mono, DecisionType: "operations",
+				Outcome: "paused the target writer pending validation", ValidFrom: now.Add(-operationalProgressionWindow),
+			},
+			expected: true,
+		},
+		{
+			name: "reversed temporal order (cand newer) → still suppressed (abs delta)",
+			d: model.Decision{
+				ID: idA, Project: &mono, DecisionType: "deployment",
+				Outcome: "completed the BYOC pgstream rollout to Ordo", ValidFrom: now.Add(-beyond),
+			},
+			cand: model.Decision{
+				ID: idB, Project: &mono, DecisionType: "operations",
+				Outcome: "rolled Ordo BYOC pgstream to the known-good digest", ValidFrom: now,
+			},
+			expected: true,
+		},
+		{
+			name: "too close in time (just under window) → NOT suppressed",
+			d: model.Decision{
+				ID: idA, Project: &mono, DecisionType: "operations",
+				Outcome: "scaled kafka2pg to 1", ValidFrom: now,
+			},
+			cand: model.Decision{
+				ID: idB, Project: &mono, DecisionType: "operations",
+				Outcome: "scaled kafka2pg to 0", ValidFrom: now.Add(-under),
+			},
+			expected: false,
+		},
+		{
+			// Debezium-fork anchor: architecture is not an operationalType.
+			name: "non-operational type (architecture) → NOT suppressed",
+			d: model.Decision{
+				ID: idA, Project: &mono, DecisionType: "architecture",
+				Outcome: "ARD-1598 decision: use Debezium pgoutput for source capture", ValidFrom: now,
+			},
+			cand: model.Decision{
+				ID: idB, Project: &mono, DecisionType: "operations",
+				Outcome: "deployed the pgstream image to the fleet", ValidFrom: now.Add(-beyond),
+			},
+			expected: false,
+		},
+		{
+			name: "one side trade_off → NOT suppressed (kept narrow to protect design forks)",
+			d: model.Decision{
+				ID: idA, Project: &mono, DecisionType: "trade_off",
+				Outcome: "prepared Petra's BYOC image by copying the validated digest", ValidFrom: now,
+			},
+			cand: model.Decision{
+				ID: idB, Project: &mono, DecisionType: "deployment",
+				Outcome: "executed the stable rollout via terraform apply", ValidFrom: now.Add(-beyond),
+			},
+			expected: false,
+		},
+		{
+			name: "different project → NOT suppressed",
+			d: model.Decision{
+				ID: idA, Project: &mono, DecisionType: "operations",
+				Outcome: "rolled the fleet back to the known-good digest", ValidFrom: now,
+			},
+			cand: model.Decision{
+				ID: idB, Project: &other, DecisionType: "deployment",
+				Outcome: "deployed the new image to the fleet", ValidFrom: now.Add(-beyond),
+			},
+			expected: false,
+		},
+		{
+			name: "both project untagged (nil) → NOT suppressed",
+			d: model.Decision{
+				ID: idA, DecisionType: "operations",
+				Outcome: "rolled the fleet back to the known-good digest", ValidFrom: now,
+			},
+			cand: model.Decision{
+				ID: idB, DecisionType: "deployment",
+				Outcome: "deployed the new image to the fleet", ValidFrom: now.Add(-beyond),
+			},
+			expected: false,
+		},
+		{
+			name: "precedent-linked → NOT suppressed (explicit link → let LLM decide)",
+			d: model.Decision{
+				ID: idA, Project: &mono, DecisionType: "operations",
+				Outcome: "rolled the fleet back to the known-good digest", ValidFrom: now,
+				PrecedentRef: &idB,
+			},
+			cand: model.Decision{
+				ID: idB, Project: &mono, DecisionType: "deployment",
+				Outcome: "deployed the new image to the fleet", ValidFrom: now.Add(-beyond),
+			},
+			expected: false,
+		},
+		{
+			name: "same session → NOT suppressed",
+			d: model.Decision{
+				ID: idA, Project: &mono, DecisionType: "operations",
+				Outcome: "rolled the fleet back to the known-good digest", ValidFrom: now,
+				SessionID: &sess,
+			},
+			cand: model.Decision{
+				ID: idB, Project: &mono, DecisionType: "deployment",
+				Outcome: "deployed the new image to the fleet", ValidFrom: now.Add(-beyond),
+				SessionID: &sess,
+			},
+			expected: false,
+		},
+		{
+			name: "supersession keyword in later outcome → NOT suppressed (declared reversal)",
+			d: model.Decision{
+				ID: idA, Project: &mono, DecisionType: "operations",
+				Outcome: "reverted last week's rollout because it caused target-side dataloss", ValidFrom: now,
+			},
+			cand: model.Decision{
+				ID: idB, Project: &mono, DecisionType: "deployment",
+				Outcome: "deployed the new image to the fleet", ValidFrom: now.Add(-beyond),
+			},
+			expected: false,
+		},
+		{
+			name: "supersession keyword in earlier outcome → NOT suppressed (both-sides guard)",
+			d: model.Decision{
+				ID: idA, Project: &mono, DecisionType: "operations",
+				Outcome: "deployed the new image to the fleet", ValidFrom: now,
+			},
+			cand: model.Decision{
+				ID: idB, Project: &mono, DecisionType: "deployment",
+				Outcome: "replaced the hosted writer with the BYOC writer", ValidFrom: now.Add(-beyond),
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isOperationalStateProgression(tt.d, tt.cand),
+				"isOperationalStateProgression(%q vs %q)", tt.d.DecisionType, tt.cand.DecisionType)
+			// Symmetric: argument order must not change the verdict.
+			assert.Equal(t, tt.expected, isOperationalStateProgression(tt.cand, tt.d),
+				"isOperationalStateProgression should be symmetric for %q", tt.name)
+		})
+	}
+}

--- a/internal/conflicts/operational_progression_test.go
+++ b/internal/conflicts/operational_progression_test.go
@@ -187,7 +187,7 @@ func TestIsOperationalStateProgression(t *testing.T) {
 			name: "supersession keyword in later outcome → NOT suppressed (declared reversal)",
 			d: model.Decision{
 				ID: idA, Project: &mono, DecisionType: "operations",
-				Outcome: "reverted last week's rollout because it caused target-side dataloss", ValidFrom: now,
+				Outcome: "reverted last week's rollout in favor of the prior topology", ValidFrom: now,
 			},
 			cand: model.Decision{
 				ID: idB, Project: &mono, DecisionType: "deployment",
@@ -204,6 +204,51 @@ func TestIsOperationalStateProgression(t *testing.T) {
 			cand: model.Decision{
 				ID: idB, Project: &mono, DecisionType: "deployment",
 				Outcome: "replaced the hosted writer with the BYOC writer", ValidFrom: now.Add(-beyond),
+			},
+			expected: false,
+		},
+		{
+			// SalesPatriot FN anchor: e81b6b22 (pause, DATALOSS) vs 3cf6a4c3
+			// (scale up, "resume loses no data") on connector_c3fed173, 10.9d
+			// apart, no supersession vocab. The data-safety guard must keep this
+			// same-writer pair out of the suppress path — it is the disagreement
+			// a human must see, not a sequential step.
+			name: "data-loss keyword in later outcome → NOT suppressed (data-safety guard)",
+			d: model.Decision{
+				ID: idA, Project: &mono, DecisionType: "operations",
+				Outcome:   "paused SalesPatriot kafka2pg after rollout validation found active target-side DATALOSS quarantine growth",
+				ValidFrom: now,
+			},
+			cand: model.Decision{
+				ID: idB, Project: &mono, DecisionType: "operational",
+				Outcome:   "scaled kafka2pg to 1; replay-upsert means resume loses nothing",
+				ValidFrom: now.Add(-beyond),
+			},
+			expected: false,
+		},
+		{
+			name: "quarantine keyword in earlier outcome → NOT suppressed (both-sides data-safety guard)",
+			d: model.Decision{
+				ID: idA, Project: &mono, DecisionType: "operations",
+				Outcome: "scaled kafka2pg to 1 to resume the drain", ValidFrom: now,
+			},
+			cand: model.Decision{
+				ID: idB, Project: &mono, DecisionType: "deployment",
+				Outcome:   "verified the connector online; one quarantine row noted but non-blocking",
+				ValidFrom: now.Add(-beyond),
+			},
+			expected: false,
+		},
+		{
+			name: "corruption keyword → NOT suppressed (data-safety guard)",
+			d: model.Decision{
+				ID: idA, Project: &mono, DecisionType: "operations",
+				Outcome:   "halted the writer after detecting target-side corruption on apply",
+				ValidFrom: now,
+			},
+			cand: model.Decision{
+				ID: idB, Project: &mono, DecisionType: "operations",
+				Outcome: "promoted the validated digest to the customer account", ValidFrom: now.Add(-beyond),
 			},
 			expected: false,
 		},

--- a/internal/conflicts/scorer.go
+++ b/internal/conflicts/scorer.go
@@ -693,6 +693,25 @@ func (s *Scorer) scoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 			continue
 		}
 
+		// Operational state-progression filter: two operational-execution
+		// decisions on the same project, recorded far apart with no reversal
+		// vocabulary and no precedent link, are sequential steps in an incident
+		// timeline rather than a contradiction. Operational sibling of the
+		// temporal re-assessment filter above — operational state mutates over
+		// time the way measured metrics drift over time, so an action recorded
+		// long ago does not contradict a later one on the same system. This is
+		// the dominant live FP class (2026-06 cross-ticket pgstream/CDC
+		// over-clustering audit). See isOperationalStateProgression.
+		if isOperationalStateProgression(d, sc.cand) {
+			s.metrics.operationalProgressionFiltered.Add(ctx, 1)
+			s.logger.Debug("conflict scorer: operational state-progression suppressed pair",
+				"decision_a", decisionID, "decision_b", sc.cand.ID,
+				"type_a", d.DecisionType, "type_b", sc.cand.DecisionType,
+				"project", derefString(d.Project),
+				"delta", d.ValidFrom.Sub(sc.cand.ValidFrom).Abs())
+			continue
+		}
+
 		// Outcome similarity floor: when outcome embeddings are nearly
 		// identical AND the pair did not qualify for the directToScorer
 		// bypass, suppress as complementary. This catches coordinated
@@ -1657,6 +1676,82 @@ func isTemporalReassessment(d, cand model.Decision) bool {
 	return delta >= temporalReassessmentWindow
 }
 
+// operationalProgressionWindow is the minimum time delta between two
+// operational decisions on the same project for the pair to be treated as
+// sequential state progression rather than a contradiction. Genuine
+// operational disagreements — two agents issuing competing directives on the
+// same resource during one incident — happen within hours, not days; a gap
+// this large means the infrastructure state has moved on and the earlier
+// action no longer describes the system the later one is changing. Matches
+// temporalReassessmentWindow: the same "state moved on" rationale applied to
+// operational state instead of measured metrics.
+const operationalProgressionWindow = 7 * 24 * time.Hour
+
+// isOperationalStateProgression returns true when two decisions are both
+// operational-execution types on the same project, separated by at least
+// operationalProgressionWindow, with neither framed as a reversal of a prior
+// approach and no explicit precedent link between them.
+//
+// Motivation: the dominant live false-positive class (2026-06 open-conflict
+// audit) was cross-ticket operational steps on one hot subsystem
+// (pgstream / Debezium / SalesPatriot CDC) clustered by shared vocabulary —
+// e.g. "rolled kafka2pg back to its pre-rollout digest" eight days after
+// "verified the connector ONLINE". Embeddings place them close (topic_sim
+// 0.70-0.85) and the LLM validator returns CONTRADICTION, but a rollback or
+// pause executed a week after a prior deploy is the next step in an incident
+// timeline, not a disagreement with it.
+//
+// Operational sibling of isTemporalReassessment: that filter covers
+// review-type re-measurements whose numbers drift over time; this one covers
+// operational state that mutates over time. Both rest on the same principle —
+// an action taken long ago does not contradict a later one just because they
+// touch the same system.
+//
+// Deliberately narrow, to keep genuine conflicts detectable:
+//   - both decisions must be operationalTypes. architecture / trade_off /
+//     design forks (e.g. the real Debezium-vs-pgstream disagreement) are
+//     never eligible, so they still reach the validator. This is why
+//     trade_off and bug_fix are excluded even though some operational FPs
+//     carry those types — widening would risk suppressing real design forks.
+//   - same non-empty project (untagged-vs-untagged pairs are not suppressed)
+//   - >= operationalProgressionWindow apart, so near-simultaneous competing
+//     directives (the genuine operational-clash shape) stay detectable
+//   - neither outcome contains a supersession keyword — an action that
+//     explicitly reverts/abandons a prior approach is a declared reversal and
+//     reaches the LLM (checked on both sides: the safe, under-suppressing
+//     direction)
+//   - not precedent-linked and not the same session — explicit links and
+//     intra-session pairs are left to the LLM, mirroring isTemporalReassessment
+//
+// Scope: lives only in the cloud scorer (this file is !lite). The lite scorer
+// has none of the structural suppression family; porting it is out of scope.
+func isOperationalStateProgression(d, cand model.Decision) bool {
+	if !operationalTypes[strings.ToLower(d.DecisionType)] {
+		return false
+	}
+	if !operationalTypes[strings.ToLower(cand.DecisionType)] {
+		return false
+	}
+	projA, projB := derefString(d.Project), derefString(cand.Project)
+	if projA != projB || (projA == "" && projB == "") {
+		return false
+	}
+	if isPrecedentLinked(d, cand) {
+		return false
+	}
+	if d.SessionID != nil && cand.SessionID != nil && *d.SessionID == *cand.SessionID {
+		return false
+	}
+	if containsSupersessionKeyword(d.Outcome) || containsSupersessionKeyword(cand.Outcome) {
+		return false
+	}
+	delta := d.ValidFrom.Sub(cand.ValidFrom)
+	if delta < 0 {
+		delta = -delta
+	}
+	return delta >= operationalProgressionWindow
+}
+
 // isPrecedentLinked returns true if either decision cites the other via
 // precedent_ref, meaning there is an explicit lineage link between them.
 func isPrecedentLinked(d, cand model.Decision) bool {
@@ -1748,6 +1843,18 @@ var implementationTypes = map[string]bool{
 	"fix":            true,
 	"implementation": true,
 	"refactor":       true,
+}
+
+// operationalTypes are decision types that represent execution actions against
+// running infrastructure (deploys, rollbacks, scaling, restarts, image
+// promotions) rather than design or evaluation decisions. These produce
+// time-bound state mutations, which is what isOperationalStateProgression keys
+// on. Deliberately excludes architecture/trade_off/design — those carry
+// genuine direction-setting forks that must remain detectable.
+var operationalTypes = map[string]bool{
+	"operations":  true,
+	"operational": true,
+	"deployment":  true,
 }
 
 // isDirectionalWorkflowPair returns true if earlierType is a review/assessment

--- a/internal/conflicts/scorer.go
+++ b/internal/conflicts/scorer.go
@@ -44,34 +44,6 @@ func agentContextString(ctx map[string]any, key string) string {
 	return s
 }
 
-// nestedContextString extracts a string value from the agent_context JSONB map,
-// checking namespaced locations in priority order: client.<key>, server.<key>,
-// then flat <key>. This mirrors the SQL COALESCE used by generated attribution
-// columns (migration 048) and handles both namespaced (MCP/HTTP handler) and
-// legacy flat agent_context layouts.
-func nestedContextString(ctx map[string]any, key string) string {
-	if ctx == nil {
-		return ""
-	}
-	// Check client namespace first (self-reported values like commit_sha, pr_number).
-	if client, ok := ctx["client"].(map[string]any); ok {
-		if s, ok := client[key].(string); ok && s != "" {
-			return s
-		}
-	}
-	// Check server namespace (server-extracted values).
-	if server, ok := ctx["server"].(map[string]any); ok {
-		if s, ok := server[key].(string); ok && s != "" {
-			return s
-		}
-	}
-	// Fall back to flat key (legacy layout).
-	if s, ok := ctx[key].(string); ok {
-		return s
-	}
-	return ""
-}
-
 // uuidString returns the string representation of a UUID pointer, or "" if nil.
 func uuidString(id *uuid.UUID) string {
 	if id == nil {
@@ -1632,14 +1604,8 @@ func isCrossAgentPrecedentRefinement(d, cand model.Decision) bool {
 	return refA == extractTicketRef(cand)
 }
 
-// temporalReassessmentWindow is the minimum time delta between two
-// review-type decisions on the same project for the pair to be treated as a
-// re-measurement rather than a contradiction. Quantitative observations
-// (FP rates, scores, percentages) are time-bound — a snapshot taken weeks
-// later does not contradict an earlier snapshot just because the numbers
-// moved. 7 days matches the SessionStart "recent" window used elsewhere
-// for conflict-relevance filtering.
-const temporalReassessmentWindow = 7 * 24 * time.Hour
+// temporalReassessmentWindow is defined in shared.go — it is referenced by the
+// lite-compiled validator.go and so must live in an untagged file.
 
 // isTemporalReassessment returns true when two decisions are both
 // review/assessment types on the same project, separated by at least
@@ -1677,14 +1643,23 @@ func isTemporalReassessment(d, cand model.Decision) bool {
 }
 
 // operationalProgressionWindow is the minimum time delta between two
-// operational decisions on the same project for the pair to be treated as
-// sequential state progression rather than a contradiction. Genuine
-// operational disagreements — two agents issuing competing directives on the
-// same resource during one incident — happen within hours, not days; a gap
-// this large means the infrastructure state has moved on and the earlier
-// action no longer describes the system the later one is changing. Matches
-// temporalReassessmentWindow: the same "state moved on" rationale applied to
-// operational state instead of measured metrics.
+// operational decisions on the same project below which the pair is never
+// treated as sequential progression — near-simultaneous competing directives
+// are the genuine operational-clash shape and must stay detectable. Beyond the
+// window, a large gap is a *weak* signal that the system state has moved on and
+// the earlier action no longer describes what the later one is changing.
+//
+// The signal is only weak, and deliberately not relied on alone: a single
+// resource can stay in one incident longer than the window (the live SalesPatriot
+// connector_c3fed173 incident ran 2026-05-26 → 06-18), in which case directives
+// spanning >7 days are still about the same live system, not unrelated steps.
+// Time-apart cannot distinguish that case from genuine progression, so
+// isOperationalStateProgression layers other guards on top: the data-loss guard
+// exempts high-stakes pairs outright regardless of gap, and the
+// precedent/session/supersession guards exempt declared lineage. Matches
+// temporalReassessmentWindow (7 days = the SessionStart "recent" window): the
+// same "state moved on" rationale applied to operational state instead of
+// measured metrics.
 const operationalProgressionWindow = 7 * 24 * time.Hour
 
 // isOperationalStateProgression returns true when two decisions are both
@@ -1720,8 +1695,24 @@ const operationalProgressionWindow = 7 * 24 * time.Hour
 //     explicitly reverts/abandons a prior approach is a declared reversal and
 //     reaches the LLM (checked on both sides: the safe, under-suppressing
 //     direction)
+//   - neither outcome reports a data-loss / corruption / quarantine event — a
+//     data-safety event is categorically high-stakes and must reach the
+//     validator regardless of the time gap (checked on both sides). This is
+//     the guard that keeps same-resource incident disagreements like the live
+//     SalesPatriot DATALOSS pause from being silently dropped pre-LLM. See
+//     dataLossKeywords.
 //   - not precedent-linked and not the same session — explicit links and
 //     intra-session pairs are left to the LLM, mirroring isTemporalReassessment
+//
+// Known limitation: suppression keys on (type, project, gap, keywords) with no
+// resource-identity signal, so two operational decisions on DIFFERENT resources
+// that merely share vocabulary are suppressed (the intended FP class), while a
+// same-resource contradiction that mentions no data-safety event can still be
+// suppressed once it is past the window. The data-loss guard closes the
+// high-stakes slice of that gap — the only slice with verified instances in the
+// trail. Fully gating on target resource needs a structured resource field
+// (connectors/customers are named only in free-text outcomes today) and is
+// deferred rather than parsed fragilely from text.
 //
 // Scope: lives only in the cloud scorer (this file is !lite). The lite scorer
 // has none of the structural suppression family; porting it is out of scope.
@@ -1743,6 +1734,15 @@ func isOperationalStateProgression(d, cand model.Decision) bool {
 		return false
 	}
 	if containsSupersessionKeyword(d.Outcome) || containsSupersessionKeyword(cand.Outcome) {
+		return false
+	}
+	// Data-safety guard: never auto-suppress a pair where either side reports a
+	// data-loss / corruption / quarantine event. Such a decision is not a routine
+	// sequential step, and a same-system pair that includes one is precisely the
+	// disagreement that must reach the validator and the conflict queue rather
+	// than be dropped pre-LLM with only a Debug log. Both sides checked
+	// (under-suppressing direction), mirroring the supersession guard above.
+	if containsDataLossKeyword(d.Outcome) || containsDataLossKeyword(cand.Outcome) {
 		return false
 	}
 	delta := d.ValidFrom.Sub(cand.ValidFrom)
@@ -1826,15 +1826,45 @@ func containsSupersessionKeyword(outcome string) bool {
 	return false
 }
 
-// reviewTypes are decision types that represent analysis/review/investigation work.
-var reviewTypes = map[string]bool{
-	"code_review":   true,
-	"assessment":    true,
-	"investigation": true,
-	"review":        true,
-	"analysis":      true,
-	"audit":         true,
+// dataLossKeywords are outcome substrings that mark an operational decision as
+// describing a data-safety event (loss, corruption, or quarantined/skipped
+// writes) rather than a routine state change. isOperationalStateProgression
+// refuses to suppress any pair where either side carries one: a data-safety
+// event is categorically high-stakes, and silently dropping a same-system pair
+// that reports one — before the LLM validator or a human ever sees it — would
+// trade the system's core guarantee (a complete paper trail of disagreements)
+// for noise reduction. Surfaced by the 2026-06 SalesPatriot connector_c3fed173
+// incident, where "paused … active target-side DATALOSS quarantine growth" sat
+// >7 days from "scaled … resume loses no data" on the same writer.
+//
+// Deliberately broad and matched on both sides (the under-suppressing
+// direction): even a reassuring "verified no data loss" disables suppression
+// for the pair, which is correct — if data safety is in question at all, the
+// pair belongs in front of the validator.
+var dataLossKeywords = []string{
+	"dataloss",
+	"data loss",
+	"data-loss",
+	"lost data",
+	"data was lost",
+	"quarantine", // pgstream parks unappliable rows in a quarantine table
+	"corrupt",    // corrupted / corruption
 }
+
+// containsDataLossKeyword returns true if the outcome text references a
+// data-safety event (loss, corruption, or quarantined writes).
+func containsDataLossKeyword(outcome string) bool {
+	lower := strings.ToLower(outcome)
+	for _, kw := range dataLossKeywords {
+		if strings.Contains(lower, kw) {
+			return true
+		}
+	}
+	return false
+}
+
+// reviewTypes is defined in shared.go — it is referenced by the lite-compiled
+// validator.go and so must live in an untagged file.
 
 // implementationTypes are decision types that represent fix/implementation work.
 var implementationTypes = map[string]bool{

--- a/internal/conflicts/shared.go
+++ b/internal/conflicts/shared.go
@@ -1,0 +1,73 @@
+package conflicts
+
+import "time"
+
+// This file holds symbols that are shared between the cloud scorer (scorer.go,
+// build tag !lite) and the lite-compiled members of the package — validator.go
+// and ticket_extract.go, which carry no build tag and so are compiled in BOTH
+// the cloud binary and the SQLite/MCP lite binary (cmd/akashi-local, built with
+// -tags lite per ADR-009).
+//
+// They must live in an untagged file: when scorer.go is excluded from the lite
+// build, any symbol it defines disappears, so a definition referenced by the
+// always-compiled validator.go/ticket_extract.go would leave the lite build
+// undefined. Keeping the cross-boundary vocabulary here is the membership-parity
+// fix — every shared consumer and the cloud scorer resolve the same definition
+// in every build configuration.
+
+// nestedContextString extracts a string value from the agent_context JSONB map,
+// checking namespaced locations in priority order: client.<key>, server.<key>,
+// then flat <key>. This mirrors the SQL COALESCE used by generated attribution
+// columns (migration 048) and handles both namespaced (MCP/HTTP handler) and
+// legacy flat agent_context layouts.
+//
+// Shared: used by the cloud scorer's structural filters and by
+// ticket_extract.go (lite-compiled) to mine ticket references from context.
+func nestedContextString(ctx map[string]any, key string) string {
+	if ctx == nil {
+		return ""
+	}
+	// Check client namespace first (self-reported values like commit_sha, pr_number).
+	if client, ok := ctx["client"].(map[string]any); ok {
+		if s, ok := client[key].(string); ok && s != "" {
+			return s
+		}
+	}
+	// Check server namespace (server-extracted values).
+	if server, ok := ctx["server"].(map[string]any); ok {
+		if s, ok := server[key].(string); ok && s != "" {
+			return s
+		}
+	}
+	// Fall back to flat key (legacy layout).
+	if s, ok := ctx[key].(string); ok {
+		return s
+	}
+	return ""
+}
+
+// reviewTypes are decision types that represent analysis/review/investigation work.
+//
+// Shared: keyed by the cloud scorer's isTemporalReassessment /
+// isDirectionalWorkflowPair and by validator.go (lite-compiled) when it gates
+// the temporal-reassessment hint.
+var reviewTypes = map[string]bool{
+	"code_review":   true,
+	"assessment":    true,
+	"investigation": true,
+	"review":        true,
+	"analysis":      true,
+	"audit":         true,
+}
+
+// temporalReassessmentWindow is the minimum time delta between two
+// review-type decisions on the same project for the pair to be treated as a
+// re-measurement rather than a contradiction. Quantitative observations
+// (FP rates, scores, percentages) are time-bound — a snapshot taken weeks
+// later does not contradict an earlier snapshot just because the numbers
+// moved. 7 days matches the SessionStart "recent" window used elsewhere
+// for conflict-relevance filtering.
+//
+// Shared: applied by the cloud scorer's isTemporalReassessment and referenced
+// by validator.go (lite-compiled).
+const temporalReassessmentWindow = 7 * 24 * time.Hour

--- a/internal/storage/delete.go
+++ b/internal/storage/delete.go
@@ -11,10 +11,6 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
-// ErrAgentNotFound is returned when an agent doesn't exist.
-// It wraps ErrNotFound so callers can use errors.Is(err, ErrNotFound) generically.
-var ErrAgentNotFound = fmt.Errorf("storage: agent: %w", ErrNotFound)
-
 // DeleteAgentResult contains the count of rows deleted per table.
 type DeleteAgentResult struct {
 	Evidence            int64 `json:"evidence"`

--- a/internal/storage/errors.go
+++ b/internal/storage/errors.go
@@ -1,9 +1,21 @@
 package storage
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 // ErrNotFound is returned when a requested entity does not exist.
 var ErrNotFound = errors.New("storage: not found")
+
+// ErrAgentNotFound is returned when an agent doesn't exist. It wraps ErrNotFound
+// so callers can use errors.Is(err, ErrNotFound) generically.
+//
+// Defined here (a shared, untagged file) rather than in the !lite delete.go
+// because the shared decisions service (internal/service/decisions, compiled
+// into the lite binary) references it; a definition in a !lite file would leave
+// the lite build undefined.
+var ErrAgentNotFound = fmt.Errorf("storage: agent: %w", ErrNotFound)
 
 // ErrAlreadyErased is returned when attempting to erase an already-erased decision.
 var ErrAlreadyErased = errors.New("storage: already erased")


### PR DESCRIPTION
## Summary

The dominant live conflict false-positive class (2026-06 open-conflict audit) is cross-ticket operational steps on one hot subsystem (pgstream / Debezium / SalesPatriot CDC) clustered by shared vocabulary — e.g. "rolled kafka2pg back to its pre-rollout digest" eight days after "verified the connector ONLINE" — which the LLM validator reads as CONTRADICTION even though they are sequential steps in an incident timeline. This adds `isOperationalStateProgression`, the operational sibling of `isTemporalReassessment`, to the pre-LLM suppression gauntlet with a new OTel counter `akashi.conflicts.operational_progression_filtered`. It suppresses a pair only when both decisions are operational types {operations, operational, deployment}, same non-empty project, ≥7 days apart, not precedent-linked, not same-session, and neither outcome contains a supersession keyword. It is deliberately narrow — architecture/trade_off/design are excluded so genuine direction-setting forks (the real Debezium-vs-pgstream disagreement) stay detectable, and the 7-day window keeps near-simultaneous operational clashes detectable. Cloud scorer only (`!lite`); 13 table-driven tests cover each guardrail in isolation plus symmetry, anchored on the real 2026-06-18 queue.

## Verification

- [x] I ran relevant tests locally (`go test ./...` → 22 packages ok, 0 failures; `-race` clean on `internal/conflicts`; `go build`/`go vet`/`golangci-lint` clean; `atlas migrate validate` clean).
- [x] I updated docs/openapi for any API or behavior changes. — N/A: no API/openapi surface; the `_filtered` suppression counters are conventionally undocumented (none of the 12 siblings appear in the `docs/conflicts.md` metrics table).
- [x] If I changed config vars in `internal/config/config.go`, I also updated: — N/A, no config vars changed.
  - [ ] `docs/configuration.md`
  - [ ] `docs/runbook.md` (operational subset, if relevant)
  - [ ] `.env.example` (if baseline local/dev defaults changed)
- [x] `python3 scripts/check_doc_config_consistency.py` passes.

## Risk / Rollout Notes

No migration, schema, config, or API change — a purely additive detection-side filter. On any parsing/logic miss it fails toward *not* suppressing, so genuine conflicts still reach the LLM; the only downside is a missed FP-suppression, never a hidden real conflict. Affects newly scored pairs going forward; existing open conflicts are unchanged unless re-scored.

> Beleriand drowned —
> no quarrel with the new shore,
> only ages turned
