### PR TITLE
feat(conflicts): suppress disjoint-resource operational false positives

### DIFF
--- a/internal/conflicts/disjoint_resource_test.go
+++ b/internal/conflicts/disjoint_resource_test.go
@@ -1,0 +1,249 @@
+//go:build !lite
+
+package conflicts
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ashita-ai/akashi/internal/model"
+)
+
+// taskCtx builds an agent_context with a client-namespaced task, matching the
+// structured layout nestedContextString reads.
+func taskCtx(task string) map[string]any {
+	return map[string]any{"client": map[string]any{"task": task}}
+}
+
+// TestExtractResourceRefs verifies the connector_/org_ extractor surfaces the
+// structured infrastructure-resource tokens that dominate live operational
+// traces, canonicalizes casing, reads the task field, and does NOT match method
+// names, short fields, or bare hex runs that lack the prefix.
+func TestExtractResourceRefs(t *testing.T) {
+	tests := []struct {
+		name string
+		dec  model.Decision
+		want []string
+	}{
+		{
+			name: "connector token in outcome",
+			dec:  model.Decision{Outcome: "Diagnosed Trellis connector_57a42328 pg2kafka restart_storm as unrecoverable"},
+			want: []string{"CONNECTOR-57a42328"},
+		},
+		{
+			name: "org token in outcome",
+			dec:  model.Decision{Outcome: "Trellis connector_57a42328 (org_54b2e846) source slot invalidated"},
+			want: []string{"CONNECTOR-57a42328", "ORG-54b2e846"},
+		},
+		{
+			name: "multiple connectors, deduped",
+			dec:  model.Decision{Outcome: "healthy reference 0307ac4b runs BOTH; connector_e1761afd idle; connector_e1761afd again"},
+			want: []string{"CONNECTOR-e1761afd"},
+		},
+		{
+			name: "connector named only in the task field",
+			dec: model.Decision{
+				Outcome:      "Executed connector reset recovery after confirming the slot was invalidated",
+				AgentContext: taskCtx("Trellis recovery connector_9b38b47d restart_storm"),
+			},
+			want: []string{"CONNECTOR-9b38b47d"},
+		},
+		{
+			name: "case-insensitive prefix and hex canonicalize to lower",
+			dec:  model.Decision{Outcome: "CONNECTOR_AB12CD34 reset dispatched"},
+			want: []string{"CONNECTOR-ab12cd34"},
+		},
+		{
+			name: "method names and short fields are not matched",
+			dec:  model.Decision{Outcome: "called connector_reset and updated org_id; POST /connectors/{id}/reset"},
+			want: nil,
+		},
+		{
+			name: "bare hex without the connector_/org_ prefix is ignored",
+			dec:  model.Decision{Outcome: "Trellis 57a42328 restart_storm; commit 50fbd79b; op_90610865 progressing"},
+			want: nil,
+		},
+		{
+			name: "nothing extractable",
+			dec:  model.Decision{Outcome: "raised Neon target endpoint to autoscale and resumed kafka2pg"},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.ElementsMatch(t, tt.want, extractResourceRefs(tt.dec))
+		})
+	}
+}
+
+// TestIsDisjointResource exercises the resource-identity sibling of the
+// disjoint-work-item filter against the 2026-06-24 cross-connector
+// restart-storm over-clustering: operational/investigation decisions about
+// different connector_/org_ resources that share dense incident vocabulary.
+func TestIsDisjointResource(t *testing.T) {
+	idA := uuid.New()
+	idB := uuid.New()
+	mono := "mono"
+	other := "other"
+
+	tests := []struct {
+		name     string
+		d        model.Decision
+		cand     model.Decision
+		expected bool
+	}{
+		{
+			// Anchor: investigation of one connector vs deployment recovery of
+			// another, sharing restart_storm/kafka2pg/slot vocabulary.
+			name: "investigation vs deployment, disjoint connectors → suppressed",
+			d: model.Decision{
+				ID: idA, Project: &mono, DecisionType: "investigation",
+				Outcome: "Diagnosed connector_57a42328 pg2kafka restart_storm as unrecoverable source slot invalidation (wal_status=lost)",
+			},
+			cand: model.Decision{
+				ID: idB, Project: &mono, DecisionType: "deployment",
+				Outcome: "Recovered connector_9b38b47d kafka2pg restart_storm ONLINE, lag 0; raised Neon target I/O",
+			},
+			expected: true,
+		},
+		{
+			name: "org-scoped disjoint → suppressed",
+			d: model.Decision{
+				ID: idA, Project: &mono, DecisionType: "operational_recovery",
+				Outcome: "Cleared the orphaned pgstream slot for org_896c32e7 via a direct service-role update",
+			},
+			cand: model.Decision{
+				ID: idB, Project: &mono, DecisionType: "investigation",
+				Outcome: "Root-caused org_54b2e846 connector wedge: engine-setup never finalized",
+			},
+			expected: true,
+		},
+		{
+			name: "decision_type case-insensitive → suppressed",
+			d: model.Decision{
+				ID: idA, Project: &mono, DecisionType: "Investigation",
+				Outcome: "connector_57a42328 slot invalidated",
+			},
+			cand: model.Decision{
+				ID: idB, Project: &mono, DecisionType: "DEPLOYMENT",
+				Outcome: "reset connector_555f7beb after confirming source up",
+			},
+			expected: true,
+		},
+		{
+			name: "same connector (overlap) → NOT suppressed",
+			d: model.Decision{
+				ID: idA, Project: &mono, DecisionType: "investigation",
+				Outcome: "Diagnosed connector_57a42328 as unrecoverable; recommend full reset",
+			},
+			cand: model.Decision{
+				ID: idB, Project: &mono, DecisionType: "deployment",
+				Outcome: "Scaled up kafka2pg for connector_57a42328 instead of resetting — resume loses no data",
+			},
+			expected: false,
+		},
+		{
+			// Data-safety guard: even across different connectors, a data-loss
+			// finding must reach the validator and the conflict queue.
+			name: "data-loss vocabulary on one side → NOT suppressed (data-safety guard)",
+			d: model.Decision{
+				ID: idA, Project: &mono, DecisionType: "investigation",
+				Outcome: "connector_e1761afd: scaling kafka2pg would skip offsets = silent permanent data loss; must re-snapshot",
+			},
+			cand: model.Decision{
+				ID: idB, Project: &mono, DecisionType: "deployment",
+				Outcome: "Recovered connector_9b38b47d kafka2pg restart_storm ONLINE",
+			},
+			expected: false,
+		},
+		{
+			// architecture is direction-setting — a cross-cutting design fork can
+			// span resources and must reach the validator.
+			name: "architecture vs investigation, disjoint → NOT suppressed (direction-setting type)",
+			d: model.Decision{
+				ID: idA, Project: &mono, DecisionType: "architecture",
+				Outcome: "connector_57a42328 cutover contract should be fail-closed and exactly-once",
+			},
+			cand: model.Decision{
+				ID: idB, Project: &mono, DecisionType: "investigation",
+				Outcome: "connector_9b38b47d restart_storm root cause: pg_net feature",
+			},
+			expected: false,
+		},
+		{
+			name: "one side has no extractable resource (customer name only) → NOT suppressed",
+			d: model.Decision{
+				ID: idA, Project: &mono, DecisionType: "deployment",
+				Outcome: "recovered the Burbuxa sink by rolling kafka2pg to stable, left pg2kafka unchanged",
+			},
+			cand: model.Decision{
+				ID: idB, Project: &mono, DecisionType: "investigation",
+				Outcome: "Diagnosed connector_57a42328 source slot invalidation",
+			},
+			expected: false,
+		},
+		{
+			name: "different project → NOT suppressed",
+			d: model.Decision{
+				ID: idA, Project: &mono, DecisionType: "investigation",
+				Outcome: "connector_57a42328 slot invalidated",
+			},
+			cand: model.Decision{
+				ID: idB, Project: &other, DecisionType: "deployment",
+				Outcome: "reset connector_9b38b47d",
+			},
+			expected: false,
+		},
+		{
+			name: "both projects untagged (nil) → NOT suppressed",
+			d: model.Decision{
+				ID: idA, DecisionType: "investigation",
+				Outcome: "connector_57a42328 slot invalidated",
+			},
+			cand: model.Decision{
+				ID: idB, DecisionType: "deployment",
+				Outcome: "reset connector_9b38b47d",
+			},
+			expected: false,
+		},
+		{
+			name: "precedent-linked → NOT suppressed (explicit lineage → let LLM decide)",
+			d: model.Decision{
+				ID: idA, Project: &mono, DecisionType: "investigation",
+				Outcome:      "connector_57a42328 slot invalidated",
+				PrecedentRef: &idB,
+			},
+			cand: model.Decision{
+				ID: idB, Project: &mono, DecisionType: "deployment",
+				Outcome: "reset connector_9b38b47d",
+			},
+			expected: false,
+		},
+		{
+			// A non-resource type pair (both code_review) is the work-item
+			// filter's job, not this one.
+			name: "non-resource types → NOT suppressed (out of scope for this filter)",
+			d: model.Decision{
+				ID: idA, Project: &mono, DecisionType: "code_review",
+				Outcome: "Reviewed connector_57a42328 wiring",
+			},
+			cand: model.Decision{
+				ID: idB, Project: &mono, DecisionType: "code_review",
+				Outcome: "Reviewed connector_9b38b47d wiring",
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isDisjointResource(tt.d, tt.cand),
+				"isDisjointResource(%q vs %q)", tt.d.DecisionType, tt.cand.DecisionType)
+			// Symmetric: argument order must not change the verdict.
+			assert.Equal(t, tt.expected, isDisjointResource(tt.cand, tt.d),
+				"isDisjointResource should be symmetric for %q", tt.name)
+		})
+	}
+}

--- a/internal/conflicts/disjoint_resource_test.go
+++ b/internal/conflicts/disjoint_resource_test.go
@@ -235,6 +235,81 @@ func TestIsDisjointResource(t *testing.T) {
 			},
 			expected: false,
 		},
+		{
+			// Cross-namespace: one side names only a connector, the other only an
+			// org. The connector may be owned by that org, so the sets are NOT
+			// comparable and the pair must reach the validator. The pre-fix
+			// flattened-overlap check wrongly suppressed this (no string in common).
+			name: "connector-only vs owning-org-only → NOT suppressed (cross-namespace not comparable)",
+			d: model.Decision{
+				ID: idA, Project: &mono, DecisionType: "investigation",
+				Outcome: "Diagnosed connector_57a42328 source slot invalidation (wal_status=lost)",
+			},
+			cand: model.Decision{
+				ID: idB, Project: &mono, DecisionType: "operational_recovery",
+				Outcome: "Cleared the orphaned pgstream slot for org_54b2e846 via a service-role update",
+			},
+			expected: false,
+		},
+		{
+			// Asymmetric namespaces: connector-only vs connector+org. Even though
+			// the connectors differ, the org named only on one side could own the
+			// other side's connector, so the pair is not comparable → validator.
+			name: "connector-only vs connector+org → NOT suppressed (asymmetric namespaces)",
+			d: model.Decision{
+				ID: idA, Project: &mono, DecisionType: "investigation",
+				Outcome: "Diagnosed connector_57a42328 restart_storm",
+			},
+			cand: model.Decision{
+				ID: idB, Project: &mono, DecisionType: "deployment",
+				Outcome: "Recovered connector_9b38b47d (org_896c32e7) kafka2pg ONLINE",
+			},
+			expected: false,
+		},
+		{
+			// Both sides populate the SAME namespace set {CONNECTOR, ORG} and differ
+			// in every namespace → provably disjoint, still suppressed.
+			name: "connector+org vs connector+org, disjoint in both namespaces → suppressed",
+			d: model.Decision{
+				ID: idA, Project: &mono, DecisionType: "investigation",
+				Outcome: "Diagnosed connector_57a42328 (org_54b2e846) restart_storm as unrecoverable",
+			},
+			cand: model.Decision{
+				ID: idB, Project: &mono, DecisionType: "deployment",
+				Outcome: "Recovered connector_9b38b47d (org_896c32e7) kafka2pg ONLINE, lag 0",
+			},
+			expected: true,
+		},
+		{
+			// Same org, different connectors: the shared org overlaps, so the pair
+			// reaches the validator — a shared resource is where a real clash lives.
+			name: "different connectors but same org → NOT suppressed (shared org overlaps)",
+			d: model.Decision{
+				ID: idA, Project: &mono, DecisionType: "investigation",
+				Outcome: "Diagnosed connector_57a42328 (org_54b2e846) restart_storm",
+			},
+			cand: model.Decision{
+				ID: idB, Project: &mono, DecisionType: "deployment",
+				Outcome: "Recovered connector_9b38b47d (org_54b2e846) kafka2pg ONLINE",
+			},
+			expected: false,
+		},
+		{
+			// Data-safety guard parity: the data-loss keyword appears only in the
+			// task field, with a clean outcome. extractResourceRefs reads the task,
+			// so the guard must too — the pre-fix outcome-only guard let this through.
+			name: "data-loss keyword only in task → NOT suppressed (guard scans task)",
+			d: model.Decision{
+				ID: idA, Project: &mono, DecisionType: "investigation",
+				Outcome:      "Recovered connector_57a42328 kafka2pg restart_storm ONLINE",
+				AgentContext: taskCtx("DATALOSS check: connector_57a42328 may have skipped offsets on resume"),
+			},
+			cand: model.Decision{
+				ID: idB, Project: &mono, DecisionType: "deployment",
+				Outcome: "Recovered connector_9b38b47d kafka2pg restart_storm ONLINE",
+			},
+			expected: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/conflicts/disjoint_work_item_test.go
+++ b/internal/conflicts/disjoint_work_item_test.go
@@ -255,6 +255,24 @@ func TestIsDisjointWorkItem(t *testing.T) {
 			expected: false,
 		},
 		{
+			// Data-safety guard parity: the work-item ref (PR #1539) and the
+			// DATALOSS keyword both live in the task field. extractWorkItemRefs
+			// mines the task, so the guard must too — otherwise this disjoint pair
+			// (PR #1539 vs PR #1543) is suppressed despite a data-safety signal.
+			// (taskCtx is shared from disjoint_resource_test.go.)
+			name: "data-loss keyword only in task → NOT suppressed (guard scans task)",
+			d: model.Decision{
+				ID: idA, Project: &mono, DecisionType: "code_review",
+				Outcome:      "Review complete; recommendations posted inline",
+				AgentContext: taskCtx("DATALOSS audit of PR #1539 evidence wiring"),
+			},
+			cand: model.Decision{
+				ID: idB, Project: &mono, DecisionType: "code_review",
+				Outcome: "Recommended not merging PR #1543 until evidence is fresh",
+			},
+			expected: false,
+		},
+		{
 			name: "one side has no extractable work item → NOT suppressed",
 			d: model.Decision{
 				ID: idA, Project: &mono, DecisionType: "code_review",

--- a/internal/conflicts/metrics.go
+++ b/internal/conflicts/metrics.go
@@ -34,6 +34,7 @@ type Metrics struct {
 	crossAgentPrecedentFiltered    metric.Int64Counter
 	operationalProgressionFiltered metric.Int64Counter
 	disjointWorkItemFiltered       metric.Int64Counter
+	disjointResourceFiltered       metric.Int64Counter
 	supersessionSuppressed         metric.Int64Counter
 
 	scoringDuration    metric.Float64Histogram
@@ -231,6 +232,14 @@ func (s *Scorer) registerMetrics() {
 	if err != nil {
 		s.logger.Warn("conflicts: failed to create akashi.conflicts.disjoint_work_item_filtered metric", "error", err)
 		s.metrics.disjointWorkItemFiltered, _ = meter.Int64Counter("akashi.conflicts.disjoint_work_item_filtered.fallback")
+	}
+
+	s.metrics.disjointResourceFiltered, err = meter.Int64Counter("akashi.conflicts.disjoint_resource_filtered",
+		metric.WithDescription("Candidate pairs suppressed as operational/investigation decisions about disjoint infrastructure resources (different connector_/org_ identifiers) — the resource-identity sibling of disjoint_work_item_filtered for live incident-recovery traces"),
+	)
+	if err != nil {
+		s.logger.Warn("conflicts: failed to create akashi.conflicts.disjoint_resource_filtered metric", "error", err)
+		s.metrics.disjointResourceFiltered, _ = meter.Int64Counter("akashi.conflicts.disjoint_resource_filtered.fallback")
 	}
 
 	s.metrics.supersessionSuppressed, err = meter.Int64Counter("akashi.conflicts.supersession_suppressed",

--- a/internal/conflicts/operational_progression_test.go
+++ b/internal/conflicts/operational_progression_test.go
@@ -252,6 +252,24 @@ func TestIsOperationalStateProgression(t *testing.T) {
 			},
 			expected: false,
 		},
+		{
+			// Data-safety guard parity: the data-loss signal sits in the task, with
+			// a clean outcome and a window-passing gap that would otherwise suppress.
+			// The guard scans task+outcome on both sides, so the pair still reaches
+			// the validator. (taskCtx is shared from disjoint_resource_test.go.)
+			name: "data-loss keyword only in task → NOT suppressed (guard scans task)",
+			d: model.Decision{
+				ID: idA, Project: &mono, DecisionType: "operations",
+				Outcome:      "scaled kafka2pg to 1 to resume the drain",
+				AgentContext: taskCtx("investigate possible DATALOSS before scaling the writer"),
+				ValidFrom:    now,
+			},
+			cand: model.Decision{
+				ID: idB, Project: &mono, DecisionType: "operational",
+				Outcome: "promoted the validated digest to the customer account", ValidFrom: now.Add(-beyond),
+			},
+			expected: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/conflicts/scorer.go
+++ b/internal/conflicts/scorer.go
@@ -705,6 +705,27 @@ func (s *Scorer) scoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 			continue
 		}
 
+		// Disjoint resource filter: two operational/investigation decisions on
+		// the same project that reference entirely different infrastructure
+		// resources — different connector_/org_ identifiers — act on different
+		// data planes and cannot contradict. This is the resource-identity
+		// sibling of the disjoint work-item filter above: live incident-recovery
+		// traces carry no PR/ticket ref, so that filter never sees them; they
+		// name a connector_/org_ token instead. Dominant live FP class
+		// (2026-06-24 cross-connector restart-storm over-clustering). Direction-
+		// setting types are excluded and the data-loss guard is preserved so
+		// genuine forks and data-safety pairs still reach the validator. See
+		// isDisjointResource.
+		if isDisjointResource(d, sc.cand) {
+			s.metrics.disjointResourceFiltered.Add(ctx, 1)
+			s.logger.Debug("conflict scorer: disjoint resource filter suppressed pair",
+				"decision_a", decisionID, "decision_b", sc.cand.ID,
+				"type_a", d.DecisionType, "type_b", sc.cand.DecisionType,
+				"project", derefString(d.Project),
+				"refs_a", extractResourceRefs(d), "refs_b", extractResourceRefs(sc.cand))
+			continue
+		}
+
 		// Outcome similarity floor: when outcome embeddings are nearly
 		// identical AND the pair did not qualify for the directToScorer
 		// bypass, suppress as complementary. This catches coordinated
@@ -1782,14 +1803,15 @@ const operationalProgressionWindow = 7 * 24 * time.Hour
 //     intra-session pairs are left to the LLM, mirroring isTemporalReassessment
 //
 // Known limitation: suppression keys on (type, project, gap, keywords) with no
-// resource-identity signal, so two operational decisions on DIFFERENT resources
-// that merely share vocabulary are suppressed (the intended FP class), while a
-// same-resource contradiction that mentions no data-safety event can still be
-// suppressed once it is past the window. The data-loss guard closes the
-// high-stakes slice of that gap — the only slice with verified instances in the
-// trail. Fully gating on target resource needs a structured resource field
-// (connectors/customers are named only in free-text outcomes today) and is
-// deferred rather than parsed fragilely from text.
+// resource-identity signal, so a same-resource contradiction that mentions no
+// data-safety event can still be suppressed once it is past the window. The
+// data-loss guard closes the high-stakes slice of that gap — the only slice
+// with verified instances in the trail. The complementary different-resource
+// slice (and operational pairs inside the same incident window, which this
+// filter's gap requirement skips) is now handled pre-LLM by isDisjointResource,
+// which keys on the structured connector_/org_ tokens this filter declined to
+// parse — those tokens are regular identifiers, not the fragile free-text
+// customer names that motivated the original deferral.
 //
 // Scope: lives only in the cloud scorer (this file is !lite). The lite scorer
 // has none of the structural suppression family; porting it is out of scope.
@@ -1912,6 +1934,80 @@ func isDisjointWorkItem(d, cand model.Decision) bool {
 	}
 	refsA := extractWorkItemRefs(d)
 	refsB := extractWorkItemRefs(cand)
+	if len(refsA) == 0 || len(refsB) == 0 {
+		return false
+	}
+	return !ticketRefsOverlap(refsA, refsB)
+}
+
+// isDisjointResource returns true when two operational / investigation decisions
+// on the same project act on entirely different infrastructure resources —
+// different connector_/org_ identifiers — and therefore cannot contradict each
+// other. A diagnosis of connector_57a42328 and a recovery of connector_9b38b47d
+// touch different data planes; they routinely share dense incident vocabulary
+// (restart_storm, kafka2pg, replication slot, wal_status, snapshot) that places
+// them close in embedding space, and the validator then manufactures a
+// CONTRADICTION between two unrelated incidents.
+//
+// This is the resource-identity sibling of isDisjointWorkItem. That filter keys
+// on PR/ticket refs, which live operational traces do not carry — they name a
+// connector_/org_ token instead — so it could never see this class. Together
+// they are the membership-parity pair: work-item identity for code reviews and
+// plans, resource identity for incident recovery. It is the dominant live FP
+// class (2026-06-24 cross-connector restart-storm over-clustering) and the
+// reason operational conflicts pile up despite the work-item filter.
+//
+// It also fills the resource-identity gap that isOperationalStateProgression
+// documents as deferred: that filter suppresses same-project operational pairs
+// only once they are >= operationalProgressionWindow apart, so different-resource
+// pairs inside the same incident window (hours apart) slip past it. This filter
+// has no time requirement — different resources cannot contradict regardless of
+// when the two decisions were traced.
+//
+// Deliberately narrow, with the same discipline as isDisjointWorkItem:
+//   - both decisions must be resourceScopedTypes. architecture / trade_off /
+//     design forks are never eligible — a cross-cutting design disagreement can
+//     legitimately span resources and must reach the validator.
+//   - same non-empty project (operational traces are all project "mono"; an
+//     untagged pair is never suppressed), mirroring the sibling filters.
+//   - both must expose at least one extractable resource ref, and the two ref
+//     sets must be fully disjoint. Any shared connector/org makes the sets
+//     overlap and the pair reaches the validator — which is correct, because a
+//     same-connector pair is exactly where a genuine operational clash lives.
+//   - not precedent-linked — an explicit lineage cite is left to the LLM.
+//   - neither outcome reports a data-loss / corruption / quarantine event. This
+//     is the non-negotiable guard: a data-safety finding is categorically
+//     high-stakes and must never be dropped pre-LLM, even across different
+//     resources (both sides checked). Same guard, same reasoning as
+//     isDisjointWorkItem and isOperationalStateProgression; see dataLossKeywords.
+//
+// Failure mode is under-suppression: a decision that names its resource only by
+// customer name ("Trellis") and not by connector_/org_ token yields no ref, which
+// disables the filter and sends the pair to the validator — never a wrongful
+// suppression of a same-resource pair, since the only way two ref sets become
+// disjoint is if both sides name resources and they genuinely differ.
+//
+// Scope: lives only in the cloud scorer (this file is !lite), alongside the rest
+// of the structural suppression family.
+func isDisjointResource(d, cand model.Decision) bool {
+	if !resourceScopedTypes[strings.ToLower(d.DecisionType)] {
+		return false
+	}
+	if !resourceScopedTypes[strings.ToLower(cand.DecisionType)] {
+		return false
+	}
+	projA, projB := derefString(d.Project), derefString(cand.Project)
+	if projA != projB || (projA == "" && projB == "") {
+		return false
+	}
+	if isPrecedentLinked(d, cand) {
+		return false
+	}
+	if containsDataLossKeyword(d.Outcome) || containsDataLossKeyword(cand.Outcome) {
+		return false
+	}
+	refsA := extractResourceRefs(d)
+	refsB := extractResourceRefs(cand)
 	if len(refsA) == 0 || len(refsB) == 0 {
 		return false
 	}
@@ -2068,6 +2164,25 @@ var workItemScopedTypes = map[string]bool{
 	"analysis":      true,
 	"audit":         true,
 	"planning":      true,
+}
+
+// resourceScopedTypes are decision types whose conflict scope is a single
+// infrastructure resource — a connector being recovered, an org/customer
+// incident being investigated or deployed against. Two such decisions about
+// DIFFERENT resources act on different data planes and cannot contradict, which
+// is what isDisjointResource keys on (via extractResourceRefs). investigation
+// is deliberately a member of BOTH this set and workItemScopedTypes: an
+// investigation can be disjoint by ticket OR by connector, and either filter may
+// suppress it. Direction-setting types (architecture / trade_off / design) are
+// excluded for the same reason as the sibling type sets — a cross-cutting design
+// fork can legitimately span resources and must remain detectable.
+var resourceScopedTypes = map[string]bool{
+	"investigation":        true,
+	"deployment":           true,
+	"operational_recovery": true,
+	"operations":           true,
+	"operational":          true,
+	"incident":             true,
 }
 
 // isDirectionalWorkflowPair returns true if earlierType is a review/assessment

--- a/internal/conflicts/scorer.go
+++ b/internal/conflicts/scorer.go
@@ -1793,12 +1793,12 @@ const operationalProgressionWindow = 7 * 24 * time.Hour
 //     explicitly reverts/abandons a prior approach is a declared reversal and
 //     reaches the LLM (checked on both sides: the safe, under-suppressing
 //     direction)
-//   - neither outcome reports a data-loss / corruption / quarantine event — a
-//     data-safety event is categorically high-stakes and must reach the
-//     validator regardless of the time gap (checked on both sides). This is
-//     the guard that keeps same-resource incident disagreements like the live
-//     SalesPatriot DATALOSS pause from being silently dropped pre-LLM. See
-//     dataLossKeywords.
+//   - neither side's task or outcome reports a data-loss / corruption /
+//     quarantine event — a data-safety event is categorically high-stakes and
+//     must reach the validator regardless of the time gap (checked on both
+//     sides, both text fields). This is the guard that keeps same-resource
+//     incident disagreements like the live SalesPatriot DATALOSS pause from
+//     being silently dropped pre-LLM. See decisionContainsDataLossKeyword.
 //   - not precedent-linked and not the same session — explicit links and
 //     intra-session pairs are left to the LLM, mirroring isTemporalReassessment
 //
@@ -1839,9 +1839,14 @@ func isOperationalStateProgression(d, cand model.Decision) bool {
 	// data-loss / corruption / quarantine event. Such a decision is not a routine
 	// sequential step, and a same-system pair that includes one is precisely the
 	// disagreement that must reach the validator and the conflict queue rather
-	// than be dropped pre-LLM with only a Debug log. Both sides checked
-	// (under-suppressing direction), mirroring the supersession guard above.
-	if containsDataLossKeyword(d.Outcome) || containsDataLossKeyword(cand.Outcome) {
+	// than be dropped pre-LLM with only a Debug log. Both sides checked, across
+	// task and outcome (under-suppressing direction), mirroring the supersession
+	// guard above. (The supersession guard stays outcome-only on purpose: a
+	// reversal verb in a task title — "migrate connector from kafka to pg" — is
+	// routine phrasing, and scanning the task for it would re-admit the very FPs
+	// this filter kills. The data-safety guard has no such cost: firing it only
+	// ever routes a pair to the validator, never suppresses one.)
+	if decisionContainsDataLossKeyword(d) || decisionContainsDataLossKeyword(cand) {
 		return false
 	}
 	delta := d.ValidFrom.Sub(cand.ValidFrom)
@@ -1886,14 +1891,18 @@ func isOperationalStateProgression(d, cand model.Decision) bool {
 //     one outcome naming the other's work item, e.g. "closed #1543 in favor of
 //     #1545") makes the sets overlap and the pair reaches the validator.
 //   - not precedent-linked — an explicit lineage cite is left to the LLM
-//   - neither outcome reports a data-loss / corruption / quarantine event — a
-//     data-safety finding is categorically high-stakes and must never be dropped
-//     pre-LLM (both sides). This is NOT a redundant copy of the operational
+//   - neither side's task or outcome reports a data-loss / corruption /
+//     quarantine event — a data-safety finding is categorically high-stakes and
+//     must never be dropped pre-LLM (both sides, both text fields — the same
+//     task+outcome extractWorkItemRefs mines for the work-item refs that make
+//     the pair eligible, so a keyword cannot hide in a field the ref scan reads
+//     but the guard does not). This is NOT a redundant copy of the operational
 //     filter's guard: cross-ticket data-safety contradictions are a real,
 //     resolved class in this trail (e.g. two investigations root-causing the
 //     same DATALOSS incident to different causes under different tickets), and
 //     disjoint work items do not make that pair safe to drop. Same guard, same
-//     reasoning as isOperationalStateProgression; see dataLossKeywords.
+//     reasoning as isOperationalStateProgression; see
+//     decisionContainsDataLossKeyword.
 //
 // Deliberately NOT guarded on supersession keywords, unlike the operational and
 // refinement siblings. Those siblings have no work-item identity signal, so a
@@ -1929,7 +1938,7 @@ func isDisjointWorkItem(d, cand model.Decision) bool {
 	if isPrecedentLinked(d, cand) {
 		return false
 	}
-	if containsDataLossKeyword(d.Outcome) || containsDataLossKeyword(cand.Outcome) {
+	if decisionContainsDataLossKeyword(d) || decisionContainsDataLossKeyword(cand) {
 		return false
 	}
 	refsA := extractWorkItemRefs(d)
@@ -1971,21 +1980,31 @@ func isDisjointWorkItem(d, cand model.Decision) bool {
 //   - same non-empty project (operational traces are all project "mono"; an
 //     untagged pair is never suppressed), mirroring the sibling filters.
 //   - both must expose at least one extractable resource ref, and the two ref
-//     sets must be fully disjoint. Any shared connector/org makes the sets
-//     overlap and the pair reaches the validator — which is correct, because a
-//     same-connector pair is exactly where a genuine operational clash lives.
+//     sets must be provably disjoint by namespace (see
+//     resourceRefsProvablyDisjoint). Disjointness is only judged WITHIN a
+//     namespace: a different connector vs connector, or org vs org, is disjoint;
+//     a connector vs an org is NOT comparable — the connector may be owned by
+//     that org, and the scorer holds no connector→org mapping — so that pair
+//     reaches the validator. Any shared connector/org, or any namespace present
+//     on only one side, also sends the pair to the validator — a shared
+//     resource is exactly where a genuine operational clash lives.
 //   - not precedent-linked — an explicit lineage cite is left to the LLM.
-//   - neither outcome reports a data-loss / corruption / quarantine event. This
-//     is the non-negotiable guard: a data-safety finding is categorically
-//     high-stakes and must never be dropped pre-LLM, even across different
-//     resources (both sides checked). Same guard, same reasoning as
-//     isDisjointWorkItem and isOperationalStateProgression; see dataLossKeywords.
+//   - neither side's task or outcome reports a data-loss / corruption /
+//     quarantine event. This is the non-negotiable guard: a data-safety finding
+//     is categorically high-stakes and must never be dropped pre-LLM, even
+//     across different resources (both sides, and both the agent_context.task
+//     and the outcome — exactly the text extractResourceRefs mines, so a keyword
+//     can never hide in a field the ref scan reads but the guard does not). Same
+//     guard, same reasoning as isDisjointWorkItem and
+//     isOperationalStateProgression; see decisionContainsDataLossKeyword.
 //
 // Failure mode is under-suppression: a decision that names its resource only by
-// customer name ("Trellis") and not by connector_/org_ token yields no ref, which
-// disables the filter and sends the pair to the validator — never a wrongful
-// suppression of a same-resource pair, since the only way two ref sets become
-// disjoint is if both sides name resources and they genuinely differ.
+// customer name ("Trellis") and not by a connector_/org_ token yields no ref,
+// which disables the filter and sends the pair to the validator. So does a
+// cross-namespace pair (a connector on one side, an org on the other) and any
+// pair sharing a resource — never a wrongful suppression, because disjointness
+// is only ever declared between same-namespace identifiers that genuinely
+// differ.
 //
 // Scope: lives only in the cloud scorer (this file is !lite), alongside the rest
 // of the structural suppression family.
@@ -2003,7 +2022,7 @@ func isDisjointResource(d, cand model.Decision) bool {
 	if isPrecedentLinked(d, cand) {
 		return false
 	}
-	if containsDataLossKeyword(d.Outcome) || containsDataLossKeyword(cand.Outcome) {
+	if decisionContainsDataLossKeyword(d) || decisionContainsDataLossKeyword(cand) {
 		return false
 	}
 	refsA := extractResourceRefs(d)
@@ -2011,7 +2030,83 @@ func isDisjointResource(d, cand model.Decision) bool {
 	if len(refsA) == 0 || len(refsB) == 0 {
 		return false
 	}
-	return !ticketRefsOverlap(refsA, refsB)
+	return resourceRefsProvablyDisjoint(refsA, refsB)
+}
+
+// resourceRefsProvablyDisjoint reports whether two non-empty canonical
+// resource-reference sets ("CONNECTOR-<hex>", "ORG-<hex>") describe provably
+// different infrastructure — so a pair naming only these resources cannot be
+// acting on the same data plane and is safe to suppress pre-LLM.
+//
+// Disjointness is only provable WITHIN a namespace. CONNECTOR-* names a single
+// pipeline; ORG-* names a whole tenant, which owns many connectors. Two
+// different connector ids are different pipelines, and two different org ids are
+// different tenants — both provably disjoint. But a connector id and an org id
+// are NOT comparable: the connector may be owned by that very org, and the
+// scorer holds no connector→org mapping to rule it out. The original check
+// flattened both namespaces into one set and ran a plain overlap test, so a
+// decision naming only connector_57a42328 and one naming only its owning
+// org_54b2e846 looked "disjoint" (no string in common) and were suppressed —
+// even though they may describe the same incident on the same data plane. That
+// is a wrongful pre-LLM suppression, the one failure mode this family exists to
+// avoid.
+//
+// The fix types the refs by namespace and declares disjointness only when the
+// comparison is apples-to-apples in every namespace:
+//   - both sides must populate exactly the same set of namespaces. A
+//     connector-only side and an org-only side — or a connector-only side and a
+//     connector+org side — are not comparable, because there is a ref on one
+//     side whose ownership relative to the other side is unknown, so the pair
+//     reaches the validator.
+//   - within every populated namespace the two id sets must be fully disjoint.
+//     Any shared connector or shared org makes the pair overlap and reach the
+//     validator.
+//
+// This is strictly more conservative than the flattened check: it can only send
+// MORE pairs to the validator, never fewer (the safe, under-suppressing
+// direction the whole family is tuned to). The dominant live FP class —
+// connector-vs-connector, both sides naming only connectors — is unaffected:
+// same namespace set {CONNECTOR}, disjoint ids, still suppressed.
+func resourceRefsProvablyDisjoint(refsA, refsB []string) bool {
+	byNsA := groupResourceRefsByNamespace(refsA)
+	byNsB := groupResourceRefsByNamespace(refsB)
+	if len(byNsA) != len(byNsB) {
+		return false // different namespaces populated → not comparable
+	}
+	for ns, idsA := range byNsA {
+		idsB, ok := byNsB[ns]
+		if !ok {
+			return false // a namespace present on one side only → not comparable
+		}
+		for id := range idsA {
+			if _, shared := idsB[id]; shared {
+				return false // a shared resource in this namespace → overlap
+			}
+		}
+	}
+	return true
+}
+
+// groupResourceRefsByNamespace partitions canonical resource refs into id sets
+// keyed by their namespace prefix ("CONNECTOR", "ORG"). extractResourceRefs
+// produces every ref as "<PREFIX>-<hex>" with exactly one hyphen, so the split
+// is unambiguous; a malformed ref carrying no hyphen is skipped rather than
+// mis-bucketed.
+func groupResourceRefsByNamespace(refs []string) map[string]map[string]struct{} {
+	byNs := make(map[string]map[string]struct{}, 2)
+	for _, ref := range refs {
+		ns, id, ok := strings.Cut(ref, "-")
+		if !ok {
+			continue
+		}
+		ids, exists := byNs[ns]
+		if !exists {
+			ids = make(map[string]struct{}, 1)
+			byNs[ns] = ids
+		}
+		ids[id] = struct{}{}
+	}
+	return byNs
 }
 
 // isPrecedentLinked returns true if either decision cites the other via
@@ -2113,16 +2208,41 @@ var dataLossKeywords = []string{
 	"corrupt",    // corrupted / corruption
 }
 
-// containsDataLossKeyword returns true if the outcome text references a
+// containsDataLossKeyword returns true if the given text references a
 // data-safety event (loss, corruption, or quarantined writes).
-func containsDataLossKeyword(outcome string) bool {
-	lower := strings.ToLower(outcome)
+func containsDataLossKeyword(text string) bool {
+	lower := strings.ToLower(text)
 	for _, kw := range dataLossKeywords {
 		if strings.Contains(lower, kw) {
 			return true
 		}
 	}
 	return false
+}
+
+// decisionContainsDataLossKeyword reports whether a decision references a
+// data-safety event in any free-text field that a pre-LLM suppressor reads to
+// judge eligibility — the agent-supplied agent_context.task and the outcome.
+//
+// The pre-LLM suppressors mine BOTH fields for their identity signal:
+// extractResourceRefs and extractWorkItemRefs both scan task and outcome, so a
+// pair can become eligible for suppression on the strength of a ref that appears
+// only in the task. The data-safety guard must therefore scan exactly those same
+// sources — otherwise a "DATALOSS recovery connector_x" task whose outcome omits
+// the word is silently dropped pre-LLM while its connector ref still drives the
+// disjoint-resource match. Guarding only the outcome (the original behavior) left
+// that hole. This is the membership-parity fix for the guard: every suppressor
+// that mines the task for identity now guards the task for data safety, so the
+// guard and the eligibility signal never read different text.
+//
+// isOperationalStateProgression shares this guard too, though it keys on a time
+// gap rather than task-extracted refs: a data-safety event anywhere in a
+// decision's salient text is categorically high-stakes and must reach the
+// validator, and a single uniform guard is one fewer place for the data-loss
+// check to drift between the sibling filters.
+func decisionContainsDataLossKeyword(d model.Decision) bool {
+	return containsDataLossKeyword(nestedContextString(d.AgentContext, "task")) ||
+		containsDataLossKeyword(d.Outcome)
 }
 
 // reviewTypes is defined in shared.go — it is referenced by the lite-compiled

--- a/internal/conflicts/ticket_extract.go
+++ b/internal/conflicts/ticket_extract.go
@@ -169,3 +169,50 @@ func extractWorkItemRefs(d model.Decision) []string {
 	}
 	return out
 }
+
+// resourceRefPattern matches the structured infrastructure-resource identifiers
+// that dominate live incident-recovery traces — "connector_57a42328",
+// "org_54b2e846". These are regular tokens (a fixed prefix + a hex run), not
+// the free-text customer names ("Trellis", "Akkari") that an earlier note in
+// isOperationalStateProgression deemed too fragile to parse: the prefix anchors
+// the match and the 6+ hex-char floor rejects method names ("connector_reset" —
+// "reset" is not a hex run) and short fields ("org_id"). Hex is canonicalized to
+// lowercase so the two casings collide in the disjoint-set namespace.
+var resourceRefPattern = regexp.MustCompile(`(?i)\b(connector|org)_([0-9a-f]{6,})\b`)
+
+// extractResourceRefs returns every infrastructure-resource identifier visible
+// in a decision: connector references (canonical "CONNECTOR-57a42328") and org
+// references (canonical "ORG-54b2e846"), parsed from the task and outcome free
+// text where live operational traces name them.
+//
+// Used only by isDisjointResource (cloud scorer), which treats two
+// operational/investigation decisions about entirely different resources as
+// non-contradictory. Kept separate from extractWorkItemRefs because the two
+// signals key different filters and must not cross-contaminate: a PR number and
+// a connector id are different identity namespaces. A missed reference only
+// costs a suppression (the safe, under-suppressing direction), never a false
+// one. Customer names are deliberately NOT parsed — an unbounded, drifting
+// free-text vocabulary is exactly the fragile signal to avoid.
+//
+// Returns nil when nothing is extractable from any source.
+func extractResourceRefs(d model.Decision) []string {
+	seen := map[string]struct{}{}
+	var out []string
+	add := func(prefix, hex string) {
+		ref := strings.ToUpper(prefix) + "-" + strings.ToLower(hex)
+		if _, dup := seen[ref]; dup {
+			return
+		}
+		seen[ref] = struct{}{}
+		out = append(out, ref)
+	}
+	for _, src := range []string{
+		nestedContextString(d.AgentContext, "task"),
+		d.Outcome,
+	} {
+		for _, m := range resourceRefPattern.FindAllStringSubmatch(src, -1) {
+			add(m[1], m[2])
+		}
+	}
+	return out
+}


### PR DESCRIPTION
## What

Adds `isDisjointResource`, a pre-LLM conflict suppressor keyed on **infrastructure-resource identity** (`connector_`/`org_` tokens) — the resource-identity sibling of `isDisjointWorkItem` (#729).

## Why

The dominant *live* conflict false-positive class is operational/incident-recovery decisions that are **disjoint by connector or org**: a diagnosis of `connector_57a42328` vs a recovery of `connector_9b38b47d`, over-clustered on dense shared vocabulary (restart_storm, kafka2pg, replication slot, wal_status, snapshot). Two recoveries of different data planes cannot contradict — but the validator manufactures a CONTRADICTION.

Neither existing suppressor catches it:
- **`isDisjointWorkItem` (#729)** keys on PR/ticket refs. Live operational traces carry none — they name a `connector_`/`org_` token instead, so `extractWorkItemRefs` returns empty and the filter no-ops.
- **`isOperationalStateProgression` (#728)** only suppresses same-project pairs `>=` its window apart, so different-resource pairs *inside the same incident window* (hours apart) slip past it. Its own doc deferred resource gating as "too fragile to parse from free-text."

This is why operational conflicts pile up despite the merged filters.

## How

- **`extractResourceRefs`** (ticket_extract.go) parses the structured `connector_<hex>` / `org_<hex>` tokens from outcome + task. These are *regular identifiers* (prefix + 6&plus; hex run), not the unbounded free-text customer names the earlier note rightly deferred — the prefix anchors the match; the hex floor rejects `connector_reset` / `org_id` / bare hashes.
- **`isDisjointResource`** (scorer.go) suppresses when both decisions are `resourceScopedTypes` (investigation / deployment / operational_recovery / operations / operational / incident), same non-empty project, both expose a resource ref, and the ref sets are fully disjoint.
- Same discipline as the work-item filter: **direction-setting types** (architecture/trade_off/design) excluded so design forks reach the validator; **precedent-linked** pairs excluded; and the **data-loss guard** (`DATALOSS`/`quarantine`/`corrupt`, both sides) preserved — no data-safety pair is ever dropped pre-LLM, even across resources.
- Emits OTel counter `akashi.conflicts.disjoint_resource_filtered`.

**Failure mode is under-suppression:** a resource named only by customer name ("Trellis") yields no ref, and the pair reaches the validator — never a wrongful suppression.

## Honest scope

This is a *safe, additive* reduction, not a silver bullet. It catches pairs where **both** sides carry a `connector_`/`org_` token, the tokens differ, and neither flags data loss. Pairs that name the resource only by customer name, or that mention a data-safety event, still reach the validator by design — consistent with "never drop a data-safety pair pre-LLM." Pile-up shrinks; it does not vanish.

## Verification

- `go test -race -count=1 ./internal/conflicts/` and the full integration suite (`-tags integration -race`) pass.
- `golangci-lint` 0 issues; `go vet ./...` clean; `go mod tidy` clean; cloud **and** `-tags lite` builds compile.
- New table-driven tests: `TestExtractResourceRefs` (token canonicalization, method-name/bare-hex rejection, task-field source) and `TestIsDisjointResource` (every guard + symmetry).

> Star Trek's transporter refuses to merge two distinct patterns into one — the buffer keys on identity, not on how alike the signals look. This filter does the same for incidents: connector_57a42328 and connector_9b38b47d share every surface signature (same kafka2pg crawl, same slot vocabulary) yet are different patterns, and conflating them is the transporter accident the resource key exists to prevent.