### PR TITLE
fix(compose): plumb the suppression sample rate into docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,10 @@ services:
       AKASHI_CONFLICT_BACKFILL_WINDOW: ${AKASHI_CONFLICT_BACKFILL_WINDOW:-0}
       AKASHI_CONFLICT_BACKFILL_BATCH_SIZE: ${AKASHI_CONFLICT_BACKFILL_BATCH_SIZE:-500}
       AKASHI_CONFLICT_BACKFILL_INTERVAL: ${AKASHI_CONFLICT_BACKFILL_INTERVAL:-5m}
+      # Fraction of structurally-suppressed pairs persisted for false-negative
+      # measurement. 0 = off, which is the code default: the table stays empty
+      # and the suppressors' recall stays unmeasurable until this is set.
+      AKASHI_CONFLICT_SUPPRESSION_SAMPLE_RATE: ${AKASHI_CONFLICT_SUPPRESSION_SAMPLE_RATE:-0}
 
       AKASHI_PORT: ${AKASHI_PORT:-8080}
       AKASHI_LOG_LEVEL: ${AKASHI_LOG_LEVEL:-info}


### PR DESCRIPTION
## A knob that could not be turned

`AKASHI_CONFLICT_SUPPRESSION_SAMPLE_RATE` shipped in #753 but never reached the compose `environment:` block. The code default is `0.0` = off, so a compose deployment would have run #753's migration, created the table, and **left it permanently empty with no supported way to enable it**.

That is worse than not shipping the feature. An empty `suppressed_pair_samples` table reads as "we sampled and found nothing" rather than "we never sampled."

## Same defect as #747, two days later

#747 plumbed `AKASHI_CONFLICT_OPENAI_MODEL` after that knob spent months unsettable, silently pinning the judge to the 8.1%-precision default while ADR-017 documented 41.5% as the intended operating point.

The shape recurs: a config var is added to `config.go`, validated, documented in `docs/configuration.md` — and never added to the deployment surface, so its default is the only value anyone ever runs. The detection/action parity rule in CLAUDE.md covers this case exactly: when a knob joins a family, it belongs everywhere its siblings already live. Worth considering a check that fails when an `AKASHI_*` var exists in `config.go` but not in `docker-compose.yml`, since this is now twice.

Default stays `0`, so this changes nothing until an operator opts in. Compose-only; no Go code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> The Weasleys' clock has no numbers, only states — "home", "travelling", "mortal peril" — which makes it the most honest instrument in the series: it reports what is happening rather than what someone hoped to measure. Molly checks it obsessively precisely because it cannot be reassuring by omission. Most dashboards would be improved by having a "mortal peril" hand and no way to hide it.