### PR TITLE
feat(conflicts): report cost-relative metrics for a rare-event detector

### DIFF
--- a/cmd/eval-conflicts/cost_report.go
+++ b/cmd/eval-conflicts/cost_report.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/ashita-ai/akashi/internal/conflicts"
+)
+
+// printCostReport adds the cost-relative view to an eval run.
+//
+// Precision and recall cannot say whether a detector is worth running: at a low
+// base rate a detector can post respectable precision and still cost more than
+// answering "no" every time. That comparison needs a stated miss:false-alarm
+// ratio, which is a fact about the operator's world, so it is opt-in rather
+// than defaulted to a number nobody chose.
+func printCostReport(m conflicts.EvalMetrics, costRatio, prevalence float64) {
+	if costRatio <= 0 && prevalence <= 0 {
+		return
+	}
+	if costRatio <= 0 || prevalence <= 0 {
+		fmt.Fprintln(os.Stderr, "--cost-ratio and --prevalence must be given together; skipping cost report")
+		return
+	}
+	cm := conflicts.ComputeCostMetrics(m.TruePositives, m.FalsePositives, m.TrueNegatives, m.FalseNegatives,
+		conflicts.CostModel{Prevalence: prevalence, MissCostRatio: costRatio})
+	fmt.Print(conflicts.FormatCostMetrics(cm, []float64{1, costRatio, 3 * costRatio}))
+}

--- a/cmd/eval-conflicts/main.go
+++ b/cmd/eval-conflicts/main.go
@@ -400,23 +400,3 @@ func callScorerEval(baseURL, token string) (scorerEvalResult, error) {
 	}
 	return envelope.Data, nil
 }
-
-// printCostReport adds the cost-relative view to an eval run.
-//
-// Precision and recall cannot say whether a detector is worth running: at a low
-// base rate a detector can post respectable precision and still cost more than
-// answering "no" every time. That comparison needs a stated miss:false-alarm
-// ratio, which is a fact about the operator's world, so it is opt-in rather
-// than defaulted to a number nobody chose.
-func printCostReport(m conflicts.EvalMetrics, costRatio, prevalence float64) {
-	if costRatio <= 0 && prevalence <= 0 {
-		return
-	}
-	if costRatio <= 0 || prevalence <= 0 {
-		fmt.Fprintln(os.Stderr, "--cost-ratio and --prevalence must be given together; skipping cost report")
-		return
-	}
-	cm := conflicts.ComputeCostMetrics(m.TruePositives, m.FalsePositives, m.TrueNegatives, m.FalseNegatives,
-		conflicts.CostModel{Prevalence: prevalence, MissCostRatio: costRatio})
-	fmt.Print(conflicts.FormatCostMetrics(cm, []float64{1, costRatio, 3 * costRatio}))
-}

--- a/cmd/eval-conflicts/main.go
+++ b/cmd/eval-conflicts/main.go
@@ -46,6 +46,8 @@ func main() {
 func run() int {
 	mode := flag.String("mode", "validator", "evaluation mode: validator, scorer, or benchmark")
 	save := flag.Bool("save", false, "save results to ./eval-results/{timestamp}.json")
+	costRatio := flag.Float64("cost-ratio", 0, "cost of a missed contradiction relative to one false alarm. When set with --prevalence, reports normalized expected cost, which answers whether the detector beats not running it at all.")
+	prevalence := flag.Float64("prevalence", 0, "share of evaluated pairs that are genuine contradictions IN PRODUCTION (not in the eval sample). Required with --cost-ratio; precision moves with prevalence and a stratified sample's own rate would flatter the detector.")
 	flag.Parse()
 
 	// Benchmark mode runs locally — no server or auth required.
@@ -78,7 +80,7 @@ func run() int {
 
 	switch *mode {
 	case "validator":
-		return runValidatorEval(baseURL, token, *save)
+		return runValidatorEval(baseURL, token, *save, *costRatio, *prevalence)
 	case "scorer":
 		return runScorerEval(baseURL, token, *save)
 	default:
@@ -87,7 +89,7 @@ func run() int {
 	}
 }
 
-func runValidatorEval(baseURL, token string, save bool) int {
+func runValidatorEval(baseURL, token string, save bool, costRatio, prevalence float64) int {
 	fmt.Fprintf(os.Stderr, "running validator eval dataset (%d pairs)...\n", len(conflicts.DefaultEvalDataset()))
 
 	metrics, results, err := callValidatorEval(baseURL, token)
@@ -97,6 +99,7 @@ func runValidatorEval(baseURL, token string, save bool) int {
 	}
 
 	fmt.Print(conflicts.FormatMetrics(metrics, results))
+	printCostReport(metrics, costRatio, prevalence)
 
 	if save {
 		if err := saveResults("validator", map[string]any{
@@ -396,4 +399,24 @@ func callScorerEval(baseURL, token string) (scorerEvalResult, error) {
 		return scorerEvalResult{}, fmt.Errorf("decode: %w", err)
 	}
 	return envelope.Data, nil
+}
+
+// printCostReport adds the cost-relative view to an eval run.
+//
+// Precision and recall cannot say whether a detector is worth running: at a low
+// base rate a detector can post respectable precision and still cost more than
+// answering "no" every time. That comparison needs a stated miss:false-alarm
+// ratio, which is a fact about the operator's world, so it is opt-in rather
+// than defaulted to a number nobody chose.
+func printCostReport(m conflicts.EvalMetrics, costRatio, prevalence float64) {
+	if costRatio <= 0 && prevalence <= 0 {
+		return
+	}
+	if costRatio <= 0 || prevalence <= 0 {
+		fmt.Fprintln(os.Stderr, "--cost-ratio and --prevalence must be given together; skipping cost report")
+		return
+	}
+	cm := conflicts.ComputeCostMetrics(m.TruePositives, m.FalsePositives, m.TrueNegatives, m.FalseNegatives,
+		conflicts.CostModel{Prevalence: prevalence, MissCostRatio: costRatio})
+	fmt.Print(conflicts.FormatCostMetrics(cm, []float64{1, costRatio, 3 * costRatio}))
 }

--- a/internal/conflicts/cost.go
+++ b/internal/conflicts/cost.go
@@ -66,9 +66,17 @@ type CostMetrics struct {
 	// running; at or above 1.0 a fixed answer is cheaper.
 	NormalizedExpectedCost float64 `json:"normalized_expected_cost"`
 
-	// BreakEvenCostRatio is the miss:false-alarm ratio at which the detector
-	// stops losing to the trivial system. NaN when no ratio makes it worthwhile.
+	// BreakEvenCostRatio is the lowest miss:false-alarm ratio at which the
+	// detector stops losing to flagging nothing. NaN when no ratio works.
 	BreakEvenCostRatio float64 `json:"break_even_cost_ratio"`
+
+	// UpperCostRatio is the ratio above which flagging EVERYTHING becomes
+	// cheaper than running the detector. A detector is only worth running for
+	// ratios strictly between BreakEvenCostRatio and this. The upper bound is
+	// easy to forget because it is counter-intuitive: once a miss is
+	// catastrophic enough, a review queue that filters anything at all costs
+	// more than reviewing everything. NaN when no ratio works.
+	UpperCostRatio float64 `json:"upper_cost_ratio"`
 }
 
 // ComputeCostMetrics derives cost-relative metrics from a confusion matrix.
@@ -83,6 +91,7 @@ func ComputeCostMetrics(tp, fp, tn, fn int, model CostModel) CostMetrics {
 		MissCostRatio:          model.MissCostRatio,
 		NormalizedExpectedCost: math.NaN(),
 		BreakEvenCostRatio:     math.NaN(),
+		UpperCostRatio:         math.NaN(),
 	}
 	if tp+fn > 0 {
 		m.Sensitivity = float64(tp) / float64(tp+fn)
@@ -97,7 +106,7 @@ func ComputeCostMetrics(tp, fp, tn, fn int, model CostModel) CostMetrics {
 		return m
 	}
 	m.NormalizedExpectedCost = normalizedExpectedCost(m.Sensitivity, m.FalsePosRate, model)
-	m.BreakEvenCostRatio = breakEvenCostRatio(m.Sensitivity, m.FalsePosRate, model.Prevalence)
+	m.BreakEvenCostRatio, m.UpperCostRatio = worthwhileCostRatios(m.Sensitivity, m.FalsePosRate, model.Prevalence)
 	return m
 }
 
@@ -115,25 +124,40 @@ func normalizedExpectedCost(sens, fpr float64, model CostModel) float64 {
 	return detector / trivial
 }
 
-// breakEvenCostRatio solves normalizedExpectedCost(r) = 1 for r.
+// worthwhileCostRatios returns the open interval of miss:false-alarm ratios for
+// which the detector beats BOTH trivial systems.
 //
-// Against the flag-nothing baseline the condition is linear in r:
+// There are two baselines, and a detector must beat whichever is cheaper.
+// Against flag-nothing (cost pi*r):
 //
-//	pi*(1-sens)*r + (1-pi)*fpr < pi*r      =>      r > (1-pi)*fpr / (pi*sens)
+//	pi*(1-sens)*r + (1-pi)*fpr < pi*r   =>   r > (1-pi)*fpr / (pi*sens)
 //
-// which is exactly the decision-curve identity: the detector pays off once the
-// odds of the cost ratio exceed (1-precision)/precision. Returns NaN when the
-// detector never beats the trivial system, which happens when it has no
-// sensitivity at all.
-func breakEvenCostRatio(sens, fpr, pi float64) float64 {
-	if sens <= 0 {
-		return math.NaN()
+// which is the decision-curve identity — the detector pays off once the cost
+// odds exceed (1-precision)/precision. Against flag-everything (cost 1-pi):
+//
+//	pi*(1-sens)*r + (1-pi)*fpr < 1-pi   =>   r < (1-pi)*(1-fpr) / (pi*(1-sens))
+//
+// The upper bound is the one that gets forgotten, and it is real: once a miss
+// is catastrophic enough relative to a false alarm, any filtering at all costs
+// more than reviewing every pair. Reporting only the lower bound tells an
+// operator with an extreme cost ratio to run a detector they should not.
+//
+// The interval is non-empty exactly when fpr < sens, i.e. when the detector is
+// better than chance. Both bounds are NaN otherwise.
+func worthwhileCostRatios(sens, fpr, pi float64) (low, high float64) {
+	if sens <= fpr {
+		// At or below chance no cost ratio makes the detector worth running.
+		return math.NaN(), math.NaN()
+	}
+	high = ((1 - pi) * (1 - fpr)) / (pi * (1 - sens))
+	if sens >= 1 {
+		high = math.Inf(1) // never misses, so flag-everything never wins
 	}
 	if fpr <= 0 {
-		// A detector with no false alarms beats flag-nothing at any positive cost.
-		return 0
+		// No false alarms: beats flag-nothing at any positive cost ratio.
+		return 0, high
 	}
-	return ((1 - pi) * fpr) / (pi * sens)
+	return ((1 - pi) * fpr) / (pi * sens), high
 }
 
 // FormatCostMetrics renders a short cost report, including a sweep over
@@ -147,10 +171,17 @@ func FormatCostMetrics(m CostMetrics, sweep []float64) string {
 	fmt.Fprintf(&b, "(sensitivity, specificity and FPR are prevalence-invariant; precision is not)\n")
 
 	if math.IsNaN(m.BreakEvenCostRatio) {
-		fmt.Fprintf(&b, "break-even: never — the detector has no sensitivity\n")
+		fmt.Fprintf(&b, "worthwhile at no cost ratio — sensitivity does not exceed the false-positive rate\n")
 		return b.String()
 	}
-	fmt.Fprintf(&b, "break-even miss:false-alarm cost ratio: %.2f:1\n", m.BreakEvenCostRatio)
+	if math.IsInf(m.UpperCostRatio, 1) {
+		fmt.Fprintf(&b, "worth running for cost ratios above %.2f:1\n", m.BreakEvenCostRatio)
+	} else {
+		fmt.Fprintf(&b, "worth running for cost ratios between %.2f:1 and %.2f:1\n",
+			m.BreakEvenCostRatio, m.UpperCostRatio)
+		fmt.Fprintf(&b, "(above %.2f:1 a miss is costly enough that reviewing every pair is cheaper)\n",
+			m.UpperCostRatio)
+	}
 
 	for _, r := range sweep {
 		nec := normalizedExpectedCost(m.Sensitivity, m.FalsePosRate, CostModel{Prevalence: m.Prevalence, MissCostRatio: r})

--- a/internal/conflicts/cost.go
+++ b/internal/conflicts/cost.go
@@ -1,0 +1,173 @@
+//go:build !lite
+
+package conflicts
+
+import (
+	"fmt"
+	"math"
+	"strings"
+)
+
+// Cost-aware evaluation for a rare-event detector.
+//
+// Conflict detection is screening, not classification: genuine contradictions
+// are roughly 3% of the pairs that reach the judge. At that prevalence,
+// precision is governed almost entirely by the false-positive rate on the
+// majority class — at a 3.35% base rate, an FPR of 5.7% yields 23% precision,
+// 1% yields 63%, and 0.1% yields 95%, while raising recall from 30% to 80% at a
+// fixed 1% FPR moves precision only from 51% to 74%.
+//
+// Two consequences drive this file.
+//
+// First, class-averaged scores actively mislead here. Measured on the blind
+// gold set, gpt-5-mini had the best sample F1 (0.704) and the worst product
+// outcome (17.3% corpus precision), because F1 cannot see a fourfold difference
+// in majority-class FPR. Sensitivity and specificity are the transportable
+// quantities; precision is not, because it moves with prevalence.
+//
+// Second, a detector that looks good on precision can still be worth less than
+// not running it. Normalized expected cost compares against the best trivial
+// system — always-flag or never-flag — so it answers the question precision
+// cannot: is this worth a reviewer's attention at all? At the operating point
+// measured for this corpus (3.35% prevalence, 50.5% recall, 2.44% FPR) the
+// answer at equal error costs is no: NEC is 1.198, and the detector only earns
+// its keep once a missed contradiction is judged ~1.4x worse than a false alarm.
+//
+// The arithmetic follows decision curve analysis (Vickers & Elkin, Medical
+// Decision Making 2006;26(6):565-574): net benefit is positive exactly when
+// precision exceeds the threshold probability, which is the same break-even
+// this file computes from the cost ratio.
+
+// CostModel describes the operating environment a detector is judged in.
+type CostModel struct {
+	// Prevalence is the fraction of evaluated pairs that are genuine
+	// contradictions. It must come from the population the detector runs on,
+	// not from a stratified eval sample, which oversamples positives by design.
+	Prevalence float64
+
+	// MissCostRatio is the cost of a missed contradiction relative to one false
+	// alarm. 1.0 means they are equally bad. There is no defensible default:
+	// it is a statement about the user's world, so callers must supply it.
+	MissCostRatio float64
+}
+
+// CostMetrics reports prevalence-invariant detector characteristics alongside
+// the cost-relative verdict.
+type CostMetrics struct {
+	Prevalence    float64 `json:"prevalence"`
+	Sensitivity   float64 `json:"sensitivity"`
+	Specificity   float64 `json:"specificity"`
+	FalsePosRate  float64 `json:"false_positive_rate"`
+	MCC           float64 `json:"mcc"`
+	MissCostRatio float64 `json:"miss_cost_ratio"`
+
+	// NormalizedExpectedCost is the detector's expected cost divided by the
+	// cost of the better trivial system. Below 1.0 the detector is worth
+	// running; at or above 1.0 a fixed answer is cheaper.
+	NormalizedExpectedCost float64 `json:"normalized_expected_cost"`
+
+	// BreakEvenCostRatio is the miss:false-alarm ratio at which the detector
+	// stops losing to the trivial system. NaN when no ratio makes it worthwhile.
+	BreakEvenCostRatio float64 `json:"break_even_cost_ratio"`
+}
+
+// ComputeCostMetrics derives cost-relative metrics from a confusion matrix.
+//
+// Counts may come from a stratified sample, but prevalence must not: pass the
+// population prevalence in the model and let sensitivity and specificity carry
+// the sample's information. Mixing a sample's prevalence into this calculation
+// is how a stratified eval flatters a detector.
+func ComputeCostMetrics(tp, fp, tn, fn int, model CostModel) CostMetrics {
+	m := CostMetrics{
+		Prevalence:             model.Prevalence,
+		MissCostRatio:          model.MissCostRatio,
+		NormalizedExpectedCost: math.NaN(),
+		BreakEvenCostRatio:     math.NaN(),
+	}
+	if tp+fn > 0 {
+		m.Sensitivity = float64(tp) / float64(tp+fn)
+	}
+	if tn+fp > 0 {
+		m.Specificity = float64(tn) / float64(tn+fp)
+		m.FalsePosRate = float64(fp) / float64(tn+fp)
+	}
+	m.MCC = matthews(tp, fp, tn, fn)
+
+	if model.Prevalence <= 0 || model.Prevalence >= 1 || model.MissCostRatio <= 0 {
+		return m
+	}
+	m.NormalizedExpectedCost = normalizedExpectedCost(m.Sensitivity, m.FalsePosRate, model)
+	m.BreakEvenCostRatio = breakEvenCostRatio(m.Sensitivity, m.FalsePosRate, model.Prevalence)
+	return m
+}
+
+// normalizedExpectedCost divides the detector's expected cost by the cost of
+// the cheaper of the two trivial systems (flag everything / flag nothing).
+func normalizedExpectedCost(sens, fpr float64, model CostModel) float64 {
+	pi, r := model.Prevalence, model.MissCostRatio
+	detector := pi*(1-sens)*r + (1-pi)*fpr
+	// Flagging nothing misses every positive; flagging everything raises a
+	// false alarm on every negative.
+	trivial := math.Min(pi*r, 1-pi)
+	if trivial <= 0 {
+		return math.NaN()
+	}
+	return detector / trivial
+}
+
+// breakEvenCostRatio solves normalizedExpectedCost(r) = 1 for r.
+//
+// Against the flag-nothing baseline the condition is linear in r:
+//
+//	pi*(1-sens)*r + (1-pi)*fpr < pi*r      =>      r > (1-pi)*fpr / (pi*sens)
+//
+// which is exactly the decision-curve identity: the detector pays off once the
+// odds of the cost ratio exceed (1-precision)/precision. Returns NaN when the
+// detector never beats the trivial system, which happens when it has no
+// sensitivity at all.
+func breakEvenCostRatio(sens, fpr, pi float64) float64 {
+	if sens <= 0 {
+		return math.NaN()
+	}
+	if fpr <= 0 {
+		// A detector with no false alarms beats flag-nothing at any positive cost.
+		return 0
+	}
+	return ((1 - pi) * fpr) / (pi * sens)
+}
+
+// FormatCostMetrics renders a short cost report, including a sweep over
+// plausible cost ratios so the reader sees where the operating point flips
+// rather than being handed a single number to trust.
+func FormatCostMetrics(m CostMetrics, sweep []float64) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "\n=== cost-aware metrics (prevalence %.2f%%) ===\n", m.Prevalence*100)
+	fmt.Fprintf(&b, "sensitivity %.1f%%   specificity %.2f%%   FPR %.2f%%   MCC %.3f\n",
+		m.Sensitivity*100, m.Specificity*100, m.FalsePosRate*100, m.MCC)
+	fmt.Fprintf(&b, "(sensitivity, specificity and FPR are prevalence-invariant; precision is not)\n")
+
+	if math.IsNaN(m.BreakEvenCostRatio) {
+		fmt.Fprintf(&b, "break-even: never — the detector has no sensitivity\n")
+		return b.String()
+	}
+	fmt.Fprintf(&b, "break-even miss:false-alarm cost ratio: %.2f:1\n", m.BreakEvenCostRatio)
+
+	for _, r := range sweep {
+		nec := normalizedExpectedCost(m.Sensitivity, m.FalsePosRate, CostModel{Prevalence: m.Prevalence, MissCostRatio: r})
+		verdict := "worse than the best trivial system"
+		if nec < 1 {
+			verdict = "worth running"
+		}
+		fmt.Fprintf(&b, "  cost ratio %6.1f:1  NEC %.3f  %s\n", r, nec, verdict)
+	}
+	return b.String()
+}
+
+func matthews(tp, fp, tn, fn int) float64 {
+	num := float64(tp)*float64(tn) - float64(fp)*float64(fn)
+	den := math.Sqrt(float64(tp+fp) * float64(tp+fn) * float64(tn+fp) * float64(tn+fn))
+	if den == 0 {
+		return 0
+	}
+	return num / den
+}

--- a/internal/conflicts/cost_test.go
+++ b/internal/conflicts/cost_test.go
@@ -1,4 +1,4 @@
-//go:build !lite && integration
+//go:build !lite
 
 package conflicts
 
@@ -52,6 +52,10 @@ func TestComputeCostMetrics_BreakEvenMatchesDecisionCurveIdentity(t *testing.T) 
 	m := ComputeCostMetrics(tp, fp, tn, fn, CostModel{Prevalence: corpusPrevalence, MissCostRatio: 1})
 
 	assert.InDelta(t, 1.39, m.BreakEvenCostRatio, 0.05)
+	// The detector also stops being worth running once a miss is catastrophic
+	// enough that reviewing every pair is cheaper. Reporting only the lower
+	// bound would tell an operator with an extreme ratio to run it anyway.
+	assert.InDelta(t, 56.86, m.UpperCostRatio, 0.5)
 
 	// Decision curve analysis says net benefit is positive exactly when
 	// precision exceeds the threshold probability, i.e. the break-even odds are
@@ -60,6 +64,19 @@ func TestComputeCostMetrics_BreakEvenMatchesDecisionCurveIdentity(t *testing.T) 
 	precision := float64(tp) / float64(tp+fp)
 	assert.InDelta(t, (1-precision)/precision, m.BreakEvenCostRatio, 0.02,
 		"cost model and decision curve analysis must give the same break-even")
+}
+
+// Above the upper bound, flagging everything is cheaper than the detector.
+func TestComputeCostMetrics_UpperBoundIsReal(t *testing.T) {
+	tp, fp, tn, fn := countsFor(corpusPrevalence, corpusSens, corpusFPR, 1_000_000)
+	m := ComputeCostMetrics(tp, fp, tn, fn, CostModel{Prevalence: corpusPrevalence, MissCostRatio: 1})
+	require.False(t, math.IsNaN(m.UpperCostRatio))
+
+	inside := ComputeCostMetrics(tp, fp, tn, fn, CostModel{Prevalence: corpusPrevalence, MissCostRatio: m.UpperCostRatio * 0.9})
+	outside := ComputeCostMetrics(tp, fp, tn, fn, CostModel{Prevalence: corpusPrevalence, MissCostRatio: m.UpperCostRatio * 1.1})
+	assert.Less(t, inside.NormalizedExpectedCost, 1.0, "inside the interval the detector must win")
+	assert.Greater(t, outside.NormalizedExpectedCost, 1.0,
+		"past the upper bound reviewing everything is cheaper than filtering")
 }
 
 // Crossing the break-even ratio must flip the verdict, in both directions.
@@ -86,6 +103,16 @@ func TestComputeCostMetrics_Boundaries(t *testing.T) {
 	blind := ComputeCostMetrics(0, 100, 900, 100, CostModel{Prevalence: 0.1, MissCostRatio: 1})
 	assert.True(t, math.IsNaN(blind.BreakEvenCostRatio), "a detector that finds nothing never pays off")
 
+	// Below chance: sensitivity 20% against a 40% false-positive rate. The
+	// naive lower-bound formula still yields a finite, confident-looking
+	// number here, so the guard has to be sens > fpr rather than sens > 0.
+	worseThanChance := ComputeCostMetrics(20, 360, 540, 80, CostModel{Prevalence: 0.1, MissCostRatio: 1})
+	require.InDelta(t, 0.20, worseThanChance.Sensitivity, 0.01)
+	require.InDelta(t, 0.40, worseThanChance.FalsePosRate, 0.01)
+	assert.True(t, math.IsNaN(worseThanChance.BreakEvenCostRatio),
+		"a below-chance detector must report no worthwhile ratio, not a finite one")
+	assert.True(t, math.IsNaN(worseThanChance.UpperCostRatio))
+
 	// An unusable cost model must not produce a confident-looking number.
 	bad := ComputeCostMetrics(10, 10, 10, 10, CostModel{Prevalence: 0, MissCostRatio: 1})
 	assert.True(t, math.IsNaN(bad.NormalizedExpectedCost))
@@ -111,7 +138,7 @@ func TestFormatCostMetrics(t *testing.T) {
 	m := ComputeCostMetrics(tp, fp, tn, fn, CostModel{Prevalence: corpusPrevalence, MissCostRatio: 1})
 	out := FormatCostMetrics(m, []float64{1, 3, 10})
 
-	assert.Contains(t, out, "break-even")
+	assert.Contains(t, out, "worth running for cost ratios")
 	assert.Contains(t, out, "prevalence-invariant")
 	assert.Contains(t, out, "worse than the best trivial system")
 	assert.Contains(t, out, "worth running")

--- a/internal/conflicts/cost_test.go
+++ b/internal/conflicts/cost_test.go
@@ -1,0 +1,118 @@
+//go:build !lite && integration
+
+package conflicts
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The measured operating point for the akashi corpus: 3.35% prevalence
+// (93 contradictions in 2,772 blind-labelled pairs), 50.5% recall and a 2.44%
+// weighted false-positive rate for gpt-5 as judge. These numbers anchor the
+// tests because the property that matters is not "the formula computes
+// something" but "the formula reproduces the verdict we acted on".
+const (
+	corpusPrevalence = 0.0335
+	corpusSens       = 0.505
+	corpusFPR        = 0.0244
+)
+
+func countsFor(prevalence, sens, fpr float64, n int) (tp, fp, tn, fn int) {
+	pos := int(math.Round(prevalence * float64(n)))
+	neg := n - pos
+	tp = int(math.Round(sens * float64(pos)))
+	fn = pos - tp
+	fp = int(math.Round(fpr * float64(neg)))
+	tn = neg - fp
+	return
+}
+
+// At equal error costs this detector is worse than never flagging anything.
+// Precision and recall cannot express that, which is the reason this file
+// exists; if this test ever starts passing at NEC < 1 without the underlying
+// numbers changing, the cost model has been broken.
+func TestComputeCostMetrics_LosesToTrivialSystemAtEqualCosts(t *testing.T) {
+	tp, fp, tn, fn := countsFor(corpusPrevalence, corpusSens, corpusFPR, 1_000_000)
+	m := ComputeCostMetrics(tp, fp, tn, fn, CostModel{Prevalence: corpusPrevalence, MissCostRatio: 1})
+
+	assert.InDelta(t, corpusSens, m.Sensitivity, 0.002)
+	assert.InDelta(t, corpusFPR, m.FalsePosRate, 0.002)
+	assert.InDelta(t, 1-corpusFPR, m.Specificity, 0.002)
+	assert.Greater(t, m.NormalizedExpectedCost, 1.0,
+		"at a 1:1 cost ratio the detector must be reported as worse than the trivial system")
+	assert.InDelta(t, 1.198, m.NormalizedExpectedCost, 0.02)
+}
+
+func TestComputeCostMetrics_BreakEvenMatchesDecisionCurveIdentity(t *testing.T) {
+	tp, fp, tn, fn := countsFor(corpusPrevalence, corpusSens, corpusFPR, 1_000_000)
+	m := ComputeCostMetrics(tp, fp, tn, fn, CostModel{Prevalence: corpusPrevalence, MissCostRatio: 1})
+
+	assert.InDelta(t, 1.39, m.BreakEvenCostRatio, 0.05)
+
+	// Decision curve analysis says net benefit is positive exactly when
+	// precision exceeds the threshold probability, i.e. the break-even odds are
+	// (1-precision)/precision. The two derivations must agree, because they are
+	// the same statement about the same trade.
+	precision := float64(tp) / float64(tp+fp)
+	assert.InDelta(t, (1-precision)/precision, m.BreakEvenCostRatio, 0.02,
+		"cost model and decision curve analysis must give the same break-even")
+}
+
+// Crossing the break-even ratio must flip the verdict, in both directions.
+func TestComputeCostMetrics_VerdictFlipsAtBreakEven(t *testing.T) {
+	tp, fp, tn, fn := countsFor(corpusPrevalence, corpusSens, corpusFPR, 1_000_000)
+	base := ComputeCostMetrics(tp, fp, tn, fn, CostModel{Prevalence: corpusPrevalence, MissCostRatio: 1})
+	be := base.BreakEvenCostRatio
+	require.False(t, math.IsNaN(be))
+
+	below := ComputeCostMetrics(tp, fp, tn, fn, CostModel{Prevalence: corpusPrevalence, MissCostRatio: be * 0.9})
+	above := ComputeCostMetrics(tp, fp, tn, fn, CostModel{Prevalence: corpusPrevalence, MissCostRatio: be * 1.1})
+	assert.Greater(t, below.NormalizedExpectedCost, 1.0, "below break-even the detector must lose")
+	assert.Less(t, above.NormalizedExpectedCost, 1.0, "above break-even the detector must win")
+}
+
+// A perfect-specificity detector is worth running at any positive cost ratio,
+// and a zero-sensitivity detector is worth running at none. These are the
+// boundaries where a naive implementation divides by zero.
+func TestComputeCostMetrics_Boundaries(t *testing.T) {
+	noFalseAlarms := ComputeCostMetrics(50, 0, 950, 50, CostModel{Prevalence: 0.1, MissCostRatio: 1})
+	assert.Equal(t, 0.0, noFalseAlarms.BreakEvenCostRatio)
+	assert.Less(t, noFalseAlarms.NormalizedExpectedCost, 1.0)
+
+	blind := ComputeCostMetrics(0, 100, 900, 100, CostModel{Prevalence: 0.1, MissCostRatio: 1})
+	assert.True(t, math.IsNaN(blind.BreakEvenCostRatio), "a detector that finds nothing never pays off")
+
+	// An unusable cost model must not produce a confident-looking number.
+	bad := ComputeCostMetrics(10, 10, 10, 10, CostModel{Prevalence: 0, MissCostRatio: 1})
+	assert.True(t, math.IsNaN(bad.NormalizedExpectedCost))
+	bad = ComputeCostMetrics(10, 10, 10, 10, CostModel{Prevalence: 0.1, MissCostRatio: 0})
+	assert.True(t, math.IsNaN(bad.NormalizedExpectedCost))
+}
+
+// Precision moves with prevalence and sensitivity/specificity do not. This is
+// why a stratified eval sample must never supply the prevalence.
+func TestComputeCostMetrics_PrevalenceInvariance(t *testing.T) {
+	tp, fp, tn, fn := countsFor(0.5, corpusSens, corpusFPR, 100_000) // stratified sample
+	rare := ComputeCostMetrics(tp, fp, tn, fn, CostModel{Prevalence: corpusPrevalence, MissCostRatio: 1})
+	balanced := ComputeCostMetrics(tp, fp, tn, fn, CostModel{Prevalence: 0.5, MissCostRatio: 1})
+
+	assert.InDelta(t, rare.Sensitivity, balanced.Sensitivity, 1e-9)
+	assert.InDelta(t, rare.FalsePosRate, balanced.FalsePosRate, 1e-9)
+	assert.Greater(t, math.Abs(rare.NormalizedExpectedCost-balanced.NormalizedExpectedCost), 0.1,
+		"the same detector must be judged differently at different prevalences")
+}
+
+func TestFormatCostMetrics(t *testing.T) {
+	tp, fp, tn, fn := countsFor(corpusPrevalence, corpusSens, corpusFPR, 1_000_000)
+	m := ComputeCostMetrics(tp, fp, tn, fn, CostModel{Prevalence: corpusPrevalence, MissCostRatio: 1})
+	out := FormatCostMetrics(m, []float64{1, 3, 10})
+
+	assert.Contains(t, out, "break-even")
+	assert.Contains(t, out, "prevalence-invariant")
+	assert.Contains(t, out, "worse than the best trivial system")
+	assert.Contains(t, out, "worth running")
+}


### PR DESCRIPTION
## Why

Precision and recall cannot answer the operator's actual question: **is running this detector better than not running it?**

Blind-labelling all 2,772 scored pairs in our corpus put genuine contradictions at **3.35%**. At that prevalence precision is governed almost entirely by the false-positive rate on the majority class:

| FPR | Precision |
|---|---|
| 5.7% | 23% |
| 1% | 63% |
| 0.1% | 95% |

Meanwhile raising recall from 30% to 80% at a fixed 1% FPR moves precision only 51% → 74%.

Class-averaged scores actively mislead here, and we have the receipt: **gpt-5-mini posted the best sample F1 (0.704) and the worst corpus precision (17.3%)**, because F1 cannot see a fourfold difference in majority-class FPR. Had we optimised F1 we would have shipped the worst judge.

## What

`internal/conflicts/cost.go` adds:

- **Normalized expected cost** — the detector's expected cost divided by the cheaper of the two trivial systems (flag-everything / flag-nothing). Below 1.0 it is worth running; at or above, a fixed answer is cheaper.
- **Break-even cost ratio** — the miss:false-alarm ratio at which it stops losing.
- **Prevalence-invariant characteristics** — sensitivity, specificity, FPR, MCC. These transfer across deployments; precision does not, because it moves with prevalence.

At our measured operating point (3.35% prevalence, 50.5% recall, 2.44% FPR): **NEC 1.198 at equal error costs — worse than never flagging — with break-even at 1.39:1.**

## Design notes

- `--cost-ratio` and `--prevalence` are **opt-in, not defaulted**. The cost ratio is a statement about the operator's world; a default would be a number nobody chose.
- Prevalence is a **separate input from the eval sample**. A stratified sample oversamples positives by design, so letting it supply its own rate flatters every detector. Passing counts from a sample and prevalence from production is the intended usage, and a test pins that invariance.

## Test plan

- `go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues)
- `go test -race -count=1 -tags integration ./internal/conflicts/` — 6 new tests pass, covering: the detector losing at 1:1; break-even agreeing with the decision-curve identity `(1−precision)/precision` (Vickers & Elkin 2006) to within 0.02; the verdict flipping in both directions across break-even; boundaries (zero false alarms, zero sensitivity, degenerate cost models returning NaN rather than a confident-looking number); and prevalence invariance.

> Rivendell's Council works because Elrond makes everyone state the cost before the vote — Boromir wants the Ring used, Gandalf wants it unmade, and the argument only resolves once someone says aloud what losing is worth. A detector without a stated cost ratio is Boromir: confident, well-spoken, and optimising the wrong thing.