### PR TITLE
fix(server): stop publishing pre-access-filter totals from run enrichments

### DIFF
--- a/adrs/ADR-018-enrichments-publish-no-pre-filter-totals.md
+++ b/adrs/ADR-018-enrichments-publish-no-pre-filter-totals.md
@@ -1,0 +1,48 @@
+# ADR-018: Decision enrichments publish no pre-access-filter totals
+
+**Status:** Accepted
+**Date:** 2026-08-11
+
+## Context
+
+`GET /v1/runs/{run_id}?include=enrichments` returns, for every decision in the run, its revision chain, lineage, conflicts, and integrity status. Two of those sub-objects carried a `total` field:
+
+- `revisions.total` — the length of the revision chain **before** `filterDecisionsByAccess` ran.
+- `conflicts.total` — the per-decision conflict count **before** `filterConflictsByAccess` ran.
+
+Three facts make that combination an authorization-boundary information disclosure rather than a documentation wart:
+
+1. The route is `readRole` (`internal/server/server.go`), so any reader-or-above token reaches it.
+2. `authz.LoadGrantedSet` returns `nil` ("unrestricted") for admin and above, so `total != count` is reachable **only** for sub-admin callers — precisely the callers whose grants are hiding rows.
+3. `HandleGetRun` authorizes the request against `run.AgentID` alone, while revision chains and conflicts span other agents. A conflict is visible only when the caller has access to *both* sides.
+
+Together those give a restricted reader an exact oracle: `revisions.total > revisions.count` means "N revisions exist on this decision that you may not read," and `conflicts.total` counts conflicts between agents the caller holds no grant for. No further request is needed to extract the number.
+
+A previous pass over this code (commit `a9416f7`) rewrote the field comments to describe `total` as post-filter without changing the computation, which left the disclosure in place while making the code read as if it had been fixed.
+
+## Decision
+
+**Enrichment responses publish no quantity derived from a pre-access-filter set.** The `total` field is removed from both `enrichmentRevisions` and `enrichmentConflicts`. What remains:
+
+- `revisions.count` — accessible revisions returned. The revision list is uncapped, so a post-filter total would be identically equal to `count`; there is nothing left to publish.
+- `conflicts.count` — accessible conflicts returned, capped at 50 per decision.
+- `conflicts.has_more` — whether the **accessible** set filled that cap, computed by `capEnrichmentConflicts` from the filtered slice alone.
+
+This matches the rule `computePagination` (`internal/server/handlers.go`) already applies to every list endpoint: when access filtering hid rows, the total is not knowable to the caller and is not published. `TestComputePagination` pins that behaviour.
+
+### Alternatives rejected
+
+- **Recompute `total` post-filter.** Provably carries zero information. Revisions are uncapped, so post-filter total ≡ `count`. Conflicts are over-fetched at `perDecisionLimit+1` = 51 (`internal/storage/conflicts.go`), so a post-filter total differs from `count` only at exactly 51 — the over-fetch sentinel, not a real total. A field that can only be redundant or meaningless exists only to be re-broken later.
+- **Gate the pre-filter total to admin+.** Keeps the disclosure primitive in the struct and makes its safety depend on a role check staying correct forever, inside a handler that already scopes authorization to `run.AgentID` only.
+- **Rename the field.** Renaming a leaked quantity does not un-leak it. This is the class of change that left the defect open once already.
+
+### Accepted cost
+
+`conflicts.has_more` can under-report: when a decision has ≥51 raw conflicts *and* access filtering hides some of them, the accessible slice may not fill the cap even though more accessible conflicts exist beyond the fetched window. Correcting that would require a post-filter counting query whose result could not be published without reopening the disclosure this decision closes. The bound is documented at `capEnrichmentConflicts`.
+
+## Consequences
+
+- `api/openapi.yaml` drops `total` from `EnrichmentRevisions` and `EnrichmentConflicts`, and from their `required` lists. This is a breaking response-shape change for any client reading those fields.
+- The UI (`ui/src/types/api.ts`, `ui/src/pages/DecisionDetail.tsx`) no longer renders "N of M"; conflicts render as `N+` when `has_more`, matching the existing `cited_by_has_more` idiom. `tsc -b` in the `build-ui` CI job fails on any surviving reference.
+- The SDKs are unaffected: none of them model the enrichment types.
+- `TestEnrichmentResponses_PublishNoTotals` (`internal/server/handlers_runs_test.go`, untagged) marshals both structs and fails if a `total` key reappears, so a future "consistency" pass cannot silently reverse this.

--- a/adrs/ADR-018-enrichments-publish-no-pre-filter-totals.md
+++ b/adrs/ADR-018-enrichments-publish-no-pre-filter-totals.md
@@ -30,6 +30,10 @@ A previous pass over this code (commit `a9416f7`) rewrote the field comments to 
 
 This matches the rule `computePagination` (`internal/server/handlers.go`) already applies to every list endpoint: when access filtering hid rows, the total is not knowable to the caller and is not published. `TestComputePagination` pins that behaviour.
 
+`cited_by_has_more` carried the identical defect and is fixed in the same change. Storage computes `CitedByMore` against the pre-filter citation set (`internal/storage/decisions.go`), and `authz.FilterLineage` rebuilt `CitedBy` without touching the flag — so a restricted caller could read `cited_by_has_more = true` beside an unfilled list and learn that citations exist which they may not read. `FilterLineage` now clears the flag whenever filtering removed an entry. That is deliberately conservative and can under-report; a truthful post-filter value cannot be published without re-opening the disclosure, and the same reasoning that removes `total` forbids publishing it.
+
+One residual is knowingly accepted: storage trims its `citedByLimit+1` probe row before returning, so when all fetched entries are accessible but the discarded probe row was not, one bit still escapes. Closing it requires storage to return the uncapped probe and cap post-filter, mirroring `capEnrichmentConflicts`. Recorded rather than silently left.
+
 ### Alternatives rejected
 
 - **Recompute `total` post-filter.** Provably carries zero information. Revisions are uncapped, so post-filter total ≡ `count`. Conflicts are over-fetched at `perDecisionLimit+1` = 51 (`internal/storage/conflicts.go`), so a post-filter total differs from `count` only at exactly 51 — the over-fetch sentinel, not a real total. A field that can only be redundant or meaningless exists only to be re-broken later.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -4859,7 +4859,7 @@ components:
 
     EnrichmentRevisions:
       type: object
-      required: [items, count, total]
+      required: [items, count]
       properties:
         items:
           type: array
@@ -4867,17 +4867,17 @@ components:
             $ref: "#/components/schemas/Decision"
         count:
           type: integer
-          description: Number of accessible revisions returned (equals total when not degraded).
-        total:
-          type: integer
-          description: Total accessible revisions after RBAC filtering.
+          description: >-
+            Number of revisions the caller is permitted to see. No total is
+            published: the list is uncapped, so a total would either equal
+            count or disclose revisions hidden by access control.
         degraded:
           type: boolean
           description: True when revision data could not be fully retrieved due to a storage or authorization error.
 
     EnrichmentConflicts:
       type: object
-      required: [items, count, total, has_more]
+      required: [items, count, has_more]
       properties:
         items:
           type: array
@@ -4885,13 +4885,13 @@ components:
             $ref: "#/components/schemas/DecisionConflict"
         count:
           type: integer
-          description: Number of accessible conflicts returned (may be less than total due to the 50-item cap).
-        total:
-          type: integer
-          description: Total accessible conflicts after RBAC filtering but before cap truncation.
+          description: Number of conflicts the caller is permitted to see, capped at 50 per decision.
         has_more:
           type: boolean
-          description: True when more conflicts exist than the 50 returned (based on pre-RBAC-filter count).
+          description: >-
+            True when the caller's accessible conflict set filled the 50-item
+            cap. Derived from the accessible set only — it never reflects
+            conflicts hidden by access control.
         degraded:
           type: boolean
           description: True when conflict data could not be fully retrieved due to a storage or authorization error.

--- a/internal/authz/authz.go
+++ b/internal/authz/authz.go
@@ -264,6 +264,17 @@ func FilterLineage(ctx context.Context, db storage.Store, claims *auth.Claims, l
 			allowed = append(allowed, e)
 		}
 	}
+	// CitedByMore is computed in storage against the PRE-filter set
+	// (decisions.go:2332) and was never recomputed here, so it published the
+	// same oracle the enrichment totals did: a restricted caller could read
+	// cited_by_has_more = true while seeing an unfilled list and learn that
+	// citations exist which they may not read. Clearing it whenever filtering
+	// removed anything is deliberately conservative — it can under-report — but
+	// a truthful post-filter value cannot be published without re-opening the
+	// disclosure. Admins short-circuit above and keep the accurate flag.
+	if len(allowed) != len(lineage.CitedBy) {
+		lineage.CitedByMore = false
+	}
 	lineage.CitedBy = allowed
 
 	return lineage, nil

--- a/internal/server/handlers_runs.go
+++ b/internal/server/handlers_runs.go
@@ -417,10 +417,20 @@ const (
 // accepted; the only alternative is a post-filter counting query whose result
 // could not be published without re-opening the disclosure this replaced.
 func capEnrichmentConflicts(conflicts []model.DecisionConflict) ([]model.DecisionConflict, bool) {
-	if len(conflicts) > maxEnrichmentConflicts {
+	// hasMore is captured BEFORE truncation. Deriving it afterwards from the
+	// clamped slice is wrong in both directions: len >= cap fires at exactly
+	// maxEnrichmentConflicts accessible conflicts, when nothing was withheld,
+	// and len > cap can never fire at all because truncation already clamped it.
+	// The pre-change code read preFilterTotal > maxEnrichmentConflicts, which
+	// was correct on this boundary, so getting it wrong here would ship a fresh
+	// regression under cover of a security fix — and it would reach every
+	// caller, not just restricted ones, since admins skip access filtering
+	// entirely (authz.go:210).
+	hasMore := len(conflicts) > maxEnrichmentConflicts
+	if hasMore {
 		conflicts = conflicts[:maxEnrichmentConflicts]
 	}
-	return conflicts, len(conflicts) >= maxEnrichmentConflicts
+	return conflicts, hasMore
 }
 
 func (h *Handlers) buildDecisionEnrichments(

--- a/internal/server/handlers_runs.go
+++ b/internal/server/handlers_runs.go
@@ -24,25 +24,34 @@ import (
 // ---------------------------------------------------------------------------
 
 // enrichmentRevisions holds the revision chain for a single decision.
-// Count is the number of items returned (post-access-filter). Total is the
-// number of revisions that exist before filtering; it is omitted when equal
-// to Count so consumers can detect hidden revisions.
+//
+// Count is the number of revisions the caller is allowed to see. No total is
+// published, deliberately: for a caller whose grants hide revisions a
+// pre-filter total is a direct oracle for records they may not read, and a
+// post-filter total is by construction equal to Count because nothing caps
+// this list. This is the same rule computePagination applies to every list
+// endpoint (handlers.go:648) — when access filtering hid rows, the total is
+// not knowable and is not published.
 type enrichmentRevisions struct {
 	Items    []model.Decision `json:"items"`
-	Count    int              `json:"count"` // Number of accessible items returned.
-	Total    int              `json:"total"` // Total accessible revisions (post access filtering).
+	Count    int              `json:"count"` // Accessible revisions returned.
 	Degraded bool             `json:"degraded,omitempty"`
 }
 
 // enrichmentConflicts holds conflicts for a single decision.
-// Count is the number of items returned (post-RBAC, post-truncation).
-// Total is the pre-RBAC count from the storage layer; omitted (zero) when
-// equal to Count so consumers can detect when RBAC or truncation hid conflicts.
+//
+// Count is the number of accessible conflicts returned, capped at
+// maxEnrichmentConflicts. HasMore reports whether the accessible set filled
+// that cap. Both are computed from the access-filtered set only, never from
+// the storage-layer count: GET /v1/runs/{run_id} is a read-role route and a
+// conflict is visible only when the caller has access to BOTH sides
+// (authz.FilterConflicts), so any quantity derived from the pre-filter count
+// tells a restricted reader how many conflicts exist between agents they hold
+// no grant for.
 type enrichmentConflicts struct {
 	Items    []model.DecisionConflict `json:"items"`
-	Count    int                      `json:"count"`    // Number of accessible items returned (may be capped).
-	Total    int                      `json:"total"`    // Pre-RBAC conflict count; 0 when equal to Count.
-	HasMore  bool                     `json:"has_more"` // True when pre-RBAC count exceeds the cap.
+	Count    int                      `json:"count"`
+	HasMore  bool                     `json:"has_more"`
 	Degraded bool                     `json:"degraded,omitempty"`
 }
 
@@ -397,6 +406,23 @@ const (
 	enrichmentRevisionFanIn = 8
 )
 
+// capEnrichmentConflicts truncates an already access-filtered conflict slice to
+// the per-decision cap and reports whether the accessible set filled it.
+//
+// Both return values derive only from the accessible slice. Known bound:
+// storage over-fetches one row per decision (perDecisionLimit+1,
+// storage/conflicts.go:302), so when a decision has more than 50 raw conflicts
+// AND access filtering hides some of them, hasMore can be false while more
+// accessible conflicts exist beyond the fetched window. That under-report is
+// accepted; the only alternative is a post-filter counting query whose result
+// could not be published without re-opening the disclosure this replaced.
+func capEnrichmentConflicts(conflicts []model.DecisionConflict) ([]model.DecisionConflict, bool) {
+	if len(conflicts) > maxEnrichmentConflicts {
+		conflicts = conflicts[:maxEnrichmentConflicts]
+	}
+	return conflicts, len(conflicts) >= maxEnrichmentConflicts
+}
+
 func (h *Handlers) buildDecisionEnrichments(
 	ctx context.Context,
 	orgID uuid.UUID,
@@ -418,7 +444,6 @@ func (h *Handlers) buildDecisionEnrichments(
 	// Phase 1: Batch-fetch lineage and conflicts concurrently.
 	var batchLineage map[uuid.UUID]storage.DecisionLineage
 	var batchConflicts map[uuid.UUID][]model.DecisionConflict
-	var batchConflictTotals map[uuid.UUID]int // pre-RBAC-filter counts
 	var lineageDegraded, conflictsDegraded atomic.Bool
 
 	g, gctx := errgroup.WithContext(ctx)
@@ -450,10 +475,9 @@ func (h *Handlers) buildDecisionEnrichments(
 			conflictsDegraded.Store(true)
 		}
 		raw := batchResult.ByDecision
-		// Track pre-filter totals, then apply access filtering.
-		totals := make(map[uuid.UUID]int, len(raw))
+		// Pre-filter counts are deliberately not retained. Any response field
+		// derived from them discloses rows the caller cannot read.
 		for decID, conflicts := range raw {
-			totals[decID] = len(conflicts)
 			filtered, filterErr := filterConflictsByAccess(gctx, h.db, claims, conflicts, h.grantCache)
 			if filterErr != nil {
 				if !errors.Is(filterErr, context.Canceled) && !errors.Is(filterErr, context.DeadlineExceeded) {
@@ -465,7 +489,6 @@ func (h *Handlers) buildDecisionEnrichments(
 			}
 			raw[decID] = filtered
 		}
-		batchConflictTotals = totals
 		batchConflicts = raw
 		return nil
 	})
@@ -483,7 +506,7 @@ func (h *Handlers) buildDecisionEnrichments(
 		g2.Go(func() error {
 			entry := h.buildSingleEnrichment(gctx2, orgID, claims, d,
 				batchLineage, &lineageDegraded,
-				batchConflicts, batchConflictTotals, &conflictsDegraded)
+				batchConflicts, &conflictsDegraded)
 			mu.Lock()
 			enrichments[d.ID.String()] = entry
 			mu.Unlock()
@@ -531,7 +554,6 @@ func (h *Handlers) buildSingleEnrichment(
 	batchLineage map[uuid.UUID]storage.DecisionLineage,
 	lineageDegraded *atomic.Bool,
 	batchConflicts map[uuid.UUID][]model.DecisionConflict,
-	batchConflictTotals map[uuid.UUID]int,
 	conflictsDegraded *atomic.Bool,
 ) decisionEnrichment {
 	decID := d.ID
@@ -566,7 +588,6 @@ func (h *Handlers) buildSingleEnrichment(
 			entry.Revisions = enrichmentRevisions{Items: []model.Decision{}}
 		}
 	} else {
-		totalRevisions := len(revisions)
 		revisions, filterErr := filterDecisionsByAccess(ctx, h.db, claims, revisions, h.grantCache)
 		if filterErr != nil {
 			if isCtxErr(filterErr) {
@@ -577,11 +598,7 @@ func (h *Handlers) buildSingleEnrichment(
 			entry.Revisions = enrichmentRevisions{Items: []model.Decision{}, Degraded: true}
 			entry.Degraded = true
 		} else {
-			er := enrichmentRevisions{Items: revisions, Count: len(revisions)}
-			if totalRevisions != len(revisions) {
-				er.Total = totalRevisions
-			}
-			entry.Revisions = er
+			entry.Revisions = enrichmentRevisions{Items: revisions, Count: len(revisions)}
 		}
 	}
 
@@ -620,21 +637,8 @@ func (h *Handlers) buildSingleEnrichment(
 		if conflicts == nil {
 			conflicts = []model.DecisionConflict{}
 		}
-		// Pre-filter total from Phase 1 (before RBAC).
-		preFilterTotal := batchConflictTotals[decID]
-		hasMore := preFilterTotal > maxEnrichmentConflicts
-		if len(conflicts) > maxEnrichmentConflicts {
-			conflicts = conflicts[:maxEnrichmentConflicts]
-		}
-		ec := enrichmentConflicts{
-			Items:   conflicts,
-			Count:   len(conflicts),
-			HasMore: hasMore,
-		}
-		if preFilterTotal != len(conflicts) {
-			ec.Total = preFilterTotal
-		}
-		entry.Conflicts = ec
+		items, hasMore := capEnrichmentConflicts(conflicts)
+		entry.Conflicts = enrichmentConflicts{Items: items, Count: len(items), HasMore: hasMore}
 	default:
 		entry.Conflicts = enrichmentConflicts{Items: []model.DecisionConflict{}}
 	}

--- a/internal/server/handlers_runs_test.go
+++ b/internal/server/handlers_runs_test.go
@@ -1,11 +1,11 @@
 package server
 
 import (
-	"encoding/json"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/ashita-ai/akashi/internal/model"
 )
@@ -15,16 +15,23 @@ import (
 // caller may hold no grant for, so a "total" field is an oracle for hidden
 // records. This test fails if anyone reintroduces one.
 func TestEnrichmentResponses_PublishNoTotals(t *testing.T) {
-	for name, v := range map[string]any{
-		"revisions": enrichmentRevisions{Items: []model.Decision{}, Count: 3},
-		"conflicts": enrichmentConflicts{Items: []model.DecisionConflict{}, Count: 3},
+	// Reflect over the struct definition rather than marshalling one instance.
+	// The instance-based form this replaces was blind to the reintroduction it
+	// existed to catch: a re-added `Total int \`json:"total,omitempty"\`` sits at
+	// its zero value in a literal, omitempty elides the key, and the assertion
+	// passes while the field ships to every caller that populates it.
+	for name, typ := range map[string]reflect.Type{
+		"revisions": reflect.TypeOf(enrichmentRevisions{}),
+		"conflicts": reflect.TypeOf(enrichmentConflicts{}),
 	} {
-		b, err := json.Marshal(v)
-		require.NoError(t, err)
-		var m map[string]json.RawMessage
-		require.NoError(t, json.Unmarshal(b, &m))
-		_, hasTotal := m["total"]
-		assert.False(t, hasTotal, "%s must not publish a total field: %s", name, b)
+		for i := range typ.NumField() {
+			f := typ.Field(i)
+			tag := f.Tag.Get("json")
+			assert.NotContains(t, strings.ToLower(f.Name), "total",
+				"%s must not carry a total-derived field: %s", name, f.Name)
+			assert.NotContains(t, strings.ToLower(tag), "total",
+				"%s must not publish a total-derived field: json tag %q", name, tag)
+		}
 	}
 }
 
@@ -38,7 +45,12 @@ func TestCapEnrichmentConflicts(t *testing.T) {
 	}{
 		{"empty", 0, 0, false},
 		{"under cap", 49, 49, false},
-		{"at cap", maxEnrichmentConflicts, maxEnrichmentConflicts, true},
+		// Exactly at the cap nothing was withheld, so has_more must be false.
+		// Storage over-fetches cap+1, so a slice of exactly cap proves the
+		// accessible set is exactly cap. The earlier version of this case
+		// asserted true and pinned an off-by-one that would have rendered a
+		// misleading "50+" for every caller, admins included.
+		{"at cap, nothing withheld", maxEnrichmentConflicts, maxEnrichmentConflicts, false},
 		{"over cap (storage +1 probe)", maxEnrichmentConflicts + 1, maxEnrichmentConflicts, true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/server/handlers_runs_test.go
+++ b/internal/server/handlers_runs_test.go
@@ -1,0 +1,50 @@
+package server
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ashita-ai/akashi/internal/model"
+)
+
+// The enrichment structs must not carry any pre-access-filter quantity.
+// GET /v1/runs/{run_id} is a read-role route and enrichments span agents the
+// caller may hold no grant for, so a "total" field is an oracle for hidden
+// records. This test fails if anyone reintroduces one.
+func TestEnrichmentResponses_PublishNoTotals(t *testing.T) {
+	for name, v := range map[string]any{
+		"revisions": enrichmentRevisions{Items: []model.Decision{}, Count: 3},
+		"conflicts": enrichmentConflicts{Items: []model.DecisionConflict{}, Count: 3},
+	} {
+		b, err := json.Marshal(v)
+		require.NoError(t, err)
+		var m map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal(b, &m))
+		_, hasTotal := m["total"]
+		assert.False(t, hasTotal, "%s must not publish a total field: %s", name, b)
+	}
+}
+
+func TestCapEnrichmentConflicts(t *testing.T) {
+	mk := func(n int) []model.DecisionConflict { return make([]model.DecisionConflict, n) }
+	for _, tc := range []struct {
+		name        string
+		in          int
+		wantLen     int
+		wantHasMore bool
+	}{
+		{"empty", 0, 0, false},
+		{"under cap", 49, 49, false},
+		{"at cap", maxEnrichmentConflicts, maxEnrichmentConflicts, true},
+		{"over cap (storage +1 probe)", maxEnrichmentConflicts + 1, maxEnrichmentConflicts, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			items, hasMore := capEnrichmentConflicts(mk(tc.in))
+			assert.Len(t, items, tc.wantLen)
+			assert.Equal(t, tc.wantHasMore, hasMore)
+		})
+	}
+}

--- a/ui/src/pages/DecisionDetail.tsx
+++ b/ui/src/pages/DecisionDetail.tsx
@@ -125,17 +125,15 @@ function IntegrityBadge({ enrichments }: { enrichments?: DecisionEnrichments }) 
 
 function RevisionChain({ enrichments }: { enrichments?: DecisionEnrichments }) {
   if (!enrichments) return null;
-  const { items, count, total, degraded } = enrichments.revisions;
+  const { items, count, degraded } = enrichments.revisions;
   if (count <= 1 && !degraded) return null;
-
-  const hiddenByRbac = total > 0 && total > count;
 
   return (
     <Card>
       <CardHeader>
         <CardTitle className="flex items-center gap-2 text-sm font-medium">
           <GitBranch className="h-4 w-4" />
-          Revision History ({count}{hiddenByRbac ? ` of ${total}` : ""} versions)
+          Revision History ({count} versions)
         </CardTitle>
       </CardHeader>
       <CardContent>
@@ -193,17 +191,15 @@ const conflictStatusVariant: Record<string, "warning" | "secondary" | "success" 
 
 function DecisionConflicts({ decisionId, enrichments }: { decisionId: string; enrichments?: DecisionEnrichments }) {
   if (!enrichments) return null;
-  const { items, count, total, has_more, degraded } = enrichments.conflicts;
+  const { items, count, has_more, degraded } = enrichments.conflicts;
   if (count === 0 && !degraded) return null;
-
-  const hiddenByRbac = total > 0 && total > count;
 
   return (
     <Card>
       <CardHeader>
         <CardTitle className="flex items-center gap-2 text-sm font-medium">
           <AlertTriangle className="h-4 w-4 text-amber-500" />
-          Related Conflicts ({count}{hiddenByRbac ? ` of ${total}` : ""})
+          Related Conflicts ({count}{has_more ? "+" : ""})
         </CardTitle>
       </CardHeader>
       <CardContent>

--- a/ui/src/types/api.ts
+++ b/ui/src/types/api.ts
@@ -496,14 +496,12 @@ export interface IntegrityStatus {
 export interface EnrichmentRevisions {
   items: Decision[];
   count: number;
-  total: number;
   degraded?: boolean;
 }
 
 export interface EnrichmentConflicts {
   items: DecisionConflict[];
   count: number;
-  total: number;
   has_more: boolean;
   degraded?: boolean;
 }


### PR DESCRIPTION
## This is an authz disclosure, not a naming inconsistency

`internal/server/handlers_runs.go` published two fields both called `Total`, one documented as post-access-filtering and one as `Pre-RBAC conflict count`. Three separate recorded conflicts (`57c839a5`, `a289e8ec`, `57f26659`) pointed at it, and a prior "fix" changed only the comments while leaving the computation byte-identical — which is why it survived five months.

The pre-filter total is an oracle. `revisions.total > 0` means exactly *"N revisions exist that you may not read."* It is reachable only by sub-admin callers (`authz.LoadGrantedSet` returns `nil` for admin+, short-circuiting the filter), on a `readRole` route whose authorization checks `run.AgentID` while revision chains and conflicts span other agents.

## Removal, not relabeling

Post-filter totals would be either redundant or meaningless: revisions are uncapped, so a post-filter total is identically `count`; conflicts are fetched at `perDecisionLimit+1`, so `Total != Count` only at the over-fetch sentinel. Gating the pre-RBAC total to admins keeps a disclosure primitive in the struct and makes its safety depend on a role check staying correct forever. Renaming a leaked quantity does not un-leak it.

What remains: `count` (accessible, returned) and `has_more` (whether the **accessible** set filled the cap). This matches the rule `computePagination` already applies to every list endpoint, pinned by `TestComputePagination`.

**No test pinned the old behaviour** — the enrichment tests' decode structs omit `total`, and the only test pinning a convention pins the opposite one. The pre-RBAC total encoded the bug, not a design choice.

## Second commit: three defects adversarial review found in the first

**`has_more` was a fresh regression.** It was derived from the already-truncated slice as `len >= cap`, which fires at exactly 50 accessible conflicts — when nothing was withheld — where the code it replaced correctly returned false. It reached **every** caller, admins included, and the UI renders it as `50+` plus "More conflicts exist than are shown here." Shipping that under cover of a security fix would have been worse than the leak. `hasMore` is now captured before truncation; deriving it after is wrong in both directions.

**`cited_by_has_more` carried the identical disclosure and was missed.** Storage computes it against the pre-filter citation set and `authz.FilterLineage` rebuilt `CitedBy` without touching the flag, so a restricted caller could read `cited_by_has_more: true` beside an unfilled list. `FilterLineage` now clears it whenever filtering removed an entry — deliberately conservative, since a truthful post-filter value cannot be published without re-opening the disclosure. ADR-018's decision sentence was false while that shipped and is corrected rather than quietly narrowed; the one remaining bit (storage trims its `+1` probe row before returning) is recorded as knowingly accepted.

**The guard test could not catch what it existed to catch.** It marshalled a struct literal and asserted no `total` key, so a re-added `Total int \`json:"total,omitempty"\`` sits at its zero value, `omitempty` elides the key, and the test passes while the field ships. It now reflects over the struct definition. Verified by mutation: reintroducing that exact field fails it.

## Blast radius

`api/openapi.yaml`, `ui/src/types/api.ts` and `ui/src/pages/DecisionDetail.tsx` updated in step. The response shape changes — `total` disappears from both enrichment objects — so this deserves a closer read than the other two PRs in this set.

Gate green: build, vet, `golangci-lint` 0 issues, atlas validate, and `go test -race` both with and without `-tags=integration` (21 packages; the only failure is the pre-existing `TestGitCommitSubject_CurrentRepo`, caused by a stray empty `internal/.git` and unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> Sauron's ring is usually read as a temptation object, but its actual engineering is a telemetry problem: it reports. Wearing it makes you visible to exactly the observer you least want watching, and Frodo's slow ruin is a story about a device whose disclosure channel runs the opposite direction from its apparent function. Gollum is what happens when you keep the feature because the count seemed useful.