### PR TITLE
feat(conflicts): take supersedes direction from the judge, not the clock

### DIFF
--- a/internal/conflicts/metrics.go
+++ b/internal/conflicts/metrics.go
@@ -38,6 +38,11 @@ type Metrics struct {
 	supersessionSuppressed         metric.Int64Counter
 	bindingConflicts               metric.Int64Counter
 
+	supersessionSideMissing           metric.Int64Counter
+	supersessionDirectionDisagreement metric.Int64Counter
+	supersedesInverseSuppressed       metric.Int64Counter
+	contractDowngraded                metric.Int64Counter
+
 	scoringDuration    metric.Float64Histogram
 	llmCallDuration    metric.Float64Histogram
 	significanceDist   metric.Float64Histogram
@@ -255,6 +260,38 @@ func (s *Scorer) registerMetrics() {
 		if err != nil {
 			s.metrics.bindingConflicts, _ = meter.Int64Counter("akashi.conflicts.binding_conflicts.fallback")
 		}
+	}
+
+	s.metrics.supersessionSideMissing, err = meter.Int64Counter("akashi.conflicts.supersession_side_missing",
+		metric.WithDescription("Supersession verdicts that reached the scorer with no superseding side named. The parser downgrades such verdicts, so a non-zero count means a ValidationResult bypassed ParseValidatorResponse; no supersedes suggestion is written."),
+	)
+	if err != nil {
+		s.logger.Warn("conflicts: failed to create akashi.conflicts.supersession_side_missing metric", "error", err)
+		s.metrics.supersessionSideMissing, _ = meter.Int64Counter("akashi.conflicts.supersession_side_missing.fallback")
+	}
+
+	s.metrics.supersessionDirectionDisagreement, err = meter.Int64Counter("akashi.conflicts.supersession_direction_disagreement",
+		metric.WithDescription("Supersedes suggestions where the validator named a superseding side whose valid_from is earlier than the side it retires (backdated trace, late-filed decision, or revert). The judge's direction is recorded; this counter is the production measurement of a rate the offline gold set cannot measure."),
+	)
+	if err != nil {
+		s.logger.Warn("conflicts: failed to create akashi.conflicts.supersession_direction_disagreement metric", "error", err)
+		s.metrics.supersessionDirectionDisagreement, _ = meter.Int64Counter("akashi.conflicts.supersession_direction_disagreement.fallback")
+	}
+
+	s.metrics.supersedesInverseSuppressed, err = meter.Int64Counter("akashi.conflicts.supersedes_inverse_suppressed",
+		metric.WithDescription("Supersedes suggestions dropped because the inverse link already existed — two passes over the same pair disagreed about which decision retired which. Direction comes from a sampled judge answer, so this is the production measurement of judge orientation instability; a rising count means suggestion direction should not be trusted."),
+	)
+	if err != nil {
+		s.logger.Warn("conflicts: failed to create akashi.conflicts.supersedes_inverse_suppressed metric", "error", err)
+		s.metrics.supersedesInverseSuppressed, _ = meter.Int64Counter("akashi.conflicts.supersedes_inverse_suppressed.fallback")
+	}
+
+	s.metrics.contractDowngraded, err = meter.Int64Counter("akashi.conflicts.contract_downgraded",
+		metric.WithDescription("Verdicts downgraded by a parser-enforced contract: a contradiction that named no question, or a supersession that named no side. Attributed by contract. Without this the downgrade is invisible at the default info log level, so a prompt or parser regression that silently discards valid verdicts looks identical to a quiet corpus."),
+	)
+	if err != nil {
+		s.logger.Warn("conflicts: failed to create akashi.conflicts.contract_downgraded metric", "error", err)
+		s.metrics.contractDowngraded, _ = meter.Int64Counter("akashi.conflicts.contract_downgraded.fallback")
 	}
 
 	// --- Histograms ---

--- a/internal/conflicts/question_contract_test.go
+++ b/internal/conflicts/question_contract_test.go
@@ -67,8 +67,15 @@ func TestParseValidatorResponse_PlaceholderQuestionsDoNotSatisfyContract(t *test
 // dispute was actually identified.
 func TestParseValidatorResponse_QuestionClearedForNonContradiction(t *testing.T) {
 	for _, rel := range []string{"supersession", "complementary", "refinement", "unrelated"} {
+		// A supersession verdict owes a REPLACES side; without it the parser
+		// downgrades to refinement and this test would be asserting the wrong
+		// relationship rather than the question-clearing property it is about.
+		var extra string
+		if rel == "supersession" {
+			extra = "REPLACES: A\n"
+		}
 		result, err := ParseValidatorResponse(fmt.Sprintf(
-			"RELATIONSHIP: %s\nQUESTION: whether to use Redis\nEXPLANATION: x", rel))
+			"RELATIONSHIP: %s\nQUESTION: whether to use Redis\n%sEXPLANATION: x", rel, extra))
 		require.NoError(t, err, "relationship=%s", rel)
 		assert.Equal(t, rel, result.Relationship)
 		assert.Empty(t, result.SharedQuestion, "relationship=%s must not carry a disputed question", rel)

--- a/internal/conflicts/replaces_contract_test.go
+++ b/internal/conflicts/replaces_contract_test.go
@@ -1,0 +1,217 @@
+//go:build !lite
+
+package conflicts
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The supersession contract: a SUPERSESSION verdict must name WHICH side
+// retired the other on its REPLACES line, and a verdict that cannot is
+// downgraded rather than trusted.
+//
+// It is the symmetric sibling of the contradiction contract in
+// question_contract_test.go, and exists for the same measured reason: the
+// prompt already refuses recency as evidence ("every pair you see has a time
+// order, so ordering alone means nothing"), but before this contract the
+// scorer re-derived supersedes direction from ValidFrom one layer down —
+// reinstating exactly what the prompt rejects, and getting backdated traces,
+// late-filed decisions, and reverts backwards.
+//
+// The contract gates on the side token only. "Did you quote real replacement
+// language" is not machine-checkable, and enforcing it would only teach the
+// model to emit filler — the failure mode #740 documents.
+
+func TestParseValidatorResponse_SupersessionWithoutReplacesIsDowngraded(t *testing.T) {
+	result, err := ParseValidatorResponse(
+		"RELATIONSHIP: supersession\nCATEGORY: strategic\nSEVERITY: medium\nEXPLANATION: B replaces A.")
+	require.NoError(t, err)
+
+	assert.Equal(t, "refinement", result.Relationship,
+		"a supersession that names no superseding side must not stand")
+	assert.False(t, result.IsConflict(), "downgraded verdicts must not open conflicts")
+	assert.Empty(t, result.SupersedingSide)
+	assert.Empty(t, result.ReplacementEvidence)
+	assert.Contains(t, result.Explanation, "downgraded",
+		"the downgrade must be visible in the explanation, not silent")
+	assert.Contains(t, result.Explanation, "B replaces A.",
+		"the validator's own explanation must be preserved")
+}
+
+func TestParseValidatorResponse_SupersessionWithReplacesSurvives(t *testing.T) {
+	result, err := ParseValidatorResponse(
+		"RELATIONSHIP: supersession\nREPLACES: B: replaced REST v1 with gRPC\n" +
+			"CATEGORY: strategic\nSEVERITY: medium\nEXPLANATION: the gRPC decision retires the REST one.")
+	require.NoError(t, err)
+
+	assert.Equal(t, "supersession", result.Relationship)
+	assert.True(t, result.IsConflict())
+	assert.Equal(t, "B", result.SupersedingSide)
+	assert.Equal(t, "replaced REST v1 with gRPC", result.ReplacementEvidence)
+	assert.NotContains(t, result.Explanation, "downgraded")
+}
+
+// The side token alone satisfies the contract. Quoted replacement language is
+// advisory: it enriches the supersedes-suggestion reason but cannot be
+// validated, and gating on it would produce filler rather than evidence.
+func TestParseValidatorResponse_ReplacesSideOnlyIsSufficient(t *testing.T) {
+	result, err := ParseValidatorResponse(
+		"RELATIONSHIP: supersession\nREPLACES: A\nEXPLANATION: x")
+	require.NoError(t, err)
+
+	assert.Equal(t, "supersession", result.Relationship)
+	assert.Equal(t, "A", result.SupersedingSide)
+	assert.Empty(t, result.ReplacementEvidence)
+	assert.NotContains(t, result.Explanation, "downgraded")
+}
+
+// Two failure families must both miss the contract: the placeholder spellings
+// models emit for "nothing here", and the answers that mean "I could not pick a
+// side". The second family is why the accepted set is closed rather than
+// "anything non-placeholder" — "Both" would otherwise read as B and
+// "Ambiguous" as A, turning the two clearest non-answers into confident
+// directions.
+func TestParseValidatorResponse_PlaceholderReplacesDoesNotSatisfyContract(t *testing.T) {
+	for _, placeholder := range []string{
+		"n/a", "N/A", "none", "NONE", "null", "nil", "not applicable", "-", "  ", "\"n/a\"", "[n/a]", "N/A.",
+		"both", "Both decisions", "A/B", "ambiguous", "neither", "unclear",
+		// Enumerations. The value's job is to SELECT one side; naming both is a
+		// refusal to choose. The first of these is the prompt's own response-format
+		// template verbatim — an echoed template is a routine LLM failure, and it
+		// parsed as a confident selection of side A until this was rejected.
+		"A or B, then the replacement language",
+		"A and B", "A, B", "A or B", "B and A",
+		// Named-then-retracted. Storing a withdrawal as the justification for a
+		// durable, agent-facing link is worse than storing nothing.
+		"A: no explicit replacement language found",
+		"A. Actually neither, they are complementary",
+		"B: none found",
+		// The English article, not a side label.
+		"a bit unclear", "a little of both",
+	} {
+		t.Run(placeholder, func(t *testing.T) {
+			result, err := ParseValidatorResponse(fmt.Sprintf(
+				"RELATIONSHIP: supersession\nREPLACES: %s\nEXPLANATION: x", placeholder))
+			require.NoError(t, err)
+			assert.Equal(t, "refinement", result.Relationship,
+				"placeholder %q must not satisfy the named-side requirement", placeholder)
+			assert.Empty(t, result.SupersedingSide, "placeholder %q must not resolve to a side", placeholder)
+		})
+	}
+}
+
+// A genuine REPLACES value wrapped in markdown must survive — the trimming must
+// not be so aggressive that it eats the side token or the evidence.
+func TestParseValidatorResponse_MarkdownWrappedReplacesSurvives(t *testing.T) {
+	result, err := ParseValidatorResponse(
+		"RELATIONSHIP: supersession\nREPLACES: **B — replaced REST v1**\nEXPLANATION: x")
+	require.NoError(t, err)
+
+	assert.Equal(t, "supersession", result.Relationship)
+	assert.Equal(t, "B", result.SupersedingSide)
+	assert.Equal(t, "replaced REST v1", result.ReplacementEvidence)
+}
+
+func TestParseValidatorResponse_ReplacesAcceptsDecisionPrefixAndCase(t *testing.T) {
+	cases := []struct {
+		raw          string
+		expectedSide string
+	}{
+		{"Decision B", "B"},
+		{"decision b — x", "B"},
+		{"b", "B"},
+		{"**A**", "A"},
+		{"[A]", "A"},
+		{"A: withdrew the earlier plan", "A"},
+		// Decorated token FOLLOWED BY evidence — the exact shape the prompt asks
+		// for. normalizeValue only unwraps a value's outer ends, so the closing
+		// "**" survives as an interior character; these all failed until the
+		// separator set covered it, and the failure was a silent downgrade.
+		{"**B**: replaced REST v1 with gRPC", "B"},
+		{"**Decision B**: replaced REST v1", "B"},
+		{`"B": replaced REST v1`, "B"},
+		{"B — replaced REST v1 with gRPC", "B"},
+		{"B, replaced REST v1", "B"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.raw, func(t *testing.T) {
+			result, err := ParseValidatorResponse(fmt.Sprintf(
+				"RELATIONSHIP: supersession\nREPLACES: %s\nEXPLANATION: x", tc.raw))
+			require.NoError(t, err)
+			assert.Equal(t, "supersession", result.Relationship)
+			assert.Equal(t, tc.expectedSide, result.SupersedingSide)
+		})
+	}
+}
+
+// Non-supersession verdicts carry no side, even when the model supplies one, so
+// downstream consumers can treat a populated SupersedingSide as proof the judge
+// actually chose a direction. Exact mirror of the question-contract sibling.
+func TestParseValidatorResponse_ReplacesClearedForNonSupersession(t *testing.T) {
+	for _, rel := range []string{"contradiction", "complementary", "refinement", "unrelated"} {
+		// contradiction owes a QUESTION or it would be downgraded, and this
+		// test is not about that contract.
+		var extra string
+		if rel == "contradiction" {
+			extra = "QUESTION: whether to use Redis\n"
+		}
+		result, err := ParseValidatorResponse(fmt.Sprintf(
+			"RELATIONSHIP: %s\n%sREPLACES: A: replaced the earlier plan\nEXPLANATION: x", rel, extra))
+		require.NoError(t, err, "relationship=%s", rel)
+		assert.Equal(t, rel, result.Relationship)
+		assert.Empty(t, result.SupersedingSide, "relationship=%s must not carry a superseding side", rel)
+		assert.Empty(t, result.ReplacementEvidence, "relationship=%s must not carry replacement evidence", rel)
+	}
+}
+
+// The contract must run AFTER the truncation-alias switch, otherwise a model
+// that shortens "supersession" to "supersede" escapes it entirely.
+func TestParseValidatorResponse_SupersedeAliasStillBoundByContract(t *testing.T) {
+	withSide, err := ParseValidatorResponse("RELATIONSHIP: supersede\nREPLACES: A\nEXPLANATION: x")
+	require.NoError(t, err)
+	assert.Equal(t, "supersession", withSide.Relationship)
+	assert.Equal(t, "A", withSide.SupersedingSide)
+
+	withoutSide, err := ParseValidatorResponse("RELATIONSHIP: supersede\nEXPLANATION: x")
+	require.NoError(t, err)
+	assert.Equal(t, "refinement", withoutSide.Relationship,
+		"the alias must be normalized before the contract runs, not after")
+}
+
+// The question contract exempts the pre-taxonomy "VERDICT: yes/no" form because
+// that prompt never asked for a question. The supersession contract needs no
+// such exemption and deliberately carries no "&& !legacyVerdict" conjunct: the
+// legacy form can only ever produce "contradiction" or "unrelated", so the
+// conjunct would be dead code implying a reachable path that does not exist.
+// This test pins that reasoning — if the legacy mapping ever grows a
+// supersession branch, it fails here and the exemption question gets reopened.
+func TestParseValidatorResponse_LegacyVerdictCannotProduceSupersession(t *testing.T) {
+	yes, err := ParseValidatorResponse("VERDICT: yes\nCATEGORY: assessment\nSEVERITY: high\nEXPLANATION: legacy format")
+	require.NoError(t, err)
+	assert.Equal(t, "contradiction", yes.Relationship,
+		"the legacy form maps yes→contradiction; it can never reach supersession")
+	assert.NotContains(t, yes.Explanation, "downgraded")
+
+	no, err := ParseValidatorResponse("VERDICT: no\nCATEGORY: factual\nSEVERITY: low\nEXPLANATION: legacy format")
+	require.NoError(t, err)
+	assert.Equal(t, "unrelated", no.Relationship,
+		"the legacy form maps no→unrelated; it can never reach supersession")
+	assert.NotContains(t, no.Explanation, "downgraded")
+}
+
+// The two contracts must not interfere: a contradiction missing its question
+// downgrades to complementary regardless of any REPLACES line the model
+// volunteered.
+func TestParseValidatorResponse_ContradictionContractUnaffectedByReplaces(t *testing.T) {
+	result, err := ParseValidatorResponse("RELATIONSHIP: contradiction\nREPLACES: A\nEXPLANATION: x")
+	require.NoError(t, err)
+
+	assert.Equal(t, "complementary", result.Relationship,
+		"a REPLACES line is not a substitute for the disputed question")
+	assert.Empty(t, result.SupersedingSide)
+	assert.Contains(t, result.Explanation, "no disputed question")
+}

--- a/internal/conflicts/scorer.go
+++ b/internal/conflicts/scorer.go
@@ -22,9 +22,32 @@ import (
 	"go.opentelemetry.io/otel/metric"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/ashita-ai/akashi/internal/compact"
 	"github.com/ashita-ai/akashi/internal/model"
 	"github.com/ashita-ai/akashi/internal/search"
 	"github.com/ashita-ai/akashi/internal/storage"
+)
+
+const (
+	// supersedesSourceSameTicket attributes a suggestion to the pre-LLM
+	// same-agent same-ticket structural filter, which has no judge verdict.
+	supersedesSourceSameTicket = "detector:same_agent_same_ticket"
+	// supersedesSourceLLM attributes a suggestion to the LLM validator's
+	// supersession verdict, with judge direction and recorded order agreeing.
+	supersedesSourceLLM = "detector:llm_supersession"
+	// supersedesSourceLLMBackdated is the same verdict where the judge named a
+	// superseding side whose valid_from is strictly EARLIER than the side it
+	// retires — a backdated trace, a late-filed decision, or a revert. Split
+	// into its own source so the two populations can be counted and, when
+	// per-source precision is finally measured, scored separately. There is no
+	// CHECK on decision_supersedes.suggested_by values, so this needs no migration.
+	supersedesSourceLLMBackdated = "detector:llm_supersession_backdated"
+	// supersedesReasonMaxDetail bounds the judge language copied into
+	// suggested_reason. The column is unbounded TEXT, so this is a payload
+	// contract rather than a storage one: internal/mcp/tools.go passes reason
+	// to agents verbatim with no truncation. 300 runes matches the bound
+	// formatPrompt already applies to reasoning text.
+	supersedesReasonMaxDetail = 300
 )
 
 // agentContextString extracts a string value from the agent_context JSONB map.
@@ -839,6 +862,9 @@ func (s *Scorer) scoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 			}
 
 			llmStart := time.Now()
+			// A is always d and B is always cand. validatorSideDecision maps the
+			// judge's REPLACES token back through this correspondence — keep them
+			// in sync.
 			result, err := s.validator.Validate(ctx, ValidateInput{
 				OutcomeA:          sc.bestOutA,
 				OutcomeB:          sc.bestOutB,
@@ -905,10 +931,22 @@ func (s *Scorer) scoreForDecision(ctx context.Context, decisionID, orgID uuid.UU
 				s.logger.Debug("conflict scorer: supersession recorded as supersedes suggestion, not opened as conflict",
 					"decision_a", decisionID, "decision_b", cand.ID,
 					"explanation", result.Explanation)
-				s.recordSupersedesSuggestionFromValidator(ctx, d, cand, sc.topicSim)
+				s.recordSupersedesSuggestionFromValidator(ctx, d, cand, sc.topicSim, result)
 				continue
 			}
 			if !result.IsConflict() {
+				// A contract downgrade is not the same event as an honest
+				// non-conflict verdict, but both land here. Count it separately —
+				// this branch logs at Debug, which is off at the default info
+				// level, so without the counter a parser or prompt regression that
+				// discards valid verdicts is indistinguishable from a quiet corpus.
+				if result.DowngradedBy != "" {
+					s.metrics.contractDowngraded.Add(ctx, 1,
+						metric.WithAttributes(attribute.String("contract", result.DowngradedBy)))
+					s.logger.Info("conflict scorer: verdict downgraded by parser contract",
+						"decision_a", decisionID, "decision_b", cand.ID,
+						"contract", result.DowngradedBy, "relationship", result.Relationship)
+				}
 				s.logger.Debug("conflict scorer: LLM classified as non-conflict",
 					"decision_a", decisionID, "decision_b", cand.ID,
 					"relationship", result.Relationship, "explanation", result.Explanation)
@@ -1572,18 +1610,42 @@ func isSameBranchSelfCorrection(d, cand model.Decision) bool {
 	return branchA != "" && branchB != "" && branchA == branchB
 }
 
-// recordSupersedesSuggestion writes the detector-inferred supersedes link
-// for a suppressed same-agent same-ticket pair so akashi_check can surface
-// it on the agent's next call (PR-2 of #708, see issue #710). The later
-// decision (by ValidFrom) is the superseding side, mirroring how a manually
-// set supersedes_id link works; suggestion confidence is the topic similarity
-// at filter time, so agents see how strongly the detector believed the pair was
-// the same work. Ordering, confidence clamping, and the fire-and-forget write
-// contract all live in insertSupersedesSuggestion.
+// validatorSideDecision maps the side token the validator named on its REPLACES
+// line back onto the scored pair.
+//
+// The mapping is fixed by the ValidateInput literal in scoreForDecision:
+// OutcomeA / TypeA / AgentA / CreatedA / FullOutcomeA / BranchA / TicketRefsA
+// are ALL built from d, and every *B field from cand. So "A" is d and "B" is
+// cand. Any change to that literal must change this function with it; there is
+// no other place the correspondence is recorded.
+func validatorSideDecision(side string, d, cand model.Decision) (superseding, superseded model.Decision, ok bool) {
+	switch side {
+	case "A":
+		return d, cand, true
+	case "B":
+		return cand, d, true
+	default:
+		return model.Decision{}, model.Decision{}, false
+	}
+}
+
+// recordSupersedesSuggestion writes the detector-inferred supersedes link for a
+// suppressed same-agent same-ticket pair so akashi_check can surface it on the
+// agent's next call (PR-2 of #708, see issue #710).
+//
+// This path runs in the pre-LLM structural-filter block: there is no judge
+// verdict, so recorded order is the ONLY direction signal available and the
+// reason string says so explicitly. Do not borrow the LLM path's language here
+// — the attribution has to stay honest about what produced it.
 func (s *Scorer) recordSupersedesSuggestion(ctx context.Context, d, cand model.Decision, topicSim float64, ticket string) {
-	s.insertSupersedesSuggestion(ctx, d, cand, topicSim,
-		"detector:same_agent_same_ticket",
-		fmt.Sprintf("same agent %q, same ticket %q", d.AgentID, ticket))
+	superseding, superseded := d, cand
+	if cand.ValidFrom.After(d.ValidFrom) {
+		superseding, superseded = cand, d
+	}
+	s.insertSupersedesSuggestion(ctx, superseding, superseded, topicSim,
+		supersedesSourceSameTicket,
+		fmt.Sprintf("same agent %q, same ticket %q; direction from recorded order (no validator verdict on this path)",
+			d.AgentID, ticket))
 }
 
 // recordSupersedesSuggestionFromValidator records the supersedes link the LLM
@@ -1592,36 +1654,84 @@ func (s *Scorer) recordSupersedesSuggestion(ctx context.Context, d, cand model.D
 // standing disagreement between live positions, so it is surfaced as a supersedes
 // suggestion (which drives the supersedes_id link on the agent's next
 // akashi_check, issue #710) instead of being opened as a conflict a human must
-// triage. This is the post-LLM sibling of the pre-LLM same-agent/cross-agent
-// refinement suppressors, which already redirect their pairs the same way. See
-// the supersession interception in scoreForDecision.
+// triage.
 //
-// Mirrors a manual supersedes_id link: the later decision (by ValidFrom) retires
-// the earlier one, regardless of whether the same or a different agent authored
-// it — a later decision that explicitly replaces an earlier one supersedes it in
-// both cases.
-func (s *Scorer) recordSupersedesSuggestionFromValidator(ctx context.Context, d, cand model.Decision, topicSim float64) {
-	superseding := d
-	if cand.ValidFrom.After(d.ValidFrom) {
-		superseding = cand
+// Direction comes from the judge's REPLACES line, never from ValidFrom. The
+// prompt refuses recency as evidence ("every candidate pair has a time order,
+// so ordering alone means nothing") and re-deriving direction from the clock
+// here reintroduced exactly that, breaking on backdated traces, late-filed
+// decisions, and reverts. When the judge's direction and recorded order
+// disagree, that is signal about the trace, not an error to resolve in favour
+// of the clock: the row is written with the judge's direction under a distinct
+// suggested_by so the two populations stay separable.
+func (s *Scorer) recordSupersedesSuggestionFromValidator(ctx context.Context, d, cand model.Decision, topicSim float64, result ValidationResult) {
+	superseding, superseded, ok := validatorSideDecision(result.SupersedingSide, d, cand)
+	if !ok {
+		// ParseValidatorResponse guarantees a supersession verdict carries a
+		// side token — it downgrades one that does not. So an empty or
+		// unrecognised side here means the ValidationResult did not come from
+		// the parser: an in-process validator, or a test double constructing
+		// the struct directly.
+		//
+		// Direction IS the content of this record, so refusing to write it is
+		// the only honest option; falling back to ValidFrom is the clock
+		// inference this function exists to remove. Logged at error rather than
+		// warn because it is a contract violation, not a transient write
+		// failure — but it still returns rather than propagating, because this
+		// is a fire-and-forget path inside the scoring loop and the documented
+		// contract is that suggestion writes never block scoring. Loud with no
+		// side effect beats silent with a guessed direction.
+		s.metrics.supersessionSideMissing.Add(ctx, 1)
+		s.logger.Error("conflict scorer: supersession verdict carried no superseding side, no supersedes suggestion written",
+			"decision_a", d.ID, "decision_b", cand.ID,
+			"side", result.SupersedingSide,
+			"validator", s.validatorLabel)
+		return
 	}
-	s.insertSupersedesSuggestion(ctx, d, cand, topicSim,
-		"detector:llm_supersession",
-		fmt.Sprintf("LLM validator classified %q's later decision as a supersession", superseding.AgentID))
+
+	// The judge quoted replacement language when it could; its one-sentence
+	// explanation is the fallback. Either way the reason carries the judge's
+	// own finding instead of a template rendered from an inference we just made.
+	detail := result.ReplacementEvidence
+	if detail == "" {
+		detail = result.Explanation
+	}
+	detail = compact.Truncate(strings.TrimSpace(detail), supersedesReasonMaxDetail)
+
+	// Decision IDs are included because agent IDs do not disambiguate the sides
+	// of a same-agent pair, which is the common case for this detector.
+	reason := fmt.Sprintf("LLM validator: %q's decision %s replaces %q's decision %s — %s",
+		superseding.AgentID, superseding.ID.String()[:8],
+		superseded.AgentID, superseded.ID.String()[:8], detail)
+
+	suggestedBy := supersedesSourceLLM
+	// Disagreement is strict: equal timestamps mean the clock has no opinion,
+	// not that it dissents.
+	if superseded.ValidFrom.After(superseding.ValidFrom) {
+		suggestedBy = supersedesSourceLLMBackdated
+		reason = "judge direction disagrees with recorded order (the retired decision has the later valid_from): " + reason
+		s.metrics.supersessionDirectionDisagreement.Add(ctx, 1)
+		s.logger.Warn("conflict scorer: supersedes direction from validator disagrees with recorded order",
+			"superseding_id", superseding.ID, "superseded_id", superseded.ID,
+			"superseding_valid_from", superseding.ValidFrom,
+			"superseded_valid_from", superseded.ValidFrom,
+			"side", result.SupersedingSide,
+			"validator", s.validatorLabel)
+	}
+
+	s.insertSupersedesSuggestion(ctx, superseding, superseded, topicSim, suggestedBy, reason)
 }
 
 // insertSupersedesSuggestion is the shared core behind the supersedes-suggestion
-// callers. It orders the pair by ValidFrom (later = superseding), clamps topicSim
+// callers. Direction is the CALLER's decision — this function does not infer it
+// — because the two callers derive it from different evidence (the judge's
+// REPLACES line vs recorded order on a path with no judge). It clamps topicSim
 // into the [0,1] confidence contract (cosine similarity is mathematically in
-// [-1,1] but the API bounds confidence to [0,1]), and writes the suggestion
-// fire-and-forget: a write failure is logged at warn and never blocks scoring,
-// because the conflict has already been filtered or redirected away from the
-// open queue by the time this runs.
-func (s *Scorer) insertSupersedesSuggestion(ctx context.Context, d, cand model.Decision, topicSim float64, suggestedBy, reason string) {
-	superseding, superseded := d, cand
-	if cand.ValidFrom.After(d.ValidFrom) {
-		superseding, superseded = cand, d
-	}
+// [-1,1] but the API bounds confidence to [0,1]) and writes fire-and-forget: a
+// write failure is logged at warn and never blocks scoring, because the pair has
+// already been filtered or redirected away from the open queue by the time this
+// runs.
+func (s *Scorer) insertSupersedesSuggestion(ctx context.Context, superseding, superseded model.Decision, topicSim float64, suggestedBy, reason string) {
 	switch {
 	case topicSim < 0:
 		topicSim = 0
@@ -1629,17 +1739,31 @@ func (s *Scorer) insertSupersedesSuggestion(ctx context.Context, d, cand model.D
 		topicSim = 1
 	}
 	conf := float32(topicSim)
-	if err := s.db.InsertSupersedesSuggestion(ctx, storage.SupersedesSuggestionInsert{
-		OrgID:         d.OrgID,
+	inverseExists, err := s.db.InsertSupersedesSuggestion(ctx, storage.SupersedesSuggestionInsert{
+		OrgID:         superseding.OrgID,
 		SupersedingID: superseding.ID,
 		SupersededID:  superseded.ID,
 		SuggestedBy:   suggestedBy,
 		Confidence:    &conf,
 		Reason:        reason,
-	}); err != nil {
+	})
+	if err != nil {
 		s.logger.Warn("conflict scorer: insert supersedes suggestion failed",
 			"superseding_id", superseding.ID, "superseded_id", superseded.ID,
 			"suggested_by", suggestedBy, "error", err)
+		return
+	}
+	if inverseExists {
+		// The opposite direction is already recorded for this pair. Since the
+		// judge now decides direction and is sampled, this means two passes over
+		// the same pair disagreed about which decision retired which. Nothing was
+		// written. Surface it at WARN rather than resolving it silently — a
+		// direction picked by whichever pass ran last is exactly the guessed link
+		// this change exists to stop recording.
+		s.metrics.supersedesInverseSuppressed.Add(ctx, 1)
+		s.logger.Warn("conflict scorer: supersedes suggestion contradicts an existing inverse link, not recorded",
+			"superseding_id", superseding.ID, "superseded_id", superseded.ID,
+			"suggested_by", suggestedBy)
 	}
 }
 

--- a/internal/conflicts/validator.go
+++ b/internal/conflicts/validator.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/ashita-ai/akashi/internal/compact"
 )
@@ -56,6 +57,37 @@ type ValidationResult struct {
 	// verdict that cannot name one is downgraded to complementary by
 	// ParseValidatorResponse. Empty for every other relationship.
 	SharedQuestion string
+
+	// SupersedingSide is the side the validator named on its REPLACES line as
+	// retiring the other: "A" or "B", matching the Decision A / Decision B
+	// labels formatPrompt writes. The prompt requires it for a SUPERSESSION
+	// verdict; a verdict that cannot name a side is downgraded to refinement by
+	// ParseValidatorResponse. Empty for every other relationship.
+	//
+	// This is the ONLY source of supersedes direction. It deliberately does not
+	// fall back to timestamp order: the prompt refuses recency as evidence, and
+	// re-deriving direction from ValidFrom one layer down reintroduced exactly
+	// what the prompt rejects, breaking on backdated traces and reverts.
+	SupersedingSide string
+
+	// ReplacementEvidence is the replacement language the validator quoted
+	// after the side token on the REPLACES line. Advisory: it is carried into
+	// the supersedes-suggestion reason but does NOT gate the contract, because
+	// free text cannot be validated and requiring it would only produce filler.
+	// Empty for every other relationship.
+	ReplacementEvidence string
+
+	// DowngradedBy names the parser-enforced contract that rewrote the verdict:
+	// "question" (a contradiction that named no disputed question) or "replaces"
+	// (a supersession that named no superseding side). Empty when the model's
+	// verdict was taken as given.
+	//
+	// It exists because a downgrade is otherwise indistinguishable downstream
+	// from an honest complementary/refinement verdict: both land in the same
+	// !IsConflict() branch, which logs at Debug and is therefore off at the
+	// default info level. A prompt or parser regression that silently discards
+	// valid verdicts would look exactly like a quiet corpus.
+	DowngradedBy string
 }
 
 // IsConflict returns true if the relationship represents an actionable conflict.
@@ -100,7 +132,12 @@ func formatPrompt(input ValidateInput) string {
 	b.WriteString("You are a relationship classifier for an AI decision audit system.\n\n")
 
 	// --- Decision by agent A ---
-	fmt.Fprintf(&b, "Agent %q decision (%s, recorded %s):\n%s\n",
+	// The "Decision A" / "Decision B" labels are the prompt's only stable way
+	// to refer to a side: agent names are not unique (same-agent pairs are the
+	// common case, see agentContext above) and timestamps are the clock the
+	// REPLACES contract exists to stop treating as evidence. The DIFFERENT
+	// BRANCHES hint below already used these labels without defining them.
+	fmt.Fprintf(&b, "Decision A (agent %q, %s, recorded %s):\n%s\n",
 		input.AgentA, input.TypeA, input.CreatedA.Format(time.RFC3339), input.OutcomeA)
 	if input.FullOutcomeA != "" && input.FullOutcomeA != input.OutcomeA {
 		fmt.Fprintf(&b, "[Full decision context: %s]\n", compact.Truncate(input.FullOutcomeA, 500))
@@ -110,7 +147,7 @@ func formatPrompt(input ValidateInput) string {
 	}
 
 	// --- Decision by agent B ---
-	fmt.Fprintf(&b, "\nAgent %q decision (%s, recorded %s):\n%s\n",
+	fmt.Fprintf(&b, "\nDecision B (agent %q, %s, recorded %s):\n%s\n",
 		input.AgentB, input.TypeB, input.CreatedB.Format(time.RFC3339), input.OutcomeB)
 	if input.FullOutcomeB != "" && input.FullOutcomeB != input.OutcomeB {
 		fmt.Fprintf(&b, "[Full decision context: %s]\n", compact.Truncate(input.FullOutcomeB, 500))
@@ -270,11 +307,11 @@ APPLY THESE TESTS IN ORDER. Stop at the first one that fits.
    work items, subsystems, incidents, tickets, or scopes, there is no shared question →
    COMPLEMENTARY (related work) or UNRELATED (different subject matter). Stop here.
 
-2. DID THE LATER DECISION EXPLICITLY RETIRE THE EARLIER ONE? Supersession requires stated evidence of
-   replacement — the later decision reverts, replaces, withdraws, or corrects the earlier position, or
+2. DID ONE DECISION EXPLICITLY RETIRE THE OTHER? Supersession requires stated evidence of
+   replacement — one decision reverts, replaces, withdraws, or corrects the other's position, or
    refers to it as done, obsolete, or changed. Being recorded later is NOT evidence of replacement:
-   every pair you see has a time order, so ordering alone means nothing. Without explicit replacement
-   language, this is not SUPERSESSION.
+   every pair you see has a time order, so ordering alone means nothing. Name the retiring side on
+   the REPLACES line. Without explicit replacement language, this is not SUPERSESSION.
 
 3. ARE BOTH POSITIONS STILL LIVE AND INCOMPATIBLE? If the two decisions answer the same question
    differently and neither has retired the other, someone must still choose between them →
@@ -285,8 +322,14 @@ CONTRADICTION REQUIRES A NAMED QUESTION:
 State on the QUESTION line the single question the two decisions answer differently, in one clause
 ("whether to run CreateFieldIndex at startup"). If you cannot name it, the answer is not CONTRADICTION.
 
+SUPERSESSION REQUIRES A NAMED SIDE:
+State on the REPLACES line which decision retired the other — A or B — then the replacement language
+you found ("B: replaced REST v1 with gRPC"). Time order is not replacement language. If you cannot
+name the side, the answer is not SUPERSESSION.
+
 RELATIONSHIP: one of [contradiction, supersession, complementary, refinement, unrelated]
 QUESTION: the single disputed question (required for contradiction; otherwise "n/a")
+REPLACES: A or B, then the replacement language (required for supersession; otherwise "n/a")
 CATEGORY: factual, assessment, strategic, or temporal
 SEVERITY: critical, high, medium, or low
 EXPLANATION: one sentence using agent names (not "Decision A" or "Decision B")`)
@@ -364,7 +407,7 @@ func formatDuration(d time.Duration) string {
 func ParseValidatorResponse(response string) (ValidationResult, error) {
 	lines := strings.Split(strings.TrimSpace(response), "\n")
 
-	var relationship, explanation, category, severity, question string
+	var relationship, explanation, category, severity, question, replaces string
 	// legacyVerdict marks a response that carried only the pre-taxonomy
 	// "VERDICT: yes/no" form. Those responses come from a prompt that never
 	// asked for a disputed question, so the contradiction contract below must
@@ -402,6 +445,9 @@ func ParseValidatorResponse(response string) (ValidationResult, error) {
 			explanation = strings.TrimLeft(strings.TrimSpace(trimmed[len("explanation:"):]), "*_ ")
 		case strings.HasPrefix(lower, "question:"):
 			question = strings.TrimLeft(strings.TrimSpace(trimmed[len("question:"):]), "*_ ")
+		case strings.HasPrefix(lower, "replaces:"):
+			// TrimLeft only — the value is a side token followed by free text.
+			replaces = strings.TrimLeft(strings.TrimSpace(trimmed[len("replaces:"):]), "*_ ")
 		case strings.HasPrefix(lower, "category:"):
 			category = strings.ToLower(strings.Trim(strings.TrimSpace(trimmed[len("category:"):]), "*_ "))
 		case strings.HasPrefix(lower, "severity:"):
@@ -452,8 +498,10 @@ func ParseValidatorResponse(response string) (ValidationResult, error) {
 	//
 	// Downgrade target is complementary, not unrelated: these pairs cleared
 	// embedding similarity, so they are topically related by construction.
+	var downgradedBy string
 	if relationship == "contradiction" && question == "" && !legacyVerdict {
 		relationship = "complementary"
+		downgradedBy = "question"
 		if explanation != "" {
 			explanation += " "
 		}
@@ -463,12 +511,48 @@ func ParseValidatorResponse(response string) (ValidationResult, error) {
 		question = ""
 	}
 
+	replacesSide, replacesEvidence := parseReplacesLine(replaces)
+
+	// Parser-enforced supersession contract, symmetric to the contradiction
+	// contract above. A SUPERSESSION verdict must name which side retired the
+	// other; a model that cannot name one has observed a timeline, not a
+	// replacement. Enforced here rather than in the prompt for the same
+	// measured reason as the question contract.
+	//
+	// Downgrade target is refinement, not complementary: the model asserted one
+	// decision evolves from the other, and that claim survives even when the
+	// replacement cannot be located. refinement is not IsConflict(), so a
+	// downgraded verdict writes nothing at all — no conflict AND no supersedes
+	// suggestion. That is deliberate: recording a link in a guessed direction is
+	// worse than recording nothing, because the link is durable and agent-facing.
+	//
+	// No legacyVerdict exemption is applied, and none is needed: the legacy
+	// "VERDICT: yes/no" form can only ever yield "contradiction" or "unrelated".
+	// "supersession" is reachable only from an explicit RELATIONSHIP line (or
+	// its "supersede" truncation alias, likewise RELATIONSHIP-only), so
+	// legacyVerdict is provably false here. Adding "&& !legacyVerdict" would be
+	// dead code implying a path that cannot exist.
+	if relationship == "supersession" && replacesSide == "" {
+		relationship = "refinement"
+		downgradedBy = "replaces"
+		if explanation != "" {
+			explanation += " "
+		}
+		explanation += "(downgraded: validator named no superseding side)"
+	}
+	if relationship != "supersession" {
+		replacesSide, replacesEvidence = "", ""
+	}
+
 	return ValidationResult{
-		Relationship:   relationship,
-		Explanation:    explanation,
-		Category:       category,
-		Severity:       severity,
-		SharedQuestion: question,
+		Relationship:        relationship,
+		Explanation:         explanation,
+		Category:            category,
+		Severity:            severity,
+		SharedQuestion:      question,
+		SupersedingSide:     replacesSide,
+		ReplacementEvidence: replacesEvidence,
+		DowngradedBy:        downgradedBy,
 	}, nil
 }
 
@@ -479,20 +563,182 @@ var placeholderQuestions = map[string]bool{
 	"not applicable": true, "-": true, "": true,
 }
 
+// normalizeValue strips the markdown, bracket, and quote wrapping models put
+// around a field value. Three interleaved passes, so "**[n/a]**" unwraps: the
+// markers can nest either way round.
+func normalizeValue(v string) string {
+	v = strings.Trim(strings.TrimSpace(v), "*_ ")
+	v = strings.Trim(strings.TrimSpace(v), "[]\"'")
+	return strings.TrimSpace(strings.Trim(v, "*_ "))
+}
+
 // normalizeSharedQuestion trims a QUESTION value and collapses placeholders to
 // the empty string so the contradiction contract treats them as unanswered.
+// A bold-wrapped placeholder ("**n/a**") must still be recognised — the key
+// parses fine, so a survivor would satisfy the contract with no question at all.
 func normalizeSharedQuestion(q string) string {
-	// Models wrap values in markdown and brackets, and a bold-wrapped
-	// placeholder ("**n/a**") must still be recognised as a placeholder — the
-	// key parses fine, so a survivor here would satisfy the contradiction
-	// contract with no question at all.
-	q = strings.Trim(strings.TrimSpace(q), "*_ ")
-	q = strings.Trim(strings.TrimSpace(q), "[]\"'")
-	q = strings.TrimSpace(strings.Trim(q, "*_ "))
+	q = normalizeValue(q)
 	if placeholderQuestions[strings.ToLower(strings.TrimRight(q, ".!"))] {
 		return ""
 	}
 	return q
+}
+
+// replacesSeparators are the characters a model may put between the side token
+// and its quoted replacement language.
+//
+// The markdown and double-quote characters are here because normalizeValue only
+// unwraps a value's outer ends: `**B**: replaced X` normalizes to `B**: replaced X`,
+// leaving the closing `**` interior. Rejecting that discarded the exact shape the
+// prompt asks for, and the discard was silent — the verdict was downgraded to
+// refinement and the judge's finding thrown away.
+//
+// Deliberately absent: `/`, so `A/B` still fails, and `'`, so an apostrophe
+// ("A's decision replaces B's") fails rather than parsing with mangled evidence.
+// Both failures are downgrades, which is the safe direction.
+const replacesSeparators = ":-–—|,.;\t *_\""
+
+// replacesCoordinators open a remainder that continues an enumeration rather
+// than quoting replacement language.
+var replacesCoordinators = map[string]bool{
+	"and": true, "or": true, "&": true, "+": true,
+	"then": true, "vs": true, "versus": true, "plus": true,
+}
+
+// replacesRetractions are standalone words by which a model takes back the
+// finding it just made. "A: no explicit replacement language found" names a side
+// and then withdraws it; storing that as the justification for a durable link is
+// worse than storing nothing.
+var replacesRetractions = map[string]bool{
+	"neither": true, "none": true, "n/a": true, "na": true, "nothing": true,
+	"unclear": true, "ambiguous": true, "unknown": true, "no": true,
+	"not": true, "cannot": true,
+}
+
+// replacesWords splits evidence into comparable words, trimming the punctuation
+// models attach to them so "B," and "**B**" both compare as "b".
+func replacesWords(evidence string) []string {
+	fields := strings.Fields(strings.ToLower(evidence))
+	out := make([]string, 0, len(fields))
+	for _, f := range fields {
+		out = append(out, strings.Trim(f, "*_[]\"'`,.;:!?()—–-"))
+	}
+	return out
+}
+
+// namesOppositeSide reports whether the evidence names the side that was NOT
+// selected as a standalone word. The value's job is to pick one of two
+// decisions, so a remainder that names the other one is an enumeration
+// ("A, B", "A or B"), not a selection.
+func namesOppositeSide(evidence, side string) bool {
+	other := "b"
+	if strings.EqualFold(side, "B") {
+		other = "a"
+	}
+	words := replacesWords(evidence)
+	for i, w := range words {
+		if w != other {
+			continue
+		}
+		// "decision b" is the same claim spelled longer.
+		if i > 0 && words[i-1] == "decision" {
+			return true
+		}
+		return true
+	}
+	return false
+}
+
+// enumeratesOrRetracts reports whether the evidence continues an enumeration or
+// withdraws the finding instead of quoting replacement language.
+func enumeratesOrRetracts(evidence string) bool {
+	words := replacesWords(evidence)
+	if len(words) == 0 {
+		return false
+	}
+	if replacesCoordinators[words[0]] {
+		return true
+	}
+	for _, w := range words {
+		if replacesRetractions[w] {
+			return true
+		}
+	}
+	return false
+}
+
+// parseReplacesLine splits a REPLACES value into the side the validator named
+// and the replacement language it quoted.
+//
+// The accepted side set is closed ("A" or "B"), which is what makes the
+// supersession contract enforceable: unlike QUESTION, "non-placeholder implies
+// valid" is not sound here, because the value's whole job is to select one of
+// two decisions. Anything that is not unambiguously one side — "n/a", "both",
+// "A/B", "ambiguous", a bare separator — fails the contract and returns "".
+// Note the placeholder table above is subsumed: every placeholder spelling
+// starts with 'n', '-', or is empty, none of which can be a side token.
+func parseReplacesLine(raw string) (side, evidence string) {
+	v := normalizeValue(raw)
+	// Models sometimes spell the side as "Decision A"; strip the noise word so
+	// "Decision B — replaced X" still resolves to B.
+	if len(v) >= len("decision ") && strings.EqualFold(v[:len("decision ")], "decision ") {
+		v = strings.TrimSpace(v[len("decision "):])
+	}
+	if v == "" {
+		return "", ""
+	}
+	// Take the WHOLE leading run of letters as the candidate token. Testing only
+	// the first byte read "Ambiguous" as A and "Both" as B — the two answers that
+	// most clearly mean the model could not pick a side — and left the closed-set
+	// property resting on the separator guard alone.
+	i := 0
+	for i < len(v) && isASCIILetter(v[i]) {
+		i++
+	}
+	token := v[:i]
+	switch token {
+	case "A", "B", "a", "b":
+		side = strings.ToUpper(token)
+	default:
+		return "", ""
+	}
+	rest := v[i:]
+	// A real side token stands alone or is followed by a separator.
+	if rest != "" {
+		r, _ := utf8.DecodeRuneInString(rest)
+		if !strings.ContainsRune(replacesSeparators, r) {
+			return "", ""
+		}
+		// A LOWERCASE token separated from what follows by nothing but whitespace
+		// is the English article far more often than a side label: "a bit unclear"
+		// is not a selection of A. "b — replaced X" is a selection of B, so the
+		// test is what the whitespace leads to, not the case on its own.
+		if token == "a" || token == "b" {
+			if after := strings.TrimLeft(rest, " \t"); len(after) != len(rest) {
+				ar, _ := utf8.DecodeRuneInString(after)
+				if after == "" || !strings.ContainsRune(replacesSeparators, ar) || ar == ' ' || ar == '\t' {
+					return "", ""
+				}
+			}
+		}
+	}
+	evidence = normalizeValue(strings.TrimLeft(rest, replacesSeparators))
+	// The value's job is to SELECT one side. A remainder naming the other side,
+	// opening with a coordinator, or retracting the finding means the model
+	// enumerated or gave up rather than choosing — and the prompt's own response
+	// template ("A or B, then the replacement language") parses as a bare side
+	// selection unless this rejects it, so an echoed template would otherwise
+	// write a guessed direction into a durable, agent-facing link.
+	if namesOppositeSide(evidence, side) || enumeratesOrRetracts(evidence) {
+		return "", ""
+	}
+	return side, evidence
+}
+
+// isASCIILetter reports whether b is an unaccented ASCII letter. Side tokens are
+// a closed two-value set, so no wider alphabet is needed.
+func isASCIILetter(b byte) bool {
+	return (b >= 'A' && b <= 'Z') || (b >= 'a' && b <= 'z')
 }
 
 // NoopValidator marks candidates as unvalidated when no LLM is configured.

--- a/internal/conflicts/validator_test.go
+++ b/internal/conflicts/validator_test.go
@@ -48,12 +48,18 @@ func TestParseValidatorResponse_Complementary(t *testing.T) {
 }
 
 func TestParseValidatorResponse_Supersession(t *testing.T) {
-	result, err := ParseValidatorResponse("RELATIONSHIP: supersession\nCATEGORY: strategic\nSEVERITY: medium\nEXPLANATION: Decision B explicitly replaces Decision A.")
+	// The REPLACES line is required by the supersession contract: a verdict
+	// that names no superseding side is downgraded to refinement. The subject
+	// of this test — that a supersession verdict round-trips as an actionable
+	// conflict — is unchanged; only the fixture had to grow the field.
+	result, err := ParseValidatorResponse("RELATIONSHIP: supersession\nREPLACES: B: explicitly replaces A's API protocol choice\n" +
+		"CATEGORY: strategic\nSEVERITY: medium\nEXPLANATION: Decision B explicitly replaces Decision A.")
 	require.NoError(t, err)
 	assert.Equal(t, "supersession", result.Relationship)
 	assert.True(t, result.IsConflict(), "supersession is an actionable conflict")
 	assert.Equal(t, "strategic", result.Category)
 	assert.Equal(t, "medium", result.Severity)
+	assert.Equal(t, "B", result.SupersedingSide)
 }
 
 func TestParseValidatorResponse_Refinement(t *testing.T) {
@@ -186,8 +192,16 @@ func TestParseValidatorResponse_AllSeverities(t *testing.T) {
 }
 
 func TestParseValidatorResponse_AllRelationships(t *testing.T) {
+	// Each relationship carries whatever its parser contract demands:
+	// contradiction owes a QUESTION, supersession owes a REPLACES side. The
+	// subject here is the five-value round-trip, not the contracts themselves
+	// (question_contract_test.go and replaces_contract_test.go own those).
+	extra := map[string]string{
+		"contradiction": "QUESTION: whether to use Redis or Memcached for the cache\n",
+		"supersession":  "REPLACES: A\n",
+	}
 	for _, rel := range []string{"contradiction", "supersession", "complementary", "refinement", "unrelated"} {
-		result, err := ParseValidatorResponse(fmt.Sprintf("RELATIONSHIP: %s\nQUESTION: whether to use Redis or Memcached for the cache\nCATEGORY: factual\nSEVERITY: low\nEXPLANATION: test", rel))
+		result, err := ParseValidatorResponse(fmt.Sprintf("RELATIONSHIP: %s\n%sCATEGORY: factual\nSEVERITY: low\nEXPLANATION: test", rel, extra[rel]))
 		require.NoError(t, err, "relationship=%s", rel)
 		assert.Equal(t, rel, result.Relationship, "relationship=%s", rel)
 	}
@@ -249,7 +263,10 @@ func TestParseValidatorResponse_TruncatedRelationships(t *testing.T) {
 		expected string
 	}{
 		{"RELATIONSHIP: refine\nEXPLANATION: x", "refinement"},
-		{"RELATIONSHIP: supersede\nEXPLANATION: x", "supersession"},
+		// REPLACES is required for the alias to survive the supersession
+		// contract; the alias-under-contract interaction has its own test in
+		// replaces_contract_test.go.
+		{"RELATIONSHIP: supersede\nREPLACES: A\nEXPLANATION: x", "supersession"},
 		{"RELATIONSHIP: contradict\nQUESTION: whether to use Redis or Memcached for the cache\nEXPLANATION: x", "contradiction"},
 		{"RELATIONSHIP: complement\nEXPLANATION: x", "complementary"},
 	}
@@ -635,6 +652,17 @@ func TestFormatPrompt_DifferentTicketRefsSameDesignQuestionCanStillConflict(t *t
 	// reachable across disjoint tickets.
 	assert.Contains(t, prompt, "CONTRADICTION REQUIRES A NAMED QUESTION")
 	assert.Contains(t, prompt, "OPPOSITE STANCES")
+
+	// The supersession contract is the symmetric sibling: a SUPERSESSION verdict
+	// owes a named side on the REPLACES line, and the parser downgrades one that
+	// cannot name it.
+	assert.Contains(t, prompt, "SUPERSESSION REQUIRES A NAMED SIDE")
+	assert.Contains(t, prompt, "REPLACES:")
+	// The Decision A / Decision B headers are the only anchor the REPLACES side
+	// token has. A header reformat that drops them silently strips the contract
+	// of its meaning, so pin them here.
+	assert.Contains(t, prompt, "Decision A (agent")
+	assert.Contains(t, prompt, "Decision B (agent")
 }
 
 func TestFormatPrompt_SharedTicketRefs(t *testing.T) {
@@ -1136,11 +1164,17 @@ func TestScoreForDecision_LLMSupersession(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	// ScoreForDecision(dB.ID) makes dB the scored decision, so the validator's
+	// side "A" is dB and side "B" is dA (see validatorSideDecision). The judge
+	// therefore names dB — the decision whose outcome carries the replacement
+	// language — as the superseding side.
 	validator := &mockValidator{result: ValidationResult{
-		Relationship: "supersession",
-		Explanation:  "Decision B explicitly replaces Decision A's API protocol choice.",
-		Category:     "strategic",
-		Severity:     "medium",
+		Relationship:        "supersession",
+		Explanation:         "The gRPC decision explicitly replaces the REST v1 API protocol choice.",
+		Category:            "strategic",
+		Severity:            "medium",
+		SupersedingSide:     "A",
+		ReplacementEvidence: "replaced REST v1 with gRPC",
 	}}
 	scorer := NewScorer(testDB, logger, 0.1, validator, 0, 0)
 	scorer = scorer.WithCandidateFinder(storage.NewPgCandidateFinder(testDB))
@@ -1181,12 +1215,192 @@ func TestScoreForDecision_LLMSupersession(t *testing.T) {
 		}
 	}
 	require.NotNil(t, found, "supersession should produce a supersedes suggestion for the dA→dB pair")
+	// Direction now comes from the judge's REPLACES side, not from ValidFrom.
+	// dB is still the superseding side here because the judge named it; that
+	// recorded order agrees is incidental, and no longer what decides it.
 	assert.Equal(t, dB.ID, found.SupersedingID)
-	assert.Equal(t, "detector:llm_supersession", found.SuggestedBy)
+	assert.Equal(t, "detector:llm_supersession", found.SuggestedBy,
+		"judge direction and recorded order agree in this fixture")
 	require.NotNil(t, found.Confidence)
 	assert.InDelta(t, 1.0, *found.Confidence, 0.01,
 		"identical topic embeddings should yield confidence ≈ 1.0")
 	assert.Contains(t, found.Reason, agentID)
+	// The judge's own replacement language must reach the durable row. Before
+	// this change the reason was a template rendered from the clock inference
+	// and the judge's finding was logged and discarded.
+	assert.Contains(t, found.Reason, "replaced REST v1 with gRPC")
+}
+
+// The case the old clock rule got backwards. The judge names the EARLIER
+// decision as the one that retired the later one — a backdated trace, a
+// late-filed decision, or a revert. Direction must follow the judge, and the
+// disagreement must be recorded rather than silently resolved in favour of the
+// clock, because "the judge and the clock disagree" is information about the
+// trace that nothing else in the system captures.
+func TestScoreForDecision_LLMSupersessionUsesJudgeDirectionOverClock(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.Default()
+	orgID := uuid.Nil
+
+	suffix := uuid.New().String()[:8]
+	agentID := "llm-backdated-" + suffix
+	_, err := testDB.CreateAgent(ctx, model.Agent{
+		AgentID: agentID, OrgID: orgID, Name: agentID, Role: model.RoleAgent,
+	})
+	require.NoError(t, err)
+
+	runOld := createRun(t, agentID, orgID)
+	runNew := createRun(t, agentID, orgID)
+
+	topicEmb := makeEmbedding(960, 1.0)
+	outcomeEmbOld := makeEmbedding(961, 1.0)
+	outcomeEmbNew := makeEmbedding(962, 1.0)
+
+	dOld, err := testDB.CreateDecision(ctx, model.Decision{
+		RunID: runOld.ID, AgentID: agentID, OrgID: orgID,
+		DecisionType: "architecture", Outcome: "reverted the gRPC migration, REST v1 stays",
+		Confidence: 0.8, Embedding: &topicEmb, OutcomeEmbedding: &outcomeEmbOld,
+		ValidFrom: time.Now().Add(-2 * time.Hour),
+	})
+	require.NoError(t, err)
+
+	dNew, err := testDB.CreateDecision(ctx, model.Decision{
+		RunID: runNew.ID, AgentID: agentID, OrgID: orgID,
+		DecisionType: "architecture", Outcome: "migrate the API to gRPC",
+		Confidence: 0.9, Embedding: &topicEmb, OutcomeEmbedding: &outcomeEmbNew,
+		ValidFrom: time.Now(),
+	})
+	require.NoError(t, err)
+
+	// dNew is the scored decision, so side "A" is dNew and side "B" is dOld.
+	// The judge names B — the decision with the EARLIER valid_from — as the one
+	// that retired the other. The clock says the opposite.
+	validator := &mockValidator{result: ValidationResult{
+		Relationship:        "supersession",
+		Explanation:         "the revert retires the gRPC migration decision.",
+		Category:            "strategic",
+		Severity:            "medium",
+		SupersedingSide:     "B",
+		ReplacementEvidence: "reverted the gRPC migration",
+	}}
+	scorer := NewScorer(testDB, logger, 0.1, validator, 0, 0)
+	scorer = scorer.WithCandidateFinder(storage.NewPgCandidateFinder(testDB))
+	scorer.ScoreForDecision(ctx, dNew.ID, orgID)
+
+	// The read path fans out on superseding_id, and the judge flipped which
+	// decision that is — so the query targets dOld, not dNew. Scope to the
+	// specific pair: this suite shares org uuid.Nil and the candidate finder
+	// returns every embedding-neighbour in it.
+	suggestions, err := testDB.ListSupersedesSuggestionsForDecisions(ctx, orgID, []uuid.UUID{dOld.ID})
+	require.NoError(t, err)
+	var found *model.SupersedesSuggestion
+	for i := range suggestions {
+		if suggestions[i].SupersededID == dNew.ID {
+			found = &suggestions[i]
+			break
+		}
+	}
+	require.NotNil(t, found,
+		"the judge named the earlier decision as superseding; the suggestion must follow the judge, not the clock")
+	assert.Equal(t, dOld.ID, found.SupersedingID)
+	assert.Equal(t, dNew.ID, found.SupersededID)
+	assert.Equal(t, "detector:llm_supersession_backdated", found.SuggestedBy,
+		"judge/clock disagreement must be attributable, not folded into the agreeing population")
+	assert.Contains(t, found.Reason, "judge direction disagrees with recorded order")
+	assert.Contains(t, found.Reason, "reverted the gRPC migration")
+
+	// The clock-ordered row must not also exist: a fallback that wrote it would
+	// leave two contradictory durable links for one pair.
+	reverse, err := testDB.ListSupersedesSuggestionsForDecisions(ctx, orgID, []uuid.UUID{dNew.ID})
+	require.NoError(t, err)
+	for i := range reverse {
+		assert.NotEqual(t, dOld.ID, reverse[i].SupersededID,
+			"no clock-ordered suggestion may be written for a pair the judge ordered the other way")
+	}
+}
+
+// A supersession verdict with no superseding side cannot reach the scorer
+// through ParseValidatorResponse — the contract downgrades it first — so this
+// exercises the remaining producer: an in-process validator or test double
+// building the struct directly. Direction IS the content of the record, so the
+// scorer refuses to write one rather than falling back to the clock. Loud with
+// no side effect beats silent with a guessed direction.
+func TestScoreForDecision_LLMSupersessionWithoutSideWritesNothing(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.Default()
+	orgID := uuid.Nil
+
+	suffix := uuid.New().String()[:8]
+	agentID := "llm-noside-" + suffix
+	_, err := testDB.CreateAgent(ctx, model.Agent{
+		AgentID: agentID, OrgID: orgID, Name: agentID, Role: model.RoleAgent,
+	})
+	require.NoError(t, err)
+
+	runA := createRun(t, agentID, orgID)
+	runB := createRun(t, agentID, orgID)
+
+	topicEmb := makeEmbedding(970, 1.0)
+	outcomeEmbA := makeEmbedding(971, 1.0)
+	outcomeEmbB := makeEmbedding(972, 1.0)
+
+	dA, err := testDB.CreateDecision(ctx, model.Decision{
+		RunID: runA.ID, AgentID: agentID, OrgID: orgID,
+		DecisionType: "architecture", Outcome: "use REST v1 API",
+		Confidence: 0.8, Embedding: &topicEmb, OutcomeEmbedding: &outcomeEmbA,
+		ValidFrom: time.Now().Add(-2 * time.Hour),
+	})
+	require.NoError(t, err)
+
+	dB, err := testDB.CreateDecision(ctx, model.Decision{
+		RunID: runB.ID, AgentID: agentID, OrgID: orgID,
+		DecisionType: "architecture", Outcome: "replaced REST v1 with gRPC",
+		Confidence: 0.9, Embedding: &topicEmb, OutcomeEmbedding: &outcomeEmbB,
+		ValidFrom: time.Now(),
+	})
+	require.NoError(t, err)
+
+	validator := &mockValidator{result: ValidationResult{
+		Relationship: "supersession",
+		Explanation:  "one of them replaces the other, unclear which.",
+		Category:     "strategic",
+		Severity:     "medium",
+		// SupersedingSide deliberately empty.
+	}}
+	scorer := NewScorer(testDB, logger, 0.1, validator, 0, 0)
+	scorer = scorer.WithCandidateFinder(storage.NewPgCandidateFinder(testDB))
+	scorer.ScoreForDecision(ctx, dB.ID, orgID)
+
+	// Without this the test could pass vacuously: an upstream structural filter
+	// suppressing the pair before the LLM would also write no suggestion, for a
+	// reason that has nothing to do with the missing side.
+	require.Positive(t, validator.callCount, "the pair must reach the LLM interception path")
+
+	for _, pair := range []struct {
+		superseding, superseded uuid.UUID
+	}{
+		{dB.ID, dA.ID},
+		{dA.ID, dB.ID},
+	} {
+		suggestions, err := testDB.ListSupersedesSuggestionsForDecisions(ctx, orgID, []uuid.UUID{pair.superseding})
+		require.NoError(t, err)
+		for i := range suggestions {
+			assert.NotEqualf(t, pair.superseded, suggestions[i].SupersededID,
+				"a supersession with no named side must write no supersedes suggestion (got %s→%s)",
+				pair.superseding, pair.superseded)
+		}
+	}
+
+	// Suppression still applies: the pair is intercepted as a supersession
+	// before the conflict-insertion path, so no conflict is opened either.
+	conflicts, err := testDB.ListConflicts(ctx, orgID, storage.ConflictFilters{}, 1000, 0)
+	require.NoError(t, err)
+	for _, c := range conflicts {
+		aMatch := c.DecisionAID == dA.ID || c.DecisionBID == dA.ID
+		bMatch := c.DecisionAID == dB.ID || c.DecisionBID == dB.ID
+		assert.Falsef(t, aMatch && bMatch,
+			"supersession must NOT be opened as a conflict (got conflict %s)", c.ID)
+	}
 }
 
 func TestScoreForDecision_LLMError(t *testing.T) {

--- a/internal/service/decisions/helpers_test.go
+++ b/internal/service/decisions/helpers_test.go
@@ -515,8 +515,8 @@ func (m *mockStore) ListSupersedesSuggestionsForDecisions(_ context.Context, _ u
 	return nil, nil
 }
 
-func (m *mockStore) InsertSupersedesSuggestion(_ context.Context, _ storage.SupersedesSuggestionInsert) error {
-	return nil
+func (m *mockStore) InsertSupersedesSuggestion(_ context.Context, _ storage.SupersedesSuggestionInsert) (bool, error) {
+	return false, nil
 }
 
 func (m *mockStore) DeleteOldSupersedesSuggestions(_ context.Context, _ time.Time) (int64, error) {

--- a/internal/service/decisions/service_test.go
+++ b/internal/service/decisions/service_test.go
@@ -192,14 +192,15 @@ func TestCheck_SurfacesSupersedesSuggestions(t *testing.T) {
 	require.NoError(t, err)
 
 	conf := float32(0.91)
-	require.NoError(t, testDB.InsertSupersedesSuggestion(ctx, storage.SupersedesSuggestionInsert{
+	_, err = testDB.InsertSupersedesSuggestion(ctx, storage.SupersedesSuggestionInsert{
 		OrgID:         uuid.Nil,
 		SupersedingID: later.DecisionID,
 		SupersededID:  earlier.DecisionID,
 		SuggestedBy:   "detector:same_agent_same_ticket",
 		Confidence:    &conf,
 		Reason:        `same agent "` + agentID + `", same ticket "ARD-958"`,
-	}))
+	})
+	require.NoError(t, err)
 
 	resp, err := testSvc.Check(ctx, uuid.Nil, decisions.CheckInput{
 		DecisionType: "implementation",

--- a/internal/storage/sqlite/supersedes_suggestions.go
+++ b/internal/storage/sqlite/supersedes_suggestions.go
@@ -18,12 +18,28 @@ import (
 // 'suggested' row in decision_supersedes. Mirrors the Postgres behavior:
 // idempotent, no-op when a row already exists for (superseding_id,
 // superseded_id) — confirmed links are never overwritten by suggestions.
-func (l *LiteDB) InsertSupersedesSuggestion(ctx context.Context, s storage.SupersedesSuggestionInsert) error {
+// It also refuses to write when the INVERSE row exists, mirroring the Postgres
+// guard: the key is the ordered pair, so (X,Y) and (Y,X) do not collide, and
+// direction now comes from a sampled judge answer rather than from stored data.
+// Guarding one backend and not the other is how the unguarded one silently
+// becomes the divergence path.
+func (l *LiteDB) InsertSupersedesSuggestion(ctx context.Context, s storage.SupersedesSuggestionInsert) (bool, error) {
 	if s.SuggestedBy == "" {
-		return errors.New("sqlite: suggested_by is required for supersedes suggestion")
+		return false, errors.New("sqlite: suggested_by is required for supersedes suggestion")
 	}
 	if s.SupersedingID == s.SupersededID {
-		return errors.New("sqlite: superseding_id and superseded_id must differ")
+		return false, errors.New("sqlite: superseding_id and superseded_id must differ")
+	}
+	var inverseExists bool
+	if err := l.db.QueryRowContext(ctx,
+		`SELECT EXISTS (SELECT 1 FROM decision_supersedes
+		                 WHERE superseding_id = ? AND superseded_id = ? AND org_id = ?)`,
+		uuidStr(s.SupersededID), uuidStr(s.SupersedingID), uuidStr(s.OrgID),
+	).Scan(&inverseExists); err != nil {
+		return false, fmt.Errorf("sqlite: check inverse supersedes suggestion: %w", err)
+	}
+	if inverseExists {
+		return true, nil
 	}
 	var conf any
 	if s.Confidence != nil {
@@ -47,9 +63,9 @@ func (l *LiteDB) InsertSupersedesSuggestion(ctx context.Context, s storage.Super
 		s.SuggestedBy, conf, reason, timeStr(time.Now().UTC()),
 	)
 	if err != nil {
-		return fmt.Errorf("sqlite: insert supersedes suggestion: %w", err)
+		return false, fmt.Errorf("sqlite: insert supersedes suggestion: %w", err)
 	}
-	return nil
+	return false, nil
 }
 
 // ListSupersedesSuggestionsForDecisions returns suggested supersedes links

--- a/internal/storage/sqlite/supersedes_suggestions_test.go
+++ b/internal/storage/sqlite/supersedes_suggestions_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ashita-ai/akashi/internal/model"
 	"github.com/ashita-ai/akashi/internal/storage"
+	"github.com/ashita-ai/akashi/internal/storage/sqlite"
 )
 
 func TestInsertSupersedesSuggestion_BasicAndIdempotent(t *testing.T) {
@@ -31,7 +32,7 @@ func TestInsertSupersedesSuggestion_BasicAndIdempotent(t *testing.T) {
 		Confidence:    &conf,
 		Reason:        `same agent "claude-code", same ticket "ARD-958"`,
 	}
-	require.NoError(t, db.InsertSupersedesSuggestion(ctx, first))
+	mustInsertSuggestion(t, db, ctx, first)
 
 	got, err := db.ListSupersedesSuggestionsForDecisions(ctx, orgID, []uuid.UUID{b.ID})
 	require.NoError(t, err)
@@ -47,7 +48,7 @@ func TestInsertSupersedesSuggestion_BasicAndIdempotent(t *testing.T) {
 	// retry is intentionally discarded — the first detector observation wins.
 	second := first
 	second.Reason = "noop on retry"
-	require.NoError(t, db.InsertSupersedesSuggestion(ctx, second))
+	mustInsertSuggestion(t, db, ctx, second)
 
 	got, err = db.ListSupersedesSuggestionsForDecisions(ctx, orgID, []uuid.UUID{b.ID})
 	require.NoError(t, err)
@@ -65,7 +66,7 @@ func TestInsertSupersedesSuggestion_RejectsEmptySource(t *testing.T) {
 	a := createTestDecision(t, db, orgID, "agent", "first")
 	b := createTestDecision(t, db, orgID, "agent", "second")
 
-	err := db.InsertSupersedesSuggestion(ctx, storage.SupersedesSuggestionInsert{
+	_, err := db.InsertSupersedesSuggestion(ctx, storage.SupersedesSuggestionInsert{
 		OrgID:         orgID,
 		SupersedingID: b.ID,
 		SupersededID:  a.ID,
@@ -82,7 +83,7 @@ func TestInsertSupersedesSuggestion_RejectsSelfReference(t *testing.T) {
 
 	a := createTestDecision(t, db, orgID, "agent", "only")
 
-	err := db.InsertSupersedesSuggestion(ctx, storage.SupersedesSuggestionInsert{
+	_, err := db.InsertSupersedesSuggestion(ctx, storage.SupersedesSuggestionInsert{
 		OrgID:         orgID,
 		SupersedingID: a.ID,
 		SupersededID:  a.ID,
@@ -101,14 +102,14 @@ func TestListSupersedesSuggestionsForDecisions_FiltersByOrgAndIDs(t *testing.T) 
 	b := createTestDecision(t, db, orgID, "agent", "b")
 	c := createTestDecision(t, db, orgID, "agent", "c")
 
-	require.NoError(t, db.InsertSupersedesSuggestion(ctx, storage.SupersedesSuggestionInsert{
+	mustInsertSuggestion(t, db, ctx, storage.SupersedesSuggestionInsert{
 		OrgID: orgID, SupersedingID: b.ID, SupersededID: a.ID,
 		SuggestedBy: "detector:t",
-	}))
-	require.NoError(t, db.InsertSupersedesSuggestion(ctx, storage.SupersedesSuggestionInsert{
+	})
+	mustInsertSuggestion(t, db, ctx, storage.SupersedesSuggestionInsert{
 		OrgID: orgID, SupersedingID: c.ID, SupersededID: a.ID,
 		SuggestedBy: "detector:t",
-	}))
+	})
 
 	// Empty input → nil, no error.
 	out, err := db.ListSupersedesSuggestionsForDecisions(ctx, orgID, nil)
@@ -168,10 +169,10 @@ func TestDeleteOldSupersedesSuggestions(t *testing.T) {
 	a := createTestDecision(t, db, orgID, "agent", "a")
 	b := createTestDecision(t, db, orgID, "agent", "b")
 
-	require.NoError(t, db.InsertSupersedesSuggestion(ctx, storage.SupersedesSuggestionInsert{
+	mustInsertSuggestion(t, db, ctx, storage.SupersedesSuggestionInsert{
 		OrgID: orgID, SupersedingID: b.ID, SupersededID: a.ID,
 		SuggestedBy: "detector:t",
-	}))
+	})
 
 	// Cutoff in the past — no rows pruned.
 	n, err := db.DeleteOldSupersedesSuggestions(ctx, time.Now().Add(-time.Hour))
@@ -231,12 +232,12 @@ func TestTrigger_RetiresMatchingSuggestionOnConfirm(t *testing.T) {
 	earlier := createTestDecision(t, db, orgID, "claude-code", "ARD-958 layer-2")
 	latent := createTestDecision(t, db, orgID, "claude-code", "ARD-958 layer-3")
 
-	require.NoError(t, db.InsertSupersedesSuggestion(ctx, storage.SupersedesSuggestionInsert{
+	mustInsertSuggestion(t, db, ctx, storage.SupersedesSuggestionInsert{
 		OrgID:         orgID,
 		SupersedingID: latent.ID,
 		SupersededID:  earlier.ID,
 		SuggestedBy:   "detector:same_agent_same_ticket",
-	}))
+	})
 
 	got, err := db.ListSupersedesSuggestionsForDecisions(ctx, orgID, []uuid.UUID{latent.ID})
 	require.NoError(t, err)
@@ -273,14 +274,14 @@ func TestTrigger_RetireSuggestionScopedByAgent(t *testing.T) {
 	latentA := createTestDecision(t, db, orgID, "agent-A", "agent A latent")
 	latentB := createTestDecision(t, db, orgID, "agent-B", "agent B latent")
 
-	require.NoError(t, db.InsertSupersedesSuggestion(ctx, storage.SupersedesSuggestionInsert{
+	mustInsertSuggestion(t, db, ctx, storage.SupersedesSuggestionInsert{
 		OrgID: orgID, SupersedingID: latentA.ID, SupersededID: earlier.ID,
 		SuggestedBy: "detector:same_agent_same_ticket",
-	}))
-	require.NoError(t, db.InsertSupersedesSuggestion(ctx, storage.SupersedesSuggestionInsert{
+	})
+	mustInsertSuggestion(t, db, ctx, storage.SupersedesSuggestionInsert{
 		OrgID: orgID, SupersedingID: latentB.ID, SupersededID: earlier.ID,
 		SuggestedBy: "detector:same_agent_same_ticket",
-	}))
+	})
 
 	supersedesEarlier := earlier.ID
 	_, _, err := db.CreateTraceTx(ctx, storage.CreateTraceParams{
@@ -302,4 +303,51 @@ func TestTrigger_RetireSuggestionScopedByAgent(t *testing.T) {
 	gotB, err := db.ListSupersedesSuggestionsForDecisions(ctx, orgID, []uuid.UUID{latentB.ID})
 	require.NoError(t, err)
 	assert.Len(t, gotB, 1, "agent B's suggestion must survive — A's confirm is not B's")
+}
+
+// mustInsertSuggestion inserts and asserts the write succeeded, for the call
+// sites that are not exercising the inverse-link guard. Tests that care about
+// the guard call InsertSupersedesSuggestion directly and assert on the returned
+// inverseExists flag.
+func mustInsertSuggestion(t *testing.T, db *sqlite.LiteDB, ctx context.Context, s storage.SupersedesSuggestionInsert) bool {
+	t.Helper()
+	inverseExists, err := db.InsertSupersedesSuggestion(ctx, s)
+	require.NoError(t, err)
+	return inverseExists
+}
+
+// Direction is no longer a function of stored data — it is whatever the judge
+// answered on that pass, sampled at the provider's default temperature. The key
+// is the ordered pair, so without this guard two passes that disagree about
+// which decision retired which would both persist, leaving contradictory
+// agent-facing claims with no reconciliation path.
+func TestInsertSupersedesSuggestion_RefusesInverseLink(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+	require.NoError(t, db.EnsureDefaultOrg(ctx))
+	orgID := uuid.Nil
+
+	a := createTestDecision(t, db, orgID, "agent", "first")
+	b := createTestDecision(t, db, orgID, "agent", "second")
+
+	inverseExists := mustInsertSuggestion(t, db, ctx, storage.SupersedesSuggestionInsert{
+		OrgID: orgID, SupersedingID: b.ID, SupersededID: a.ID,
+		SuggestedBy: "detector:llm_supersession",
+	})
+	assert.False(t, inverseExists, "first write has no inverse to contend with")
+
+	// Same pair, opposite direction — the judge flipped its answer.
+	inverseExists = mustInsertSuggestion(t, db, ctx, storage.SupersedesSuggestionInsert{
+		OrgID: orgID, SupersedingID: a.ID, SupersededID: b.ID,
+		SuggestedBy: "detector:llm_supersession",
+	})
+	assert.True(t, inverseExists, "the opposing direction must be reported, not written")
+
+	fromB, err := db.ListSupersedesSuggestionsForDecisions(ctx, orgID, []uuid.UUID{b.ID})
+	require.NoError(t, err)
+	assert.Len(t, fromB, 1, "the original link stands")
+
+	fromA, err := db.ListSupersedesSuggestionsForDecisions(ctx, orgID, []uuid.UUID{a.ID})
+	require.NoError(t, err)
+	assert.Empty(t, fromA, "the contradicting inverse link must not have been written")
 }

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -12630,8 +12630,10 @@ func TestInsertSupersedesSuggestion_BasicAndIdempotent_PG(t *testing.T) {
 		Confidence:    &conf,
 		Reason:        `same agent "` + agentID + `", same ticket "ARD-958"`,
 	}
-	require.NoError(t, testDB.InsertSupersedesSuggestion(ctx, ins))
-	require.NoError(t, testDB.InsertSupersedesSuggestion(ctx, ins), "duplicate insert is a no-op")
+	_, err = testDB.InsertSupersedesSuggestion(ctx, ins)
+	require.NoError(t, err)
+	_, err = testDB.InsertSupersedesSuggestion(ctx, ins)
+	require.NoError(t, err)
 
 	got, err := testDB.ListSupersedesSuggestionsForDecisions(ctx, uuid.Nil, []uuid.UUID{b.ID})
 	require.NoError(t, err)
@@ -12659,7 +12661,7 @@ func TestInsertSupersedesSuggestion_RejectedBySuggestionFieldsCheck_PG(t *testin
 	require.NoError(t, err)
 
 	// Empty SuggestedBy is caught at the application layer before SQL.
-	err = testDB.InsertSupersedesSuggestion(ctx, storage.SupersedesSuggestionInsert{
+	_, err = testDB.InsertSupersedesSuggestion(ctx, storage.SupersedesSuggestionInsert{
 		OrgID:         uuid.Nil,
 		SupersedingID: b.ID,
 		SupersededID:  a.ID,
@@ -12710,10 +12712,11 @@ func TestDeleteOldSupersedesSuggestions_PG(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	require.NoError(t, testDB.InsertSupersedesSuggestion(ctx, storage.SupersedesSuggestionInsert{
+	_, err = testDB.InsertSupersedesSuggestion(ctx, storage.SupersedesSuggestionInsert{
 		OrgID: uuid.Nil, SupersedingID: b.ID, SupersededID: a.ID,
 		SuggestedBy: "detector:t",
-	}))
+	})
+	require.NoError(t, err)
 
 	n, err := testDB.DeleteOldSupersedesSuggestions(ctx, time.Now().Add(-time.Hour))
 	require.NoError(t, err)
@@ -12749,14 +12752,15 @@ func TestTrigger_RetiresMatchingSuggestionOnConfirm_PG(t *testing.T) {
 	// Detector inserts a suggestion: latent supersedes earlier (same agent
 	// forgot the link).
 	conf := float32(0.91)
-	require.NoError(t, testDB.InsertSupersedesSuggestion(ctx, storage.SupersedesSuggestionInsert{
+	_, err = testDB.InsertSupersedesSuggestion(ctx, storage.SupersedesSuggestionInsert{
 		OrgID:         uuid.Nil,
 		SupersedingID: latent.ID,
 		SupersededID:  earlier.ID,
 		SuggestedBy:   "detector:same_agent_same_ticket",
 		Confidence:    &conf,
 		Reason:        "test fixture",
-	}))
+	})
+	require.NoError(t, err)
 
 	got, err := testDB.ListSupersedesSuggestionsForDecisions(ctx, uuid.Nil, []uuid.UUID{latent.ID})
 	require.NoError(t, err)
@@ -12815,14 +12819,16 @@ func TestTrigger_RetireSuggestionScopedByAgent_PG(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	require.NoError(t, testDB.InsertSupersedesSuggestion(ctx, storage.SupersedesSuggestionInsert{
+	_, err = testDB.InsertSupersedesSuggestion(ctx, storage.SupersedesSuggestionInsert{
 		OrgID: uuid.Nil, SupersedingID: latentA.ID, SupersededID: earlier.ID,
 		SuggestedBy: "detector:same_agent_same_ticket",
-	}))
-	require.NoError(t, testDB.InsertSupersedesSuggestion(ctx, storage.SupersedesSuggestionInsert{
+	})
+	require.NoError(t, err)
+	_, err = testDB.InsertSupersedesSuggestion(ctx, storage.SupersedesSuggestionInsert{
 		OrgID: uuid.Nil, SupersedingID: latentB.ID, SupersededID: earlier.ID,
 		SuggestedBy: "detector:same_agent_same_ticket",
-	}))
+	})
+	require.NoError(t, err)
 
 	// Agent A confirms — trigger should retire only A's suggestion.
 	supersedesEarlier := earlier.ID

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -163,7 +163,11 @@ type Store interface {
 	// supersedes_id link as a 'suggested' row in decision_supersedes.
 	// Idempotent: a row already present for (superseding_id, superseded_id) —
 	// confirmed or earlier-suggested — is left intact.
-	InsertSupersedesSuggestion(ctx context.Context, s SupersedesSuggestionInsert) error
+	//
+	// Returns true when the INVERSE link already exists, in which case nothing is
+	// written: the key is the ordered pair, so the two directions would otherwise
+	// both persist as contradictory agent-facing claims.
+	InsertSupersedesSuggestion(ctx context.Context, s SupersedesSuggestionInsert) (inverseExists bool, err error)
 
 	// ListSupersedesSuggestionsForDecisions returns all 'suggested' rows
 	// where superseding_id is in supersedingIDs. Ordered by superseding_id,

--- a/internal/storage/supersedes_suggestions.go
+++ b/internal/storage/supersedes_suggestions.go
@@ -18,28 +18,52 @@ import (
 // for (superseding_id, superseded_id) — whether confirmed or earlier-suggested
 // — the insert is a no-op, leaving any confirmed link intact.
 //
+// It also refuses to write when the INVERSE row exists. The primary key is the
+// ordered pair (superseding_id, superseded_id), so (X,Y) and (Y,X) do not
+// collide, and direction is no longer a function of stored data: it is whatever
+// the judge answered on that pass, sampled at the provider's default
+// temperature. The same pair is judged in both orientations routinely — the
+// per-run pairCache does not span backfill runs — so an inconsistent answer
+// across two passes would otherwise persist two contradictory, agent-facing
+// links with no reconciliation path. Reports inverseExists so the caller can
+// surface the disagreement rather than silently resolve it.
+//
+// Residual race: the existence check and the insert share one statement and so
+// one snapshot, but under READ COMMITTED a concurrent transaction can still
+// commit the inverse between them. Closing that fully needs a unique index on
+// the unordered pair (LEAST/GREATEST) for suggested rows; this narrows the
+// window to concurrent inserts of the same pair rather than any two runs.
+//
 // SuggestedBy must be non-empty (enforced by migration 105's CHECK constraint).
 // SupersedingID and SupersededID must be distinct (enforced by table CHECK).
-func (db *DB) InsertSupersedesSuggestion(ctx context.Context, s SupersedesSuggestionInsert) error {
+func (db *DB) InsertSupersedesSuggestion(ctx context.Context, s SupersedesSuggestionInsert) (inverseExists bool, err error) {
 	if s.SuggestedBy == "" {
-		return errors.New("storage: suggested_by is required for supersedes suggestion")
+		return false, errors.New("storage: suggested_by is required for supersedes suggestion")
 	}
 	if s.SupersedingID == s.SupersededID {
-		return errors.New("storage: superseding_id and superseded_id must differ")
+		return false, errors.New("storage: superseding_id and superseded_id must differ")
 	}
-	_, err := db.pool.Exec(ctx,
-		`INSERT INTO decision_supersedes
-		    (superseding_id, superseded_id, org_id, relationship, is_primary,
-		     suggested_by, suggested_confidence, suggested_reason)
-		 VALUES ($1, $2, $3, 'suggested', FALSE, $4, $5, $6)
-		 ON CONFLICT (superseding_id, superseded_id) DO NOTHING`,
+	err = db.pool.QueryRow(ctx,
+		`WITH inverse AS (
+		     SELECT 1 FROM decision_supersedes
+		      WHERE superseding_id = $2 AND superseded_id = $1 AND org_id = $3
+		 ), ins AS (
+		     INSERT INTO decision_supersedes
+		         (superseding_id, superseded_id, org_id, relationship, is_primary,
+		          suggested_by, suggested_confidence, suggested_reason)
+		     SELECT $1, $2, $3, 'suggested', FALSE, $4, $5, $6
+		      WHERE NOT EXISTS (SELECT 1 FROM inverse)
+		     ON CONFLICT (superseding_id, superseded_id) DO NOTHING
+		     RETURNING 1
+		 )
+		 SELECT EXISTS (SELECT 1 FROM inverse)`,
 		s.SupersedingID, s.SupersededID, s.OrgID,
 		s.SuggestedBy, s.Confidence, nullableString(s.Reason),
-	)
+	).Scan(&inverseExists)
 	if err != nil {
-		return fmt.Errorf("storage: insert supersedes suggestion: %w", err)
+		return false, fmt.Errorf("storage: insert supersedes suggestion: %w", err)
 	}
-	return nil
+	return inverseExists, nil
 }
 
 // ListSupersedesSuggestionsForDecisions returns all detector-suggested


### PR DESCRIPTION
## The contradiction this removes

#740 rewrote the validator prompt to refuse recency as evidence — *"being recorded later is not evidence, since every candidate pair has a time order"* — and the suggestion writer then reintroduced exactly that rule one layer down.

`scoreForDecision` logged the judge's explanation, which names what replaced what, and threw it away. `insertSupersedesSuggestion` re-derived direction by comparing `ValidFrom`. On a backdated trace, a late-filed decision, or a revert, the clock and the evidence disagree — and the clock was winning.

## The fix

Direction now comes from a parser-enforced `REPLACES:` contract, symmetric to the `QUESTION:` contract #740 established for contradictions. A SUPERSESSION verdict must name which side retired the other; one that cannot is downgraded to refinement rather than trusted.

Enforcement lives in the parser for the same measured reason as the question contract: prompt-level hints for this class were shown not to work. The prompt's decision headers now establish the A/B labels they were already using undefined.

## Three defects found in adversarial review of the first cut

Each was reproduced by **executing** the parser, not by reading it.

**1. The exact shape the prompt asks for was rejected.** `**B**: replaced X` failed, because `normalizeValue` only unwraps a value's outer ends — the closing `**` stayed interior and failed the separator check. The verdict was silently downgraded and the judge's finding discarded. The separator set now covers markdown and double quotes; `/` and `'` stay out so `A/B` still fails.

**2. The prompt's own response template parsed as a confident answer.** `"A or B, then the replacement language"` — the literal schema line the model is shown — resolved to side A. So did `"A and B"`, `"A, B"`, `"A: no explicit replacement language found"`, and `"a bit unclear"`. The guard only inspected the first rune after the side letter, and `,`, `.` and space are separators. The side token is now the whole leading letter run, and a remainder that names the other side, opens with a coordinator, or retracts the finding fails the contract.

**3. Direction became sampled while the key stayed ordered.** The judge runs at the provider's default temperature and the primary key is `(superseding_id, superseded_id)`, so `(X,Y)` and `(Y,X)` do not collide. Two passes over one pair — routine, since `pairCache` does not span backfill runs — could disagree and persist both as contradictory agent-facing claims with no reconciliation path. The insert now refuses to write when the inverse exists and reports it, in both backends.

## Observability gap closed in the same change

A contract downgrade was indistinguishable downstream from an honest non-conflict verdict — both land in the same `!IsConflict()` branch, which logs at Debug and is off at the default info level. A parser or prompt regression that discarded valid verdicts would have looked exactly like a quiet corpus. Verdicts now carry `DowngradedBy`, counted by contract, with the question contract instrumented in the same change rather than left as the odd one out.

## What this does not claim

**Direction accuracy is not measurable against the existing gold set.** `conflict_gold_labels` records the *class* of a pair, not which side supersedes. The judge-vs-clock disagreement rate is therefore emitted as a production counter rather than reported here as an offline number. I would rather ship a counter than a figure the data cannot support.

## Testing

Ten REPLACES-contract cases plus the preserved QUESTION-contract cases, including the legacy `VERDICT: yes` exemption — which is provably unreachable for supersession, and documented as such rather than guarded with dead code. All the shapes above are in the trap table. Full gate green including `-tags integration`.

Note that `internal/conflicts/validator_test.go` and `question_contract_test.go` are behind `//go:build !lite && integration`, so a bare `go test ./internal/conflicts/...` compiles neither — it reports `ok` without running them. The tagged run is the one that matters here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> Batman's real preparation is not the shark repellent, it is the contingency file on his own team, and the Tower of Babel arc turns that into the argument against him: those plans work perfectly, which is exactly the problem, because they are stolen and executed by someone else. The most competent planner in DC is undone not by failing to anticipate a threat but by having written the threat down.