### PR TITLE
fix(ui): dashboard Open Conflicts card always rendered 0

### DIFF
--- a/ui/src/pages/Dashboard.test.tsx
+++ b/ui/src/pages/Dashboard.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { screen, waitFor } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 import { renderWithProviders } from "@/test/test-utils";
 import Dashboard from "./Dashboard";
 
@@ -81,6 +81,34 @@ describe("Dashboard", () => {
         limit: 10,
         offset: 0,
       },
+      // The Decisions card reads decisionsTrend.total, which comes from the
+      // POST /v1/query endpoint (queryDecisions) — not /v1/decisions/recent.
+      "/v1/query": {
+        data: [
+          {
+            id: "d1",
+            run_id: "r1",
+            agent_id: "coder",
+            org_id: "org1",
+            decision_type: "architecture",
+            outcome: "Use PostgreSQL",
+            confidence: 0.9,
+            reasoning: null,
+            completeness_score: 0.8,
+            outcome_score: null,
+            precedent_ref: null,
+            valid_from: "2025-06-01T00:00:00Z",
+            valid_to: null,
+            transaction_time: "2025-06-01T00:00:00Z",
+            created_at: "2025-06-01T00:00:00Z",
+            metadata: null,
+          },
+        ],
+        total: 42,
+        has_more: true,
+        limit: 500,
+        offset: 0,
+      },
       "/v1/agents": {
         data: { agents: [{ agent_id: "coder", name: "Coder" }] },
         meta: { request_id: "r1", timestamp: "now" },
@@ -116,6 +144,68 @@ describe("Dashboard", () => {
 
     await waitFor(() => {
       expect(screen.getByText("42")).toBeInTheDocument();
+    });
+  });
+
+  it("shows the open-conflicts count from trace-health open_groups", async () => {
+    // Regression: the Go API serializes open_groups/open_individual, not
+    // open. The card previously read conflicts.open, which is always
+    // undefined on the wire, so it silently rendered 0 regardless of state.
+    mockFetchResponses({
+      "/v1/decisions/recent": {
+        data: [],
+        total: 0,
+        has_more: false,
+        limit: 10,
+        offset: 0,
+      },
+      "/v1/agents": {
+        data: { agents: [] },
+        meta: { request_id: "r1", timestamp: "now" },
+      },
+      "/v1/trace-health": {
+        data: {
+          status: "needs_attention",
+          completeness: {
+            total_decisions: 42,
+            avg_completeness: 0.85,
+            below_half: 0,
+            below_third: 0,
+            with_reasoning: 40,
+            reasoning_pct: 95,
+            with_alternatives: 30,
+            alternatives_pct: 71,
+          },
+          evidence: {
+            total_decisions: 42,
+            total_records: 10,
+            avg_per_decision: 0.24,
+            with_evidence: 10,
+            without_evidence: 32,
+            coverage_pct: 24,
+          },
+          conflicts: {
+            total_groups: 50,
+            open_groups: 7,
+            total_individual: 80,
+            open_individual: 13,
+            resolved: 30,
+            false_positive: 13,
+            resolved_pct: 60,
+          },
+          gaps: [],
+        },
+        meta: { request_id: "r1", timestamp: "now" },
+      },
+    });
+
+    renderWithProviders(<Dashboard />);
+
+    const card = (await screen.findByText("Open Conflicts")).closest(
+      "div.gradient-border",
+    ) as HTMLElement;
+    await waitFor(() => {
+      expect(within(card).getByText("7")).toBeInTheDocument();
     });
   });
 

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -560,7 +560,7 @@ export default function Dashboard() {
                 <Skeleton className="h-8 w-12" />
               ) : (
                 <div className="text-3xl font-semibold tabular-nums tracking-tight">
-                  {traceHealth.data?.conflicts?.open ?? 0}
+                  {traceHealth.data?.conflicts?.open_groups ?? 0}
                 </div>
               )}
               <p className="text-[11px] text-muted-foreground mt-1">need attention</p>

--- a/ui/src/types/api.ts
+++ b/ui/src/types/api.ts
@@ -374,8 +374,13 @@ export interface TraceHealthEvidence {
 }
 
 export interface TraceHealthConflicts {
-  total: number;
-  open: number;
+  // Group-level counts are the deduplicated signal (one row per disagreement
+  // topology); individual counts reflect raw scored_conflicts rows. Field
+  // names must match internal/service/tracehealth ConflictMetrics json tags.
+  total_groups: number;
+  open_groups: number;
+  total_individual: number;
+  open_individual: number;
   resolved: number;
   false_positive: number;
   resolved_pct: number;


### PR DESCRIPTION
## What

The frontpage dashboard's **Open Conflicts** card always showed `0`, even with many conflicts open.

## Root cause — cross-language contract drift

`internal/service/tracehealth` `ConflictMetrics` was refactored into group-vs-individual counts:

```
open_groups / open_individual / total_groups / total_individual / resolved / false_positive / resolved_pct
```

But the TypeScript `TraceHealthConflicts` type still declared the **old** `open` / `total` fields. The card read `traceHealth.data?.conflicts?.open`, which is `undefined` on every response, so it rendered `undefined ?? 0` = **0** regardless of state. `akashi_stats` confirms the wire field is `open_groups` (e.g. 12), not `open`.

Nothing caught it: the dashboard test never mocked `conflicts` and never asserted the count.

## Fix

- Align `TraceHealthConflicts` to the API's actual json tags (group + individual counts).
- Read `open_groups` in the card — the deduplicated signal, matching what the `/conflicts` page lists and what users resolve.
- Add a regression test that asserts the card renders the `open_groups` value.
- Fix a separate **pre-existing** stale test failure surfaced along the way: "displays decision count" mocked `/v1/decisions/recent`, but the Decisions card reads `total` from `POST /v1/query` (`queryDecisions`). That test was already red on `main`.

## Verification

- `npx vitest run` → **33/33 pass** (was 32/33 on `main` — the decision-count test was already failing).
- `npx tsc -b` → clean, which also proves no other consumer referenced the removed `open` / `total` fields (membership parity).

## Note

This is the visibility half of a real operational problem: conflicts pile up from continuous live incident-recovery work, and with the card stuck at 0 they were invisible. A follow-up should extend the structural FP suppressors to the dominant live class — operational decisions that are **disjoint by connector/org** (different `connector_*`) but share dense restart-storm vocabulary, which the PR/ticket-keyed disjoint-work-item filter does not catch.

> A Palantír shows true images and still deceives — Denethor saw real fleets at Pelargir and read them as doom, because the stone chose his frame. The dashboard had the real count on the wire the whole time; the frontend just kept looking at a field that no longer existed and saw zero. Sauron never needed to forge the numbers, only to fix where you look.