### PR TITLE
feat(conflicts): suppress supersession + disjoint-work-item false positives

### DIFF
--- a/internal/conflicts/disjoint_work_item_test.go
+++ b/internal/conflicts/disjoint_work_item_test.go
@@ -1,0 +1,332 @@
+//go:build !lite
+
+package conflicts
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ashita-ai/akashi/internal/model"
+)
+
+// clientCtx builds an agent_context with a client-namespaced pr_number, matching
+// the structured layout nestedContextString reads first.
+func clientCtx(prNumber string) map[string]any {
+	return map[string]any{"client": map[string]any{"pr_number": prNumber}}
+}
+
+func TestCanonicalPRRef(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"1539", "PR-1539"},
+		{"#1539", "PR-1539"},
+		{"PR-1539", "PR-1539"},
+		{"pr #1543", "PR-1543"},
+		{"", ""},
+		{"none", ""},
+		{"v2", ""}, // single digit run below the 2-digit floor
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			assert.Equal(t, tt.want, canonicalPRRef(tt.in))
+		})
+	}
+}
+
+// TestExtractWorkItemRefs verifies the union extractor surfaces both ticket
+// references and PR/issue references, prefers the structured pr_number, and does
+// not over-match the dense numeric vocabulary of cutover decision outcomes
+// (migration timestamps, test counts, LSNs).
+func TestExtractWorkItemRefs(t *testing.T) {
+	tests := []struct {
+		name string
+		dec  model.Decision
+		want []string
+	}{
+		{
+			name: "bare PR ref in outcome",
+			dec:  model.Decision{Outcome: "Recommended not merging PR #1539 until evidence is fresh"},
+			want: []string{"PR-1539"},
+		},
+		{
+			name: "ticket and PR together",
+			dec:  model.Decision{Outcome: "Reviewed ARD-1660 cutover evidence in PR #1539"},
+			want: []string{"ARD-1660", "PR-1539"},
+		},
+		{
+			name: "multiple PRs, deduped",
+			dec:  model.Decision{Outcome: "closed #1543 in favor of #1545 and #1545 again"},
+			want: []string{"PR-1543", "PR-1545"},
+		},
+		{
+			name: "structured pr_number with no # in outcome",
+			dec: model.Decision{
+				Outcome:      "Fixed the Greptile cutover findings on the engine-flip read",
+				AgentContext: clientCtx("1531"),
+			},
+			want: []string{"PR-1531"},
+		},
+		{
+			name: "structured pr_number plus a different PR in text",
+			dec: model.Decision{
+				Outcome:      "Rebased onto #1542 after fixing findings",
+				AgentContext: clientCtx("1543"),
+			},
+			want: []string{"PR-1543", "PR-1542"},
+		},
+		{
+			name: "dense numeric prose does not over-match",
+			dec:  model.Decision{Outcome: "573 unit tests pass; migration 20260623000001; target_checkpoint_lsn advanced; 8 findings"},
+			want: nil,
+		},
+		{
+			name: "single-digit and hex-like tokens are ignored",
+			dec:  model.Decision{Outcome: "finding #3 in palette #1a2b3c remains open"},
+			want: nil,
+		},
+		{
+			name: "nothing extractable",
+			dec:  model.Decision{Outcome: "kept the freeze fail-closed and added a bounded retry"},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.ElementsMatch(t, tt.want, extractWorkItemRefs(tt.dec))
+		})
+	}
+}
+
+// TestIsDisjointWorkItem exercises the structural escalation of the
+// disjoint-ticket validator prompt hint. The table covers each guardrail plus
+// anchor cases drawn verbatim-in-spirit from the 2026-06-23 open-conflict queue,
+// where 9 of 19 open false positives were review/planning pairs about different
+// PRs/tickets sharing dense cutover vocabulary, and a single review of "PR #1539"
+// fanned out into nine of them.
+func TestIsDisjointWorkItem(t *testing.T) {
+	idA := uuid.New()
+	idB := uuid.New()
+	mono := "mono"
+	other := "other"
+
+	tests := []struct {
+		name     string
+		d        model.Decision
+		cand     model.Decision
+		expected bool
+	}{
+		{
+			// Group 8 anchor: the hub review carries only a PR number, not an
+			// ARD ticket — a ticket-only rule could never have matched it. Also
+			// proves "replaced the boolean" (a code-diff verb) no longer blocks
+			// suppression now that the supersession-keyword guard is gone here.
+			name: "PR-only review vs PR-only review, disjoint → suppressed",
+			d: model.Decision{
+				ID: idA, AgentID: "coder", Project: &mono, DecisionType: "code_review",
+				Outcome: "Fixed PR #1531 Greptile/Cursor cutover findings: replaced the engine_flip_attempted boolean with a confirmed connector read",
+			},
+			cand: model.Decision{
+				ID: idB, AgentID: "codex-mcp-client", Project: &mono, DecisionType: "code_review",
+				Outcome: "Recommended not merging PR #1539 until cutover evidence uses a fresh live replica-identity proof",
+			},
+			expected: true,
+		},
+		{
+			// Group 7c anchor: ticket-scoped review vs PR-scoped review.
+			name: "ticket review vs PR review, disjoint → suppressed",
+			d: model.Decision{
+				ID: idA, AgentID: "claude-code", Project: &mono, DecisionType: "code_review",
+				Outcome: "Reviewed ARD-1662 commit 50fbd79b 'Fix Debezium cutover restore audit attribution'. Verdict: APPROVE",
+			},
+			cand: model.Decision{
+				ID: idB, AgentID: "codex-mcp-client", Project: &mono, DecisionType: "code_review",
+				Outcome: "Recommended not merging PR #1539 until cutover evidence uses a fresh live replica-identity proof",
+			},
+			expected: true,
+		},
+		{
+			// Group 4 anchor: two plans for different tickets.
+			name: "planning vs planning, disjoint tickets → suppressed",
+			d: model.Decision{
+				ID: idA, AgentID: "codex-mcp-client", Project: &mono, DecisionType: "planning",
+				Outcome: "ARD-1606 implementation should build on existing mainline contract/table/gate pieces rather than redesigning cutover",
+			},
+			cand: model.Decision{
+				ID: idB, AgentID: "claude-code", Project: &mono, DecisionType: "planning",
+				Outcome: "Set up the ARD-1662 cutover workflow on its own branch with the durable evidence reader wired in",
+			},
+			expected: true,
+		},
+		{
+			name: "structured pr_number (no # in outcome) vs PR in text, disjoint → suppressed",
+			d: model.Decision{
+				ID: idA, Project: &mono, DecisionType: "code_review",
+				Outcome:      "Fixed the Greptile cutover findings on the engine-flip read path",
+				AgentContext: clientCtx("1531"),
+			},
+			cand: model.Decision{
+				ID: idB, Project: &mono, DecisionType: "code_review",
+				Outcome: "Reviewed the cutover evidence wiring in PR #1539; gate consumption is fail-closed",
+			},
+			expected: true,
+		},
+		{
+			name: "decision_type case-insensitive → suppressed",
+			d: model.Decision{
+				ID: idA, Project: &mono, DecisionType: "Code_Review",
+				Outcome: "Reviewed PR #1529 retirement contract fixes",
+			},
+			cand: model.Decision{
+				ID: idB, Project: &mono, DecisionType: "PLANNING",
+				Outcome: "Planned the ARD-1660 evidence collector follow-up",
+			},
+			expected: true,
+		},
+		{
+			// Group 1 anchor: architecture is direction-setting — a genuine
+			// cross-cutting design fork can span tickets and must reach the LLM.
+			name: "architecture vs architecture, disjoint → NOT suppressed (design forks preserved)",
+			d: model.Decision{
+				ID: idA, Project: &mono, DecisionType: "architecture",
+				Outcome: "Implemented ARD-1693 pgstream Init as a privilege-safe idempotent startup path",
+			},
+			cand: model.Decision{
+				ID: idB, Project: &mono, DecisionType: "architecture",
+				Outcome: "ARD-1599: cannot wire install_ardent_ddl_capture into the live pgstream setup path — payload-incompatibility blocker",
+			},
+			expected: false,
+		},
+		{
+			// Group 6a anchor: trade_off is direction-setting.
+			name: "trade_off vs code_review, disjoint → NOT suppressed (direction-setting type)",
+			d: model.Decision{
+				ID: idA, Project: &mono, DecisionType: "trade_off",
+				Outcome: "Addressed Greptile's ARD-1690 concerns by requiring a fresh proof on the live evidence path",
+			},
+			cand: model.Decision{
+				ID: idB, Project: &mono, DecisionType: "code_review",
+				Outcome: "Reviewed PR #1539 cutover-proof reader wiring",
+			},
+			expected: false,
+		},
+		{
+			// Group 7i anchor: the merge-order plan names #1539, so the sets
+			// overlap and the genuinely-about-the-same-PR pair reaches the LLM.
+			name: "shared PR ref (overlap) → NOT suppressed",
+			d: model.Decision{
+				ID: idA, Project: &mono, DecisionType: "code_review",
+				Outcome: "Recommended not merging PR #1539 until evidence is fresh",
+			},
+			cand: model.Decision{
+				ID: idB, Project: &mono, DecisionType: "planning",
+				Outcome: "Recommended merge order: land #1542 first, then merge #1539 before #1543",
+			},
+			expected: false,
+		},
+		{
+			name: "shared ticket ref (overlap) → NOT suppressed",
+			d: model.Decision{
+				ID: idA, Project: &mono, DecisionType: "code_review",
+				Outcome: "Reviewed ARD-1660 evidence readers; gate is fail-closed",
+			},
+			cand: model.Decision{
+				ID: idB, Project: &mono, DecisionType: "planning",
+				Outcome: "Planned the remaining ARD-1660 live-collection producer work",
+			},
+			expected: false,
+		},
+		{
+			// Group 7a anchor: the review text names DATALOSS/quarantine. Even
+			// across tickets, a data-safety pair must reach the validator — this
+			// is the evidenced cross-ticket data-safety contradiction class.
+			name: "data-loss vocabulary on one side → NOT suppressed (data-safety guard)",
+			d: model.Decision{
+				ID: idA, Project: &mono, DecisionType: "code_review",
+				Outcome: "Reviewed ARD-1661 wiring: no persistence of apply/quarantine/DATALOSS findings to debezium_migration_events",
+			},
+			cand: model.Decision{
+				ID: idB, Project: &mono, DecisionType: "code_review",
+				Outcome: "Recommended not merging PR #1539 until evidence is fresh",
+			},
+			expected: false,
+		},
+		{
+			name: "one side has no extractable work item → NOT suppressed",
+			d: model.Decision{
+				ID: idA, Project: &mono, DecisionType: "code_review",
+				Outcome: "Reviewed the cutover freeze path; kept it fail-closed with a bounded retry",
+			},
+			cand: model.Decision{
+				ID: idB, Project: &mono, DecisionType: "code_review",
+				Outcome: "Recommended not merging PR #1539 until evidence is fresh",
+			},
+			expected: false,
+		},
+		{
+			name: "different project → NOT suppressed",
+			d: model.Decision{
+				ID: idA, Project: &mono, DecisionType: "code_review",
+				Outcome: "Reviewed PR #1531 cutover findings",
+			},
+			cand: model.Decision{
+				ID: idB, Project: &other, DecisionType: "code_review",
+				Outcome: "Reviewed PR #1539 evidence wiring",
+			},
+			expected: false,
+		},
+		{
+			name: "both projects untagged (nil) → NOT suppressed",
+			d: model.Decision{
+				ID: idA, DecisionType: "code_review",
+				Outcome: "Reviewed PR #1531 cutover findings",
+			},
+			cand: model.Decision{
+				ID: idB, DecisionType: "code_review",
+				Outcome: "Reviewed PR #1539 evidence wiring",
+			},
+			expected: false,
+		},
+		{
+			name: "precedent-linked → NOT suppressed (explicit lineage → let LLM decide)",
+			d: model.Decision{
+				ID: idA, Project: &mono, DecisionType: "code_review",
+				Outcome:      "Reviewed PR #1531 cutover findings",
+				PrecedentRef: &idB,
+			},
+			cand: model.Decision{
+				ID: idB, Project: &mono, DecisionType: "code_review",
+				Outcome: "Reviewed PR #1539 evidence wiring",
+			},
+			expected: false,
+		},
+		{
+			// A declared cross-work-item supersession names the other item, so
+			// the sets overlap and it reaches the LLM (then the supersession→
+			// suggestion path) — no keyword guard needed in this filter.
+			name: "cross-reference by name (overlap) → NOT suppressed",
+			d: model.Decision{
+				ID: idA, Project: &mono, DecisionType: "planning",
+				Outcome: "closed PR #1543 in favor of #1545 which already carries the spine",
+			},
+			cand: model.Decision{
+				ID: idB, Project: &mono, DecisionType: "code_review",
+				Outcome: "Reviewed #1545; the shadow-apply spine landed cleanly",
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isDisjointWorkItem(tt.d, tt.cand),
+				"isDisjointWorkItem(%q vs %q)", tt.d.DecisionType, tt.cand.DecisionType)
+			// Symmetric: argument order must not change the verdict.
+			assert.Equal(t, tt.expected, isDisjointWorkItem(tt.cand, tt.d),
+				"isDisjointWorkItem should be symmetric for %q", tt.name)
+		})
+	}
+}

--- a/internal/conflicts/metrics.go
+++ b/internal/conflicts/metrics.go
@@ -33,6 +33,8 @@ type Metrics struct {
 	supersedesCandidateFiltered    metric.Int64Counter
 	crossAgentPrecedentFiltered    metric.Int64Counter
 	operationalProgressionFiltered metric.Int64Counter
+	disjointWorkItemFiltered       metric.Int64Counter
+	supersessionSuppressed         metric.Int64Counter
 
 	scoringDuration    metric.Float64Histogram
 	llmCallDuration    metric.Float64Histogram
@@ -221,6 +223,22 @@ func (s *Scorer) registerMetrics() {
 	if err != nil {
 		s.logger.Warn("conflicts: failed to create akashi.conflicts.operational_progression_filtered metric", "error", err)
 		s.metrics.operationalProgressionFiltered, _ = meter.Int64Counter("akashi.conflicts.operational_progression_filtered.fallback")
+	}
+
+	s.metrics.disjointWorkItemFiltered, err = meter.Int64Counter("akashi.conflicts.disjoint_work_item_filtered",
+		metric.WithDescription("Candidate pairs suppressed as review/planning decisions about disjoint work items (different PR/ticket) — the hard-rule escalation of the disjoint-ticket validator prompt hint, extended to PR references"),
+	)
+	if err != nil {
+		s.logger.Warn("conflicts: failed to create akashi.conflicts.disjoint_work_item_filtered metric", "error", err)
+		s.metrics.disjointWorkItemFiltered, _ = meter.Int64Counter("akashi.conflicts.disjoint_work_item_filtered.fallback")
+	}
+
+	s.metrics.supersessionSuppressed, err = meter.Int64Counter("akashi.conflicts.supersession_suppressed",
+		metric.WithDescription("Candidate pairs the LLM classified as supersession, recorded as a supersedes suggestion instead of an open conflict (supersession is a lifecycle event, not a standing disagreement)"),
+	)
+	if err != nil {
+		s.logger.Warn("conflicts: failed to create akashi.conflicts.supersession_suppressed metric", "error", err)
+		s.metrics.supersessionSuppressed, _ = meter.Int64Counter("akashi.conflicts.supersession_suppressed.fallback")
 	}
 
 	// --- Histograms ---

--- a/internal/conflicts/scorer.go
+++ b/internal/conflicts/scorer.go
@@ -684,6 +684,27 @@ func (s *Scorer) scoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 			continue
 		}
 
+		// Disjoint work-item filter: two work-item-scoped decisions (reviews,
+		// plans) on the same project that reference entirely different work
+		// items — different PRs or different tickets — examine different
+		// code/scope and cannot contradict each other. This is the structural,
+		// PR-aware escalation of the disjoint-ticket validator prompt hint
+		// (eef7eb2c), which the LLM ignored on dense shared-subsystem
+		// vocabulary; it is the dominant 2026-06-23 false-positive class (9 of
+		// 19 open) and the mechanism behind the single-review fan-out (a review
+		// of "PR #1539" matched against nine other-PR/-ticket decisions).
+		// Direction-setting types are excluded so genuine design forks stay
+		// detectable. See isDisjointWorkItem.
+		if isDisjointWorkItem(d, sc.cand) {
+			s.metrics.disjointWorkItemFiltered.Add(ctx, 1)
+			s.logger.Debug("conflict scorer: disjoint work-item filter suppressed pair",
+				"decision_a", decisionID, "decision_b", sc.cand.ID,
+				"type_a", d.DecisionType, "type_b", sc.cand.DecisionType,
+				"project", derefString(d.Project),
+				"refs_a", extractWorkItemRefs(d), "refs_b", extractWorkItemRefs(sc.cand))
+			continue
+		}
+
 		// Outcome similarity floor: when outcome embeddings are nearly
 		// identical AND the pair did not qualify for the directToScorer
 		// bypass, suppress as complementary. This catches coordinated
@@ -835,6 +856,30 @@ func (s *Scorer) scoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 				attribute.String("result", "success"),
 				attribute.String("validator", s.validatorLabel),
 			))
+			// Supersession is a lifecycle event, not a standing disagreement:
+			// the validator judged that one decision explicitly REPLACES the
+			// other (vs CONTRADICTION, where both positions are live and
+			// incompatible). Record it as a supersedes suggestion — which drives
+			// the supersedes_id link on the agent's next akashi_check (#710) and
+			// retires the stale side — instead of opening a conflict a human must
+			// triage. Without this, every "closed PR #1543 as obsolete once the
+			// work merged via #1545" trace opened a conflict against the earlier
+			// plan that proposed #1543: a dominant false-positive class in the
+			// 2026-06-23 open-conflict audit, and the mechanism behind the
+			// never_superseded=3045/3045 trace-health signal (supersessions were
+			// landing in the conflict queue instead of as supersedes links). The
+			// validator still RETURNS "supersession" so the IsConflict-based
+			// precision/recall eval is unchanged; only the scorer's handling of
+			// that verdict changes. Placed before IsConflict() (which counts
+			// supersession as actionable) so supersession never reaches insertion.
+			if result.Relationship == "supersession" {
+				s.metrics.supersessionSuppressed.Add(ctx, 1)
+				s.logger.Debug("conflict scorer: supersession recorded as supersedes suggestion, not opened as conflict",
+					"decision_a", decisionID, "decision_b", cand.ID,
+					"explanation", result.Explanation)
+				s.recordSupersedesSuggestionFromValidator(ctx, d, cand, sc.topicSim)
+				continue
+			}
 			if !result.IsConflict() {
 				s.logger.Debug("conflict scorer: LLM classified as non-conflict",
 					"decision_a", decisionID, "decision_b", cand.ID,
@@ -1475,18 +1520,50 @@ func isSameBranchSelfCorrection(d, cand model.Decision) bool {
 
 // recordSupersedesSuggestion writes the detector-inferred supersedes link
 // for a suppressed same-agent same-ticket pair so akashi_check can surface
-// it on the agent's next call (PR-2 of #708, see issue #710). Fire-and-forget:
-// suggestion-write failures are logged at warn but never block scoring or
-// fail the pair — the conflict has already been filtered.
-//
-// The "later" decision (by ValidFrom) is treated as the superseding side.
-// This mirrors how a manually set supersedes_id link works: the newer trace
-// retires the older one. Suggestion confidence is the topic similarity at
-// filter time — agents see how strongly the detector believed the pair was
-// the same work. Cosine similarity is mathematically in [-1, 1] but the
-// API contract bounds confidence to [0, 1]; we clamp here so callers and
-// dashboards never see a value that violates the schema.
+// it on the agent's next call (PR-2 of #708, see issue #710). The later
+// decision (by ValidFrom) is the superseding side, mirroring how a manually
+// set supersedes_id link works; suggestion confidence is the topic similarity
+// at filter time, so agents see how strongly the detector believed the pair was
+// the same work. Ordering, confidence clamping, and the fire-and-forget write
+// contract all live in insertSupersedesSuggestion.
 func (s *Scorer) recordSupersedesSuggestion(ctx context.Context, d, cand model.Decision, topicSim float64, ticket string) {
+	s.insertSupersedesSuggestion(ctx, d, cand, topicSim,
+		"detector:same_agent_same_ticket",
+		fmt.Sprintf("same agent %q, same ticket %q", d.AgentID, ticket))
+}
+
+// recordSupersedesSuggestionFromValidator records the supersedes link the LLM
+// validator inferred when it classified a pair as a supersession. A supersession
+// is a lifecycle event — one decision explicitly replaces another — not a
+// standing disagreement between live positions, so it is surfaced as a supersedes
+// suggestion (which drives the supersedes_id link on the agent's next
+// akashi_check, issue #710) instead of being opened as a conflict a human must
+// triage. This is the post-LLM sibling of the pre-LLM same-agent/cross-agent
+// refinement suppressors, which already redirect their pairs the same way. See
+// the supersession interception in scoreForDecision.
+//
+// Mirrors a manual supersedes_id link: the later decision (by ValidFrom) retires
+// the earlier one, regardless of whether the same or a different agent authored
+// it — a later decision that explicitly replaces an earlier one supersedes it in
+// both cases.
+func (s *Scorer) recordSupersedesSuggestionFromValidator(ctx context.Context, d, cand model.Decision, topicSim float64) {
+	superseding := d
+	if cand.ValidFrom.After(d.ValidFrom) {
+		superseding = cand
+	}
+	s.insertSupersedesSuggestion(ctx, d, cand, topicSim,
+		"detector:llm_supersession",
+		fmt.Sprintf("LLM validator classified %q's later decision as a supersession", superseding.AgentID))
+}
+
+// insertSupersedesSuggestion is the shared core behind the supersedes-suggestion
+// callers. It orders the pair by ValidFrom (later = superseding), clamps topicSim
+// into the [0,1] confidence contract (cosine similarity is mathematically in
+// [-1,1] but the API bounds confidence to [0,1]), and writes the suggestion
+// fire-and-forget: a write failure is logged at warn and never blocks scoring,
+// because the conflict has already been filtered or redirected away from the
+// open queue by the time this runs.
+func (s *Scorer) insertSupersedesSuggestion(ctx context.Context, d, cand model.Decision, topicSim float64, suggestedBy, reason string) {
 	superseding, superseded := d, cand
 	if cand.ValidFrom.After(d.ValidFrom) {
 		superseding, superseded = cand, d
@@ -1498,17 +1575,17 @@ func (s *Scorer) recordSupersedesSuggestion(ctx context.Context, d, cand model.D
 		topicSim = 1
 	}
 	conf := float32(topicSim)
-	reason := fmt.Sprintf("same agent %q, same ticket %q", d.AgentID, ticket)
 	if err := s.db.InsertSupersedesSuggestion(ctx, storage.SupersedesSuggestionInsert{
 		OrgID:         d.OrgID,
 		SupersedingID: superseding.ID,
 		SupersededID:  superseded.ID,
-		SuggestedBy:   "detector:same_agent_same_ticket",
+		SuggestedBy:   suggestedBy,
 		Confidence:    &conf,
 		Reason:        reason,
 	}); err != nil {
 		s.logger.Warn("conflict scorer: insert supersedes suggestion failed",
-			"superseding_id", superseding.ID, "superseded_id", superseded.ID, "error", err)
+			"superseding_id", superseding.ID, "superseded_id", superseded.ID,
+			"suggested_by", suggestedBy, "error", err)
 	}
 }
 
@@ -1752,6 +1829,95 @@ func isOperationalStateProgression(d, cand model.Decision) bool {
 	return delta >= operationalProgressionWindow
 }
 
+// isDisjointWorkItem returns true when two work-item-scoped decisions (reviews,
+// plans) on the same project reference entirely different work items — different
+// PRs or different tickets — and therefore cannot be contradicting each other.
+// A review of PR #1539 and a review of PR #1543 examine different code; a plan
+// for ARD-1606 and a plan for ARD-1662 scope different tickets. They routinely
+// share dense subsystem vocabulary (cutover, pgstream, freeze, replica-identity,
+// shadow-apply) that places them close in embedding space, and the LLM validator
+// then manufactures a CONTRADICTION between them.
+//
+// This is the hard-rule escalation of the disjoint-ticket signal that
+// eef7eb2c shipped as a *validator prompt hint* ("DIFFERENT TICKETS ... classify
+// as UNRELATED or COMPLEMENTARY unless ..."). The live 2026-06-23 open-conflict
+// audit showed the hint is ignored once shared vocabulary is dense enough: 9 of
+// 19 open false positives were disjoint-work-item review/planning pairs the
+// prompt failed to deflect. Promoting it to a structural pre-LLM suppressor is
+// the membership-parity follow-through, and — unlike the ticket-only hint — this
+// one is PR-aware via extractWorkItemRefs, which is what closes the dominant
+// fan-out hole: the hub decision in that audit (a review of "PR #1539") carries
+// NO ARD-style ticket ref at all, so a ticket-only rule could never have matched
+// the nine pairs it spawned.
+//
+// Deliberately narrow, to keep genuine conflicts detectable:
+//   - both decisions must be workItemScopedTypes. architecture / trade_off /
+//     design forks are never eligible — a cross-cutting design disagreement
+//     (e.g. the real Debezium-vs-pgstream fork) can legitimately span work
+//     items and must reach the validator. Same exclusion rationale as
+//     isOperationalStateProgression.
+//   - same non-empty project (PR/ticket numbers are repo-scoped; an untagged
+//     pair, or a cross-repo pair sharing a PR number, is never suppressed —
+//     mirrors isCoordinatedChange's same-project requirement for pr_number)
+//   - both decisions must expose at least one extractable work-item ref, and
+//     the two ref sets must be fully disjoint. Any shared PR/ticket (including
+//     one outcome naming the other's work item, e.g. "closed #1543 in favor of
+//     #1545") makes the sets overlap and the pair reaches the validator.
+//   - not precedent-linked — an explicit lineage cite is left to the LLM
+//   - neither outcome reports a data-loss / corruption / quarantine event — a
+//     data-safety finding is categorically high-stakes and must never be dropped
+//     pre-LLM (both sides). This is NOT a redundant copy of the operational
+//     filter's guard: cross-ticket data-safety contradictions are a real,
+//     resolved class in this trail (e.g. two investigations root-causing the
+//     same DATALOSS incident to different causes under different tickets), and
+//     disjoint work items do not make that pair safe to drop. Same guard, same
+//     reasoning as isOperationalStateProgression; see dataLossKeywords.
+//
+// Deliberately NOT guarded on supersession keywords, unlike the operational and
+// refinement siblings. Those siblings have no work-item identity signal, so a
+// "replaced X" / "superseded by Y" phrase is their only cue that a pair might be
+// a declared reversal that should reach the validator. This filter HAS that
+// signal: a genuine cross-work-item supersession names the other work item, so
+// the ref sets overlap and the pair already reaches the validator (then the
+// post-LLM supersession→suggestion path). Adding a keyword guard here would only
+// re-admit the false positives this filter exists to kill — review prose is full
+// of code-diff verbs ("replaced the boolean", "dropped the dead reader") that
+// describe a diff, not a decision reversal. A vague reversal that names no work
+// item is the sole edge this forgoes; it stays suppressed, which is correct (an
+// unnamed antecedent cannot be linked anyway). The difference from the siblings
+// is intentional, not drift.
+//
+// Failure mode is under-suppression: a missed PR/ticket extraction leaves the
+// ref sets looking smaller (or one side empty), which disables the filter and
+// sends the pair to the validator — never a wrongful suppression.
+//
+// Scope: lives only in the cloud scorer (this file is !lite), alongside the rest
+// of the structural suppression family.
+func isDisjointWorkItem(d, cand model.Decision) bool {
+	if !workItemScopedTypes[strings.ToLower(d.DecisionType)] {
+		return false
+	}
+	if !workItemScopedTypes[strings.ToLower(cand.DecisionType)] {
+		return false
+	}
+	projA, projB := derefString(d.Project), derefString(cand.Project)
+	if projA != projB || (projA == "" && projB == "") {
+		return false
+	}
+	if isPrecedentLinked(d, cand) {
+		return false
+	}
+	if containsDataLossKeyword(d.Outcome) || containsDataLossKeyword(cand.Outcome) {
+		return false
+	}
+	refsA := extractWorkItemRefs(d)
+	refsB := extractWorkItemRefs(cand)
+	if len(refsA) == 0 || len(refsB) == 0 {
+		return false
+	}
+	return !ticketRefsOverlap(refsA, refsB)
+}
+
 // isPrecedentLinked returns true if either decision cites the other via
 // precedent_ref, meaning there is an explicit lineage link between them.
 func isPrecedentLinked(d, cand model.Decision) bool {
@@ -1885,6 +2051,23 @@ var operationalTypes = map[string]bool{
 	"operations":  true,
 	"operational": true,
 	"deployment":  true,
+}
+
+// workItemScopedTypes are decision types whose conflict scope is a single work
+// item — a PR under review, a ticket being planned or investigated. Two such
+// decisions about DIFFERENT work items examine different code/scope and cannot
+// contradict each other, which is what isDisjointWorkItem keys on. Deliberately
+// excludes the direction-setting types (architecture / trade_off / design):
+// a cross-cutting design fork can legitimately span work items and must remain
+// detectable, the same reason operationalTypes excludes them.
+var workItemScopedTypes = map[string]bool{
+	"code_review":   true,
+	"review":        true,
+	"assessment":    true,
+	"investigation": true,
+	"analysis":      true,
+	"audit":         true,
+	"planning":      true,
 }
 
 // isDirectionalWorkflowPair returns true if earlierType is a review/assessment

--- a/internal/conflicts/ticket_extract.go
+++ b/internal/conflicts/ticket_extract.go
@@ -99,3 +99,73 @@ func matchTicketRef(s string) string {
 	}
 	return strings.ToUpper(m[1]) + "-" + m[2]
 }
+
+// prRefPattern matches pull-request / issue references embedded in free text,
+// e.g. "#1539", "PR #1539", "(#1543)". The leading "#" is required so the
+// pattern does not swallow unrelated numbers that saturate decision outcomes
+// (migration timestamps "20260623000001", counts like "573 unit tests", LSNs).
+// The 2-digit floor skips single-digit enumerations ("(1)", "finding #3") and
+// the trailing \b prevents partial matches inside alphanumeric runs (hex
+// colors "#1a2b", ids). Numbers are canonicalized to "PR-<n>" so PR refs share
+// the disjoint-set namespace with ticket refs ("ARD-958") without colliding.
+var prRefPattern = regexp.MustCompile(`#(\d{2,7})\b`)
+
+// prNumberDigits extracts the numeric run from the structured
+// agent_context.pr_number field, which agents may send as "1539", "#1539", or
+// "PR-1539" — none of which the "#"-anchored prRefPattern reliably matches.
+// The structured field is already known to be a PR/issue identifier, so a bare
+// digit run is a safe signal there (unlike free text).
+var prNumberDigits = regexp.MustCompile(`\d{2,7}`)
+
+// canonicalPRRef normalizes a structured pr_number value to the canonical
+// "PR-<digits>" form, or "" when it carries no digit run of the expected length.
+func canonicalPRRef(s string) string {
+	digits := prNumberDigits.FindString(s)
+	if digits == "" {
+		return ""
+	}
+	return "PR-" + digits
+}
+
+// extractWorkItemRefs returns every work-item identifier visible in a decision:
+// ticket references (canonical "ARD-958") AND pull-request / issue references
+// (canonical "PR-1539"). PR refs are sourced first from the structured
+// agent_context.pr_number (most reliable), then parsed from the task and outcome
+// free text as a fallback — the live trail carries them almost entirely in
+// outcome prose ("recommended not merging PR #1539 ...").
+//
+// Used only by isDisjointWorkItem (cloud scorer), which treats two
+// work-item-scoped decisions about entirely different work items as
+// non-contradictory. Deliberately separate from extractTicketRefs so the
+// ticket-only refinement filters — which join on an *identical* ticket key —
+// are unaffected by PR-number parsing. A missed reference only costs a
+// suppression (the safe, under-suppressing direction), never a false one.
+//
+// Returns nil when nothing is extractable from any source.
+func extractWorkItemRefs(d model.Decision) []string {
+	seen := map[string]struct{}{}
+	var out []string
+	add := func(s string) {
+		if s == "" {
+			return
+		}
+		if _, dup := seen[s]; dup {
+			return
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	for _, t := range extractTicketRefs(d) {
+		add(t)
+	}
+	add(canonicalPRRef(nestedContextString(d.AgentContext, "pr_number")))
+	for _, src := range []string{
+		nestedContextString(d.AgentContext, "task"),
+		d.Outcome,
+	} {
+		for _, m := range prRefPattern.FindAllStringSubmatch(src, -1) {
+			add("PR-" + m[1])
+		}
+	}
+	return out
+}

--- a/internal/conflicts/validator_test.go
+++ b/internal/conflicts/validator_test.go
@@ -1120,6 +1120,7 @@ func TestScoreForDecision_LLMSupersession(t *testing.T) {
 		RunID: runA.ID, AgentID: agentID, OrgID: orgID,
 		DecisionType: "architecture", Outcome: "use REST v1 API",
 		Confidence: 0.8, Embedding: &topicEmb, OutcomeEmbedding: &outcomeEmbA,
+		ValidFrom: time.Now().Add(-2 * time.Hour),
 	})
 	require.NoError(t, err)
 
@@ -1127,6 +1128,7 @@ func TestScoreForDecision_LLMSupersession(t *testing.T) {
 		RunID: runB.ID, AgentID: agentID, OrgID: orgID,
 		DecisionType: "architecture", Outcome: "replaced REST v1 with gRPC",
 		Confidence: 0.9, Embedding: &topicEmb, OutcomeEmbedding: &outcomeEmbB,
+		ValidFrom: time.Now(),
 	})
 	require.NoError(t, err)
 
@@ -1140,23 +1142,35 @@ func TestScoreForDecision_LLMSupersession(t *testing.T) {
 	scorer = scorer.WithCandidateFinder(storage.NewPgCandidateFinder(testDB))
 	scorer.ScoreForDecision(ctx, dB.ID, orgID)
 
+	// A supersession is a lifecycle event, not a standing disagreement: the
+	// later decision explicitly replaces the earlier one. It must NOT be opened
+	// as a conflict for human triage — that was the dominant false-positive
+	// class in the 2026-06-23 open-conflict audit ("closed PR #X as obsolete"
+	// landing in the queue against the plan that proposed #X) and the reason
+	// supersession links were never recorded (never_superseded=3045/3045).
+	// Instead the scorer records a supersedes suggestion so akashi_check can
+	// drive the supersedes_id link on the agent's next call (#710).
 	conflicts, err := testDB.ListConflicts(ctx, orgID, storage.ConflictFilters{}, 1000, 0)
 	require.NoError(t, err)
-
-	var found bool
 	for _, c := range conflicts {
 		aMatch := c.DecisionAID == dA.ID || c.DecisionBID == dA.ID
 		bMatch := c.DecisionAID == dB.ID || c.DecisionBID == dB.ID
-		if aMatch && bMatch {
-			found = true
-			assert.Equal(t, "llm_v2", c.ScoringMethod)
-			require.NotNil(t, c.Relationship)
-			assert.Equal(t, "supersession", *c.Relationship,
-				"supersession should be stored as a conflict")
-			break
-		}
+		assert.Falsef(t, aMatch && bMatch,
+			"supersession must NOT be opened as a conflict (got conflict %s)", c.ID)
 	}
-	assert.True(t, found, "supersession should produce a conflict between dA and dB")
+
+	// The later decision (dB) is recorded as the superseding side via an
+	// LLM-supersession suggestion targeting the earlier decision (dA).
+	suggestions, err := testDB.ListSupersedesSuggestionsForDecisions(ctx, orgID, []uuid.UUID{dB.ID})
+	require.NoError(t, err)
+	require.Len(t, suggestions, 1, "supersession should produce exactly one supersedes suggestion")
+	assert.Equal(t, dB.ID, suggestions[0].SupersedingID)
+	assert.Equal(t, dA.ID, suggestions[0].SupersededID)
+	assert.Equal(t, "detector:llm_supersession", suggestions[0].SuggestedBy)
+	require.NotNil(t, suggestions[0].Confidence)
+	assert.InDelta(t, 1.0, *suggestions[0].Confidence, 0.01,
+		"identical topic embeddings should yield confidence ≈ 1.0")
+	assert.Contains(t, suggestions[0].Reason, agentID)
 }
 
 func TestScoreForDecision_LLMError(t *testing.T) {


### PR DESCRIPTION
## Summary

- Two conflict-detector precision fixes, grounded in the 2026-06-23 open queue (19 sub-conflicts / 9 groups / **0 genuine**; 30-day FP rate **0.85**; `never_superseded=3045/3045`).
- **Supersession → suggestion, not conflict:** `scoreForDecision` now intercepts a validator `supersession` verdict *before* `IsConflict()` and records a supersedes suggestion (later supersedes earlier, the #710 surface) instead of opening a conflict — this is why supersessions polluted the queue and why supersedes links were never recorded. `IsConflict()` is unchanged, so the precision/recall eval is untouched.
- **`isDisjointWorkItem`:** a new pre-LLM suppressor — two work-item-scoped decisions (code_review/review/assessment/investigation/analysis/audit/planning) on the same project that reference fully disjoint work items (PR *or* ticket) cannot contradict each other; `extractWorkItemRefs` adds PR-number awareness (`#1539`, structured `pr_number`) atop the ARD-ticket extractor, which is what catches the PR-only fan-out hub (a review of "PR #1539") the ticket-only prompt hint (`eef7eb2c`) could never match.
- Excludes direction-setting types (architecture/trade_off/design) so genuine cross-cutting forks stay detectable; keeps the data-loss guard (cross-ticket data-safety contradictions are a real resolved class); drops the supersession-keyword guard (subsumed by the overlap check). Both filters emit OTel counters.

## Verification

- [x] I ran relevant tests locally (`go test ./...` or targeted package tests). — full unit suite (22 pkgs) + conflicts integration tests pass, incl. the rewritten `TestScoreForDecision_LLMSupersession`; plus `go build`, `go vet`, `golangci-lint run ./...` (0 issues), `atlas migrate validate`, and the `-tags lite` build.
- [x] I updated docs/openapi for any API or behavior changes. — N/A: no API/openapi surface changed; the new OTel counters are not doc-catalogued, consistent with #717/#728.
- [x] If I changed config vars in `internal/config/config.go`, I also updated: — N/A: no config vars changed.
  - [ ] `docs/configuration.md`
  - [ ] `docs/runbook.md` (operational subset, if relevant)
  - [ ] `.env.example` (if baseline local/dev defaults changed)
- [x] `python3 scripts/check_doc_config_consistency.py` passes.

## Risk / Rollout Notes

- No migration, schema, or config change; behavior change is confined to the cloud conflict scorer (`!lite`). Effect is fewer conflicts created (supersessions become suggestions; disjoint review/planning pairs are suppressed pre-LLM). Existing conflict rows are unaffected until a rescore/backfill runs. Failure mode is under-suppression by design — a missed PR/ticket ref disables the disjoint filter rather than wrongly killing a conflict — and `IsConflict()`/the validator are unchanged, so the eval and lite build are unaffected.

> The seeing-stone shows
> true shapes, but never their weight —
> Denethor despairs
