### PR TITLE
security: redact two third-party identifiers from source and tests

### DIFF
--- a/internal/conflicts/disjoint_resource_test.go
+++ b/internal/conflicts/disjoint_resource_test.go
@@ -179,7 +179,7 @@ func TestIsDisjointResource(t *testing.T) {
 			name: "one side has no extractable resource (customer name only) → NOT suppressed",
 			d: model.Decision{
 				ID: idA, Project: &mono, DecisionType: "deployment",
-				Outcome: "recovered the Burbuxa sink by rolling kafka2pg to stable, left pg2kafka unchanged",
+				Outcome: "recovered the Globex sink by rolling kafka2pg to stable, left pg2kafka unchanged",
 			},
 			cand: model.Decision{
 				ID: idB, Project: &mono, DecisionType: "investigation",

--- a/internal/conflicts/operational_progression_test.go
+++ b/internal/conflicts/operational_progression_test.go
@@ -16,7 +16,7 @@ import (
 // isTemporalReassessment. The table covers each guardrail in isolation plus
 // anchor cases drawn from the 2026-06-18 open-conflict queue:
 //
-//   - SalesPatriot (suppressed): codex "rolled kafka2pg back to its pre-rollout
+//   - Acme (suppressed): codex "rolled kafka2pg back to its pre-rollout
 //     digest" (operations, 06-18) vs claude "verified the connector ONLINE"
 //     (deployment, 06-10) — eight days apart, same project, no reversal vocab.
 //     A remediation step in an incident timeline, not a disagreement.
@@ -43,18 +43,18 @@ func TestIsOperationalStateProgression(t *testing.T) {
 		expected bool
 	}{
 		{
-			// SalesPatriot anchor: operations vs deployment, 8 days apart.
+			// Acme anchor: operations vs deployment, 8 days apart.
 			name: "both operational, same project, far apart, no reversal vocab → suppressed",
 			d: model.Decision{
 				ID: idA, AgentID: "codex-mcp-client", Project: &mono,
 				DecisionType: "operations",
-				Outcome:      "restored SalesPatriot online by rolling kafka2pg back to its pre-rollout digest and scaling it to 1",
+				Outcome:      "restored Acme online by rolling kafka2pg back to its pre-rollout digest and scaling it to 1",
 				ValidFrom:    now,
 			},
 			cand: model.Decision{
 				ID: idB, AgentID: "claude-code", Project: &mono,
 				DecisionType: "deployment",
-				Outcome:      "verified SalesPatriot connector_c3fed173 is online and branchable on the deployed pgstream image",
+				Outcome:      "verified Acme connector_redacted01 is online and branchable on the deployed pgstream image",
 				ValidFrom:    now.Add(-beyond),
 			},
 			expected: true,
@@ -208,15 +208,15 @@ func TestIsOperationalStateProgression(t *testing.T) {
 			expected: false,
 		},
 		{
-			// SalesPatriot FN anchor: e81b6b22 (pause, DATALOSS) vs 3cf6a4c3
-			// (scale up, "resume loses no data") on connector_c3fed173, 10.9d
+			// Acme FN anchor: e81b6b22 (pause, DATALOSS) vs 3cf6a4c3
+			// (scale up, "resume loses no data") on connector_redacted01, 10.9d
 			// apart, no supersession vocab. The data-safety guard must keep this
 			// same-writer pair out of the suppress path — it is the disagreement
 			// a human must see, not a sequential step.
 			name: "data-loss keyword in later outcome → NOT suppressed (data-safety guard)",
 			d: model.Decision{
 				ID: idA, Project: &mono, DecisionType: "operations",
-				Outcome:   "paused SalesPatriot kafka2pg after rollout validation found active target-side DATALOSS quarantine growth",
+				Outcome:   "paused Acme kafka2pg after rollout validation found active target-side DATALOSS quarantine growth",
 				ValidFrom: now,
 			},
 			cand: model.Decision{

--- a/internal/conflicts/scorer.go
+++ b/internal/conflicts/scorer.go
@@ -2053,8 +2053,8 @@ func isTemporalReassessment(d, cand model.Decision) bool {
 // the earlier action no longer describes what the later one is changing.
 //
 // The signal is only weak, and deliberately not relied on alone: a single
-// resource can stay in one incident longer than the window (the live SalesPatriot
-// connector_c3fed173 incident ran 2026-05-26 → 06-18), in which case directives
+// resource can stay in one incident longer than the window (the live Acme
+// connector_redacted01 incident ran 2026-05-26 → 06-18), in which case directives
 // spanning >7 days are still about the same live system, not unrelated steps.
 // Time-apart cannot distinguish that case from genuine progression, so
 // isOperationalStateProgression layers other guards on top: the data-loss guard
@@ -2072,7 +2072,7 @@ const operationalProgressionWindow = 7 * 24 * time.Hour
 //
 // Motivation: the dominant live false-positive class (2026-06 open-conflict
 // audit) was cross-ticket operational steps on one hot subsystem
-// (pgstream / Debezium / SalesPatriot CDC) clustered by shared vocabulary —
+// (pgstream / Debezium / Acme CDC) clustered by shared vocabulary —
 // e.g. "rolled kafka2pg back to its pre-rollout digest" eight days after
 // "verified the connector ONLINE". Embeddings place them close (topic_sim
 // 0.70-0.85) and the LLM validator returns CONTRADICTION, but a rollback or
@@ -2102,7 +2102,7 @@ const operationalProgressionWindow = 7 * 24 * time.Hour
 //     quarantine event — a data-safety event is categorically high-stakes and
 //     must reach the validator regardless of the time gap (checked on both
 //     sides, both text fields). This is the guard that keeps same-resource
-//     incident disagreements like the live SalesPatriot DATALOSS pause from
+//     incident disagreements like the live Acme DATALOSS pause from
 //     being silently dropped pre-LLM. See decisionContainsDataLossKeyword.
 //   - not precedent-linked and not the same session — explicit links and
 //     intra-session pairs are left to the LLM, mirroring isTemporalReassessment
@@ -2298,8 +2298,8 @@ func isDisjointWorkItem(d, cand model.Decision) bool {
 // No data-safety guard here (removed 2026-07-23). The guard is load-bearing and
 // deliberately chosen in the TEMPORAL sibling isOperationalStateProgression
 // (decision efc42730): two decisions on the SAME writer a week apart can be one
-// incident disagreeing with itself — verified against the SalesPatriot
-// connector_c3fed173 DATALOSS pause. That rationale cannot hold here, because a
+// incident disagreeing with itself — verified against the Acme
+// connector_redacted01 DATALOSS pause. That rationale cannot hold here, because a
 // connector_/org_ id is the PHYSICAL identity of a data plane: connector_57a42328
 // and connector_f924df29 are different incidents by construction, so a DATALOSS
 // finding on one can neither be the same incident as, nor contradict, a finding
@@ -2504,7 +2504,7 @@ func containsSupersessionKeyword(outcome string) bool {
 // event is categorically high-stakes, and silently dropping a same-system pair
 // that reports one — before the LLM validator or a human ever sees it — would
 // trade the system's core guarantee (a complete paper trail of disagreements)
-// for noise reduction. Surfaced by the 2026-06 SalesPatriot connector_c3fed173
+// for noise reduction. Surfaced by the 2026-06 Acme connector_redacted01
 // incident, where "paused … active target-side DATALOSS quarantine growth" sat
 // >7 days from "scaled … resume loses no data" on the same writer.
 //


### PR DESCRIPTION
Two third-party identifiers and one resource id were committed to this public repository. Superseded by a full history rewrite; closing unmerged.

Details deliberately omitted from this description. See the private incident note.