### PR TITLE
fix(api): accept bindings over HTTP, not only over MCP

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -4497,6 +4497,34 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/TraceEvidence"
+        bindings:
+          type: array
+          description: |
+            Named parameters this decision sets, and the values it sets them to.
+
+            Two decisions binding the same parameter to different values are
+            detected as a conflict exactly, by lookup rather than by the LLM
+            judge — no model call, and no false-positive rate. 27% of the real
+            contradictions in our labelled corpus have this shape.
+
+            Values are compared literally and never interpreted: `5m` and `300s`
+            are different values, because deciding otherwise would require the
+            parameter's type, which is not recorded.
+          items:
+            $ref: "#/components/schemas/TraceBinding"
+
+    TraceBinding:
+      type: object
+      required: [parameter, value]
+      properties:
+        parameter:
+          type: string
+          description: The named knob this decision sets, e.g. `cache.ttl`.
+          example: "conflict_llm_timeout"
+        value:
+          type: string
+          description: The value it is set to, compared literally.
+          example: "120s"
 
     TraceAlternative:
       type: object

--- a/examples/python/base_rate.py
+++ b/examples/python/base_rate.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Why conflict detection is a screening problem, not a classification problem.
+
+At a low base rate, precision is governed almost entirely by the false-positive
+rate on the majority class — not by recall. This is the single most useful thing
+to understand before tuning any rare-event detector, and it is why F1 pointed us
+at the wrong judge for months.
+
+No server, no dependencies, no network. Runs anywhere Python does.
+
+Run:
+    python examples/python/base_rate.py
+"""
+
+PREVALENCE = 0.0335  # 93 real contradictions in 2,772 blind-labelled pairs
+
+
+def precision(prevalence: float, sensitivity: float, fpr: float) -> float:
+    """P(real | flagged). fpr is the false-positive rate on the majority class."""
+    tp = prevalence * sensitivity
+    fp = (1 - prevalence) * fpr
+    return tp / (tp + fp) if tp + fp else 0.0
+
+
+def main() -> None:
+    print(f"Base rate: {PREVALENCE:.2%} of candidate pairs are real contradictions\n")
+
+    print("Hold recall at 50%. Move only the false-positive rate:")
+    print(f"  {'majority-class FPR':>20}  {'precision':>10}")
+    for fpr in (0.057, 0.020, 0.010, 0.005, 0.001):
+        print(f"  {fpr:>19.1%}  {precision(PREVALENCE, 0.50, fpr):>10.1%}")
+
+    print("\nNow hold FPR at 1%. Move only recall:")
+    print(f"  {'recall':>20}  {'precision':>10}")
+    for s in (0.30, 0.50, 0.80, 0.95):
+        print(f"  {s:>19.0%}  {precision(PREVALENCE, s, 0.01):>10.1%}")
+
+    lo = precision(PREVALENCE, 0.30, 0.01)
+    hi = precision(PREVALENCE, 0.80, 0.01)
+    tight = precision(PREVALENCE, 0.50, 0.01)
+    loose = precision(PREVALENCE, 0.50, 0.02)
+
+    print(
+        f"\nRecall 30% -> 80% buys {(hi - lo) * 100:.0f} precision points."
+        f"\nHalving FPR 2% -> 1% buys {(tight - loose) * 100:.0f}, for far less work."
+        "\n\nSpend your effort on the false-positive rate against the boring majority."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/python/binding_collision.py
+++ b/examples/python/binding_collision.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Conflict detection by exact join — no language model in the loop.
+
+Two agents set the same named parameter to different values. That is not a
+language problem, it is a lookup: same org, same project, both decisions
+current, different value. 27% of the real contradictions in our corpus have
+this shape, and the join finds them at zero LLM cost with no false-positive
+rate at all.
+
+Contrast with prose conflict detection, which at a 3.35% base rate tops out
+around 41% precision even with a strong judge (see base_rate.py).
+
+Prerequisites:
+    docker compose -f docker-compose.complete.yml up -d
+    export AKASHI_TOKEN=<a JWT for your instance>
+
+Run:
+    python examples/python/binding_collision.py
+"""
+
+from __future__ import annotations  # keeps `dict | None` working on Python 3.7+
+
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+
+BASE = os.environ.get("AKASHI_URL", "http://localhost:8081")
+TOKEN = os.environ.get("AKASHI_TOKEN", "")
+PARAM = "conflict_llm_timeout"
+
+
+def call(method: str, path: str, body: dict | None = None) -> dict:
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(BASE + path, data=data, method=method)
+    req.add_header("Authorization", f"Bearer {TOKEN}")
+    if data:
+        req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as r:
+            return json.loads(r.read())
+    except urllib.error.HTTPError as e:
+        sys.exit(f"{method} {path} -> {e.code}: {e.read().decode()[:200]}")
+
+
+def trace(agent: str, outcome: str, value: str) -> str:
+    """Record one decision that binds PARAM to value."""
+    resp = call(
+        "POST",
+        "/v1/trace",
+        {
+            "agent_id": agent,
+            "decision": {
+                "decision_type": "architecture",
+                "outcome": outcome,
+                "confidence": 0.8,
+                "bindings": [{"parameter": PARAM, "value": value}],
+            },
+        },
+    )
+    return resp["data"]["decision_id"]
+
+
+def main() -> None:
+    if not TOKEN:
+        sys.exit("Set AKASHI_TOKEN to a JWT for your instance.")
+
+    print(f"akashi at {BASE}\n")
+
+    a = trace(
+        "timeout-agent-a",
+        "Set the conflict judge timeout to 15s — enough for chat-completion models.",
+        "15s",
+    )
+    print(f"  agent-a  {PARAM} = 15s   ({a[:8]})")
+
+    b = trace(
+        "timeout-agent-b",
+        "Set the conflict judge timeout to 120s — reasoning models need far longer.",
+        "120s",
+    )
+    print(f"  agent-b  {PARAM} = 120s  ({b[:8]})")
+
+    # Scoring runs inline on trace; the join needs no model call, so this is fast.
+    print("\nlooking for the collision...")
+    for _ in range(20):
+        found = [
+            c
+            for c in call("GET", "/v1/conflicts?status=open&limit=50")["data"]
+            if b in (c.get("decision_a_id"), c.get("decision_b_id"))
+        ]
+        if found:
+            c = found[0]
+            print("\nCONFLICT")
+            print(f"  method:      {c.get('scoring_method', '(n/a)')}")
+            print(f"  explanation: {c.get('explanation', '')}")
+            print(
+                "\nThat sentence was generated from a join, not a judge.\n"
+                "No tokens were spent deciding it, and it cannot be a false positive:\n"
+                "the two values are either equal or they are not."
+            )
+            return
+        time.sleep(1)
+
+    print("No collision found. Is conflict scoring enabled on this instance?")
+
+
+if __name__ == "__main__":
+    main()

--- a/internal/model/api.go
+++ b/internal/model/api.go
@@ -316,6 +316,14 @@ func (d TraceDecision) ConfidencePresent() bool {
 // supplied a confidence value, distinguishing "omitted" from "explicitly 0".
 func (d *TraceDecision) UnmarshalJSON(data []byte) error {
 	*d = TraceDecision{}
+	// Every JSON-tagged field on TraceDecision must appear here. This shadow
+	// struct decodes with DisallowUnknownFields, so a field present on
+	// TraceDecision but missing here does not degrade — it rejects the whole
+	// request with 400 "invalid request body". That is how "bindings" was
+	// unusable over HTTP and in all three SDKs while working over MCP:
+	// TraceDecision declared it, this struct did not, and adding it to a
+	// previously-working call broke that call outright.
+	// TestTraceDecisionUnmarshalJSON_RoundTripsEveryField pins the invariant.
 	type rawDecision struct {
 		DecisionType string             `json:"decision_type"`
 		Outcome      string             `json:"outcome"`
@@ -323,6 +331,7 @@ func (d *TraceDecision) UnmarshalJSON(data []byte) error {
 		Reasoning    *string            `json:"reasoning,omitempty"`
 		Alternatives []TraceAlternative `json:"alternatives,omitempty"`
 		Evidence     []TraceEvidence    `json:"evidence,omitempty"`
+		Bindings     []TraceBinding     `json:"bindings,omitempty"`
 	}
 	var raw rawDecision
 	dec := json.NewDecoder(bytes.NewReader(data))
@@ -335,6 +344,7 @@ func (d *TraceDecision) UnmarshalJSON(data []byte) error {
 	d.Reasoning = raw.Reasoning
 	d.Alternatives = raw.Alternatives
 	d.Evidence = raw.Evidence
+	d.Bindings = raw.Bindings
 	if raw.Confidence != nil {
 		d.Confidence = *raw.Confidence
 		d.confidencePresent = true

--- a/internal/model/api_test.go
+++ b/internal/model/api_test.go
@@ -587,3 +587,44 @@ func TestTraceDecisionUnmarshalJSON_PreservesOtherFields(t *testing.T) {
 	require.Len(t, d.Evidence, 1)
 	assert.Equal(t, "document", d.Evidence[0].SourceType)
 }
+
+// TestTraceDecisionUnmarshalJSON_RoundTripsEveryField is the durable version of
+// PreservesOtherFields, which enumerates fields by hand and therefore missed
+// "bindings" entirely: TraceDecision declared it, the custom unmarshaler's
+// shadow struct did not, and because that struct decodes with
+// DisallowUnknownFields the result was a hard 400 on any HTTP trace carrying
+// bindings — unusable from curl and all three SDKs while working over MCP.
+//
+// Marshalling a fully-populated TraceDecision and unmarshalling it back fails
+// loudly for ANY field added to TraceDecision but not to the shadow struct,
+// without this test needing to know the field exists.
+func TestTraceDecisionUnmarshalJSON_RoundTripsEveryField(t *testing.T) {
+	reasoning := "reasoning text"
+	rejection := "loses history"
+	original := model.TraceDecision{
+		DecisionType: "architecture",
+		Outcome:      "use event sourcing",
+		Confidence:   0.72,
+		Reasoning:    &reasoning,
+		Alternatives: []model.TraceAlternative{{Label: "CRUD", RejectionReason: &rejection}},
+		Evidence:     []model.TraceEvidence{{SourceType: "document", Content: "ADR-007"}},
+		Bindings:     []model.TraceBinding{{Parameter: "storage.mode", Value: "event_sourced"}},
+	}
+
+	raw, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var got model.TraceDecision
+	require.NoError(t, json.Unmarshal(raw, &got),
+		"a field on TraceDecision is missing from the unmarshaler's shadow struct: %s", raw)
+
+	assert.Equal(t, original.DecisionType, got.DecisionType)
+	assert.Equal(t, original.Outcome, got.Outcome)
+	assert.InDelta(t, original.Confidence, got.Confidence, 1e-6)
+	require.NotNil(t, got.Reasoning)
+	assert.Equal(t, *original.Reasoning, *got.Reasoning)
+	assert.Equal(t, original.Alternatives, got.Alternatives)
+	assert.Equal(t, original.Evidence, got.Evidence)
+	assert.Equal(t, original.Bindings, got.Bindings,
+		"bindings must survive the round trip — this is the regression that shipped")
+}


### PR DESCRIPTION
## The flagship join feature was unreachable from HTTP

`TraceDecision.UnmarshalJSON` decodes into a private `rawDecision` shadow struct that had no `Bindings` field — and that struct uses `DisallowUnknownFields()`. So every HTTP trace carrying `bindings` was rejected:

```
POST /v1/trace {"decision":{...,"bindings":[{"parameter":"x","value":"15s"}]}}
→ 400 {"code":"INVALID_INPUT","message":"invalid request body"}
```

Not degraded — **rejected**. Adding bindings to a previously-working call broke that call.

The field is declared on `TraceDecision`, documented in its own comment, populated by the MCP path, and stored end to end. It was simply unreachable from curl, the Go/Python/TypeScript SDKs, and anything else speaking HTTP. Since #744 this is the path for detecting conflicts by **exact join instead of LLM judge** — 27% of real contradictions in the labelled corpus — so the headline feature has been MCP-only since it shipped.

## How it drifted

#713 added the custom unmarshaler to track whether `confidence` was present in the payload. #744 added `bindings` to `TraceDecision` and not to the shadow struct. `api/openapi.yaml` never described the field, so no contract check could catch it.

`TestTraceDecisionUnmarshalJSON_PreservesOtherFields` exists to guard precisely this, and its comment says so — it "guards against the custom UnmarshalJSON accidentally dropping any sibling field." It missed, because it enumerates fields by hand and nobody added the new one.

## The fix, and a guard that can't miss the next one

Two lines restore the field. The test is the durable part: marshal a fully-populated `TraceDecision`, unmarshal it back. Any field on `TraceDecision` missing from the shadow struct now fails loudly **without the test needing to know the field exists**.

Verified by mutation — reverting the fix fails the new test while the old one still passes:

```
--- FAIL: TestTraceDecisionUnmarshalJSON_RoundTripsEveryField
    a field on TraceDecision is missing from the unmarshaler's shadow struct
```

## Verified end to end

Rebuilt `docker-compose.complete.yml` and ran the new example against it — plain HTTP, no SDK:

```
agent-a  conflict_llm_timeout = 15s
agent-b  conflict_llm_timeout = 120s

CONFLICT
  method:      binding_v1
  explanation: timeout-agent-b set conflict_llm_timeout to "120s"; timeout-agent-a
               set the same parameter to "15s". Both decisions are current, so a
               reader has no way to know which value holds.
```

## Also here

- `api/openapi.yaml` gains the `bindings` array and a `TraceBinding` schema.
- `examples/python/binding_collision.py` — reproduces the join over stdlib HTTP, no dependencies.
- `examples/python/base_rate.py` — derives ADR-017's precision table from the 3.35% prevalence, so the operating-point argument can be checked rather than taken on faith. Output matches the ADR exactly (23/46/63/78/95).

Gate green; the only failure is the pre-existing `TestGitCommitSubject_CurrentRepo` caused by a stray empty `internal/.git`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> Chekhov's gun says a rifle on the wall in act one must fire by act three. The interesting failure is the inverse: a rifle carefully mounted, documented in the playbill, described by the characters — and welded to the wall. Everyone believed it worked because nobody in the cast had tried to pick it up.