### PR TITLE
fix(compose): plumb the conflict judge knobs into docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,11 @@ services:
       # One-shot: clears open, non-gold-labelled conflicts and re-scores every
       # decision pair. Resolved/false_positive rows are preserved. Unset after use.
       AKASHI_FORCE_CONFLICT_RESCORE: ${AKASHI_FORCE_CONFLICT_RESCORE:-false}
+      # Bounds how far back the backfill reaches. Pair with the rescue flag above:
+      # an unbounded rescore re-judges the whole corpus at one LLM call per pair.
+      AKASHI_CONFLICT_BACKFILL_WINDOW: ${AKASHI_CONFLICT_BACKFILL_WINDOW:-0}
+      AKASHI_CONFLICT_BACKFILL_BATCH_SIZE: ${AKASHI_CONFLICT_BACKFILL_BATCH_SIZE:-500}
+      AKASHI_CONFLICT_BACKFILL_INTERVAL: ${AKASHI_CONFLICT_BACKFILL_INTERVAL:-5m}
 
       AKASHI_PORT: ${AKASHI_PORT:-8080}
       AKASHI_LOG_LEVEL: ${AKASHI_LOG_LEVEL:-info}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,8 +42,20 @@ services:
       OLLAMA_URL: ${OLLAMA_URL:-}
       OLLAMA_MODEL: ${OLLAMA_MODEL:-mxbai-embed-large}
 
-      # Optional — LLM conflict validation (reduces false positives ~93%).
+      # Optional — LLM conflict validation. The judge is the only component that
+      # discriminates (scorer features are label-noise: significance AUC 0.500).
+      # Corpus-projected precision by judge, per ADR-017: gpt-4o-mini 8.1%,
+      # gpt-4o 26.9%, gpt-4.1 28.7%, gpt-5 41.5%. Leaving the default in place
+      # means a 726-pair review queue on a corpus of this size.
       AKASHI_CONFLICT_LLM_MODEL: ${AKASHI_CONFLICT_LLM_MODEL:-}
+      AKASHI_CONFLICT_OPENAI_MODEL: ${AKASHI_CONFLICT_OPENAI_MODEL:-gpt-4o-mini}
+      # Reasoning models need far more than the 15s default: a gpt-5 run at 15s
+      # failed 159 of 200 calls, and validation timeout is fail-safe — it presents
+      # as a silent drop in detections, not an error. Change both together.
+      AKASHI_CONFLICT_LLM_TIMEOUT: ${AKASHI_CONFLICT_LLM_TIMEOUT:-15s}
+      # One-shot: clears open, non-gold-labelled conflicts and re-scores every
+      # decision pair. Resolved/false_positive rows are preserved. Unset after use.
+      AKASHI_FORCE_CONFLICT_RESCORE: ${AKASHI_FORCE_CONFLICT_RESCORE:-false}
 
       AKASHI_PORT: ${AKASHI_PORT:-8080}
       AKASHI_LOG_LEVEL: ${AKASHI_LOG_LEVEL:-info}


### PR DESCRIPTION
## The gap

`AKASHI_CONFLICT_OPENAI_MODEL` was added in #740 but never reached the compose `environment:` block, so a compose deployment had no way to set it and silently ran on the `gpt-4o-mini` default.

ADR-017 measures that default at **8.1%** corpus-projected precision with a 726-pair review queue, against **41.5%** and 113 for the gpt-5 operating point the ADR names as the intended one. So the distance between the documented decision and the shipped behaviour was about 5x in precision, with nothing in the config surface to reveal it. This deployment had been running at the 8.1% point since #740 landed.

## What

Adds `AKASHI_CONFLICT_OPENAI_MODEL`, `AKASHI_CONFLICT_LLM_TIMEOUT`, `AKASHI_FORCE_CONFLICT_RESCORE`, `AKASHI_CONFLICT_BACKFILL_WINDOW`, `AKASHI_CONFLICT_BACKFILL_BATCH_SIZE` and `AKASHI_CONFLICT_BACKFILL_INTERVAL`. Every default preserves current behaviour, so this changes nothing until an operator sets one.

The timeout is documented next to the model because they must move together: a gpt-5 run at the 15s default failed 159 of 200 calls, and validation timeout is fail-safe, so it presents as a quiet drop in detections rather than an error. An operator who changes only the model gets fewer conflicts and no indication why.

## Also

Drops the `reduces false positives ~93%` claim from the comment. ADR-017's full-corpus gold labelling put the shipped detector at 3.4% precision, which falsifies it.

## Note on ordering

The three backfill variables are inert until #745 and #746 land — compose setting an env var the binary does not read yet is harmless. They are grouped here because they are all the same defect: knobs that exist in config but never reached the container.

Compose-only change; no Go code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> The Room of Requirement only opens for someone who already knows what they need, which makes it useless for the problem you have not yet named — and Hogwarts' most dangerous hour arrives when a room full of hidden things becomes a room full of fire. Rowling put a wish-granting machine in the castle and then quietly established that its output is bounded by the precision of the asking.