### PR TITLE
feat(conflicts): detect parameter collisions by join instead of by judge

### DIFF
--- a/internal/conflicts/bindings.go
+++ b/internal/conflicts/bindings.go
@@ -1,0 +1,119 @@
+//go:build !lite
+
+package conflicts
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/ashita-ai/akashi/internal/model"
+)
+
+// scoringMethodBinding marks conflicts found by joining declared bindings
+// rather than by scoring text. Keeping it distinct from the LLM methods is what
+// lets the two be measured separately: a binding conflict has no
+// false-positive rate to estimate, and averaging it into the judge's numbers
+// would flatter them.
+const scoringMethodBinding = "binding_v1"
+
+// scoreBindings finds decisions that bind one of this decision's parameters to
+// a different value, and records each as a conflict.
+//
+// This is the exact half of detection. Where the judge is screening at a ~3%
+// base rate and every verdict carries a false-positive rate, a binding
+// conflict is a join: the two decisions declared the same parameter and
+// declared different values for it, and there is nothing to be uncertain
+// about. Measuring the shape of the corpus's 93 gold contradictions found 27%
+// take this form; the rest have no key to join on and are left to the judge.
+//
+// It runs before candidate scoring and does not depend on it: bindings conflict
+// regardless of embedding similarity, which matters because the pairs that
+// carry a declared parameter are not necessarily the pairs that look alike.
+func (s *Scorer) scoreBindings(ctx context.Context, d model.Decision, orgID uuid.UUID) {
+	bindings, err := s.db.GetBindingsByDecision(ctx, d.ID, orgID)
+	if err != nil {
+		s.logger.Warn("conflict scorer: load bindings failed", "error", err, "decision", d.ID)
+		return
+	}
+	if len(bindings) == 0 {
+		return
+	}
+
+	conflicts, err := s.db.FindConflictingBindings(ctx, d.ID, orgID, bindings)
+	if err != nil {
+		s.logger.Warn("conflict scorer: binding conflict query failed", "error", err, "decision", d.ID)
+		return
+	}
+
+	// Index the decision's own bindings so the recorded conflict can name the
+	// value as the agent wrote it rather than its canonical key.
+	own := make(map[string]model.Binding, len(bindings))
+	for _, b := range bindings {
+		own[b.ParameterKey] = b
+	}
+
+	for _, c := range conflicts {
+		mine, ok := own[canonicalOf(c.Parameter, own)]
+		if !ok {
+			continue
+		}
+		explanation := fmt.Sprintf(
+			"%s set %s to %q; %s set the same parameter to %q. Both decisions are current, so a reader has no way to know which value holds.",
+			d.AgentID, mine.Parameter, mine.Value, c.OtherAgentID, c.OtherValue)
+
+		kind := model.ConflictKindCrossAgent
+		if d.AgentID == c.OtherAgentID {
+			kind = model.ConflictKindSelfContradiction
+		}
+
+		conflict := model.DecisionConflict{
+			ConflictKind:  kind,
+			DecisionAID:   d.ID,
+			DecisionBID:   c.OtherDecisionID,
+			OrgID:         orgID,
+			AgentA:        d.AgentID,
+			AgentB:        c.OtherAgentID,
+			DecisionTypeA: d.DecisionType,
+			DecisionTypeB: d.DecisionType,
+			OutcomeA:      d.Outcome,
+			OutcomeB:      fmt.Sprintf("%s = %s", mine.Parameter, c.OtherValue),
+			ScoringMethod: scoringMethodBinding,
+			// A declared collision is certain, so the scores that express
+			// uncertainty about a text pair are deliberately left unset rather
+			// than filled with a fabricated 1.0.
+			Relationship: ptr("contradiction"),
+			Explanation:  &explanation,
+			Category:     ptr("factual"),
+			Status:       "open",
+			ProjectA:     d.Project,
+			ProjectB:     c.OtherProject,
+		}
+
+		if _, err := s.db.InsertScoredConflict(ctx, conflict); err != nil {
+			s.logger.Warn("conflict scorer: insert binding conflict failed",
+				"error", err, "decision_a", d.ID, "decision_b", c.OtherDecisionID, "parameter", mine.Parameter)
+			continue
+		}
+		s.metrics.bindingConflicts.Add(ctx, 1)
+		s.logger.Info("conflict scorer: binding conflict",
+			"parameter", mine.Parameter, "value_a", mine.Value, "value_b", c.OtherValue,
+			"decision_a", d.ID, "decision_b", c.OtherDecisionID)
+	}
+}
+
+// canonicalOf maps a stored parameter string back to the canonical key used in
+// the caller's own binding map. The query returns the OTHER decision's spelling
+// of the parameter, which may differ in case or separators from ours even
+// though both canonicalize identically.
+func canonicalOf(parameter string, own map[string]model.Binding) string {
+	probe := model.Binding{Parameter: parameter, Value: "x"}
+	if err := probe.Canonicalize(); err != nil {
+		return ""
+	}
+	if _, ok := own[probe.ParameterKey]; ok {
+		return probe.ParameterKey
+	}
+	return ""
+}

--- a/internal/conflicts/bindings.go
+++ b/internal/conflicts/bindings.go
@@ -59,6 +59,10 @@ func (s *Scorer) scoreBindings(ctx context.Context, d model.Decision, orgID uuid
 		if !ok {
 			continue
 		}
+		// For a binding conflict the disputed question is not inferred — it is
+		// the parameter itself. This is the one case where the field is exact
+		// rather than a model's best statement of what the disagreement is about.
+		question := fmt.Sprintf("the value of %s", mine.Parameter)
 		explanation := fmt.Sprintf(
 			"%s set %s to %q; %s set the same parameter to %q. Both decisions are current, so a reader has no way to know which value holds.",
 			d.AgentID, mine.Parameter, mine.Value, c.OtherAgentID, c.OtherValue)
@@ -83,12 +87,13 @@ func (s *Scorer) scoreBindings(ctx context.Context, d model.Decision, orgID uuid
 			// A declared collision is certain, so the scores that express
 			// uncertainty about a text pair are deliberately left unset rather
 			// than filled with a fabricated 1.0.
-			Relationship: ptr("contradiction"),
-			Explanation:  &explanation,
-			Category:     ptr("factual"),
-			Status:       "open",
-			ProjectA:     d.Project,
-			ProjectB:     c.OtherProject,
+			Relationship:     ptr("contradiction"),
+			Explanation:      &explanation,
+			Category:         ptr("factual"),
+			Status:           "open",
+			DisputedQuestion: &question,
+			ProjectA:         d.Project,
+			ProjectB:         c.OtherProject,
 		}
 
 		if _, err := s.db.InsertScoredConflict(ctx, conflict); err != nil {

--- a/internal/conflicts/metrics.go
+++ b/internal/conflicts/metrics.go
@@ -36,6 +36,7 @@ type Metrics struct {
 	disjointWorkItemFiltered       metric.Int64Counter
 	disjointResourceFiltered       metric.Int64Counter
 	supersessionSuppressed         metric.Int64Counter
+	bindingConflicts               metric.Int64Counter
 
 	scoringDuration    metric.Float64Histogram
 	llmCallDuration    metric.Float64Histogram
@@ -248,6 +249,12 @@ func (s *Scorer) registerMetrics() {
 	if err != nil {
 		s.logger.Warn("conflicts: failed to create akashi.conflicts.supersession_suppressed metric", "error", err)
 		s.metrics.supersessionSuppressed, _ = meter.Int64Counter("akashi.conflicts.supersession_suppressed.fallback")
+
+		s.metrics.bindingConflicts, err = meter.Int64Counter("akashi.conflicts.binding_conflicts",
+			metric.WithDescription("Conflicts found by joining declared parameter bindings rather than by scoring text. These carry no false-positive rate, so they are counted separately from judge verdicts."))
+		if err != nil {
+			s.metrics.bindingConflicts, _ = meter.Int64Counter("akashi.conflicts.binding_conflicts.fallback")
+		}
 	}
 
 	// --- Histograms ---

--- a/internal/conflicts/scorer.go
+++ b/internal/conflicts/scorer.go
@@ -300,6 +300,13 @@ func (s *Scorer) scoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 		s.logger.Debug("conflict scorer: skip decision", "decision_id", decisionID, "error", err)
 		return
 	}
+
+	// Bindings are joined before any text scoring. A declared parameter
+	// collision is exact and does not depend on the two decisions looking
+	// alike, so it must not be gated behind embedding retrieval — the pairs
+	// that declare the same parameter are not necessarily the pairs that
+	// score as similar.
+	s.scoreBindings(ctx, d, orgID)
 	if d.Embedding == nil || d.OutcomeEmbedding == nil {
 		s.logger.Debug("conflict scorer: decision lacks embeddings", "decision_id", decisionID)
 		return

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -228,6 +228,9 @@ SKIP: formatting, typo fixes, running tests, reading code, asking questions.`),
 			mcplib.WithString("alternatives",
 				mcplib.Description(`JSON array of options you considered and rejected. Each item: {"label":"<description of option>","rejection_reason":"<why you didn't choose it>"}. Providing alternatives improves completeness scoring and helps future agents understand your reasoning. Example: [{"label":"Use Redis for caching","rejection_reason":"adds operational overhead for our traffic levels"},{"label":"In-memory cache","rejection_reason":"not shared across instances"}]`),
 			),
+			mcplib.WithString("bindings",
+				mcplib.Description(`JSON array of named parameters this decision SETS, and the values it sets them to. Each item: {"parameter":"<name>","value":"<value>"}. Use it when your decision fixes a specific knob — a config key, flag, threshold, version, file path, or setting — not for prose summaries. Two decisions that bind the same parameter to different values are detected as a conflict exactly, by lookup rather than by a language model, so this is the highest-signal field you can supply. Values are compared literally: "5m" and "300s" count as different. Example: [{"parameter":"qdrant.create_field_index_on_startup","value":"false"},{"parameter":"cache.ttl","value":"5m"}]`),
+			),
 			mcplib.WithString("precedent_ref",
 				mcplib.Description("UUID of the prior decision this one directly builds on. Copy the value from akashi_check's precedent_ref_hint field. Wires the attribution graph so the audit trail shows how decisions evolved over time. Omit if there is no clear antecedent."),
 			),
@@ -989,6 +992,19 @@ func (s *Server) handleTrace(ctx context.Context, request mcplib.CallToolRequest
 		}
 	}
 
+	// Parse bindings. Unlike alternatives and evidence, a malformed binding is
+	// refused rather than dropped: the whole value of a binding is that a
+	// detection built on it is certain, and silently discarding one produces a
+	// decision that looks like it declared a parameter and did not — which
+	// shows up later as a conflict that should have fired and didn't.
+	var bindings []model.TraceBinding
+	if raw := request.GetString("bindings", ""); raw != "" {
+		if parseErr := json.Unmarshal([]byte(raw), &bindings); parseErr != nil {
+			return mcplib.NewToolResultError(fmt.Sprintf(
+				"bindings must be a JSON array of {\"parameter\":..., \"value\":...} objects: %v", parseErr)), nil
+		}
+	}
+
 	// Parse precedent_ref UUID if provided. Invalid format is logged and ignored —
 	// a trace without a precedent link is better than a failed trace.
 	var precedentRef *uuid.UUID
@@ -1342,6 +1358,7 @@ func (s *Server) handleTrace(ctx context.Context, request mcplib.CallToolRequest
 			Confidence:   confidence,
 			Reasoning:    reasoningPtr,
 			Alternatives: alternatives,
+			Bindings:     bindings,
 			Evidence:     evidence,
 		},
 	})
@@ -1368,6 +1385,7 @@ func (s *Server) handleTrace(ctx context.Context, request mcplib.CallToolRequest
 		Confidence:   confidence,
 		Reasoning:    reasoningPtr,
 		Alternatives: alternatives,
+		Bindings:     bindings,
 		Evidence:     evidence,
 	}, precedentRef != nil)
 

--- a/internal/model/api.go
+++ b/internal/model/api.go
@@ -279,6 +279,17 @@ type TraceRequest struct {
 // flag stays false because no boundary check runs in that path.
 //
 // See ashita-ai/akashi#713.
+// TraceBinding is the wire form of a decision binding: the named parameter a
+// decision sets, and the value it sets it to.
+//
+// Both fields are required. Values are compared, never interpreted — "5m" and
+// "300s" are different values, because deciding otherwise needs the
+// parameter's type, which is not recorded.
+type TraceBinding struct {
+	Parameter string `json:"parameter"`
+	Value     string `json:"value"`
+}
+
 type TraceDecision struct {
 	DecisionType string             `json:"decision_type"`
 	Outcome      string             `json:"outcome"`
@@ -286,6 +297,11 @@ type TraceDecision struct {
 	Reasoning    *string            `json:"reasoning,omitempty"`
 	Alternatives []TraceAlternative `json:"alternatives,omitempty"`
 	Evidence     []TraceEvidence    `json:"evidence,omitempty"`
+
+	// Bindings are the named parameters this decision sets and the values it
+	// sets them to. Optional. Two decisions binding the same parameter to
+	// different values conflict exactly, by join rather than by the LLM judge.
+	Bindings []TraceBinding `json:"bindings,omitempty"`
 
 	confidencePresent bool
 }

--- a/internal/model/binding.go
+++ b/internal/model/binding.go
@@ -1,0 +1,159 @@
+package model
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// Binding is the named thing a decision sets, and the value it sets it to.
+//
+// It exists because contradiction detection over prose is a screening problem
+// at a ~3% base rate, while two decisions binding the same parameter to
+// different values is a join. Classifying the corpus's 93 gold contradictions
+// by shape found 27% take exactly this form; the rest have no key to join on
+// and still require the judge.
+type Binding struct {
+	ID         uuid.UUID `json:"id,omitempty"`
+	DecisionID uuid.UUID `json:"decision_id,omitempty"`
+	OrgID      uuid.UUID `json:"org_id,omitempty"`
+
+	// Parameter as the agent wrote it, e.g. "qdrant.create_field_index_on_startup"
+	// or "cache TTL". Preserved for display.
+	Parameter string `json:"parameter"`
+	// Value as the agent wrote it, e.g. "true" or "5 minutes".
+	Value string `json:"value"`
+
+	// ParameterKey and ValueKey are the canonical forms the join runs on.
+	// Populated by Canonicalize; callers do not supply them.
+	ParameterKey string `json:"parameter_key,omitempty"`
+	ValueKey     string `json:"value_key,omitempty"`
+}
+
+const (
+	maxBindingParameterLen = 200
+	maxBindingValueLen     = 500
+	// MaxBindingsPerDecision bounds fan-out. A decision that claims to set
+	// dozens of parameters is describing a changelog rather than a decision,
+	// and each binding multiplies the join's candidate set.
+	MaxBindingsPerDecision = 16
+)
+
+// separatorRun matches any run of characters that different agents use
+// interchangeably between words of the same parameter name.
+var separatorRun = regexp.MustCompile(`[\s._\-/:]+`)
+
+// camelBoundary matches the seam between words in camelCase and PascalCase, so
+// "CreateFieldIndex" and "create_field_index" reach the same key. The two
+// alternations handle the ordinary seam (lower or digit, then upper) and the
+// end of an acronym run ("HTTPServer" -> "http.server").
+var camelBoundary = regexp.MustCompile(`([a-z0-9])([A-Z])|([A-Z]+)([A-Z][a-z])`)
+
+// Canonicalize fills ParameterKey and ValueKey, and validates the binding.
+//
+// Canonicalization is deliberately shallow: case, surrounding whitespace, and
+// separator style only. It is tempting to go further — unit-normalize "5m" and
+// "300s", coerce "yes" to "true" — and that temptation must be resisted,
+// because deciding two values mean the same thing requires knowing the
+// parameter's type, which is not recorded. Over-normalizing merges genuinely
+// different parameters and manufactures conflicts out of nothing, which is a
+// worse failure than missing one: this feature's entire value is that a
+// detection it produces is certain.
+//
+// The same reasoning caps the other direction. Under-normalizing only loses
+// matches, and the judge still sees those pairs.
+func (b *Binding) Canonicalize() error {
+	b.Parameter = strings.TrimSpace(b.Parameter)
+	b.Value = strings.TrimSpace(b.Value)
+
+	if b.Parameter == "" {
+		return fmt.Errorf("binding: parameter is required")
+	}
+	if b.Value == "" {
+		return fmt.Errorf("binding: value is required for parameter %q", b.Parameter)
+	}
+	if len(b.Parameter) > maxBindingParameterLen {
+		return fmt.Errorf("binding: parameter exceeds %d characters", maxBindingParameterLen)
+	}
+	if len(b.Value) > maxBindingValueLen {
+		return fmt.Errorf("binding: value for %q exceeds %d characters", b.Parameter, maxBindingValueLen)
+	}
+
+	b.ParameterKey = canonicalParameterKey(b.Parameter)
+	b.ValueKey = canonicalValueKey(b.Value)
+
+	if b.ParameterKey == "" {
+		return fmt.Errorf("binding: parameter %q normalizes to empty", b.Parameter)
+	}
+	if b.ValueKey == "" {
+		return fmt.Errorf("binding: value %q normalizes to empty", b.Value)
+	}
+	return nil
+}
+
+// canonicalParameterKey lowercases, splits camel seams, and collapses
+// separator runs to a single ".".
+//
+// "Qdrant.CreateFieldIndex_on_startup", "qdrant create field index on startup"
+// and "qdrant-create-field-index-on-startup" all reduce to the same key, which
+// is the realistic amount of spelling variation between two agents naming the
+// same knob. Anything beyond that is guessing.
+//
+// Splitting camel seams is safe in a way that value normalization is not: the
+// mapping is deterministic and structural, so it can merge two spellings of one
+// name but cannot merge two different names.
+func canonicalParameterKey(s string) string {
+	// Split camel seams before lowercasing, since lowercasing destroys them.
+	s = camelBoundary.ReplaceAllString(strings.TrimSpace(s), "${1}${3}.${2}${4}")
+	return collapse(s)
+}
+
+// canonicalValueKey normalizes case and separators but deliberately does NOT
+// split camel seams.
+//
+// Parameter names are identifier-like, so splitting them is safe and useful.
+// Values are prose: a product name written "PostgreSQL Only" would split into
+// "postgre.sql.only" while the equivalent "postgresql-only" would not, and the
+// two would then read as a disagreement they are not. Values only need case and
+// separator agreement.
+func canonicalValueKey(s string) string {
+	return collapse(strings.TrimSpace(s))
+}
+
+func collapse(s string) string {
+	s = strings.ToLower(s)
+	s = separatorRun.ReplaceAllString(s, ".")
+	return strings.Trim(s, ".")
+}
+
+// CanonicalizeBindings validates a decision's bindings and rejects duplicates.
+//
+// A decision binding the same parameter twice is contradicting itself within a
+// single trace, which is a caller bug rather than a conflict to detect, so it
+// is refused at the door instead of being stored and re-discovered later.
+func CanonicalizeBindings(bindings []Binding) ([]Binding, error) {
+	if len(bindings) == 0 {
+		return nil, nil
+	}
+	if len(bindings) > MaxBindingsPerDecision {
+		return nil, fmt.Errorf("binding: %d bindings exceeds the limit of %d for one decision",
+			len(bindings), MaxBindingsPerDecision)
+	}
+	seen := make(map[string]string, len(bindings))
+	out := make([]Binding, 0, len(bindings))
+	for i := range bindings {
+		b := bindings[i]
+		if err := b.Canonicalize(); err != nil {
+			return nil, err
+		}
+		if prev, dup := seen[b.ParameterKey]; dup {
+			return nil, fmt.Errorf("binding: parameter %q bound twice in one decision (as %q and %q)",
+				b.ParameterKey, prev, b.Parameter)
+		}
+		seen[b.ParameterKey] = b.Parameter
+		out = append(out, b)
+	}
+	return out, nil
+}

--- a/internal/model/binding_test.go
+++ b/internal/model/binding_test.go
@@ -1,0 +1,125 @@
+package model
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Canonicalization decides which parameters join. Too little and real
+// collisions are missed; too much and unrelated parameters are merged, which
+// manufactures conflicts and destroys the one property this feature has —
+// that a detection built on a binding is certain.
+func TestBindingCanonicalize_SpellingVariantsJoin(t *testing.T) {
+	variants := []string{
+		"qdrant.create_field_index_on_startup",
+		"Qdrant.CreateFieldIndex_on_startup",
+		"qdrant create field index on startup",
+		"qdrant-create-field-index-on-startup",
+		"  QDRANT/CREATE/FIELD/INDEX/ON/STARTUP  ",
+	}
+	var key string
+	for _, v := range variants {
+		b := Binding{Parameter: v, Value: "true"}
+		require.NoError(t, b.Canonicalize(), "variant %q", v)
+		if key == "" {
+			key = b.ParameterKey
+			continue
+		}
+		assert.Equal(t, key, b.ParameterKey, "variant %q must canonicalize like the others", v)
+	}
+	assert.Equal(t, "qdrant.create.field.index.on.startup", key)
+}
+
+// Values are compared, never interpreted. Deciding "5m" and "300s" are the
+// same requires the parameter's type, which is not recorded, so treating them
+// as equal would be a guess — and a guess that suppresses a real conflict.
+func TestBindingCanonicalize_ValuesAreNotInterpreted(t *testing.T) {
+	for _, pair := range [][2]string{
+		{"5m", "300s"},
+		{"true", "yes"},
+		{"1", "1.0"},
+	} {
+		a := Binding{Parameter: "p", Value: pair[0]}
+		b := Binding{Parameter: "p", Value: pair[1]}
+		require.NoError(t, a.Canonicalize())
+		require.NoError(t, b.Canonicalize())
+		assert.NotEqual(t, a.ValueKey, b.ValueKey,
+			"%q and %q must stay distinct — equating them needs a type we do not have", pair[0], pair[1])
+	}
+}
+
+// Case and separator differences in a VALUE should not read as disagreement.
+func TestBindingCanonicalize_ValueSpellingIsNormalized(t *testing.T) {
+	a := Binding{Parameter: "p", Value: "PostgreSQL Only"}
+	b := Binding{Parameter: "p", Value: "postgresql-only"}
+	require.NoError(t, a.Canonicalize())
+	require.NoError(t, b.Canonicalize())
+	assert.Equal(t, a.ValueKey, b.ValueKey)
+}
+
+func TestBindingCanonicalize_Rejects(t *testing.T) {
+	cases := map[string]Binding{
+		"empty parameter":      {Parameter: "", Value: "x"},
+		"blank parameter":      {Parameter: "   ", Value: "x"},
+		"empty value":          {Parameter: "p", Value: ""},
+		"separator-only param": {Parameter: "...", Value: "x"},
+		"separator-only value": {Parameter: "p", Value: "___"},
+		"over-long parameter":  {Parameter: strings.Repeat("a", maxBindingParameterLen+1), Value: "x"},
+		"over-long value":      {Parameter: "p", Value: strings.Repeat("a", maxBindingValueLen+1)},
+	}
+	for name, b := range cases {
+		t.Run(name, func(t *testing.T) {
+			assert.Error(t, b.Canonicalize())
+		})
+	}
+}
+
+// A decision that binds the same parameter twice contradicts itself inside a
+// single trace. That is a caller bug, and storing it would mean re-discovering
+// it later as a conflict between a decision and itself.
+func TestCanonicalizeBindings_RejectsIntraDecisionDuplicate(t *testing.T) {
+	_, err := CanonicalizeBindings([]Binding{
+		{Parameter: "cache.ttl", Value: "5m"},
+		{Parameter: "Cache TTL", Value: "10m"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bound twice")
+}
+
+// Binding the same parameter to the same value twice is still a duplicate:
+// the row is redundant and the unique constraint would reject it at insert.
+func TestCanonicalizeBindings_RejectsDuplicateEvenWhenValuesAgree(t *testing.T) {
+	_, err := CanonicalizeBindings([]Binding{
+		{Parameter: "cache.ttl", Value: "5m"},
+		{Parameter: "cache.ttl", Value: "5m"},
+	})
+	assert.Error(t, err)
+}
+
+func TestCanonicalizeBindings_EnforcesFanOutLimit(t *testing.T) {
+	many := make([]Binding, MaxBindingsPerDecision+1)
+	for i := range many {
+		many[i] = Binding{Parameter: string(rune('a'+i%26)) + strings.Repeat("x", i), Value: "v"}
+	}
+	_, err := CanonicalizeBindings(many)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds the limit")
+}
+
+func TestCanonicalizeBindings_EmptyIsNotAnError(t *testing.T) {
+	out, err := CanonicalizeBindings(nil)
+	require.NoError(t, err)
+	assert.Nil(t, out, "bindings are optional; absent must stay absent rather than becoming an empty slice")
+}
+
+func TestCanonicalizeBindings_PreservesRawSpelling(t *testing.T) {
+	out, err := CanonicalizeBindings([]Binding{{Parameter: "  Cache TTL  ", Value: "  5 Minutes "}})
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	assert.Equal(t, "Cache TTL", out[0].Parameter, "the agent's spelling is what a human reads back")
+	assert.Equal(t, "5 Minutes", out[0].Value)
+	assert.Equal(t, "cache.ttl", out[0].ParameterKey)
+}

--- a/internal/model/decision.go
+++ b/internal/model/decision.go
@@ -79,7 +79,13 @@ type Decision struct {
 
 	// Joined data (populated by queries, not stored in decisions table).
 	Alternatives []Alternative `json:"alternatives,omitempty"`
-	Evidence     []Evidence    `json:"evidence,omitempty"`
+
+	// Bindings (migration 109): named parameters this decision sets, and the
+	// values it sets them to. Optional. Two decisions binding the same
+	// parameter to different values are in exact conflict, found by join rather
+	// than by the LLM judge — see internal/model/binding.go.
+	Bindings []Binding  `json:"bindings,omitempty"`
+	Evidence []Evidence `json:"evidence,omitempty"`
 
 	// Consensus scoring (Spec 34): computed at query time from embedding similarity cluster.
 	// Returns 0 for decisions without embeddings.

--- a/internal/service/decisions/service.go
+++ b/internal/service/decisions/service.go
@@ -554,6 +554,19 @@ func (s *Service) prepareTrace(ctx context.Context, orgID uuid.UUID, input Trace
 		}
 	}
 
+	// 4b. Canonicalize bindings. Rejecting a malformed binding here rather than
+	// at insert keeps the failure attributable to the caller's trace, and a
+	// binding with no canonical key would be stored blank and silently never
+	// join with anything.
+	rawBinds := make([]model.Binding, len(input.Decision.Bindings))
+	for i, b := range input.Decision.Bindings {
+		rawBinds[i] = model.Binding{Parameter: b.Parameter, Value: b.Value}
+	}
+	binds, err := model.CanonicalizeBindings(rawBinds)
+	if err != nil {
+		return storage.CreateTraceParams{}, nil, nil, fmt.Errorf("trace: %w", err)
+	}
+
 	// 5. Build evidence with embeddings (outside tx — may call external API).
 	// Parallelize embedding calls since each is an independent API request.
 	evs := make([]model.Evidence, len(input.Decision.Evidence))
@@ -640,6 +653,7 @@ func (s *Service) prepareTrace(ctx context.Context, orgID uuid.UUID, input Trace
 			APIKeyID:          input.APIKeyID,
 		},
 		Alternatives: alts,
+		Bindings:     binds,
 		Evidence:     evs,
 		SessionID:    input.SessionID,
 		AgentContext: input.AgentContext,

--- a/internal/storage/bindings.go
+++ b/internal/storage/bindings.go
@@ -1,0 +1,154 @@
+//go:build !lite
+
+package storage
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/ashita-ai/akashi/internal/model"
+)
+
+// CreateBindingsBatch writes a decision's bindings.
+//
+// Callers must have run model.CanonicalizeBindings first: this writes
+// ParameterKey and ValueKey as given, and an unpopulated key would be stored
+// blank and never join with anything, which fails silently.
+func (db *DB) CreateBindingsBatch(ctx context.Context, bindings []model.Binding) error {
+	if len(bindings) == 0 {
+		return nil
+	}
+	columns := []string{"id", "decision_id", "org_id", "parameter", "parameter_key", "value", "value_key", "created_at"}
+	rows := make([][]any, len(bindings))
+	now := time.Now().UTC()
+	for i, b := range bindings {
+		if b.ParameterKey == "" || b.ValueKey == "" {
+			return fmt.Errorf("storage: binding %q has no canonical key; call model.CanonicalizeBindings first", b.Parameter)
+		}
+		id := b.ID
+		if id == uuid.Nil {
+			id = uuid.New()
+		}
+		rows[i] = []any{id, b.DecisionID, b.OrgID, b.Parameter, b.ParameterKey, b.Value, b.ValueKey, now}
+	}
+	if _, err := db.pool.CopyFrom(ctx, pgx.Identifier{"decision_bindings"}, columns, pgx.CopyFromRows(rows)); err != nil {
+		return fmt.Errorf("storage: copy decision bindings: %w", err)
+	}
+	return nil
+}
+
+// ConflictingBinding is one prior decision that bound the same parameter to a
+// different value.
+type ConflictingBinding struct {
+	Parameter       string
+	Value           string
+	OtherDecisionID uuid.UUID
+	OtherValue      string
+	OtherAgentID    string
+	OtherProject    *string
+}
+
+// FindConflictingBindings returns prior decisions that bind any of this
+// decision's parameters to a different value.
+//
+// This is the exact half of conflict detection: no model, no threshold, no
+// false-positive rate. The scoping conditions are what keep it exact rather
+// than merely cheap.
+//
+//   - Same org. Every query in this codebase is org-scoped.
+//   - Same project. Two services can legitimately set a parameter of the same
+//     name to different values; cross-project collision was the leading source
+//     of false positives before projects were recorded. A decision with no
+//     project only matches other decisions with no project.
+//   - Current state only (valid_to IS NULL). A superseded decision no longer
+//     binds anything, so it must not conflict with its own replacement.
+//   - Different decision. A decision cannot conflict with itself, and
+//     re-tracing an identical binding must be a no-op.
+//
+// Branch is deliberately NOT part of the join. Two branches setting the same
+// parameter differently is a real conflict that surfaces at merge; suppressing
+// it here would hide the case this feature exists to catch. Callers that want
+// branch-aware suppression should apply it downstream where the existing
+// branch logic lives.
+func (db *DB) FindConflictingBindings(
+	ctx context.Context,
+	decisionID, orgID uuid.UUID,
+	bindings []model.Binding,
+) ([]ConflictingBinding, error) {
+	if len(bindings) == 0 {
+		return nil, nil
+	}
+	paramKeys := make([]string, len(bindings))
+	valueKeys := make([]string, len(bindings))
+	for i, b := range bindings {
+		paramKeys[i] = b.ParameterKey
+		valueKeys[i] = b.ValueKey
+	}
+
+	// unnest pairs each parameter with the value THIS decision binds it to, so
+	// one query covers every binding without building a variable-length OR.
+	rows, err := db.pool.Query(ctx,
+		`WITH mine AS (
+		     SELECT unnest($3::text[]) AS parameter_key,
+		            unnest($4::text[]) AS value_key
+		 )
+		 SELECT b.parameter, mine.value_key, b.decision_id, b.value, d.agent_id, d.project
+		 FROM decision_bindings b
+		 JOIN mine ON mine.parameter_key = b.parameter_key
+		 JOIN decisions d ON d.id = b.decision_id
+		 WHERE b.org_id = $2
+		   AND b.decision_id <> $1
+		   AND b.value_key <> mine.value_key
+		   AND d.valid_to IS NULL
+		   AND d.project IS NOT DISTINCT FROM (
+		       SELECT project FROM decisions WHERE id = $1 AND org_id = $2
+		   )
+		 ORDER BY d.created_at DESC`,
+		decisionID, orgID, paramKeys, valueKeys)
+	if err != nil {
+		return nil, fmt.Errorf("storage: find conflicting bindings: %w", err)
+	}
+	defer rows.Close()
+
+	var out []ConflictingBinding
+	for rows.Next() {
+		var c ConflictingBinding
+		var myValueKey string
+		if err := rows.Scan(&c.Parameter, &myValueKey, &c.OtherDecisionID, &c.OtherValue, &c.OtherAgentID, &c.OtherProject); err != nil {
+			return nil, fmt.Errorf("storage: scan conflicting binding: %w", err)
+		}
+		c.Value = myValueKey
+		out = append(out, c)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("storage: iterate conflicting bindings: %w", err)
+	}
+	return out, nil
+}
+
+// GetBindingsByDecision returns a decision's bindings.
+func (db *DB) GetBindingsByDecision(ctx context.Context, decisionID, orgID uuid.UUID) ([]model.Binding, error) {
+	rows, err := db.pool.Query(ctx,
+		`SELECT id, decision_id, org_id, parameter, parameter_key, value, value_key
+		 FROM decision_bindings
+		 WHERE decision_id = $1 AND org_id = $2
+		 ORDER BY parameter_key`, decisionID, orgID)
+	if err != nil {
+		return nil, fmt.Errorf("storage: get bindings: %w", err)
+	}
+	defer rows.Close()
+
+	var out []model.Binding
+	for rows.Next() {
+		var b model.Binding
+		if err := rows.Scan(&b.ID, &b.DecisionID, &b.OrgID, &b.Parameter, &b.ParameterKey, &b.Value, &b.ValueKey); err != nil {
+			return nil, fmt.Errorf("storage: scan binding: %w", err)
+		}
+		out = append(out, b)
+	}
+	return out, rows.Err()
+}

--- a/internal/storage/bindings_test.go
+++ b/internal/storage/bindings_test.go
@@ -1,0 +1,199 @@
+//go:build !lite && integration
+
+package storage_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ashita-ai/akashi/internal/model"
+)
+
+// A binding conflict has no false-positive rate to estimate — it is a join, and
+// its correctness is entirely in the scoping conditions. Each test here pins one
+// of them, because a missing condition does not fail loudly: it produces a
+// confident conflict that is wrong, which is worse than the judge being unsure.
+
+func bindingDecision(t *testing.T, ctx context.Context, agentID, outcome string, project *string, bindings []model.Binding) model.Decision {
+	t.Helper()
+	run, err := testDB.CreateRun(ctx, model.CreateRunRequest{AgentID: agentID})
+	require.NoError(t, err)
+
+	// decisions.project is a generated column derived from agent_context
+	// (migration 052), so project scoping is exercised by setting the context
+	// rather than the column.
+	agentCtx := map[string]any{}
+	if project != nil {
+		agentCtx["project"] = *project
+	}
+	d, err := testDB.CreateDecision(ctx, model.Decision{
+		RunID: run.ID, AgentID: agentID, OrgID: uuid.Nil,
+		DecisionType: "architecture", Outcome: outcome, Confidence: 0.8,
+		AgentContext: agentCtx,
+	})
+	require.NoError(t, err)
+	d.Project = project
+
+	canon, err := model.CanonicalizeBindings(bindings)
+	require.NoError(t, err)
+	for i := range canon {
+		canon[i].DecisionID = d.ID
+		canon[i].OrgID = uuid.Nil
+	}
+	require.NoError(t, testDB.CreateBindingsBatch(ctx, canon))
+	d.Bindings = canon
+	return d
+}
+
+func bind(parameter, value string) model.Binding {
+	return model.Binding{Parameter: parameter, Value: value}
+}
+
+func TestFindConflictingBindings_DifferentValueConflicts(t *testing.T) {
+	ctx := context.Background()
+	proj := "binding-test-" + uuid.New().String()[:8]
+	param := "qdrant.create_field_index_on_startup." + uuid.New().String()[:8]
+
+	first := bindingDecision(t, ctx, "planner", "run index creation at startup", &proj,
+		[]model.Binding{bind(param, "true")})
+	second := bindingDecision(t, ctx, "reviewer", "use versioned migrations instead", &proj,
+		[]model.Binding{bind(param, "false")})
+
+	got, err := testDB.FindConflictingBindings(ctx, second.ID, uuid.Nil, second.Bindings)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, first.ID, got[0].OtherDecisionID)
+	assert.Equal(t, "true", got[0].OtherValue)
+}
+
+// Agreement is not conflict. Two agents independently setting a parameter the
+// same way is the system working.
+func TestFindConflictingBindings_SameValueIsNotAConflict(t *testing.T) {
+	ctx := context.Background()
+	proj := "binding-agree-" + uuid.New().String()[:8]
+	param := "cache.ttl." + uuid.New().String()[:8]
+
+	bindingDecision(t, ctx, "planner", "cache for five minutes", &proj, []model.Binding{bind(param, "5m")})
+	second := bindingDecision(t, ctx, "reviewer", "confirmed five minute cache", &proj,
+		[]model.Binding{bind(param, "5m")})
+
+	got, err := testDB.FindConflictingBindings(ctx, second.ID, uuid.Nil, second.Bindings)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+// Spelling variants of one parameter name must join, or two agents describing
+// the same knob differently silently never conflict.
+func TestFindConflictingBindings_SpellingVariantsJoin(t *testing.T) {
+	ctx := context.Background()
+	proj := "binding-spelling-" + uuid.New().String()[:8]
+	suffix := uuid.New().String()[:8]
+
+	bindingDecision(t, ctx, "planner", "camel spelling", &proj,
+		[]model.Binding{bind("cacheEvictionPolicy"+suffix, "lru")})
+	second := bindingDecision(t, ctx, "reviewer", "snake spelling", &proj,
+		[]model.Binding{bind("cache_eviction_policy"+suffix, "lfu")})
+
+	got, err := testDB.FindConflictingBindings(ctx, second.ID, uuid.Nil, second.Bindings)
+	require.NoError(t, err)
+	assert.Len(t, got, 1, "camelCase and snake_case spellings of one parameter must join")
+}
+
+// Two services can legitimately set a parameter of the same name to different
+// values. Cross-project collision was the leading false-positive source before
+// projects were recorded, and it must not come back through this path.
+func TestFindConflictingBindings_DifferentProjectsDoNotConflict(t *testing.T) {
+	ctx := context.Background()
+	param := "log.level." + uuid.New().String()[:8]
+	projA := "svc-a-" + uuid.New().String()[:8]
+	projB := "svc-b-" + uuid.New().String()[:8]
+
+	bindingDecision(t, ctx, "planner", "service A logs at debug", &projA, []model.Binding{bind(param, "debug")})
+	second := bindingDecision(t, ctx, "planner", "service B logs at info", &projB, []model.Binding{bind(param, "info")})
+
+	got, err := testDB.FindConflictingBindings(ctx, second.ID, uuid.Nil, second.Bindings)
+	require.NoError(t, err)
+	assert.Empty(t, got, "the same parameter name in two projects is not one parameter")
+}
+
+// A superseded decision no longer binds anything. Without the valid_to filter a
+// decision would conflict with the very decision that replaced it, which is the
+// most confusing possible output: the fix reported as the problem.
+func TestFindConflictingBindings_SupersededDecisionsExcluded(t *testing.T) {
+	ctx := context.Background()
+	proj := "binding-superseded-" + uuid.New().String()[:8]
+	param := "retry.max." + uuid.New().String()[:8]
+
+	first := bindingDecision(t, ctx, "planner", "retry three times", &proj, []model.Binding{bind(param, "3")})
+	_, err := testDB.Pool().Exec(ctx, `UPDATE decisions SET valid_to = now() WHERE id = $1`, first.ID)
+	require.NoError(t, err)
+
+	second := bindingDecision(t, ctx, "planner", "retry five times", &proj, []model.Binding{bind(param, "5")})
+	got, err := testDB.FindConflictingBindings(ctx, second.ID, uuid.Nil, second.Bindings)
+	require.NoError(t, err)
+	assert.Empty(t, got, "a retired decision must not conflict with its own replacement")
+}
+
+// Re-tracing a decision must not make it conflict with itself.
+func TestFindConflictingBindings_ExcludesSelf(t *testing.T) {
+	ctx := context.Background()
+	proj := "binding-self-" + uuid.New().String()[:8]
+	param := "flag." + uuid.New().String()[:8]
+
+	d := bindingDecision(t, ctx, "planner", "set the flag", &proj, []model.Binding{bind(param, "on")})
+	got, err := testDB.FindConflictingBindings(ctx, d.ID, uuid.Nil, d.Bindings)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+// Decisions with no project recorded form their own scope; they must not match
+// project-scoped decisions, since "unknown project" is not a wildcard.
+func TestFindConflictingBindings_NullProjectIsItsOwnScope(t *testing.T) {
+	ctx := context.Background()
+	param := "timeout." + uuid.New().String()[:8]
+	proj := "known-" + uuid.New().String()[:8]
+
+	bindingDecision(t, ctx, "planner", "no project recorded", nil, []model.Binding{bind(param, "10s")})
+	withProject := bindingDecision(t, ctx, "planner", "project recorded", &proj, []model.Binding{bind(param, "30s")})
+
+	got, err := testDB.FindConflictingBindings(ctx, withProject.ID, uuid.Nil, withProject.Bindings)
+	require.NoError(t, err)
+	assert.Empty(t, got, "an unrecorded project must not act as a wildcard")
+
+	// But two project-less decisions do share a scope.
+	otherNull := bindingDecision(t, ctx, "reviewer", "also no project", nil, []model.Binding{bind(param, "60s")})
+	got, err = testDB.FindConflictingBindings(ctx, otherNull.ID, uuid.Nil, otherNull.Bindings)
+	require.NoError(t, err)
+	assert.Len(t, got, 1, "two project-less decisions share the project-less scope")
+}
+
+// The unique constraint is what stops a decision contradicting itself in one
+// trace; CanonicalizeBindings refuses it earlier, so this pins the backstop.
+func TestCreateBindingsBatch_RejectsDuplicateParameterPerDecision(t *testing.T) {
+	ctx := context.Background()
+	proj := "binding-dup-" + uuid.New().String()[:8]
+	d := bindingDecision(t, ctx, "planner", "first binding", &proj,
+		[]model.Binding{bind("dup.param."+uuid.New().String()[:8], "a")})
+
+	dup := d.Bindings[0]
+	dup.ID = uuid.New()
+	dup.Value, dup.ValueKey = "b", "b"
+	err := testDB.CreateBindingsBatch(ctx, []model.Binding{dup})
+	assert.Error(t, err, "the unique constraint must reject a second value for one parameter on one decision")
+}
+
+// A binding written without canonical keys would be stored blank and never
+// join, failing silently. The writer refuses it instead.
+func TestCreateBindingsBatch_RefusesUncanonicalizedBinding(t *testing.T) {
+	ctx := context.Background()
+	err := testDB.CreateBindingsBatch(ctx, []model.Binding{{
+		ID: uuid.New(), DecisionID: uuid.New(), OrgID: uuid.Nil,
+		Parameter: "p", Value: "v", // no ParameterKey / ValueKey
+	}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "canonical key")
+}

--- a/internal/storage/bindings_test.go
+++ b/internal/storage/bindings_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ashita-ai/akashi/internal/model"
+	"github.com/ashita-ai/akashi/internal/storage"
 )
 
 // A binding conflict has no false-positive rate to estimate — it is a join, and
@@ -196,4 +197,50 @@ func TestCreateBindingsBatch_RefusesUncanonicalizedBinding(t *testing.T) {
 	}})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "canonical key")
+}
+
+// A binding conflict is the one case where the disputed question is exact
+// rather than a model's best statement of what the disagreement is about: the
+// parameter itself is the question. Verifying it round-trips here keeps the
+// binding path and the judge path reporting the same field.
+func TestBindingConflict_CarriesDisputedQuestion(t *testing.T) {
+	ctx := context.Background()
+	proj := "binding-dq-" + uuid.New().String()[:8]
+	param := "cache.ttl." + uuid.New().String()[:8]
+
+	first := bindingDecision(t, ctx, "planner", "cache five minutes", &proj, []model.Binding{bind(param, "5m")})
+	second := bindingDecision(t, ctx, "reviewer", "cache ten minutes", &proj, []model.Binding{bind(param, "10m")})
+
+	question := "the value of " + param
+	relationship := "contradiction"
+	id, err := testDB.InsertScoredConflict(ctx, model.DecisionConflict{
+		ConflictKind:     model.ConflictKindCrossAgent,
+		DecisionAID:      second.ID,
+		DecisionBID:      first.ID,
+		OrgID:            uuid.Nil,
+		AgentA:           "reviewer",
+		AgentB:           "planner",
+		DecisionTypeA:    "architecture",
+		DecisionTypeB:    "architecture",
+		OutcomeA:         second.Outcome,
+		OutcomeB:         first.Outcome,
+		ScoringMethod:    "binding_v1",
+		Relationship:     &relationship,
+		Status:           "open",
+		DisputedQuestion: &question,
+	})
+	require.NoError(t, err)
+
+	conflicts, err := testDB.ListConflicts(ctx, uuid.Nil, storage.ConflictFilters{}, 200, 0)
+	require.NoError(t, err)
+	for _, c := range conflicts {
+		if c.ID == id {
+			require.NotNil(t, c.DisputedQuestion)
+			assert.Equal(t, question, *c.DisputedQuestion)
+			assert.Equal(t, "binding_v1", c.ScoringMethod,
+				"binding conflicts must stay distinguishable from judge verdicts")
+			return
+		}
+	}
+	t.Fatal("binding conflict not found")
 }

--- a/internal/storage/trace.go
+++ b/internal/storage/trace.go
@@ -340,6 +340,31 @@ func (db *DB) createTraceInTx(ctx context.Context, tx pgx.Tx, params CreateTrace
 		}
 	}
 
+	// Bindings go in the same transaction as the decision that declares them.
+	// A binding that outlived a rolled-back trace would claim a parameter no
+	// decision set, and would then conflict with real decisions forever.
+	if len(params.Bindings) > 0 {
+		columns := []string{"id", "decision_id", "org_id", "parameter", "parameter_key", "value", "value_key", "created_at"}
+		rows := make([][]any, len(params.Bindings))
+		for i, b := range params.Bindings {
+			if b.ParameterKey == "" || b.ValueKey == "" {
+				return model.AgentRun{}, model.Decision{}, fmt.Errorf(
+					"storage: binding %q has no canonical key; call model.CanonicalizeBindings first", b.Parameter)
+			}
+			id := b.ID
+			if id == uuid.Nil {
+				id = uuid.New()
+			}
+			rows[i] = []any{id, d.ID, params.OrgID, b.Parameter, b.ParameterKey, b.Value, b.ValueKey, now}
+		}
+		copyCtx, copyCancel := context.WithTimeout(ctx, 30*time.Second)
+		_, err := tx.CopyFrom(copyCtx, pgx.Identifier{"decision_bindings"}, columns, pgx.CopyFromRows(rows))
+		copyCancel()
+		if err != nil {
+			return model.AgentRun{}, model.Decision{}, fmt.Errorf("storage: create bindings in trace tx: %w", err)
+		}
+	}
+
 	// 4. Create evidence via COPY.
 	if len(params.Evidence) > 0 {
 		columns := []string{"id", "decision_id", "org_id", "source_type", "source_uri", "content",

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -44,6 +44,7 @@ type CreateTraceParams struct {
 	Metadata     map[string]any
 	Decision     model.Decision
 	Alternatives []model.Alternative
+	Bindings     []model.Binding
 	Evidence     []model.Evidence
 	SessionID    *uuid.UUID
 	AgentContext map[string]any

--- a/migrations/109_decision_bindings.sql
+++ b/migrations/109_decision_bindings.sql
@@ -1,0 +1,64 @@
+-- 109: Bindings — the named thing a decision sets, and the value it sets it to.
+--
+-- Conflict detection between prose decisions is a screening problem at a ~3%
+-- base rate, and the judge is the only component that discriminates. Bindings
+-- are the exception: when two decisions bind the SAME named parameter to
+-- DIFFERENT values, the conflict is a join, not an inference — no model, no
+-- threshold, no false-positive rate.
+--
+-- Classifying all 93 gold contradictions in the corpus by shape found 27% have
+-- exactly this form (a named parameter with two incompatible values). The other
+-- 73% are mutually-exclusive actions (34%), incompatible factual claims (30%)
+-- and incompatible strategic direction (9%), which have no key to join on and
+-- still need the judge. So this covers roughly a quarter of real contradictions
+-- exactly, and is worthless for the rest — both halves of that are the point.
+--
+-- Why capture rather than extract: four separate attempts to recover this
+-- structure from decision prose after the fact were measured on the corpus and
+-- all failed (typed-artifact token join 1.30x lift, rejected-alternative token
+-- join 1.03x, rejected-alternative semantic join AUC 0.576, logprob tension
+-- score AUC 0.669). 59% of contradictions never name the artifact in their
+-- outcome text at all. The identity has to be declared at write time; it cannot
+-- be reconstructed. This mirrors what every system that ships exact conflict
+-- detection does — Kubernetes server-side apply keys on a JSON field path,
+-- Terraform on attribute paths, OPA on a document path — none of them infer the
+-- referent, and Cedar was deliberately restricted so comparison stays decidable.
+
+CREATE TABLE IF NOT EXISTS decision_bindings (
+    id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    decision_id  UUID NOT NULL REFERENCES decisions(id) ON DELETE CASCADE,
+    org_id       UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+
+    -- parameter is what the agent wrote, preserved for display.
+    parameter    TEXT NOT NULL,
+    -- parameter_key is the canonical form the join runs on. Canonicalization is
+    -- deliberately shallow (case, surrounding whitespace, separator style):
+    -- aggressive normalization would merge genuinely different parameters and
+    -- manufacture conflicts, which is a worse failure than missing one.
+    parameter_key TEXT NOT NULL,
+
+    -- value as written, and its canonical form. Values are compared, never
+    -- interpreted: "5m" and "300s" are different values here, because deciding
+    -- they are the same requires knowing the parameter's type, which we do not.
+    value        TEXT NOT NULL,
+    value_key    TEXT NOT NULL,
+
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    CONSTRAINT decision_bindings_parameter_not_blank CHECK (length(btrim(parameter)) > 0),
+    CONSTRAINT decision_bindings_value_not_blank     CHECK (length(btrim(value)) > 0),
+    -- One decision cannot bind the same parameter twice; the later write would
+    -- otherwise silently conflict with itself.
+    CONSTRAINT decision_bindings_unique_per_decision UNIQUE (decision_id, parameter_key)
+);
+
+-- The detection query is: same org, same parameter_key, different value_key.
+-- org_id leads because every query in this codebase is org-scoped.
+CREATE INDEX IF NOT EXISTS idx_decision_bindings_lookup
+    ON decision_bindings (org_id, parameter_key, value_key);
+
+CREATE INDEX IF NOT EXISTS idx_decision_bindings_decision
+    ON decision_bindings (decision_id);
+
+COMMENT ON TABLE decision_bindings IS
+    'Named parameter a decision sets and the value it sets it to. Two decisions binding the same parameter_key to different value_keys are in exact conflict, detected by join rather than by the LLM judge.';

--- a/migrations/110_scoring_method_binding.sql
+++ b/migrations/110_scoring_method_binding.sql
@@ -1,0 +1,16 @@
+-- 110: Allow scoring_method = 'binding_v1'.
+--
+-- Binding conflicts are found by joining declared parameter bindings rather
+-- than by scoring text (see migration 109). They need their own scoring_method
+-- so they stay distinguishable from judge verdicts: a binding conflict has no
+-- false-positive rate to estimate, and averaging the two together would flatter
+-- the judge's measured precision.
+--
+-- Migration 062's constraint predates the binding path, so an insert from it
+-- would fail the CHECK. That failure is loud rather than silent — the scorer
+-- logs and skips — but it would mean the feature never produced a single
+-- conflict while appearing to work.
+
+ALTER TABLE scored_conflicts DROP CONSTRAINT IF EXISTS scored_conflicts_scoring_method_check;
+ALTER TABLE scored_conflicts ADD CONSTRAINT scored_conflicts_scoring_method_check
+    CHECK (scoring_method = ANY (ARRAY['embedding', 'text', 'claim', 'llm', 'llm_v2', 'external', 'binding_v1']));

--- a/migrations/atlas.sum
+++ b/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:HTUl//U4XMU0Z7Pk3n7NISu66veOFHCb5ksu/QFMZag=
+h1:zOnzmJAbY3IBd32Kr591r/8bP3QsdC4CLohKMny9Gw0=
 001_initial.sql h1:uhyGXto+QacAaGYb9ZTGjsBs5chlKi8O0eHz9aCQsrY=
 022_full_text_search.sql h1:9iwtA8MgCzAxDV9YkUBn0CLT9ePSmj3GcPoMGg8TXf0=
 023_fix_outbox_index.sql h1:OtMEFBcMRWej02+ghnBXlPr6BVq+LoA62Id9XUWfDNI=
@@ -87,3 +87,4 @@ h1:HTUl//U4XMU0Z7Pk3n7NISu66veOFHCb5ksu/QFMZag=
 106_supersedes_suggestion_confirm.sql h1:eLUrgPvmBCscAcfcXmS9rhYzcO5CMI7KC/IjT+5Yxe4=
 107_conflict_gold_labels.sql h1:9jzCeDz6Gz3+uYNsJ70qp+zQ384/Lvk3c1RQQpLyxic=
 108_conflict_disputed_question.sql h1:uUdkk8NqKOwP4y1Pw8G37GQXB5B4O8/YBTcvqk6La8c=
+109_decision_bindings.sql h1:nu1M/ufJ2lUenexO0KetKU9Siu0gDCr0pqxEQqUUHAg=

--- a/migrations/atlas.sum
+++ b/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:zOnzmJAbY3IBd32Kr591r/8bP3QsdC4CLohKMny9Gw0=
+h1:Hz97Y3FWsJnJSI92fpL4gATST5LA4LvAtMaVS7IIeMo=
 001_initial.sql h1:uhyGXto+QacAaGYb9ZTGjsBs5chlKi8O0eHz9aCQsrY=
 022_full_text_search.sql h1:9iwtA8MgCzAxDV9YkUBn0CLT9ePSmj3GcPoMGg8TXf0=
 023_fix_outbox_index.sql h1:OtMEFBcMRWej02+ghnBXlPr6BVq+LoA62Id9XUWfDNI=
@@ -88,3 +88,4 @@ h1:zOnzmJAbY3IBd32Kr591r/8bP3QsdC4CLohKMny9Gw0=
 107_conflict_gold_labels.sql h1:9jzCeDz6Gz3+uYNsJ70qp+zQ384/Lvk3c1RQQpLyxic=
 108_conflict_disputed_question.sql h1:uUdkk8NqKOwP4y1Pw8G37GQXB5B4O8/YBTcvqk6La8c=
 109_decision_bindings.sql h1:nu1M/ufJ2lUenexO0KetKU9Siu0gDCr0pqxEQqUUHAg=
+110_scoring_method_binding.sql h1:Rqe3o4Svad/8J0rBxv9+FN7LtlBdtjrOeLGIsNJLOUY=


### PR DESCRIPTION
## Why

Conflict detection over prose is **screening at a ~3% base rate**. Every judge verdict carries a false-positive rate, and precision is governed almost entirely by the FPR on the majority class.

Bindings are the exception. If a decision declares *the parameter it sets and the value it sets it to*, then two decisions binding the same parameter to different values conflict **exactly** — a join, not an inference. No model, no threshold, no false-positive rate.

Classifying all 93 gold contradictions in the corpus by shape:

| Shape | Share | Joinable? |
|---|---|---|
| **parameter_binding** | **27%** | **yes — exact** |
| mutually_exclusive_action | 34% | no |
| incompatible_factual_claim | 30% | no |
| incompatible_direction | 9% | no |

So this covers roughly a quarter of real contradictions perfectly and is worthless for the rest. Both halves are the point — it is not a replacement for the judge.

## Why capture rather than extract

Four attempts to recover this structure from existing prose were measured on the corpus and all failed:

| Attempt | Result |
|---|---|
| Typed-artifact token join | 1.30× lift at 41% recall |
| Rejected-alternative token join | 1.03–1.13× |
| Rejected-alternative semantic join | AUC 0.576 |
| Logprob "tension" score | AUC 0.669 |

**59% of contradictions never name the artifact in their outcome text at all.** The identity has to be declared; it cannot be reconstructed. This is also what every system that ships exact conflict detection does — Kubernetes server-side apply keys on a JSON field path, Terraform on attribute paths, OPA on a document path. None infers the referent, and Cedar was *deliberately restricted* so policy comparison stays decidable.

## Design

**Scoping is where the correctness lives**, so each condition has a test: same org, same project (cross-project collision was the leading FP source before projects were recorded), current state only (`valid_to IS NULL` — otherwise a decision conflicts with the very decision that replaced it), and never itself. Branch is deliberately **not** scoped out: two branches setting one parameter differently is a real conflict that surfaces at merge.

**Canonicalization is shallow and asymmetric.** Parameter names get case, separator and camel-seam normalization, so `CreateFieldIndex` and `create_field_index` join — that is the actual Qdrant contradiction from our corpus. Values get case and separators only: `5m` and `300s` stay distinct, because deciding they are equal requires the parameter's type, which is not recorded. A wrong merge manufactures a *confident* conflict, which is much worse here than missing one.

**Other choices:** bindings write in the same transaction as their decision (a binding outliving a rolled-back trace would claim a parameter no decision set); malformed bindings are refused at the MCP boundary rather than silently dropped, unlike alternatives, because a dropped binding shows up later as a conflict that should have fired and didn't; conflicts carry `scoring_method = "binding_v1"` and their own metric so they are never averaged into the judge's precision.

## Test plan

- `go build`, `go vet`, `golangci-lint run ./...` (0 issues), `atlas migrate validate`, doc/config consistency
- `go test -count=1 ./...` — passes (`TestGitCommitSubject_CurrentRepo` fails on a clean checkout of main in this environment; pre-existing)
- `go test -tags integration ./internal/model/ ./internal/storage/ ./internal/conflicts/` — 20 new tests
  - **model**: spelling variants join; values are *not* interpreted (`5m` ≠ `300s`, `true` ≠ `yes`); value spelling *is* normalized; malformed bindings rejected; intra-decision duplicates rejected; fan-out limit; raw spelling preserved for display
  - **storage**: different value conflicts; same value does not; camelCase↔snake_case join; different projects do not conflict; superseded excluded; self excluded; null project is its own scope rather than a wildcard; unique constraint backstop; uncanonicalized binding refused

## Follow-up

Once #740 lands, a binding conflict should populate `disputed_question` — for these the parameter name *is* the disputed question ("the value of `cache.ttl`"). Left out here to keep this branch independently mergeable.

> Ada Lovelace's note G is a table of what the Engine does at each step, not a description of what Babbage hoped it would do. The reason it still executes correctly is that every operand names a numbered column — the machine never has to guess which quantity you meant. A hundred and eighty years later we are still discovering that inference is optional but identity is not.