### PR TITLE
fix(compose): let .env.cloud reach the container instead of only interpolating

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,22 @@ services:
     ports:
       - "127.0.0.1:${AKASHI_PORT:-8080}:${AKASHI_PORT:-8080}"
     env_file:
+      # Both are optional and additive; the environment: block below still wins
+      # where it sets a key explicitly.
+      #
+      # .env.cloud is listed because deployments pass it via --env-file, which
+      # only feeds ${...} interpolation — it does NOT inject anything into the
+      # container. Without this entry a var set there reaches the process only
+      # if it also appears in the environment: block, so adding a knob to
+      # .env.cloud silently does nothing. That cost two fixes: #747
+      # (AKASHI_CONFLICT_OPENAI_MODEL, which pinned the judge to the 8.1%
+      # operating point while ADR-017 documented 41.5% as intended) and #754
+      # (AKASHI_CONFLICT_SUPPRESSION_SAMPLE_RATE, which left a shipped table
+      # permanently empty). Listing it here removes the failure mode rather than
+      # requiring every future knob to be plumbed twice.
       - path: .env
+        required: false
+      - path: .env.cloud
         required: false
     environment:
       # Required: set these in .env or pass directly.


### PR DESCRIPTION
## The mechanism behind #747 and #754

Deployments pass `.env.cloud` via `--env-file`, which feeds `${...}` interpolation **only** — it injects nothing into the container. A var set there reached the process only if it *also* appeared in the `environment:` block. Otherwise adding a knob to `.env.cloud` did nothing, silently.

That is what actually caused both prior fixes:

- **#747** — `AKASHI_CONFLICT_OPENAI_MODEL` left the judge pinned to the `gpt-4o-mini` default, 8.1% corpus-projected precision, while ADR-017 documented 41.5% as the intended operating point.
- **#754** — `AKASHI_CONFLICT_SUPPRESSION_SAMPLE_RATE` would have left #753's shipped table permanently empty, reading as "we sampled and found nothing."

Each was fixed by plumbing one more variable. Neither addressed why the next one breaks identically. Listing `.env.cloud` as an optional `env_file` removes the class.

Entries are additive and the `environment:` block still wins where it sets a key explicitly, so resolved values are unchanged — verified with `docker compose config`: `OPENAI_MODEL: gpt-5`, `SUPPRESSION_SAMPLE_RATE: "0.05"`, `BACKFILL_WINDOW: 720h`, all as before. `required: false` makes it a no-op for deployments without the file.

## Retracting the follow-up I suggested in #754

That PR proposed a CI check failing when an `AKASHI_*` var exists in `config.go` but not in `docker-compose.yml`. **I measured it after merging and it is wrong advice.**

`config.go` reads **88** such vars; `docker-compose.yml` names **17**. The other 71 are not defects — the compose file deliberately lists the commonly configured subset and everything else falls through to `env_file` or its code default. That check would have demanded 71 spurious additions to silence itself, and the noise would have buried the real cases.

The narrower true invariant — *every var in `.env.cloud` is reachable* — cannot run in CI at all, because `.env.cloud` is gitignored. Making reachability structural is the fix that needs no lint.

I also checked whether any var is currently being dropped: none is. `AKASHI_HOOKS_API_KEY` is set in `.env.cloud` and looked unreachable, but it is also present in `.env`, which *is* an `env_file`, so it arrives. No live gap — this is prophylactic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> The Fellowship's council spends a whole chapter establishing that nobody can be trusted to carry the Ring, and then resolves it by having the least powerful person volunteer. That is not a compromise, it is the actual finding: the safest custodian is the one with the least capacity to use it. Most access-control designs reach for the opposite instinct and hand the artifact to whoever is most capable.