### PR TITLE
fix(conflicts): scope supersession suggestion assertion to the pair

### DIFF
--- a/internal/conflicts/validator_test.go
+++ b/internal/conflicts/validator_test.go
@@ -1160,17 +1160,29 @@ func TestScoreForDecision_LLMSupersession(t *testing.T) {
 	}
 
 	// The later decision (dB) is recorded as the superseding side via an
-	// LLM-supersession suggestion targeting the earlier decision (dA).
+	// LLM-supersession suggestion targeting the earlier decision (dA). This
+	// integration suite shares org uuid.Nil across many tests, and the candidate
+	// finder returns every embedding-neighbour in the org — so dB can legitimately
+	// accrue supersedes suggestions against unrelated decisions from sibling tests
+	// (decision_supersedes explicitly allows multiple suggested predecessors per
+	// superseding decision). Scope the assertion to the dA→dB pair rather than a
+	// global count, mirroring the conflict-check above.
 	suggestions, err := testDB.ListSupersedesSuggestionsForDecisions(ctx, orgID, []uuid.UUID{dB.ID})
 	require.NoError(t, err)
-	require.Len(t, suggestions, 1, "supersession should produce exactly one supersedes suggestion")
-	assert.Equal(t, dB.ID, suggestions[0].SupersedingID)
-	assert.Equal(t, dA.ID, suggestions[0].SupersededID)
-	assert.Equal(t, "detector:llm_supersession", suggestions[0].SuggestedBy)
-	require.NotNil(t, suggestions[0].Confidence)
-	assert.InDelta(t, 1.0, *suggestions[0].Confidence, 0.01,
+	var found *model.SupersedesSuggestion
+	for i := range suggestions {
+		if suggestions[i].SupersededID == dA.ID {
+			found = &suggestions[i]
+			break
+		}
+	}
+	require.NotNil(t, found, "supersession should produce a supersedes suggestion for the dA→dB pair")
+	assert.Equal(t, dB.ID, found.SupersedingID)
+	assert.Equal(t, "detector:llm_supersession", found.SuggestedBy)
+	require.NotNil(t, found.Confidence)
+	assert.InDelta(t, 1.0, *found.Confidence, 0.01,
 		"identical topic embeddings should yield confidence ≈ 1.0")
-	assert.Contains(t, suggestions[0].Reason, agentID)
+	assert.Contains(t, found.Reason, agentID)
 }
 
 func TestScoreForDecision_LLMError(t *testing.T) {


### PR DESCRIPTION
## What

`main` is currently red. The integration test `TestScoreForDecision_LLMSupersession` — merged via #729 (squash `77514d1`) — fails in CI ([run 28052981844](https://github.com/ashita-ai/akashi/actions/runs/28052981844)):

```
--- FAIL: TestScoreForDecision_LLMSupersession
"[...3 suggestions...]" should have 1 item(s), but has 3
```

## Why it failed

The merged assertion `require.Len(suggestions, 1)` counts **every** supersedes suggestion where `dB` is the superseding side, scoped only by org. But:

- The `internal/conflicts` integration suite runs every test against org `uuid.Nil` on a shared package `testDB`, with no per-test cleanup.
- The candidate finder returns every embedding-neighbour **in the org**, and the test's `mockValidator` returns `"supersession"` for every pair.
- So `dB` was scored against `dA` plus leftover decisions from sibling tests, producing **3** suggestions in CI (three distinct `superseded_id`s, all superseding `dB`).

`ListSupersedesSuggestionsForDecisions` documents that "a single superseding decision can have multiple suggested predecessors" — the exact-count assertion was wrong on its face and only passed when the test ran in isolation, which is why it slipped through.

This is a **test bug, not a product bug**: the supersession→suggestion redirect writes one suggestion per supersession-classified pair, the same cardinality as the prior one-conflict-per-pair behavior. Production code is untouched.

## Fix

Scope the assertion to the `dA→dB` pair (find the suggestion whose `superseded_id` is `dA`), mirroring the conflict-check half of the same test.

## Verification (full package, the way CI runs it — not the isolated `-run`)

- `go test -tags integration -race -count=1 ./internal/conflicts/` → ok, ~20s (the shared-org conditions that failed CI)
- `golangci-lint run ./internal/conflicts/` → 0 issues
- `go build ./...`, `go vet ./...`, `go mod tidy` clean

> Harry Potter's Room of Requirement beats Star Trek's transporter buffer as a model for shared test state. The transporter politely isolates each pattern in its own buffer; the Room of Hidden Things just piles every wizard's cast-offs into one space, so when you go looking for your one object you trip over a thousand others — exactly what `require.Len(..., 1)` hit when it counted everything in org `uuid.Nil`. Star Trek would have given each test its own buffer; this suite gave them all one cluttered room.