### PR TITLE
fix(tracehealth): stop reporting calibrated on evidence that cannot support it

### DIFF
--- a/internal/service/tracehealth/service.go
+++ b/internal/service/tracehealth/service.go
@@ -345,17 +345,41 @@ func confidenceCalibrationGap(cal storage.ConfidenceCalibration, cd storage.Conf
 	mid, hasMid := tiers["mid"]
 
 	// Tier 1: Assessment-based calibration (highest signal).
-	if cal.HasOutcomeData && hasHigh && hasMid && high.AvgOutcome != nil && mid.AvgOutcome != nil && high.AssessedCount >= 3 && mid.AssessedCount >= 3 {
+	if cal.HasOutcomeData && hasHigh && hasMid && high.AvgOutcome != nil && mid.AvgOutcome != nil &&
+		high.AssessedCount >= storage.MinAssessedToFlag && mid.AssessedCount >= storage.MinAssessedToFlag {
 		if *high.AvgOutcome < *mid.AvgOutcome {
 			return fmt.Sprintf(
 				"High-confidence decisions (>= 0.85) have avg outcome score %.2f vs %.2f for mid-range — confidence is not predicting outcomes.",
 				*high.AvgOutcome, *mid.AvgOutcome)
 		}
-		return "" // calibrated by outcome data
+		// A low tier that beats mid means the ordering carries no information,
+		// even though the high-vs-mid comparison above looks healthy. Checking
+		// only the two adjacent tiers cannot see it.
+		if low, hasLow := tiers["low"]; hasLow && low.AvgOutcome != nil &&
+			low.AssessedCount >= storage.MinAssessedToFlag && *low.AvgOutcome > *mid.AvgOutcome {
+			return fmt.Sprintf(
+				"Low-confidence decisions (< 0.5) have avg outcome score %.2f vs %.2f for mid-range — confidence ordering does not track outcomes.",
+				*low.AvgOutcome, *mid.AvgOutcome)
+		}
+		// Ordering looks right, but saying so needs a sample that can carry the
+		// claim. Reporting nothing here is what let the trail read as healthy on
+		// a handful of assessments.
+		if high.AssessedCount < storage.MinAssessedToClear || mid.AssessedCount < storage.MinAssessedToClear {
+			return fmt.Sprintf(
+				"Confidence calibration is unverified: only %d of %d high-confidence and %d of %d mid-range decisions have recorded outcomes (need %d per tier). Assess more decisions before trusting confidence scores.",
+				high.AssessedCount, high.Total, mid.AssessedCount, mid.Total, storage.MinAssessedToClear)
+		}
+		return "" // calibrated by outcome data, on a sample that supports it
 	}
 
 	// Tier 2: Revision-rate proxy (temporal signal).
-	if hasHigh && hasMid && high.Total >= 5 && mid.Total >= 5 {
+	//
+	// Requires at least one tier to show revisions. A corpus where nothing is
+	// ever superseded reports a uniform 0% revision rate, and "0% <= 0%" would
+	// clear calibration on a signal that is structurally incapable of firing —
+	// which is the state this deployment is in (never_superseded == total).
+	if hasHigh && hasMid && high.Total >= 5 && mid.Total >= 5 &&
+		(high.RevisionRate > 0 || mid.RevisionRate > 0) {
 		if high.RevisionRate > mid.RevisionRate && high.RevisionRate > 5 {
 			return fmt.Sprintf(
 				"High-confidence decisions (>= 0.85) are revised within 48h at %.0f%% vs %.0f%% for mid-range — agents may be over-committing.",

--- a/internal/service/tracehealth/service_test.go
+++ b/internal/service/tracehealth/service_test.go
@@ -615,13 +615,16 @@ func TestConfidenceCalibrationGap_OutcomeBased_Miscalibrated(t *testing.T) {
 	assert.Contains(t, g, "confidence is not predicting outcomes")
 }
 
-// Tier 1: Assessment-based calibration passes when high >= mid.
+// Tier 1: Assessment-based calibration passes when high >= mid on a sample that
+// can carry the claim. Counts are at MinAssessedToClear: below that the ordering
+// may look right but "calibrated" is not an answer the data supports, which is
+// covered separately by the unverified tests below.
 func TestConfidenceCalibrationGap_OutcomeBased_Calibrated(t *testing.T) {
 	cal := storage.ConfidenceCalibration{
 		HasOutcomeData: true,
 		Tiers: []storage.ConfidenceTier{
-			{Tier: "high", Total: 40, AssessedCount: 10, AvgOutcome: ptrFloat(0.80), RevisionRate: 5},
-			{Tier: "mid", Total: 50, AssessedCount: 15, AvgOutcome: ptrFloat(0.72), RevisionRate: 3},
+			{Tier: "high", Total: 90, AssessedCount: 40, AvgOutcome: ptrFloat(0.80), RevisionRate: 5},
+			{Tier: "mid", Total: 100, AssessedCount: 50, AvgOutcome: ptrFloat(0.72), RevisionRate: 3},
 		},
 	}
 	g := confidenceCalibrationGap(cal, storage.ConfidenceDistribution{})
@@ -777,8 +780,8 @@ func TestConfidenceCalibrationGap_OutcomeTakesPrecedenceOverRevision(t *testing.
 	cal := storage.ConfidenceCalibration{
 		HasOutcomeData: true,
 		Tiers: []storage.ConfidenceTier{
-			{Tier: "high", Total: 30, AssessedCount: 5, AvgOutcome: ptrFloat(0.80), RevisionRate: 25},
-			{Tier: "mid", Total: 50, AssessedCount: 10, AvgOutcome: ptrFloat(0.70), RevisionRate: 2},
+			{Tier: "high", Total: 90, AssessedCount: 40, AvgOutcome: ptrFloat(0.80), RevisionRate: 25},
+			{Tier: "mid", Total: 100, AssessedCount: 50, AvgOutcome: ptrFloat(0.70), RevisionRate: 2},
 		},
 	}
 	g := confidenceCalibrationGap(cal, storage.ConfidenceDistribution{})
@@ -800,4 +803,55 @@ func TestConfidenceCalibrationGap_MissingMidTier(t *testing.T) {
 	g := confidenceCalibrationGap(cal, storage.ConfidenceDistribution{})
 
 	assert.Empty(t, g, "cannot calibrate without mid tier")
+}
+
+// The defect this guards: high >= mid on a handful of assessments used to
+// return no gap at all, so a trail with 2% outcome coverage read as healthy in
+// the one place an operator would look before trusting a confidence score.
+func TestConfidenceCalibrationGap_OutcomeOrderingRightButSampleTooThin(t *testing.T) {
+	cal := storage.ConfidenceCalibration{
+		HasOutcomeData: true,
+		Tiers: []storage.ConfidenceTier{
+			{Tier: "high", Total: 968, AssessedCount: 19, AvgOutcome: ptrFloat(0.95), RevisionRate: 0},
+			{Tier: "mid", Total: 2991, AssessedCount: 205, AvgOutcome: ptrFloat(0.87), RevisionRate: 0},
+		},
+	}
+	g := confidenceCalibrationGap(cal, storage.ConfidenceDistribution{})
+
+	assert.Contains(t, g, "unverified")
+	assert.Contains(t, g, "19 of 968")
+}
+
+// A low tier that outperforms mid means the ordering carries no information,
+// even when high-vs-mid looks healthy. Comparing only adjacent tiers misses it.
+func TestConfidenceCalibrationGap_NonMonotonicTiers(t *testing.T) {
+	cal := storage.ConfidenceCalibration{
+		HasOutcomeData: true,
+		Tiers: []storage.ConfidenceTier{
+			{Tier: "high", Total: 90, AssessedCount: 40, AvgOutcome: ptrFloat(0.95)},
+			{Tier: "mid", Total: 100, AssessedCount: 50, AvgOutcome: ptrFloat(0.87)},
+			{Tier: "low", Total: 40, AssessedCount: 30, AvgOutcome: ptrFloat(0.91)},
+		},
+	}
+	g := confidenceCalibrationGap(cal, storage.ConfidenceDistribution{})
+
+	assert.Contains(t, g, "ordering does not track outcomes")
+}
+
+// A corpus where nothing is ever superseded reports a uniform 0% revision rate.
+// "0% <= 0%" must not clear calibration on a signal that cannot fire.
+func TestConfidenceCalibrationGap_ZeroRevisionRateIsNotEvidence(t *testing.T) {
+	cal := storage.ConfidenceCalibration{
+		HasOutcomeData: false,
+		Tiers: []storage.ConfidenceTier{
+			{Tier: "high", Total: 968, RevisionRate: 0},
+			{Tier: "mid", Total: 2991, RevisionRate: 0},
+		},
+	}
+	// Falls through to the distribution-shape fallback rather than clearing.
+	g := confidenceCalibrationGap(cal, storage.ConfidenceDistribution{
+		TotalDecisions: 4143, AvgConfidence: 0.78, OverconfidentPct: 65,
+	})
+
+	assert.NotEmpty(t, g, "a dead proxy must not be reported as calibration")
 }

--- a/internal/storage/sqlite/tracehealth.go
+++ b/internal/storage/sqlite/tracehealth.go
@@ -300,7 +300,7 @@ func (l *LiteDB) GetConfidenceCalibration(ctx context.Context, orgID uuid.UUID, 
 			break
 		}
 	}
-	cal.Calibrated = storage.ComputeCalibrated(tierMap, cal.HasOutcomeData)
+	cal.Calibrated, cal.CalibrationBasis = storage.ComputeCalibrated(tierMap, cal.HasOutcomeData)
 
 	// Per-agent calibration.
 	agentQuery := `SELECT` + //nolint:gosec // G202: timeFilter contains only parameterized time-range clauses

--- a/internal/storage/tracehealth.go
+++ b/internal/storage/tracehealth.go
@@ -291,7 +291,7 @@ func (db *DB) GetConfidenceCalibration(ctx context.Context, orgID uuid.UUID, fro
 		}
 	}
 
-	cal.Calibrated = ComputeCalibrated(tierMap, cal.HasOutcomeData)
+	cal.Calibrated, cal.CalibrationBasis = ComputeCalibrated(tierMap, cal.HasOutcomeData)
 
 	// Per-agent calibration: revision rate + outcome by agent.
 	agentRows, err := db.pool.Query(ctx, `

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -319,10 +319,17 @@ type AgentCalibration struct {
 // ConfidenceCalibration measures whether declared confidence actually predicts
 // decision outcomes, using both assessment data and temporal proxy signals.
 type ConfidenceCalibration struct {
-	Tiers          []ConfidenceTier   `json:"tiers"`
-	ByAgent        []AgentCalibration `json:"by_agent"`
-	Calibrated     bool               `json:"calibrated"`       // true if high-conf outcomes >= mid-conf
-	HasOutcomeData bool               `json:"has_outcome_data"` // true if any outcome_score IS NOT NULL
+	Tiers   []ConfidenceTier   `json:"tiers"`
+	ByAgent []AgentCalibration `json:"by_agent"`
+	// Calibrated is true only when confidence is DEMONSTRATED to predict
+	// outcomes on a sample large enough to carry the claim. It is not the
+	// negation of "miscalibrated": see CalibrationBasis to tell a measured
+	// result from an absence of evidence.
+	Calibrated bool `json:"calibrated"`
+	// CalibrationBasis is why Calibrated holds the value it does: "outcome",
+	// "revision_rate", "non_monotonic", or "insufficient_evidence".
+	CalibrationBasis string `json:"calibration_basis"`
+	HasOutcomeData   bool   `json:"has_outcome_data"` // true if any outcome_score IS NOT NULL
 }
 
 // ---------------------------------------------------------------------------
@@ -391,25 +398,77 @@ func TruncateOutcome(s string, maxLen int) string {
 	return string(runes[:maxLen])
 }
 
-// ComputeCalibrated determines if high-confidence decisions actually outperform mid-confidence.
-// With outcome data: high-conf avg_outcome must be >= mid-conf avg_outcome.
-// Without: high-conf revision rate must be <= mid-conf revision rate.
-func ComputeCalibrated(tiers map[string]*ConfidenceTier, hasOutcomeData bool) bool {
-	high, mid := tiers["high"], tiers["mid"]
+// Evidence thresholds for calibration claims. They are deliberately asymmetric.
+//
+// Declaring a fleet calibrated is a positive claim that declared confidence
+// predicts outcomes, and it is exactly the claim that is dangerous to get wrong:
+// it tells an operator to trust a number. Flagging possible miscalibration is a
+// warning, and a warning on thin evidence costs an operator a glance.
+//
+// So: MinAssessedToFlag is low enough to warn early, MinAssessedToClear is a
+// real sample. Below the clear bar the answer is "not established", never "yes".
+const (
+	MinAssessedToFlag  = 3
+	MinAssessedToClear = 30
+)
+
+// Calibration bases reported alongside the Calibrated flag, so a consumer can
+// tell a demonstrated result from an absence of evidence.
+const (
+	CalibrationBasisOutcome      = "outcome"
+	CalibrationBasisRevisionRate = "revision_rate"
+	CalibrationBasisInsufficient = "insufficient_evidence"
+	CalibrationBasisNonMonotonic = "non_monotonic"
+)
+
+// ComputeCalibrated reports whether declared confidence is DEMONSTRATED to
+// predict outcomes, and the basis for that answer.
+//
+// It previously returned true in three distinct situations: calibration was
+// shown, no tiers existed, and there was not enough data to call it
+// miscalibrated. Collapsing "shown" together with "unknown" is what let the API
+// answer calibrated=true on 19 assessed decisions out of 968 high-confidence
+// ones — an assertion the data could not support, in the one field an operator
+// would consult before trusting a confidence score. Absence of evidence is now
+// reported as CalibrationBasisInsufficient with calibrated=false.
+//
+// The low tier participates too. Comparing only high against mid cannot see a
+// low tier that outperforms mid, which is not calibration in any useful sense:
+// it says the ordering carries no information.
+func ComputeCalibrated(tiers map[string]*ConfidenceTier, hasOutcomeData bool) (bool, string) {
+	high, mid, low := tiers["high"], tiers["mid"], tiers["low"]
 	if high == nil || mid == nil {
-		return true // insufficient data to determine miscalibration
+		return false, CalibrationBasisInsufficient
 	}
 
-	if hasOutcomeData && high.AvgOutcome != nil && mid.AvgOutcome != nil {
-		return *high.AvgOutcome >= *mid.AvgOutcome
+	if hasOutcomeData && high.AvgOutcome != nil && mid.AvgOutcome != nil &&
+		high.AssessedCount >= MinAssessedToFlag && mid.AssessedCount >= MinAssessedToFlag {
+		if *high.AvgOutcome < *mid.AvgOutcome {
+			return false, CalibrationBasisOutcome
+		}
+		if low != nil && low.AvgOutcome != nil && low.AssessedCount >= MinAssessedToFlag &&
+			*low.AvgOutcome > *mid.AvgOutcome {
+			return false, CalibrationBasisNonMonotonic
+		}
+		if high.AssessedCount >= MinAssessedToClear && mid.AssessedCount >= MinAssessedToClear {
+			return true, CalibrationBasisOutcome
+		}
+		// Ordering looks right but the sample cannot carry the claim.
+		return false, CalibrationBasisInsufficient
 	}
 
 	// Temporal proxy: high-confidence decisions should not be revised more often.
-	if high.Total >= 5 && mid.Total >= 5 {
-		return high.RevisionRate <= mid.RevisionRate
+	// Only meaningful where revisions actually occur — a corpus in which nothing
+	// is ever superseded produces a uniform 0% revision rate, which would
+	// otherwise read as proof of calibration rather than as absence of signal.
+	if high.Total >= 5 && mid.Total >= 5 && (high.RevisionRate > 0 || mid.RevisionRate > 0) {
+		if high.RevisionRate > mid.RevisionRate {
+			return false, CalibrationBasisRevisionRate
+		}
+		return true, CalibrationBasisRevisionRate
 	}
 
-	return true // not enough data to call it miscalibrated
+	return false, CalibrationBasisInsufficient
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/storage/types_test.go
+++ b/internal/storage/types_test.go
@@ -60,3 +60,80 @@ func TestClampPagination(t *testing.T) {
 		assert.Equal(t, 0, offset)
 	})
 }
+
+// ComputeCalibrated must distinguish "shown" from "unknown". Collapsing them is
+// what let the API answer calibrated=true on 19 assessed decisions out of 968.
+func TestComputeCalibrated(t *testing.T) {
+	tier := func(assessed int, outcome float64, total int, revision float64) *ConfidenceTier {
+		o := outcome
+		return &ConfidenceTier{AssessedCount: assessed, AvgOutcome: &o, Total: total, RevisionRate: revision}
+	}
+
+	tests := []struct {
+		name      string
+		tiers     map[string]*ConfidenceTier
+		hasData   bool
+		wantCal   bool
+		wantBasis string
+	}{
+		{
+			name:      "demonstrated on a sample that carries it",
+			tiers:     map[string]*ConfidenceTier{"high": tier(40, 0.90, 90, 0), "mid": tier(50, 0.70, 100, 0)},
+			hasData:   true,
+			wantCal:   true,
+			wantBasis: CalibrationBasisOutcome,
+		},
+		{
+			name:      "right ordering but too few assessments is not a yes",
+			tiers:     map[string]*ConfidenceTier{"high": tier(19, 0.95, 968, 0), "mid": tier(205, 0.87, 2991, 0)},
+			hasData:   true,
+			wantCal:   false,
+			wantBasis: CalibrationBasisInsufficient,
+		},
+		{
+			name:      "high underperforms mid",
+			tiers:     map[string]*ConfidenceTier{"high": tier(40, 0.55, 90, 0), "mid": tier(50, 0.72, 100, 0)},
+			hasData:   true,
+			wantCal:   false,
+			wantBasis: CalibrationBasisOutcome,
+		},
+		{
+			name: "low beats mid — ordering carries no information",
+			tiers: map[string]*ConfidenceTier{
+				"high": tier(40, 0.95, 90, 0), "mid": tier(50, 0.87, 100, 0), "low": tier(30, 0.91, 40, 0),
+			},
+			hasData:   true,
+			wantCal:   false,
+			wantBasis: CalibrationBasisNonMonotonic,
+		},
+		{
+			name:      "uniform zero revision rate is absence of signal, not proof",
+			tiers:     map[string]*ConfidenceTier{"high": tier(0, 0, 968, 0), "mid": tier(0, 0, 2991, 0)},
+			hasData:   false,
+			wantCal:   false,
+			wantBasis: CalibrationBasisInsufficient,
+		},
+		{
+			name:      "revision proxy fires when revisions actually occur",
+			tiers:     map[string]*ConfidenceTier{"high": tier(0, 0, 90, 2), "mid": tier(0, 0, 100, 8)},
+			hasData:   false,
+			wantCal:   true,
+			wantBasis: CalibrationBasisRevisionRate,
+		},
+		{
+			name:      "missing mid tier is unknown, not calibrated",
+			tiers:     map[string]*ConfidenceTier{"high": tier(40, 0.90, 90, 0)},
+			hasData:   true,
+			wantCal:   false,
+			wantBasis: CalibrationBasisInsufficient,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotCal, gotBasis := ComputeCalibrated(tc.tiers, tc.hasData)
+			assert.Equal(t, tc.wantCal, gotCal)
+			assert.Equal(t, tc.wantBasis, gotBasis)
+		})
+	}
+}


### PR DESCRIPTION
## The bug

`akashi_stats` answered `calibrated: true` on **19 assessed decisions out of 968** high-confidence ones — 5.7% outcome coverage across the trail — in the one field an operator consults before deciding whether to trust a confidence score.

`ComputeCalibrated` returned `true` in three different situations: calibration was demonstrated, the tiers were missing, and there was not enough data to call it miscalibrated. Collapsing *shown* together with *unknown* is the whole defect.

## The fix

Absence of evidence now reports `calibrated: false` with basis `insufficient_evidence`, and the basis is carried on the response so a consumer can tell the two apart.

**The thresholds are deliberately asymmetric.** `MinAssessedToFlag` stays at 3; `MinAssessedToClear` is 30.

Raising a single threshold was the obvious fix and the wrong one — it would have silenced the miscalibration warning too, since the existing miscalibrated fixture fires at 10 and 15 assessments. Declaring a fleet calibrated is a positive claim that tells someone to trust a number and is dangerous when wrong. Flagging possible miscalibration is a warning that costs a glance. Those merit different bars.

## Two signals the old logic could not see

**The low tier never participated.** Comparing only high against mid cannot detect a low tier that outperforms mid, which is not calibration in any useful sense — it says the ordering carries no information.

**A uniform 0% revision rate read as proof.** The temporal proxy cleared calibration whenever `high.RevisionRate <= mid.RevisionRate`, and a corpus where nothing is ever superseded reports 0% for every tier. It now requires at least one tier to show revisions before concluding anything. This is a defect in the logic, not a property of this data — any corpus that never supersedes got a false positive result rather than no result.

## Verified against the live trail

Before: `calibrated: true`. After:

```json
"calibrated": false,
"calibration_basis": "non_monotonic"
```

with a new gap that was previously invisible:

> Low-confidence decisions (< 0.5) have avg outcome score 0.91 vs 0.87 for mid-range — confidence ordering does not track outcomes.

It tripped the **non-monotonic** check, not the insufficient-evidence one. Low-confidence decisions (0.911, n=14) are outperforming mid-confidence ones (0.873, n=205). That is not "we cannot tell yet" — it is a measurable statement that confidence ordering carries no information on this trail, and the old code was structurally blind to it.

## Testing

Table-driven tests on `ComputeCalibrated` covering all six states, including the exact production numbers. Three new gap tests. Two existing fixtures asserting no-gap at 5 and 10 assessments were **raised, not reinterpreted** — those tests are about tier precedence and the calibrated path, and both intents remain correct; what changed is that their sample sizes no longer clear a bar the old code never enforced.

No SDK, OpenAPI, or UI surface exposes this field, so the response change is contained to the stats payload and MCP tool output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> Vision lifts Mjolnir in front of everyone and the scene plays as a joke about Thor's face, but it is the only honest audit in the film: worthiness is not self-reported, and the hammer does not care how sure you are. Every other Avenger in that room had already privately concluded they deserved it.