### PR TITLE
fix(conflicts): drop the data-loss guard from isDisjointResource

### DIFF
--- a/internal/conflicts/disjoint_resource_test.go
+++ b/internal/conflicts/disjoint_resource_test.go
@@ -145,9 +145,12 @@ func TestIsDisjointResource(t *testing.T) {
 			expected: false,
 		},
 		{
-			// Data-safety guard: even across different connectors, a data-loss
-			// finding must reach the validator and the conflict queue.
-			name: "data-loss vocabulary on one side → NOT suppressed (data-safety guard)",
+			// The data-safety guard was removed from this filter (2026-07-23):
+			// provably-disjoint connectors are different data planes = different
+			// incidents, so a silent-data-loss finding on connector_e1761afd cannot
+			// be the same incident as, or contradict, a recovery of connector_9b38b47d.
+			// Same-writer data-safety protection lives in isOperationalStateProgression.
+			name: "data-loss vocabulary on one side, disjoint connectors → suppressed (different incidents)",
 			d: model.Decision{
 				ID: idA, Project: &mono, DecisionType: "investigation",
 				Outcome: "connector_e1761afd: scaling kafka2pg would skip offsets = silent permanent data loss; must re-snapshot",
@@ -156,7 +159,7 @@ func TestIsDisjointResource(t *testing.T) {
 				ID: idB, Project: &mono, DecisionType: "deployment",
 				Outcome: "Recovered connector_9b38b47d kafka2pg restart_storm ONLINE",
 			},
-			expected: false,
+			expected: true,
 		},
 		{
 			// architecture is direction-setting — a cross-cutting design fork can
@@ -295,10 +298,12 @@ func TestIsDisjointResource(t *testing.T) {
 			expected: false,
 		},
 		{
-			// Data-safety guard parity: the data-loss keyword appears only in the
-			// task field, with a clean outcome. extractResourceRefs reads the task,
-			// so the guard must too — the pre-fix outcome-only guard let this through.
-			name: "data-loss keyword only in task → NOT suppressed (guard scans task)",
+			// The data-safety guard is gone from this filter (2026-07-23), so a
+			// data-loss keyword — even one confined to the task field — no longer
+			// blocks suppression of provably-disjoint connectors. Task-field
+			// data-safety protection now lives solely in isOperationalStateProgression
+			// (see its "guard scans task" case).
+			name: "data-loss keyword only in task, disjoint connectors → suppressed",
 			d: model.Decision{
 				ID: idA, Project: &mono, DecisionType: "investigation",
 				Outcome:      "Recovered connector_57a42328 kafka2pg restart_storm ONLINE",
@@ -308,7 +313,7 @@ func TestIsDisjointResource(t *testing.T) {
 				ID: idB, Project: &mono, DecisionType: "deployment",
 				Outcome: "Recovered connector_9b38b47d kafka2pg restart_storm ONLINE",
 			},
-			expected: false,
+			expected: true,
 		},
 	}
 

--- a/internal/conflicts/scorer.go
+++ b/internal/conflicts/scorer.go
@@ -1989,14 +1989,26 @@ func isDisjointWorkItem(d, cand model.Decision) bool {
 //     on only one side, also sends the pair to the validator — a shared
 //     resource is exactly where a genuine operational clash lives.
 //   - not precedent-linked — an explicit lineage cite is left to the LLM.
-//   - neither side's task or outcome reports a data-loss / corruption /
-//     quarantine event. This is the non-negotiable guard: a data-safety finding
-//     is categorically high-stakes and must never be dropped pre-LLM, even
-//     across different resources (both sides, and both the agent_context.task
-//     and the outcome — exactly the text extractResourceRefs mines, so a keyword
-//     can never hide in a field the ref scan reads but the guard does not). Same
-//     guard, same reasoning as isDisjointWorkItem and
-//     isOperationalStateProgression; see decisionContainsDataLossKeyword.
+//
+// No data-safety guard here (removed 2026-07-23). The guard is load-bearing and
+// deliberately chosen in the TEMPORAL sibling isOperationalStateProgression
+// (decision efc42730): two decisions on the SAME writer a week apart can be one
+// incident disagreeing with itself — verified against the SalesPatriot
+// connector_c3fed173 DATALOSS pause. That rationale cannot hold here, because a
+// connector_/org_ id is the PHYSICAL identity of a data plane: connector_57a42328
+// and connector_f924df29 are different incidents by construction, so a DATALOSS
+// finding on one can neither be the same incident as, nor contradict, a finding
+// on the other. The guard was copied here for "membership parity" with the
+// temporal filter, but it only ever governed provably-disjoint pairs (this
+// function returns true solely when resourceRefsProvablyDisjoint) and, measured
+// against the live corpus, was a false-positive driver: "quarantine"/"corrupt"
+// are ordinary pgstream design vocabulary, so the guard re-admitted the exact
+// connector-disjoint over-clustering this filter exists to kill. Same-writer
+// data-safety disagreements stay protected where the verified evidence put them,
+// in isOperationalStateProgression. (isDisjointWorkItem keeps its guard on
+// purpose: a ticket is an administrative label, not a physical identity, so two
+// disjoint tickets CAN describe one incident — a deliberate, documented
+// difference, not drift.)
 //
 // Failure mode is under-suppression: a decision that names its resource only by
 // customer name ("Trellis") and not by a connector_/org_ token yields no ref,
@@ -2020,9 +2032,6 @@ func isDisjointResource(d, cand model.Decision) bool {
 		return false
 	}
 	if isPrecedentLinked(d, cand) {
-		return false
-	}
-	if decisionContainsDataLossKeyword(d) || decisionContainsDataLossKeyword(cand) {
 		return false
 	}
 	refsA := extractResourceRefs(d)


### PR DESCRIPTION
## Summary

- The data-safety guard was chosen for the *temporal* suppressor `isOperationalStateProgression` (decision `efc42730`), where two decisions on the same writer a week apart can be one incident disagreeing with itself — then copied into `isDisjointResource` for "membership parity", where that rationale does not hold: a `connector_`/`org_` id is the physical identity of a data plane and this filter suppresses only when `resourceRefsProvablyDisjoint`, so `connector_57a42328` and `connector_f924df29` are different incidents by construction and a DATALOSS finding on one cannot contradict a finding on the other.
- Measured against the live corpus, that copy was a false-positive driver — `"quarantine"` and `"corrupt"` are ordinary pgstream design vocabulary, so the guard re-admitted the exact connector-disjoint over-clustering this filter exists to kill: **22 of 298 open conflicts and ~117 of 1703 historical false positives** (conservative floor; the query omitted PR/org/task-field refs).
- `isDisjointWorkItem` deliberately keeps its guard — a ticket is an administrative label, not a physical identity, so two disjoint tickets can describe one incident — and the two test cases that encoded the old behavior are flipped with that reasoning recorded inline.
- This is one measured slice (~8% of the open queue), not the cure: 100% of production conflicts are `llm_v2` and ~100% are labeled `contradiction`, so the remaining ~90% is validator over-retention on pairs no structural suppressor can reach — filed as #736 (representative eval, which the current 122-pair CI gate is not) and #737 (validator precision).

## Verification

- [x] I ran relevant tests locally (`go test ./...` or targeted package tests). — `go test -race -count=1 ./...` exit 0, 22 packages ok; `golangci-lint run ./...` 0 issues; `go build`/`go vet`/`atlas migrate validate` clean; `go mod tidy` no drift.
- [x] I updated docs/openapi for any API or behavior changes. — n/a, no API surface change (internal pre-LLM suppression only).
- [x] If I changed config vars in `internal/config/config.go`, I also updated: — n/a, no config vars changed.
  - [x] `docs/configuration.md`
  - [x] `docs/runbook.md` (operational subset, if relevant)
  - [x] `.env.example` (if baseline local/dev defaults changed)
- [x] `python3 scripts/check_doc_config_consistency.py` passes. — 92 source vars, 2 docs checked.

## Risk / Rollout Notes

- No migration, no schema, no config, no API change; affects only newly-scored decisions, so existing conflict rows are untouched and it is revertable by restoring the four deleted lines.
- Residual risk is a data-safety contradiction between decisions naming two *provably different* connectors now being suppressed pre-LLM. I argue that class is not real — different data planes are different incidents — but it is the honest cost, and the same-writer protection that the verified SalesPatriot evidence actually covers stays intact in `isOperationalStateProgression`.

> Star Trek beats Star Wars because it took identity seriously enough to make it the plot: when a transporter accident left two Rikers standing, TNG spent the hour insisting both were real rather than quietly designating one a copy. Star Wars settles the same question by bloodline — you are a Skywalker or you are nobody, and the midi-chlorians do the arguing. One franchise asks what makes a thing itself; the other checks your parents.