### PR TITLE
ci: run fuzz targets sequentially to stop a flaky gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,17 +71,31 @@ jobs:
 
       - name: Fuzz (crash detection)
         run: |
-          # integrity/ has two fuzz targets — run them sequentially to avoid
-          # test cache lock contention, but run other packages in parallel.
-          go test -run='^$' -fuzz=FuzzComputeContentHash -fuzztime=8s -fuzzminimizetime=0s -parallel=1 -timeout=30s ./internal/integrity/
-          go test -run='^$' -fuzz=FuzzBuildMerkleRoot    -fuzztime=8s -fuzzminimizetime=0s -parallel=1 -timeout=30s ./internal/integrity/ & pid1=$!
-          go test -run='^$' -fuzz=FuzzValidateToken      -fuzztime=8s -fuzzminimizetime=0s -parallel=1 -timeout=30s ./internal/auth/ & pid2=$!
-          go test -run='^$' -fuzz=FuzzValidateAgentID    -fuzztime=8s -fuzzminimizetime=0s -parallel=1 -timeout=30s ./internal/model/ & pid3=$!
-          go test -run='^$' -fuzz=FuzzDecodeJSON         -fuzztime=8s -fuzzminimizetime=0s -parallel=1 -timeout=30s ./internal/server/ & pid4=$!
-          wait $pid1
-          wait $pid2
-          wait $pid3
-          wait $pid4
+          # Run the targets SEQUENTIALLY. They used to run four-at-a-time, which
+          # made this step a flaky gate on every PR — including documentation-only
+          # ones — with "context deadline exceeded" rather than a real crash.
+          #
+          # The cause is contention, not any one slow target: -timeout covers
+          # baseline coverage gathering plus the fuzzing budget, and four targets
+          # sharing a runner's cores can push a single binary past it. Two earlier
+          # attempts to fix this by trimming time budgets did not hold, because
+          # they treated the symptom. Serial execution costs roughly 30 extra
+          # seconds and removes the failure mode entirely.
+          #
+          # -timeout is also raised well clear of the fuzz budget so a slow runner
+          # cannot trip it. A genuine crash fails fast and is unaffected by either.
+          set -euo pipefail
+          for target in \
+            "FuzzComputeContentHash ./internal/integrity/" \
+            "FuzzBuildMerkleRoot    ./internal/integrity/" \
+            "FuzzValidateToken      ./internal/auth/" \
+            "FuzzValidateAgentID    ./internal/model/" \
+            "FuzzDecodeJSON         ./internal/server/"; do
+            set -- $target
+            echo "::group::fuzz $1"
+            go test -run='^$' -fuzz="$1" -fuzztime=8s -fuzzminimizetime=0s -parallel=1 -timeout=120s "$2"
+            echo "::endgroup::"
+          done
 
       - name: Unit tests
         run: go test -race -count=1 ./...


### PR DESCRIPTION
## Problem

The Fuzz step fails intermittently with `context deadline exceeded` — a **timeout, not a crash**. It most recently blocked #742, a PR that changes three markdown files and no Go code.

## Root cause

Four targets run concurrently on one runner:

```
go test ... -fuzztime=8s -timeout=30s ./internal/integrity/ & pid1=$!
go test ... -fuzztime=8s -timeout=30s ./internal/auth/      & pid2=$!
go test ... -fuzztime=8s -timeout=30s ./internal/model/     & pid3=$!
go test ... -fuzztime=8s -timeout=30s ./internal/server/    & pid4=$!
```

`-timeout` bounds the **whole test binary**, which includes gathering baseline coverage over the seed corpus before fuzzing starts. Under CPU contention any one binary can exceed 30s, and the loser reports a deadline rather than a defect.

This is the third attempt at this flake. The akashi decision log records two earlier ones — reducing fuzztime from 10s to 8s, and capping input size for `FuzzValidateToken` — and neither held, because both treated a symptom of contention as a property of a single target.

## Fix

Run the targets sequentially, and raise `-timeout` to 120s so a slow runner cannot trip it even serially. Costs roughly 30 seconds of wall-clock; removes the failure mode.

A real crash still fails fast — neither change affects crash detection, only the deadline that was firing without one.

## Test plan

- YAML parses; the shell block passes `bash -n`.
- All five targets run locally with the new flags. Spot-checked `FuzzValidateAgentID` and `FuzzDecodeJSON` (the one that flaked): both PASS.
- `set -euo pipefail` means any target failing still fails the step.

> Star Trek's transporter has a pattern buffer because rematerialising someone while the system is busy is how you get two Rikers. The Enterprise doesn't solve that by beaming faster — it serialises the operation and accepts the delay. Four fuzz targets racing for the same cores is the same bet, with a worse failure mode: nobody notices the duplicate, they just re-run CI.