### PR TITLE
ci(fuzz): retire the per-PR fuzz gate, move mutation fuzzing to a nightly job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,34 +69,20 @@ jobs:
         continue-on-error: true
         run: govulncheck ./...
 
-      - name: Fuzz (crash detection)
-        run: |
-          # Run the targets SEQUENTIALLY. They used to run four-at-a-time, which
-          # made this step a flaky gate on every PR — including documentation-only
-          # ones — with "context deadline exceeded" rather than a real crash.
-          #
-          # The cause is contention, not any one slow target: -timeout covers
-          # baseline coverage gathering plus the fuzzing budget, and four targets
-          # sharing a runner's cores can push a single binary past it. Two earlier
-          # attempts to fix this by trimming time budgets did not hold, because
-          # they treated the symptom. Serial execution costs roughly 30 extra
-          # seconds and removes the failure mode entirely.
-          #
-          # -timeout is also raised well clear of the fuzz budget so a slow runner
-          # cannot trip it. A genuine crash fails fast and is unaffected by either.
-          set -euo pipefail
-          for target in \
-            "FuzzComputeContentHash ./internal/integrity/" \
-            "FuzzBuildMerkleRoot    ./internal/integrity/" \
-            "FuzzValidateToken      ./internal/auth/" \
-            "FuzzValidateAgentID    ./internal/model/" \
-            "FuzzDecodeJSON         ./internal/server/"; do
-            set -- $target
-            echo "::group::fuzz $1"
-            go test -run='^$' -fuzz="$1" -fuzztime=8s -fuzzminimizetime=0s -parallel=1 -timeout=120s "$2"
-            echo "::endgroup::"
-          done
-
+      # Fuzzing is NOT on the merge path. `go test` without -fuzz runs every
+      # fuzz target's seed corpus as ordinary subtests (testing/fuzz.go, the
+      # "Fuzzing is not enabled" branch), so the step below already gives
+      # deterministic, race-detected crash coverage of every seed and of any
+      # crasher committed under testdata/fuzz/.
+      #
+      # Timed fuzzing (-fuzztime=<duration>) additionally spuriously fails on
+      # go1.26 — golang/go#75804, a race between the coordinator's deadline
+      # context and the child context its error suppression compares against.
+      # The fix (CL 774140) is in master and go1.27 only, and there is no
+      # go1.26 backport. Five months and seven remediation commits produced
+      # zero findings and repeated red builds on doc-only PRs.
+      # Mutation fuzzing now runs in .github/workflows/fuzz-nightly.yml with a
+      # count-based budget, which never constructs the deadline context.
       - name: Unit tests
         run: go test -race -count=1 ./...
 

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -1,0 +1,75 @@
+name: Fuzz (nightly)
+
+# Not a merge gate. Budgets are count-based (-fuzztime=Nx) rather than
+# duration-based on purpose: internal/fuzz only builds the deadline context
+# when opts.Timeout > 0 (fuzz.go:105), so a count budget structurally cannot
+# hit golang/go#75804, the spurious "context deadline exceeded" that made the
+# per-PR gate flaky on go1.26.
+#
+# When this job fails, the run log names the target and go test has written the
+# failing input to <pkg>/testdata/fuzz/<Target>/. Commit that file: it then
+# runs as a seed in `go test -race ./...` on every PR, forever.
+
+on:
+  schedule:
+    - cron: "17 7 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  fuzz:
+    name: ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: FuzzComputeContentHash
+            pkg: ./internal/integrity/
+          - target: FuzzBuildMerkleRoot
+            pkg: ./internal/integrity/
+          - target: FuzzValidateToken
+            pkg: ./internal/auth/
+          - target: FuzzValidateAgentID
+            pkg: ./internal/model/
+          - target: FuzzDecodeJSON
+            pkg: ./internal/server/
+    env:
+      # Dedicated GOCACHE so the generated fuzz corpus ($GOCACHE/fuzz/<pkg>)
+      # can be cached with restore-keys and actually accumulate across runs.
+      # setup-go's built-in cache is exact-match only (no restore-keys), which
+      # is why the per-PR gate always fuzzed from a frozen corpus.
+      GOCACHE: ${{ github.workspace }}/.gocache
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Go
+        # cache: false is required, not incidental. With cache: true and a
+        # job-level GOCACHE, setup-go would cache this same directory under its
+        # own exact-match key and fight the corpus cache below.
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Restore fuzz corpus
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ${{ github.workspace }}/.gocache/fuzz
+          key: fuzz-corpus-${{ matrix.target }}-${{ github.run_id }}
+          restore-keys: |
+            fuzz-corpus-${{ matrix.target }}-
+
+      - name: Fuzz
+        run: go test -run='^$' -fuzz='^${{ matrix.target }}$' -parallel=2 -fuzztime=5000000x -timeout=40m ${{ matrix.pkg }}
+
+      - name: Upload crashers
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: fuzz-crashers-${{ matrix.target }}
+          path: "**/testdata/fuzz/**"
+          if-no-files-found: ignore

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -17,12 +17,19 @@ on:
 
 permissions:
   contents: read
+  issues: write # the failure notifier below opens an issue
 
 jobs:
   fuzz:
     name: ${{ matrix.target }}
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    # Must stay comfortably above the -timeout passed to go test below, so an
+    # overrun surfaces as a step failure (which the notifier catches) instead of
+    # a job cancellation (which it does not). The corpus cache accumulates
+    # entries across runs by design, so per-exec cost rises over time and the
+    # 5M-exec budget will get slower — measured ~9.5k execs/s locally, and a
+    # hosted runner is 2-4x slower, so 5M execs is 18-35 min today and growing.
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -64,12 +71,49 @@ jobs:
             fuzz-corpus-${{ matrix.target }}-
 
       - name: Fuzz
-        run: go test -run='^$' -fuzz='^${{ matrix.target }}$' -parallel=2 -fuzztime=5000000x -timeout=40m ${{ matrix.pkg }}
+        # The grep is load-bearing. "go test -fuzz=^NoSuchTarget$" prints
+        # "testing: warning: no fuzz tests to fuzz" and exits 0, so a renamed or
+        # deleted target would report green here forever while contributing zero
+        # mutation coverage — and this job is now the ONLY mutation coverage, so
+        # nothing else would notice. Verified: -fuzz='^FuzzDoesNotExist$' exits 0.
+        #
+        # -timeout must stay under the job's timeout-minutes so an overrun panics
+        # as a step failure (which triggers the notifier below) rather than being
+        # cancelled at the job level (which would not).
+        run: |
+          set -o pipefail
+          go test -run='^$' -fuzz='^${{ matrix.target }}$' -parallel=2 \
+            -fuzztime=5000000x -timeout=50m ${{ matrix.pkg }} 2>&1 | tee fuzz.log
+          if grep -q 'no fuzz tests to fuzz' fuzz.log; then
+            echo "::error::fuzz target ${{ matrix.target }} not found in ${{ matrix.pkg }} — renamed or deleted"
+            exit 1
+          fi
 
       - name: Upload crashers
-        if: failure()
+        # always(), not failure(): a job-level cancellation skips failure(), and
+        # the crashing input is exactly what is needed to diagnose one.
+        if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: fuzz-crashers-${{ matrix.target }}
           path: "**/testdata/fuzz/**"
           if-no-files-found: ignore
+
+      - name: Open an issue on failure
+        # Without this the recovery loop documented at the top of this file has
+        # no trigger: a scheduled job that goes red notifies nobody by default,
+        # and this repo has a single maintainer. A crasher found at 07:17 UTC is
+        # worthless if it sits unread.
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue create \
+            --title "Nightly fuzz failed: ${{ matrix.target }}" \
+            --body "Target \`${{ matrix.target }}\` in \`${{ matrix.pkg }}\` failed.
+
+          Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+          If this is a crash, the failing input is in the \`fuzz-crashers-${{ matrix.target }}\` artifact under \`testdata/fuzz/${{ matrix.target }}/\`. Commit it — it then replays as a seed in \`go test -race ./...\` on every PR.
+
+          If the log says \`no fuzz tests to fuzz\`, the target was renamed or deleted and this matrix entry needs updating."


### PR DESCRIPTION
## Third attempt at this flake; the first two treated symptoms

The per-PR gate failed again on 2026-08-11, on **#747 — a docker-compose-only change with zero Go code**:

```
--- FAIL: FuzzValidateAgentID (8.04s)
    context deadline exceeded
```

It passed on re-run. Prior attempts: #728 trimmed `-fuzztime` 8s→5s for the auth target, #743 made targets serial and stated that "removes the failure mode entirely." That claim is falsified by the run above.

**Mechanism.** `internal/fuzz` only builds the deadline context when `opts.Timeout > 0` (`fuzz.go:105`), so a *duration* budget on go1.26 can surface the spurious `context deadline exceeded` that neither previous fix addressed. A **count** budget (`-fuzztime=Nx`) structurally cannot hit it. That is why this change is not a third round of budget tuning.

## What changes

Per-PR mutation fuzzing is removed. A nightly job runs each target at `-fuzztime=5000000x` with a corpus cache that accumulates across runs — which is how fuzzing is supposed to work and what an 8-second-from-fixed-seed run on every PR never was.

**Crash protection is not lost, and this is the part to check rather than take on faith.** `go test -race ./...` already replays every committed seed corpus entry on every PR: no fuzz file carries a build tag, and `testing/fuzz.go:402-405` is the "fuzzing not enabled, only run the seed corpus" path. Verified by planting `internal/model/testdata/fuzz/FuzzValidateAgentID/probe-entry` and observing `--- PASS: FuzzValidateAgentID/probe-entry` without `-fuzz`. So a committed crasher regresses loudly on every PR, forever — which is exactly the recovery loop documented at the top of the new workflow.

Worth stating plainly: `git ls-files | grep -c testdata/fuzz` is **0**. In the gate's entire lifetime it has caught zero crashers while flaking at least three times.

## Second commit: two ways the nightly could have been silently useless

**A renamed or deleted target would report green forever.** `go test -fuzz='^NoSuchTarget$'` prints `testing: warning: no fuzz tests to fuzz` and **exits 0** — verified locally against `./internal/model`. The matrix hardcodes five target/pkg pairs with nothing cross-checking them against the actual `func Fuzz*` set. Since this job is now the *only* mutation coverage, nothing else would notice. The step greps for that warning and fails on it.

**A failing nightly notified nobody.** The recovery loop has no trigger if nothing tells a human the job went red, and this repo has one maintainer. Adds an issue-opening step on failure plus the `issues: write` permission it needs. Crasher upload moves `failure()` → `always()`, since a job-level cancellation skips `failure()` and the crashing input is precisely what's needed to diagnose one.

**Timeout margin corrected.** `go test` must panic *before* the job budget expires or the overrun arrives as a cancellation and the notifier never fires: `-timeout=50m` against `timeout-minutes: 60`. The corpus accumulates by design so per-exec cost rises — measured ~9.5k execs/s locally, a hosted runner is 2-4x slower, putting 5M execs at 18-35 minutes today and growing.

Gate green on this branch; note that a local gate cannot verify a *removed* CI job, so the YAML needs eyes rather than a green check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> Starfleet's transporter has a pattern buffer that can hold a person indefinitely, and Scotty survives 75 years inside one — which quietly establishes that the crew's routine commute is also a device for suspending a human being outside time. Nobody in-universe treats this as remarkable. The most radical technology on the ship is the one they use to get to work.