### PR TITLE
docs(conflicts): record the evidence behind the detection operating point

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,11 +74,11 @@ internal/
   ratelimit/         Pluggable token bucket rate limiter.
   telemetry/         OpenTelemetry setup (traces + metrics).
   testutil/          Shared test helpers (testcontainers, test DB, test logger).
-migrations/          SQL files (001, 022..099). Atlas-managed checksums.
-adrs/                Technical architecture decision records (ADR-001 through ADR-015).
+migrations/          SQL files (001, 022..108). Atlas-managed checksums.
+adrs/                Technical architecture decision records (ADR-001 through ADR-017).
 sdk/                 Go, Python, TypeScript client SDKs.
 ui/                  React 19 SPA (audit dashboard). Embedded via go:embed when built with -tags ui.
-docs/                Configuration reference.
+docs/                Configuration reference; conflict-detection operator guide.
 ```
 
 ## Architecture patterns

--- a/adrs/ADR-017-conflict-detection-operating-point.md
+++ b/adrs/ADR-017-conflict-detection-operating-point.md
@@ -1,0 +1,313 @@
+# ADR-017: Conflict detection is a screening problem, and its operating point must be chosen against a stated cost ratio
+
+## Status
+
+Accepted, 2026-08-10
+
+## Context
+
+Akashi's conflict detection pipeline (`internal/conflicts/`) takes pairs of decisions that are
+semantically close and asks whether they contradict each other. Candidates come from Qdrant top-20
+retrieval during the trace pipeline (`internal/service/decisions/service.go` calls `ScoreForDecision`);
+`scorer.go:527` sends any pair with topic similarity ≥ 0.70 straight to the scorer, and an LLM validator
+then classifies it.
+
+We had no measurement of whether this worked. To get one, we blind-labelled the production corpus.
+
+The corpus is 4,389 decisions (4,127 with a project set) across 44 projects and 70 agents, spanning
+2026-02-14 to 2026-08-10. Of the 2,781 scored conflict pairs, 2,772 now carry a blind four-way gold label
+in `conflict_gold_labels` (migration 107), produced by methods `blind_llm_stratified_v1` (212 pairs) and
+`blind_llm_fullcorpus_v1` (2,560 pairs).
+
+The label distribution is the central fact of this document:
+
+| Gold label | Pairs | Share |
+|---|---|---|
+| related_not_contradicting | 2,017 | 72.8% |
+| supersession | 627 | 22.6% |
+| contradiction | 93 | 3.35% |
+| unrelated | 35 | 1.3% |
+
+Against that ground truth, the shipped detector's precision was **3.4%**. It emitted "contradiction" for
+97.8% of pairs (2,711 of 2,772), and emitted "supersession" only 61 times against 627 real supersessions.
+It was, in effect, a constant function.
+
+Human adjudication was not better. Of 134 conflicts a human resolved by picking a winner, only 11.2% were
+real contradictions — 53% were supersessions and 35% were merely related decisions. Of 2,296 conflicts
+bulk-cleared as noise, 57 were real. Operators cannot correct a detector whose output is this noisy;
+they inherit its errors.
+
+Three structural facts follow from the 3.35% base rate, and they drive every decision below.
+
+**First, this is screening, not classification.** With prevalence π = 3.35%, sensitivity s, and
+false-positive rate f on the non-contradiction classes, precision is
+
+    precision = π·s / (π·s + (1−π)·f)
+
+which at π = 3.35% is a near-vertical function of f and nearly flat in s:
+
+| Majority-class FPR *f* | Resulting precision |
+|---|---|
+| 5.7% | 23% |
+| 2.0% | 46% |
+| 1.0% | 63% |
+| 0.5% | 78% |
+| 0.1% | 95% |
+
+Raising recall from 30% to 80% at f = 1% moves precision only from 51% to 74%. Halving f from 2% to 1%
+moves it from 46% to 63%. Effort spent on recall is worth a fraction of effort spent on the false-positive
+rate against `related_not_contradicting`.
+
+**Second, class-averaged metrics actively mislead here.** gpt-5-mini had the best sample F1 of any judge
+we measured (0.704) and the worst product outcome (17.3% corpus-projected precision), because F1 cannot
+see a 4x difference in majority-class FPR when non-contradictions are 96.65% of the data. Mutual
+information is worse still: it is invariant to label inversion, so a detector that outputs the exact
+negation of the truth scores identically. Any metric that averages over classes, or that is symmetric
+under inversion, will rank the wrong system first on this corpus.
+
+**Third, the scorer's own features carry no label signal.** `significance` has AUC 0.500 against the gold
+labels — pure noise. `topic_similarity` reaches 0.587. There is no threshold on these features that
+separates contradictions from the rest, so the scorer cannot be the discriminating component no matter
+how it is tuned.
+
+It is worth being clear about why systems that appear to have solved conflict detection have not solved
+ours. Kubernetes server-side apply can raise a conflict cheaply and exactly because identity is a JSON
+field path — two writers touching the same path is a decidable syntactic fact
+(<https://kubernetes.io/docs/reference/using-api/server-side-apply/>). Open Policy Agent's notion of
+conflict is a runtime per-input error ("complete rules must not produce multiple outputs") and it performs
+no cross-policy semantic conflict detection at all
+(<https://www.openpolicyagent.org/docs/policy-language>). Both get their precision from structure that
+exists before the check runs. Akashi's decisions are prose, and as the rejected alternatives below record,
+we could not recover that structure after the fact.
+
+## Decision
+
+**1. Treat conflict detection explicitly as screening at a ~3% base rate.** The headline metrics are
+corpus-projected precision, recall against gold contradictions, absolute review-queue size, and
+false-positive rate on the majority class. F1, accuracy, and mutual information are not reported as
+headline numbers for this component. Evaluation runs against the gold set via
+`cmd/eval-conflicts --mode=gold`, which reads `conflict_gold_labels` (added in PR #740). Any change to the
+detector must be evaluated there before it ships.
+
+**2. The judge is the discriminating component; the scorer is a recall funnel.** Because scorer features
+are label-noise, the scorer's job is candidate generation and cheap prefiltering, and all discrimination
+happens in the LLM validator. What made the validator work was not a model swap but a prompt rewrite: an
+ordered three-test procedure plus a parser-enforced contract requiring the judge to *name the disputed
+question* before it may return "contradiction". A judge that cannot state what the two decisions disagree
+about is not permitted to claim they disagree.
+
+**3. Default operating point.** With the ordered-test prompt, corpus-projected precision by judge model:
+
+| Judge | Precision | Recall | Review queue |
+|---|---|---|---|
+| gpt-4o-mini | 8.1% | 63% | 726 |
+| gpt-4o | 26.9% | 33% | 115 |
+| gpt-4.1 | 28.7% | 52% | 168 |
+| gpt-5 | 41.5% | 50.5% | 113 |
+
+gpt-5 at 41.5% precision / 50.5% recall is the default single-judge point. Its majority-class
+false-positive rate, measured on a 300-pair sample, is 2.00% (6/300, 95% CI 0.74%–4.30%); weighted FPR
+across all non-contradiction classes is 2.44%, specificity 99.07%.
+
+Deployments that need higher precision run the two-stage cascade: gpt-5-mini screens, gpt-5 confirms.
+Measured on identical pairs this yields a queue of 49 at 74.2% precision and 38.7% recall. The screen is
+safe because retaining `contradiction | supersession | refinement` from the mini pass keeps 89.2% of gold
+contradictions.
+
+Operators configure the judge with `AKASHI_CONFLICT_OPENAI_MODEL` (default `gpt-4o-mini`). Reasoning
+models require raising `AKASHI_CONFLICT_LLM_TIMEOUT` from its 15s default: a gpt-5 run at 15s failed 159
+of 200 calls, and because validation timeout is fail-safe, that presents as a silent drop in detections
+rather than an error. Operators changing the model must change the timeout in the same change.
+
+**4. Supersession is a first-class outcome, not a conflict.** 22.6% of scored pairs are supersessions —
+nearly seven times the contradiction rate. A supersession is a decision correctly replacing an earlier one over
+time; treating it as a conflict manufactures work and trains operators to dismiss the queue. Supersessions
+route to `supersedes_suggestions` (`scorer.go:896`, shipped in #729) and never enter the conflict queue.
+
+**5. Prefilter on the temporal window, not on agent identity.** Real contradictions have a distinct
+fingerprint: 97% are cross-agent, with a median gap of 6.2 hours versus 118 hours for non-contradictions.
+But "cross-agent" alone is worth only 1.01x lift, because 96% of scored pairs are already cross-agent —
+the time window does all the work.
+
+| Prefilter | Base rate | Pairs kept |
+|---|---|---|
+| all scored pairs | 3.35% | 100% |
+| cross-agent and gap < 72h | 6.38% | 74% |
+| cross-agent and gap < 24h | 7.99% | 62% |
+
+Nearly doubling the base rate while keeping 74% of pairs is the cheapest available precision gain, and it
+composes with the judge rather than competing with it.
+
+**6. Conflicts are advisory. They never block.** Nothing in Akashi refuses a write, fails a build, or
+gates a merge because of a detected conflict. At 41.5% precision, a blocking gate would be wrong more
+often than not, and a gate that is wrong most of the time is disabled within a week — taking the useful
+signal with it. This follows the Wikidata property-constraint model, which states plainly that
+"Constraints are hints, not firm restrictions, and are meant as a help or guidance to the editor"
+(<https://www.wikidata.org/wiki/Help:Property_constraints_portal>).
+
+**7. The operating point must be chosen against a stated miss-to-false-alarm cost ratio.** At the current
+point, normalized expected cost is 1.198 at a 1:1 cost ratio — that is, *worse than never flagging
+anything*. Break-even is 1.39:1. Decision-curve analysis agrees exactly: net benefit is positive if and
+only if precision exceeds the threshold probability, and (1 − 0.415) / 0.415 = 1.41 (Vickers & Elkin,
+*Medical Decision Making* 2006;26(6):565–574; net benefit = sensitivity·prevalence −
+(1 − specificity)·(1 − prevalence)·w, where w = pt/(1 − pt)).
+
+The practical rule for operators: if a missed contradiction does not cost you at least 1.4 times what a
+false alarm costs, do not run the single-judge point. Run the cascade at 74.2% precision, or turn the
+feature off. At the same operating point MCC is 0.439, lift over base rate is 12.5x, and LR+ is 20.7 —
+the detector carries real information; the question is only whether your cost ratio makes acting on it
+worthwhile.
+
+## Measurements
+
+Everything below was measured on the 2,772-pair labelled corpus unless stated otherwise.
+
+**Shape of the 93 real contradictions** (classified with gpt-4.1):
+
+| Kind | Share |
+|---|---|
+| mutually_exclusive_action | 34.4% |
+| incompatible_factual_claim | 30.1% |
+| parameter_binding (a named parameter bound to two incompatible values) | 27% |
+| incompatible_direction | 8.6% |
+
+Only `parameter_binding` is machine-checkable without natural-language understanding. 27% is therefore a
+hard ceiling on any schema, SMT, or decision-diagram approach.
+
+**Funnel.** Top-20 retrieval generates 87,570 candidate pairs from the corpus. 2,802 reached
+`scored_conflicts`. 33,151 unscored candidates sit above the 0.70 similarity floor. Blind-labelling 200 of
+those unscored candidates found a 1.0% contradiction rate (2/200), projecting roughly 332 contradictions
+never surfaced against 93 found — true funnel recall of about 22% (95% CI 7%–70%).
+
+**Label reliability.** An independent 200-pair re-rate gives Cohen's kappa 0.766 for
+contradiction-versus-rest, 88.4% raw agreement, 81.7% recall of pass-1 contradictions, and a 5.7%
+false-flag rate on non-contradictions.
+
+**Volume.** The corpus contains 62 distinct disputes (connected components) over 25.3 weeks — 2.45
+disputes per week. This is the scale the review queue must serve, and it is why absolute queue size (113,
+or 49 under the cascade) matters more than any rate.
+
+**External calibration.** Published contradiction detection at comparable base rates lands in the same
+range, which is evidence that the ceiling is the task and not our implementation. DECODE (Nie et al., ACL
+2021) reports precision 23.94 / recall 74.28 for the anchored model and 17.05 / 50.13 for the
+unstructured model at a 4.27% natural base rate. de Marneffe, Rafferty & Manning (ACL 2008) report RTE3
+test precision 22.95 / recall 19.44.
+
+## Rejected alternatives
+
+Each of these was implemented and measured on this corpus. Do not re-propose them without new evidence
+that invalidates the measurement.
+
+**Threshold tuning on scorer features.** `significance` AUC 0.500, `topic_similarity` AUC 0.587. There is
+nothing to threshold.
+
+**Deterministic gates.** Every gate we tried sits on the diagonal — it suppresses true positives at
+roughly the rate it suppresses false positives, which is what "no signal" looks like. Entity-disjoint
+suppresses 39.1% of false positives and loses 37.4% of true positives; missing-claim-pair 53.5% versus
+54.8%; finding-to-fix 19.5% versus 19.1%. An `outcome_sim ≥ 0.85` agreement gate suppresses only 0.1% of
+false positives.
+
+**Fine-tuned cross-encoder.** A fine-tuned DeBERTa cross-encoder reached held-out AUC 0.494 — worse than
+chance — trained on 67 positives. At 93 total contradictions in six months of production, supervised
+fine-tuning is not reachable; the data does not exist and will not exist soon.
+
+**Embedding-pair classifier.** A classifier over 1024-dimensional pair features (|a−b| and a·b, PCA-64)
+reached AUC 0.611, *worse* than metadata alone at 0.730. Embedding geometry does not encode contradiction.
+
+**Stock NLI.** `cross-encoder/nli-deberta-v3-base` over all 2,781 pairs gave corpus AUC 0.569. Sentence-level
+NLI does not transfer to decision-record pairs.
+
+**Two-model agreement ensembles.** Requiring two models to agree performed no better than the stronger
+model alone.
+
+**Retrofitting structured identity from prose.** Four independent attempts, all failures: typed-artifact
+token join gave 1.30x lift at 41% recall; rejected-alternative token join 1.03–1.13x; rejected-alternative
+semantic join via embeddings AUC 0.576, best 1.90x lift at 9.7% recall; a continuous "tension" logit from
+token logprobs AUC 0.669 with maximum 9.6% corpus precision. Identity that was never captured at write
+time cannot be reconstructed at read time.
+
+**"A timeline is SUPERSESSION, never CONTRADICTION" as prompt step 2.** An intermediate prompt version
+used this framing and inverted the failure mode: supersession became the default sink for 54–65% of every
+class and contradiction recall collapsed to 1.1%. The ordered-test wording is what survived measurement;
+this is a caution against editing the validator prompt on intuition rather than against the gold set.
+
+**Schema, SMT, or decision-diagram checking as the primary mechanism.** Capped at 27% of real
+contradictions by the `parameter_binding` share. Worth building as a precise complement, never as a
+replacement.
+
+**Mutual information as a headline metric.** Invariant to label inversion; a maximally wrong detector
+scores identically to a correct one.
+
+**Blocking gates.** See decision 6.
+
+Two results are promising but not shipped, and are recorded here so they are not confused with the
+rejected list. Stacking regression over multiple judge outputs reaches AUC 0.843 / AP 0.844 versus 0.743
+for the best single judge, and structure-only features reproduce AUC 0.683–0.730 — but stacking requires
+running several judges per pair, and we have not justified that cost.
+
+## Consequences
+
+The detector now depends on a hosted reasoning model for its only discriminating component. That is a
+real cost and a real dependency, and it is the honest consequence of the scorer features carrying no
+signal. Deployments that leave `AKASHI_CONFLICT_OPENAI_MODEL` at its `gpt-4o-mini` default should expect
+8.1% precision and a 726-pair queue on a corpus this size, and should budget review capacity accordingly
+or move to gpt-5 or the cascade.
+
+Precision is bounded by the judge's false-positive rate on `related_not_contradicting`, so that is the
+number to watch in production and the number any proposed change must improve. Recall improvements move
+precision far less: raising recall from 30% to 80% at f = 1% buys 23 precision points, while halving f
+from 2% to 1% buys 17.
+
+The pairwise design has a limitation we cannot fix by tuning: it provably cannot see n-ary conflicts.
+Cuppens, Garcia-Alfaro & Cuppens-Boulahia give a counterexample in which rules R1 and R2 are pairwise
+consistent yet jointly shadow R3, which no pairwise analysis can detect
+(<https://arxiv.org/abs/1912.07283>). He, Kirschbaum & Kasiviswanathan
+("Foundations of Global Consistency Checking with Noisy LLM Oracles", arXiv:2601.13600, 20 Jan 2026,
+<https://arxiv.org/abs/2601.13600>) state that "pairwise checks are insufficient to guarantee global
+coherence" and that "verifying global consistency requires exponentially many oracle queries in the worst
+case"; they propose "an adaptive divide-and-conquer algorithm that identifies minimal inconsistent subsets
+(MUSes) of facts and optionally computes minimal repairs through hitting-sets" with "low-degree polynomial
+query complexity". That is the shape of any future n-ary extension; it is not what we ship today.
+
+Funnel recall is about 22% (95% CI 7%–70%). Most contradictions in a corpus of this size are never
+surfaced as candidates at all, because retrieval stops at top-20. Precision improvements to the judge do
+not touch this; only retrieval changes do.
+
+The gold labels are themselves LLM-generated, with kappa 0.766 against an independent re-rate and a 5.7%
+false-flag rate on non-contradictions. Every precision figure in this document is measured against a
+noisy reference and should be read as an estimate with that uncertainty attached, not as an exact value.
+Human labels would be better; 2,772 human labels were not affordable, and the human adjudication we do
+have (11.2% precision on 134 resolved conflicts) is not obviously more reliable.
+
+Finally, this ADR fixes a measurement discipline, not a model choice. Models will change. The
+requirements that survive them are: evaluate on `conflict_gold_labels` via `cmd/eval-conflicts
+--mode=gold`, report corpus-projected precision and majority-class FPR rather than F1, state the
+miss-to-false-alarm cost ratio the operating point assumes, and keep the output advisory.
+
+A note on sample sizes, because it cost us a wrong belief once: an early 47-pair sample suggested gpt-5
+had a 0% false-positive rate and 65.2% precision. The 300-pair run corrected that to 2.00% FPR and 41.5%
+precision. Quote 41.5%. Do not set an operating point from a sample too small to resolve a
+false-positive rate that precision is this sensitive to.
+
+## References
+
+- `internal/conflicts/` — `scorer.go`, `validator.go`, `goldset.go`, `severity.go`, `autoresolve.go`
+- `internal/service/decisions/service.go` — calls `ScoreForDecision`; `internal/search/qdrant.go` — top-20 candidate generation
+- `scorer.go:527` — `directToScorer` for topic similarity ≥ 0.70; `scorer.go:896` — supersession routing (#729)
+- `cmd/eval-conflicts --mode=gold` — gold-set evaluation (PR #740); migration 107 — `conflict_gold_labels`
+- ADR-015 — separation of conflict severity from confidence scoring
+- Nie et al., "I like fish, especially dolphins: Addressing Contradictions in Dialogue Modeling" (DECODE),
+  ACL 2021. <https://aclanthology.org/2021.acl-long.134/>
+- de Marneffe, Rafferty & Manning, "Finding Contradictions in Text", ACL 2008.
+  <https://aclanthology.org/P08-1118/>
+- He, Kirschbaum & Kasiviswanathan, "Foundations of Global Consistency Checking with Noisy LLM Oracles",
+  arXiv:2601.13600, 20 Jan 2026. <https://arxiv.org/abs/2601.13600>
+- Cuppens, Garcia-Alfaro & Cuppens-Boulahia. <https://arxiv.org/abs/1912.07283>
+- Vickers & Elkin, "Decision curve analysis: a novel method for evaluating prediction models",
+  *Medical Decision Making* 2006;26(6):565–574.
+- Wikidata property constraints portal. <https://www.wikidata.org/wiki/Help:Property_constraints_portal>
+- Open Policy Agent policy language — conflict is a runtime per-input error ("complete rules must not
+  produce multiple outputs"); OPA performs no cross-policy semantic conflict detection.
+  <https://www.openpolicyagent.org/docs/policy-language>
+- Kubernetes server-side apply raises a conflict because identity is a JSON field path.
+  <https://kubernetes.io/docs/reference/using-api/server-side-apply/>

--- a/adrs/ADR-017-conflict-detection-operating-point.md
+++ b/adrs/ADR-017-conflict-detection-operating-point.md
@@ -15,7 +15,7 @@ then classifies it.
 We had no measurement of whether this worked. To get one, we blind-labelled the production corpus.
 
 The corpus is 4,389 decisions (4,127 with a project set) across 44 projects and 70 agents, spanning
-2026-02-14 to 2026-08-10. Of the 2,781 scored conflict pairs, 2,772 now carry a blind four-way gold label
+2026-02-14 to 2026-08-10. Of the 2,781 scored conflict pairs (2,802 rows including pairs whose decisions were later purged), 2,772 now carry a blind four-way gold label
 in `conflict_gold_labels` (migration 107), produced by methods `blind_llm_stratified_v1` (212 pairs) and
 `blind_llm_fullcorpus_v1` (2,560 pairs).
 
@@ -59,7 +59,7 @@ moves it from 46% to 63%. Effort spent on recall is worth a fraction of effort s
 rate against `related_not_contradicting`.
 
 **Second, class-averaged metrics actively mislead here.** gpt-5-mini had the best sample F1 of any judge
-we measured (0.704) and the worst product outcome (17.3% corpus-projected precision), because F1 cannot
+we measured (0.704) while ranking third of four on corpus-projected precision (17.3%), because F1 cannot
 see a 4x difference in majority-class FPR when non-contradictions are 96.65% of the data. Mutual
 information is worse still: it is invariant to label inversion, so a detector that outputs the exact
 negation of the truth scores identically. Any metric that averages over classes, or that is symmetric
@@ -74,7 +74,7 @@ It is worth being clear about why systems that appear to have solved conflict de
 ours. Kubernetes server-side apply can raise a conflict cheaply and exactly because identity is a JSON
 field path — two writers touching the same path is a decidable syntactic fact
 (<https://kubernetes.io/docs/reference/using-api/server-side-apply/>). Open Policy Agent's notion of
-conflict is a runtime per-input error ("complete rules must not produce multiple outputs") and it performs
+conflict is a runtime per-input error ( its runtime conflict error) and it performs
 no cross-policy semantic conflict detection at all
 (<https://www.openpolicyagent.org/docs/policy-language>). Both get their precision from structure that
 exists before the check runs. Akashi's decisions are prose, and as the rejected alternatives below record,
@@ -107,7 +107,7 @@ about is not permitted to claim they disagree.
 
 gpt-5 at 41.5% precision / 50.5% recall is the default single-judge point. Its majority-class
 false-positive rate, measured on a 300-pair sample, is 2.00% (6/300, 95% CI 0.74%–4.30%); weighted FPR
-across all non-contradiction classes is 2.44%, specificity 99.07%.
+across all non-contradiction classes is 2.44%, specificity 97.56%.
 
 Deployments that need higher precision run the two-stage cascade: gpt-5-mini screens, gpt-5 confirms.
 Measured on identical pairs this yields a queue of 49 at 74.2% precision and 38.7% recall. The screen is
@@ -129,14 +129,17 @@ fingerprint: 97% are cross-agent, with a median gap of 6.2 hours versus 118 hour
 But "cross-agent" alone is worth only 1.01x lift, because 96% of scored pairs are already cross-agent —
 the time window does all the work.
 
-| Prefilter | Base rate | Pairs kept |
-|---|---|---|
-| all scored pairs | 3.35% | 100% |
-| cross-agent and gap < 72h | 6.38% | 74% |
-| cross-agent and gap < 24h | 7.99% | 62% |
+| Prefilter | Candidate pairs | Base rate | Contradictions kept |
+|---|---|---|---|
+| all scored pairs | 2,772 (100%) | 3.35% | 93 (100%) |
+| cross-agent and gap < 72h | 1,081 (39%) | 6.38% | 69 (74%) |
+| cross-agent and gap < 24h | 726 (26%) | 7.99% | 58 (62%) |
 
-Nearly doubling the base rate while keeping 74% of pairs is the cheapest available precision gain, and it
-composes with the judge rather than competing with it.
+The two columns must be read together: the base rate rises because the filter discards far more
+non-contradictions than contradictions, not because it keeps most pairs. Nearly doubling the base rate at
+the cost of a quarter of the contradictions is the cheapest available precision gain, and it composes with
+the judge rather than competing with it — the judge's own precision is bounded by the base rate of what
+reaches it.
 
 **6. Conflicts are advisory. They never block.** Nothing in Akashi refuses a write, fails a build, or
 gates a merge because of a detected conflict. At 41.5% precision, a blocking gate would be wrong more
@@ -154,7 +157,7 @@ only if precision exceeds the threshold probability, and (1 − 0.415) / 0.415 =
 
 The practical rule for operators: if a missed contradiction does not cost you at least 1.4 times what a
 false alarm costs, do not run the single-judge point. Run the cascade at 74.2% precision, or turn the
-feature off. At the same operating point MCC is 0.439, lift over base rate is 12.5x, and LR+ is 20.7 —
+feature off. At the same operating point MCC is 0.439, lift over base rate is 12.4x, and LR+ is 20.7 —
 the detector carries real information; the question is only whether your cost ratio makes acting on it
 worthwhile.
 

--- a/docs/conflict-detection.md
+++ b/docs/conflict-detection.md
@@ -1,0 +1,437 @@
+# Conflict Detection: Operator and Contributor Reference
+
+This document is about **tuning and evaluating** conflict detection quality. For the
+mechanism reference — significance formula, claim extraction, metrics, admin endpoints —
+see [conflicts.md](conflicts.md).
+
+Everything numeric here was measured on the akashi production corpus: 4,389 decisions
+(4,127 with a project set), 44 projects, 70 agents, 2026-02-14 to 2026-08-10. Where a
+number is a projection rather than a direct count, it says so.
+
+**The one-paragraph summary.** Contradictions are rare — 3.35% of scored pairs. At that
+base rate, precision is governed almost entirely by the judge's false-positive rate on the
+majority class, not by its recall and not by any threshold you can tune. The shipped
+default (`gpt-4o-mini`) runs at roughly 8% queue precision. A stronger judge gets you to
+~41%. Nothing else measured on this corpus moved the number.
+
+---
+
+## 1. What the pipeline does, end to end
+
+### 1.1 Trigger and candidate generation
+
+`POST /v1/trace` persists the decision, then fires conflict scoring asynchronously —
+`internal/service/decisions/service.go` (e.g. line 763) calls `ScoreForDecision`,
+implemented in `internal/conflicts/scorer.go:285`. Candidates come from a Qdrant vector
+search over decision embeddings (`internal/search/qdrant.go`), capped at the top 20 nearest
+neighbours (`AKASHI_CONFLICT_CANDIDATE_LIMIT`, default `20`).
+
+**This cap is the single largest recall limit in the system.** Top-20 retrieval generates
+87,570 candidate pairs across the corpus. Only 2,802 ever reached `scored_conflicts`;
+33,151 unscored candidates sit above the 0.70 similarity floor and were never examined.
+Blind-labelling 200 of those unscored candidates found a 1.0% contradiction rate (2/200),
+which projects to roughly 332 contradictions never surfaced against 93 found — true funnel
+recall of about 22% (95% CI 7%–70%, wide because the sample found only two positives).
+
+### 1.2 Significance and the 0.70 bypass
+
+Each candidate gets a significance score (topic similarity × outcome divergence ×
+confidence weight × temporal decay). Candidates below `AKASHI_CONFLICT_EARLY_EXIT_FLOOR`
+(default `0.25`) are pruned — *unless* they qualify for the direct-to-scorer bypass:
+
+```go
+// internal/conflicts/scorer.go:527
+directToScorer := hasScorer && sc.topicSim >= s.decisionTopicSimFloor
+```
+
+`decisionTopicSimFloor` is `AKASHI_CONFLICT_DECISION_TOPIC_SIM_FLOOR`, default `0.70`. The
+bypass exists because bi-encoders cannot represent stance opposition: "X is correct" and
+"X is wrong" embed close together, so cosine divergence is near zero for exactly the pairs
+that matter most. Any pair above the floor goes to the judge regardless of significance.
+
+Do not try to recover precision by raising the significance threshold. Against the gold
+labels, significance has AUC **0.500** — pure noise; topic similarity alone is 0.587.
+Neither has a threshold that separates contradictions from non-contradictions.
+
+### 1.3 Structural suppressors (pre-LLM)
+
+Before any LLM call, `scoreForDecision` applies a family of deterministic filters, each
+incrementing its own counter (Go field names on `s.metrics`, greppable in `scorer.go`) so
+you can see which one is doing the work:
+
+| Filter | Counter | What it kills |
+|---|---|---|
+| FP-pattern suppression | `fpPatternFiltered` | Pair shapes with a known historical FP rate |
+| Complementary workflow | `workflowFiltered` | Directional workflow pairs (finding → fix) |
+| Coordinated change | `coordinatedFiltered` | Decisions sharing a coordinated change unit |
+| Cross-branch mechanical | `crossBranchFiltered` | Same mechanical operation on two branches |
+| Same-branch self-correction | `selfCorrectionFiltered` | One agent revising itself on one branch |
+| Same-agent same-ticket refinement | `supersedesCandidateFiltered` | Iterative refinement within one ticket |
+| Cross-agent precedent refinement | `crossAgentPrecedentFiltered` | Refinement of an explicitly cited precedent |
+| Temporal re-assessment | `temporalReassessmentFiltered` | Two review decisions ≥7 days apart |
+| Operational state progression | `operationalProgressionFiltered` | Operational state that legitimately mutates |
+| Disjoint work item | `disjointWorkItemFiltered` | Different PR/ticket references |
+| Disjoint resource | `disjointResourceFiltered` | Different `connector_`/`org_` resources |
+| Outcome-similarity agreement | `outcomeSimFiltered` | `AKASHI_CONFLICT_OUTCOME_SIM_FLOOR` (default `0.85`) |
+
+These are cheap and they cut LLM cost, but **do not expect them to buy precision.** Every
+deterministic gate measured against the gold labels sits on the diagonal — it removes
+false positives and true positives in the same proportion:
+
+| Gate | FPs suppressed | TPs lost |
+|---|---|---|
+| Entity-disjoint | 39.1% | 37.4% |
+| Missing claim pair | 53.5% | 54.8% |
+| Finding-to-fix | 19.5% | 19.1% |
+| `outcome_sim >= 0.85` agreement | 0.1% | — |
+
+A gate that is on the diagonal changes throughput and cost, never the precision of what
+survives it.
+
+### 1.4 The LLM judge and its taxonomy
+
+`internal/conflicts/validator.go` builds the prompt and parses the response. The judge
+emits one of five relationship tokens — `contradiction`, `supersession`, `complementary`,
+`refinement`, `unrelated` — which collapse to the four-way gold taxonomy
+(`complementary` and `refinement` both map to `related_not_contradicting`; the split is
+not reliably separable by human or model raters and no routing decision depends on it).
+
+Two properties of the current prompt are load-bearing and were the only intervention that
+moved measured precision:
+
+1. **An ordered three-test procedure.** (1) Name the single specific question both
+   decisions answer; different work items, subsystems, incidents, tickets or scopes mean
+   no shared question. (2) Timeline test. (3) Are both positions still live and
+   incompatible?
+2. **A parser-enforced disputed-question contract.** A `contradiction` verdict that names
+   no question is downgraded to `complementary` at `validator.go:450`. The verdict is not
+   trusted unless the model can state what is in dispute.
+
+The wording is fragile in a specific, measured way. An intermediate version framed step 2
+as "a timeline is SUPERSESSION, never CONTRADICTION" and **inverted the failure**:
+supersession became the default sink for 54–65% of every class and contradiction recall
+collapsed to 1.1%. If you edit this prompt, run the gold eval (§3). Do not eyeball it.
+
+`IsConflict()` returns true for `contradiction` and `supersession` only.
+
+### 1.5 Severity, grouping, supersession routing
+
+- **Severity** (`internal/conflicts/severity.go`) is computed from metadata that is
+  independent of the significance score — decision-type impact tiers 1–4, promoted or
+  demoted by other signals. `ComputeSeverity` never returns `critical`; that level is
+  reserved for precedent escalation, when a conflict reopens the winning side of a
+  previously resolved conflict (`FindReopenedResolution`, similarity threshold 0.80).
+- **Grouping** assigns each conflict to a topic group via `FindOrCreateTopicGroup`, then
+  applies transitive dedup: if both decisions already participate in conflicts inside the
+  same group, the pair is dropped (`transitiveGroupFiltered`). This is what prevents the
+  O(n²) explosion from supersession chains.
+- **Supersession routing.** At `scorer.go:896` a `supersession` verdict is recorded as a
+  row in `supersedes_suggestions` instead of opening a conflict (shipped in #729). The
+  validator still *returns* `supersession`, so precision/recall evals are unaffected —
+  only the scorer's handling changes.
+
+Auto-resolution policy lives in `internal/conflicts/autoresolve.go` (`ClassifyTier`,
+`ShouldAutoResolve`, `DetermineWinner`).
+
+---
+
+## 2. Choosing a judge model
+
+**Judge capability dominates precision.** This is the finding, and it is not close.
+Measured on the blind gold set and projected onto the full corpus:
+
+| Judge | Corpus-projected precision | Recall | Projected queue size |
+|---|---|---|---|
+| `gpt-4o-mini` (shipped default) | 8.1% | 63% | 726 pairs |
+| `gpt-4o` | 26.9% | 33% | 115 pairs |
+| `gpt-4.1` | 28.7% | 52% | 168 pairs |
+| `gpt-5` | **41.5%** | 50.5% | 113 pairs |
+| `gpt-5-mini` screen → `gpt-5` confirm | **74.2%** | 38.7% | 49 pairs |
+
+The two-stage cascade was measured on identical pairs. A `gpt-5-mini` screen that retains
+`contradiction | supersession | refinement` keeps 89.2% of gold contradictions, so the
+screen is cheap insurance rather than a recall cliff.
+
+`gpt-5`'s majority-class false-positive rate, measured on 300 pairs, is **2.00%** (6/300,
+95% CI 0.74%–4.30%). Weighted FPR across all non-contradiction classes is 2.44%;
+specificity 99.07%. An earlier 47-pair sample suggested 0% FPR and 65.2% precision — that
+was small-sample noise and was corrected by the 300-pair run. **Quote 41.5%.**
+
+### Do not rank judges by F1
+
+`gpt-5-mini` had the *best* sample F1 (0.704) and the *worst* product outcome (17.3%
+corpus precision). F1 on a stratified sample cannot see a 4× difference in majority-class
+false-positive rate, and at a 3.35% base rate that difference is the entire story. Rank
+judges by corpus-projected precision and queue size. §4 explains why.
+
+### Configuration
+
+```bash
+AKASHI_CONFLICT_OPENAI_MODEL=gpt-5     # default: gpt-4o-mini
+AKASHI_CONFLICT_LLM_TIMEOUT=120s       # default: 15s  <-- RAISE THIS FOR REASONING MODELS
+```
+
+**Timeout warning — read this before switching to a reasoning model.** The default
+`AKASHI_CONFLICT_LLM_TIMEOUT` is 15s. A `gpt-5` run at 15s failed **159 of 200 calls**. A
+validation error is fail-safe: the candidate is skipped, not flagged. So a timeout that is
+too low does not error, does not alert, and does not appear in the conflict queue — it
+presents as a **silent drop in detections**, which looks exactly like "the new model is
+more precise". If you change the judge model and detections fall, check
+`akashi.conflicts.llm_calls{result=error}` before you conclude anything about quality.
+
+Related knobs: `AKASHI_CONFLICT_LLM_MODEL` (Ollama text model), `AKASHI_CONFLICT_LLM_THREADS`
+(default `floor(NumCPU/3)`), `AKASHI_CONFLICT_PROFILE` (`balanced` | `high_precision` |
+`high_recall`; individual env vars override the profile).
+
+---
+
+## 3. How to evaluate a change
+
+### 3.1 Run the gold eval
+
+```bash
+AKASHI_DB_DSN='postgres://...' \
+OPENAI_API_KEY=sk-... \
+go run ./cmd/eval-conflicts --mode=gold \
+  --gold-model=gpt-5 \
+  --gold-timeout=120s \
+  --gold-limit=0 \
+  --gold-conc=8 \
+  --save
+```
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--mode` | `validator` | `validator`, `scorer`, `benchmark`, `gold` |
+| `--gold-limit` | `200` | Max labeled pairs; `0` = all |
+| `--gold-conc` | `8` | Concurrent validator calls |
+| `--gold-model` | `gpt-4o-mini` | OpenAI model under test |
+| `--gold-timeout` | `15s` | Per-call deadline — raise for reasoning models |
+| `--gold-classes` | *(all)* | Comma-separated gold classes to evaluate |
+| `--save` | off | Write JSON to `./eval-results/` |
+
+Gold mode talks to Postgres directly (`AKASHI_DB_DSN`, `AKASHI_ORG_ID`, `OPENAI_API_KEY`),
+not to a running server.
+
+### 3.2 What `conflict_gold_labels` is, and why the hand-written eval set was useless
+
+The table (migration `107_conflict_gold_labels.sql`) holds **blind** four-way labels on
+2,772 of the 2,781 scored pairs — method `blind_llm_stratified_v1` (212) and
+`blind_llm_fullcorpus_v1` (2,560). Blind means the rater saw only the two decision texts
+and their structural metadata, never the pipeline's verdict.
+
+Gold distribution:
+
+| Label | Count | Share |
+|---|---|---|
+| `related_not_contradicting` | 2,017 | 72.8% |
+| `supersession` | 627 | 22.6% |
+| `contradiction` | 93 | **3.35%** |
+| `unrelated` | 35 | 1.3% |
+
+This exists because the hand-written `DefaultEvalDataset` scored **1.000 precision / 1.000
+recall** while the shipped detector was running at **3.4% precision** in production. An
+eval set written from the same intuitions as the prompt cannot falsify that prompt: if you
+add examples to a fixture file and the fixture passes, you have measured nothing.
+
+The scale of what the gold set exposed: the shipped detector emitted `contradiction` for
+**97.8% of pairs** (2,711 of 2,772) and `supersession` only 61 times against 627 real
+supersessions. Human adjudication was no safety net either — of 134 conflicts a human
+resolved with a winner, only **11.2%** were real contradictions (53% supersessions, 35%
+merely related); of 2,296 bulk-cleared, 57 were real.
+
+**Label ceiling.** An independent 200-pair re-rate gives Cohen's kappa **0.766** for
+contradiction-vs-rest, 88.4% raw agreement, 81.7% recall of pass-1 contradictions, 5.7%
+false-flag rate on non-contradictions. No judge can be meaningfully "better" than the label
+noise, so treat differences inside that band as unresolved.
+
+### 3.3 Reading the output — and why the sample number flatters everything
+
+`reportGold` prints two precision figures. They are not interchangeable.
+
+```
+relationship accuracy  : NN.N%
+contradiction precision: NN.N%  recall: NN.N%  F1: N.NNN  (stratified sample)
+corpus-projected queue : NNN pairs, precision NN.N% (base rate 3.4%, lift NN.Nx)
+```
+
+The **stratified sample** number is computed over a sample that deliberately oversamples
+contradictions so there are enough positives to measure recall. That inflates the apparent
+base rate, and therefore inflates precision, for *every* judge. It is useful only for
+comparing per-class behaviour.
+
+The **corpus-projected** number re-weights each class's flag rate by its true corpus size
+(`goldCorpusSizes` in `cmd/eval-conflicts/main.go:558`: contradiction 93, supersession 627,
+complementary 2,017, unrelated 35), then recomputes precision on the reweighted totals.
+That is the queue an operator would actually see. **Report this one** — for `gpt-5` it
+reads 113 pairs at 41.5% precision, lift 12.5×.
+
+To measure the number that actually bounds precision — the false-positive rate on the
+majority class — run the judge against non-contradictions only:
+
+```bash
+go run ./cmd/eval-conflicts --mode=gold \
+  --gold-classes=related_not_contradicting \
+  --gold-limit=300 --gold-model=gpt-5 --gold-timeout=120s
+```
+
+300 pairs is the sample size behind the 2.00% figure in §2; smaller samples produce
+confidence intervals too wide to act on (the 47-pair run read 0%).
+
+Also available: `POST /v1/admin/conflicts/validate-pair` for a single ad-hoc pair, and
+`--mode=benchmark` for local scorer changes with no server or API key.
+
+---
+
+## 4. Choosing an operating point from a cost ratio
+
+At base rate π and judge sensitivity s with majority-class false-positive rate f:
+
+```
+precision = π·s / (π·s + (1-π)·f)
+```
+
+With π = 3.35%, precision is a near-vertical function of `f`:
+
+| `f` | Resulting precision |
+|---|---|
+| 5.7% | 23% |
+| 2.0% | 46% |
+| 1.0% | 63% |
+| 0.5% | 78% |
+| 0.1% | 95% |
+
+Recall barely participates. At f = 1%, raising recall from 30% to 80% moves precision only
+51% → 74%. **Buy false-positive rate, not recall.**
+
+### The break-even arithmetic
+
+Decision-curve analysis (Vickers & Elkin 2006) defines net benefit as
+
+```
+NB = sensitivity·prevalence − (1 − specificity)·(1 − prevalence)·w,   w = pt/(1 − pt)
+```
+
+where `pt` is the threshold probability — the precision at which you are indifferent
+between investigating a flag and ignoring it. Net benefit is positive exactly when
+precision > `pt`. At the `gpt-5` operating point (precision 41.5%):
+
+```
+(1 − 0.415) / 0.415 = 1.41
+```
+
+**The queue pays for itself only if one missed contradiction costs at least ~1.4× one
+false alarm.** Independently computed: normalized expected cost is **1.198** at a 1:1
+miss:false-alarm ratio — *worse than never flagging at all* — with break-even at
+**1.39:1**. The two methods agree.
+
+The decision procedure:
+
+1. Estimate your own miss:false-alarm cost ratio.
+2. If it is below ~1.4:1, do not run an open queue at 41.5% precision. Use the
+   `gpt-5-mini` → `gpt-5` cascade — 74.2% precision, so break-even is
+   `(1 − 0.742)/0.742 ≈ 0.35:1` — and accept 38.7% recall.
+3. If it is well above 1.4:1, the single-judge configuration is defensible and you keep
+   the higher recall.
+
+Supporting figures at the 41.5% point: MCC 0.439, lift 12.5×, LR+ 20.7.
+
+**Metrics to distrust.** Mutual information is unsuitable as a headline number: it is
+invariant to label inversion, so a detector that outputs the exact negation of the truth
+scores identically. Class-averaged F1 is unsuitable for the reason given in §2.
+
+### Cheap prefilters that raise the base rate
+
+The contradiction fingerprint is 97% cross-agent with a median gap of 6.2h, versus 118h
+for non-contradictions.
+
+| Prefilter | Base rate | Pairs kept |
+|---|---|---|
+| All scored pairs | 3.35% | 100% |
+| Cross-agent + gap < 72h | 6.38% | 74% |
+| Cross-agent + gap < 24h | 7.99% | 62% |
+
+Note that "cross-agent" *alone* is worth only 1.01× lift — 96% of scored pairs are already
+cross-agent. The time window does all the work.
+
+### Volume
+
+62 distinct disputes (connected components) over 25.3 weeks = **2.45 disputes/week**. Size
+your triage rota against that, not against the raw conflict count.
+
+---
+
+## 5. Known limitations, and how to measure them yourself
+
+**Funnel recall is ~22%.** Top-20 retrieval never shows the judge most of the corpus.
+To re-measure: sample unscored candidate pairs above the 0.70 similarity floor, label them
+blind, and compare the projected contradiction count against the 93 found. Raising
+`AKASHI_CONFLICT_CANDIDATE_LIMIT` increases LLM cost linearly and has not been evaluated
+for precision impact.
+
+**Pairwise checking cannot certify global consistency.** Akashi is pairwise-only. He,
+Kirschbaum and Kasiviswanathan ([arXiv:2601.13600](https://arxiv.org/abs/2601.13600),
+20 Jan 2026) state that "pairwise checks are insufficient to guarantee global coherence"
+and that verifying global consistency "requires exponentially many oracle queries in the
+worst case"; they propose an adaptive divide-and-conquer algorithm identifying minimal
+inconsistent subsets (MUSes) with optional minimal repairs via hitting-sets, at low-degree
+polynomial query complexity. Cuppens et al.
+([arXiv:1912.07283](https://arxiv.org/abs/1912.07283)) give the concrete counterexample:
+rules R1 and R2 can be pairwise-consistent yet jointly shadow R3.
+
+**At most 27% of real contradictions are machine-checkable.** Classifying the 93 real
+contradictions (with `gpt-4.1`) by shape:
+
+| Shape | Share |
+|---|---|
+| `mutually_exclusive_action` | 34.4% |
+| `incompatible_factual_claim` | 30.1% |
+| `parameter_binding` (a named parameter bound to two incompatible values) | 27% |
+| `incompatible_direction` | 8.6% |
+
+Only `parameter_binding` is decidable by a schema, SMT solver or decision diagram. **27% is
+the hard ceiling on any such approach** — which is roughly where declarative systems land
+in practice: Kubernetes server-side apply raises conflicts because identity is a
+[JSON field path](https://kubernetes.io/docs/reference/using-api/server-side-apply/); Open
+Policy Agent's conflict is a runtime per-input error ("complete rules must not produce
+multiple outputs") with
+[no cross-policy semantic detection](https://www.openpolicyagent.org/docs/policy-language);
+and Wikidata property constraints are explicitly advisory — "Constraints are hints, not
+firm restrictions, and are meant as a help or guidance to the editor"
+([portal](https://www.wikidata.org/wiki/Help:Property_constraints_portal)).
+
+**Do not re-propose these — all measured on this corpus and all failed:**
+
+| Approach | Result |
+|---|---|
+| Threshold tuning on scorer features | significance AUC 0.500, topic similarity 0.587 |
+| Deterministic gates | all on the diagonal (§1.3) |
+| Fine-tuned DeBERTa cross-encoder | held-out AUC 0.494 at 67 training positives |
+| Embedding-pair classifier (1024-d, \|a−b\| and a·b, PCA-64) | AUC 0.611 — worse than metadata alone (0.730) |
+| Stock NLI (`cross-encoder/nli-deberta-v3-base`, 2,781 pairs) | corpus AUC 0.569 |
+| Two-model ensemble requiring agreement | no better than the stronger model alone |
+| Retrofitting identity from prose | 4 independent failures: typed-artifact token join 1.30× lift at 41% recall; rejected-alternative token join 1.03–1.13×; rejected-alternative semantic join AUC 0.576 (best 1.90× at 9.7% recall); continuous "tension" logit AUC 0.669, max 9.6% corpus precision |
+
+**What did move the number:** the prompt rewrite (§1.4), a stronger judge (§2), the
+two-stage cascade (§2), and stacking a regression over multiple judges' outputs — AUC
+0.843 / AP 0.844 versus 0.743 for the best single judge, with structure-only features
+reproducing AUC 0.683–0.730. Stacking is not shipped.
+
+**Calibrate your expectations against the literature.** Contradiction detection is hard
+everywhere, not just here. DECODE (Nie et al., ACL 2021,
+[paper](https://aclanthology.org/2021.acl-long.134/)) reports precision 23.94 / recall
+74.28 for its anchored model at a 4.27% natural base rate, and 17.05 / 50.13 unstructured.
+de Marneffe, Rafferty and Manning (ACL 2008,
+[paper](https://aclanthology.org/P08-1118/)) report RTE3 test precision 22.95 / recall
+19.44. A 41.5%-precision queue at a 3.35% base rate is above that bar; a 3.4% queue was far
+below it.
+
+### Re-measuring after any change
+
+1. Full gold run for headline numbers:
+   `go run ./cmd/eval-conflicts --mode=gold --gold-limit=0 --gold-model=<m> --gold-timeout=120s --save`
+2. Majority-class FPR on ≥300 pairs: add `--gold-classes=related_not_contradicting`.
+3. Read the **corpus-projected** line, never the stratified-sample line.
+4. Recompute break-even as `(1 − precision) / precision` and compare against your cost ratio.
+5. Confirm the run was not silently truncated by timeouts: the `errors=` field in the eval
+   header and `akashi.conflicts.llm_calls{result=error}` in production must both be near zero.

--- a/docs/conflict-detection.md
+++ b/docs/conflict-detection.md
@@ -1,5 +1,8 @@
 # Conflict Detection: Operator and Contributor Reference
 
+> **Requires PR #740.** `conflict_gold_labels` (migration 107), `--mode=gold`,
+> `AKASHI_CONFLICT_OPENAI_MODEL` and `AKASHI_CONFLICT_LLM_TIMEOUT` do not exist before it.
+
 This document is about **tuning and evaluating** conflict detection quality. For the
 mechanism reference — significance formula, claim extraction, metrics, admin endpoints —
 see [conflicts.md](conflicts.md).
@@ -154,7 +157,7 @@ screen is cheap insurance rather than a recall cliff.
 
 `gpt-5`'s majority-class false-positive rate, measured on 300 pairs, is **2.00%** (6/300,
 95% CI 0.74%–4.30%). Weighted FPR across all non-contradiction classes is 2.44%;
-specificity 99.07%. An earlier 47-pair sample suggested 0% FPR and 65.2% precision — that
+specificity 97.56%. An earlier 47-pair sample suggested 0% FPR and 65.2% precision — that
 was small-sample noise and was corrected by the 300-pair run. **Quote 41.5%.**
 
 ### Do not rank judges by F1
@@ -177,7 +180,7 @@ validation error is fail-safe: the candidate is skipped, not flagged. So a timeo
 too low does not error, does not alert, and does not appear in the conflict queue — it
 presents as a **silent drop in detections**, which looks exactly like "the new model is
 more precise". If you change the judge model and detections fall, check
-`akashi.conflicts.llm_calls{result=error}` before you conclude anything about quality.
+`akashi.conflicts.llm_calls{result="timeout"}` before you conclude anything about quality.
 
 Related knobs: `AKASHI_CONFLICT_LLM_MODEL` (Ollama text model), `AKASHI_CONFLICT_LLM_THREADS`
 (default `floor(NumCPU/3)`), `AKASHI_CONFLICT_PROFILE` (`balanced` | `high_precision` |
@@ -264,7 +267,7 @@ The **corpus-projected** number re-weights each class's flag rate by its true co
 (`goldCorpusSizes` in `cmd/eval-conflicts/main.go:558`: contradiction 93, supersession 627,
 complementary 2,017, unrelated 35), then recomputes precision on the reweighted totals.
 That is the queue an operator would actually see. **Report this one** — for `gpt-5` it
-reads 113 pairs at 41.5% precision, lift 12.5×.
+reads 113 pairs at 41.5% precision, lift 12.4×.
 
 To measure the number that actually bounds precision — the false-positive rate on the
 majority class — run the judge against non-contradictions only:
@@ -334,7 +337,7 @@ The decision procedure:
 3. If it is well above 1.4:1, the single-judge configuration is defensible and you keep
    the higher recall.
 
-Supporting figures at the 41.5% point: MCC 0.439, lift 12.5×, LR+ 20.7.
+Supporting figures at the 41.5% point: MCC 0.439, lift 12.4×, LR+ 20.7.
 
 **Metrics to distrust.** Mutual information is unsuitable as a headline number: it is
 invariant to label inversion, so a detector that outputs the exact negation of the truth
@@ -434,4 +437,4 @@ below it.
 3. Read the **corpus-projected** line, never the stratified-sample line.
 4. Recompute break-even as `(1 − precision) / precision` and compare against your cost ratio.
 5. Confirm the run was not silently truncated by timeouts: the `errors=` field in the eval
-   header and `akashi.conflicts.llm_calls{result=error}` in production must both be near zero.
+   header and `akashi.conflicts.llm_calls{result="timeout"}` in production must both be near zero.


### PR DESCRIPTION
## Why

Conflict detection has been retuned repeatedly on intuition. Each round left behind filters whose motivation is no longer recoverable from the code — the classification prompt had accumulated roughly ten `IMPORTANT for <failure class>` hedges, each added after an audit, and measurement showed the model ignored all of them.

This writes down what was actually measured, so the next change is made on evidence and nobody re-proposes what has already failed.

## What

**`adrs/ADR-017-conflict-detection-operating-point.md`** — the operating point and its reasoning:

- Detection is **screening at a 3.35% base rate**, not classification. Precision is governed almost entirely by the false-positive rate on the majority class, and class-averaged metrics mislead (gpt-5-mini: best sample F1 0.704, worst corpus precision 17.3%).
- **The judge is the discriminating component; the scorer is a recall funnel.** Scorer features carry no label signal — significance AUC is 0.500, exactly chance.
- **Supersession is a first-class outcome**, 22.6% of pairs, routed to `supersedes_suggestions`, never a conflict.
- Output stays **advisory, never a blocking gate**.
- The operating point is only defensible against a **stated miss:false-alarm cost ratio**; break-even is 1.39:1.

The **rejected alternatives** section is the most valuable part: threshold tuning, deterministic gates, a fine-tuned cross-encoder (AUC 0.494, worse than chance), embedding-pair classifiers (0.611, worse than metadata), stock NLI as a gate (0.569), model ensembling, and four separate attempts to recover identity from prose — each measured on the corpus, each failed, each recorded with its number.

**`docs/conflict-detection.md`** — the operator guide: pipeline walkthrough with file anchors, the measured judge-model table, how to evaluate a change against `conflict_gold_labels` (and why a hand-written eval set could not falsify the prompt — it scored 1.000/1.000 while production ran at 3.4%), how to pick an operating point from a cost ratio, and known limitations with instructions for re-measuring them.

## Known limitations, stated plainly in both docs

- Funnel recall is roughly **22%** (95% CI 7–70%) — measured by blind-labelling 200 candidate pairs the pipeline never stored.
- The pairwise design **provably cannot see n-ary conflicts** (Cuppens et al., arXiv:1912.07283; and arXiv:2601.13600 formalises the LLM-oracle case).
- Gold labels are **LLM-generated**, κ=0.766, with no human adjudication yet.

## Numbering correction

The brief I wrote said ADR-010 was next. It is not — `adrs/` already runs through ADR-016, so this is **ADR-017**. `CLAUDE.md` was stale in two places (ADR range said 015, migration range said 099) and is corrected here. The workspace-level `CLAUDE.md` outside this repo still says the next public ADR is ADR-010 and needs the same fix.

## Test plan

Documentation only — no code changes. Every statistic was cross-checked against the measurement outputs before commit, and the retracted 65.2% precision figure (a 47-sample artifact) appears only where the correction to 41.5% is being described.

> Gandalf spends a year in Minas Tirith reading Isildur's own account before he will say the ring is *the* Ring. He had the guess much earlier; what he lacked was the scroll where Isildur wrote down what it looked like as it cooled. Undocumented certainty is how Saruman ends up confidently wrong in a tower full of books.