### PR TITLE
Fix the contributor on-ramp: a reachable database, a visible PR contract, one local gate

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,6 +11,13 @@
   - [ ] `docs/runbook.md` (operational subset, if relevant)
   - [ ] `.env.example` (if baseline local/dev defaults changed)
 - [ ] `python3 scripts/check_doc_config_consistency.py` passes.
+- [ ] If I added or changed an **API endpoint or a storage query**:
+  - [ ] Every new query is scoped by `org_id`.
+  - [ ] Queries returning current state include `valid_to IS NULL`.
+  - [ ] `api/openapi.yaml` is updated (enforced by `internal/server/openapi_test.go`).
+  - [ ] The lite build still compiles: `go build -tags lite -o /dev/null ./cmd/akashi-local`.
+- [ ] This PR description ends with a blockquote about Marvel, DC, Harry Potter, Star Wars,
+      Star Trek, or Tolkien — an argument or an original haiku (see AGENTS.md).
 
 ## Risk / Rollout Notes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,19 +98,40 @@ docs/                Configuration reference; conflict-detection operator guide.
 1. Add the handler method to the appropriate `handlers_*.go` file:
 ```go
 func (h *Handlers) HandleMyThing(w http.ResponseWriter, r *http.Request) {
-    orgID := OrgIDFromContext(r.Context())        // always extract org
-    agentID := AgentIDFromContext(r.Context())     // from auth middleware
+    orgID := OrgIDFromContext(r.Context())   // always extract org
+    claims := ClaimsFromContext(r.Context()) // caller identity: claims.ActorID(), claims.Role
     // ... business logic ...
     writeJSON(w, r, http.StatusOK, result)
 }
 ```
+There is no `AgentIDFromContext`. The caller's identity comes off `ClaimsFromContext`, whose
+`ActorID()` prefers `AgentID` (API-key auth) and falls back to `Subject` (JWT auth).
+
 2. Register the route in `server.go`:
 ```go
 mux.Handle("GET /v1/my-thing", readRole(http.HandlerFunc(h.HandleMyThing)))
 ```
-3. Add the storage query in the appropriate `internal/storage/*.go` file. Always filter by `org_id`.
-4. Add the endpoint to `api/openapi.yaml`.
-5. Run the full pre-commit checks.
+`adminOnly`, `orgOwnerOnly`, `writeRole` and `readRole` are local variables declared inside
+`New()` (server.go:158, :172, :185, :192), not package-level functions — they exist only in that
+scope. Pick the lowest role that is still correct: `readRole` (reader+) for queries, `writeRole`
+(agent+) for ingestion, `adminOnly` for management, `orgOwnerOnly` for anything irreversible.
+`POST /v1/decisions/{id}/erase` at server.go:173 is the worked example of the last case. The full
+five-level ladder is in `docs/faq.md`; changing an existing endpoint's role is an ask-first item.
+
+3. Add the storage query in the appropriate `internal/storage/*.go` file. Always filter by
+   `org_id`, and add `valid_to IS NULL` if the query should return current state.
+
+4. Add a cross-org test. `TestHandlersCritical_GetDecisionCrossOrgReturns404` is the template:
+   a caller from org B must get 404, not 403, for a resource in org A.
+
+5. Add the endpoint to `api/openapi.yaml`. This one is machine-checked —
+   `internal/server/openapi_test.go` parses the route registrations out of server.go and fails
+   on any route missing from the spec.
+
+6. Run `make preflight`.
+
+SDK parity is **not** required for a new endpoint. All three SDKs cover well under the spec's 86
+operations and always have; adding a method is welcome, and opening a follow-up issue is the norm.
 
 ## How to add a migration
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,12 +24,14 @@ This registers a `PostToolUse` hook that fires after every `git commit` and remi
 
 **Before every commit (mandatory, CI rejects failures):**
 ```sh
-go mod tidy && git diff --exit-code go.mod go.sum
-go build ./...
-go vet ./...
-golangci-lint run ./...
-atlas migrate validate --dir file://migrations
+make preflight
 ```
+
+This is `ci.yml`'s build job minus the tests: tidy + go.mod diff, doc/config consistency,
+Atlas migration validation, `go build`, the **lite build** (`-tags lite ./cmd/akashi-local`),
+lint, and vet. No Docker, no database, no API keys. The Makefile target is the only definition —
+do not restate the command list here, which is how the two CI-enforced gates went missing from
+it for months. The raw commands are kept as a comment above the target.
 
 **Before every push (mandatory, CI runs with `-race`):**
 ```sh
@@ -54,11 +56,15 @@ make ci                                  # full local CI mirror
 ```
 cmd/akashi/          Server entrypoint. Config loading, dependency wiring, signal handling.
 cmd/akashi-local/    Local-lite MCP server (SQLite, stdio transport, zero-infra). See ADR-009.
-cmd/eval-conflicts/  Offline evaluation tool for conflict detection precision/recall.
+cmd/eval-conflicts/  Evaluation harness for conflict detection precision/recall. Only
+                     --mode=benchmark runs standalone; --mode=validator and --mode=scorer
+                     need a running server, and --mode=gold needs AKASHI_DB_DSN plus a
+                     populated conflict_gold_labels table. See docs/conflict-detection.md.
 internal/
   server/            HTTP handlers (handlers*.go), middleware (middleware.go), SSE broker.
   storage/           PostgreSQL queries. One file per entity (decisions.go, agents.go, events.go...).
-  storage/sqlite/    SQLite storage backend for local/lite mode (build tag: lite).
+  storage/sqlite/    SQLite storage backend for local/lite mode. Carries NO build tag — it
+                     compiles in every build and is simply not imported outside cmd/akashi-local.
   service/           Business logic. decisions/ (trace pipeline), embedding/, quality/, query/, search/,
                      trace/ (event buffer, WAL), autoassess/, autoresolve/, tracehealth/.
   model/             Domain types. Decision, AgentEvent, Alternative, Evidence, etc.
@@ -152,7 +158,7 @@ If you still believe the behavior should change, update the tests in the same co
 **Always:**
 - Scope every storage query by `org_id`
 - Include `valid_to IS NULL` when querying current decision state
-- Run the 5 pre-commit checks + `go test -race` before pushing
+- Run `make preflight` + `go test -race` before pushing
 - Use `require.NoError(t, err)` / `assert.*` from testify in tests
 - Use `writeJSON(w, r, statusCode, payload)` for HTTP responses
 - Use `slog` structured logging (never `fmt.Print` or `log.*`)
@@ -160,7 +166,7 @@ If you still believe the behavior should change, update the tests in the same co
 **Never:**
 - Commit `.env` files, API keys, or credentials
 - Add `Co-Authored-By` trailers to commits
-- Skip pre-commit checks ("just this once" has caused two CI failures)
+- Skip `make preflight` ("just this once" has caused two CI failures)
 - Modify already-applied migrations (create a new one instead)
 - Use `os.Exit` inside `run()` (it skips defers; return an error instead)
 - Remove a failing test without understanding why it fails first

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -255,3 +255,17 @@ For deeper context on the codebase, see:
 - [diagrams.md](docs/diagrams.md) — Mermaid diagrams of all major data flows
 - [configuration.md](docs/configuration.md) — Full environment variable reference
 - [faq.md](docs/faq.md) — Concepts, auth, integrity; includes the five-level RBAC role table
+- [conflict-detection.md](docs/conflict-detection.md) — The detector's measured operating point,
+  how to evaluate a change, and the alternatives already tried and rejected
+
+### Changing conflict detection
+
+`internal/conflicts/` is held to a higher evidence bar than the rest of the repo, because it has
+been retuned on intuition before and the retunings did not survive measurement. Read
+[conflict-detection.md](docs/conflict-detection.md) and [ADR-017](adrs/) first.
+
+Two things to know before you start. The gold-label corpus behind the published precision numbers
+is **not distributed** — `--mode=gold` will find an empty table on your machine, and §3 of that
+document explains what evidence to bring instead. And the structural suppressors are individually
+unit-testable with no database and no API key, which makes them the best entry point:
+`go test ./internal/conflicts/...`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,16 @@ If you want a persistent local stack for manual testing or running the server:
 docker compose -f docker-compose.complete.yml up -d postgres qdrant
 ```
 
-This starts TimescaleDB (with pgvector) on port 5432 and Qdrant on port 6333.
+This starts TimescaleDB (with pgvector) on port 5432 and Qdrant on port 6333, both bound to
+loopback only. Verify before going further — the containers report healthy whether or not the
+ports reached your host:
+
+```sh
+psql postgres://akashi:akashi@localhost:5432/akashi -c 'select 1'
+```
+
+If you already run Postgres or Qdrant locally, the bind fails loudly. Set `POSTGRES_PORT` or
+`QDRANT_PORT` to move the published port, and adjust `DATABASE_URL` to match.
 
 For the complete stack (database + Qdrant + Ollama + Akashi server):
 
@@ -35,6 +44,33 @@ First launch downloads Ollama models (~7 GB total) and takes 10–20 minutes. Tr
 ```sh
 docker compose -f docker-compose.complete.yml logs -f ollama-init
 ```
+
+### Running the server from source
+
+Once the database is reachable, point a locally built binary at it. Akashi reads a `.env` from
+the working directory on startup (`akashi.go:112`).
+
+```sh
+cp .env.example .env
+```
+
+Then edit `.env` for a host run — `.env.example` is written for the container:
+
+- `AKASHI_JWT_PRIVATE_KEY` and `AKASHI_JWT_PUBLIC_KEY` point at `/data/*.pem`, which does not
+  exist on your host. **Comment both out.** When both are empty, Akashi generates an ephemeral
+  Ed25519 keypair in memory (`internal/auth/auth.go:58`) — fine for development, and it means
+  tokens do not survive a restart.
+- `AKASHI_EMBEDDING_PROVIDER=noop` keeps the server off Ollama and OpenAI. Semantic search and
+  conflict detection then run at low recall by design — see [Embedding provider note](#embedding-provider-note).
+
+```sh
+make build
+./bin/akashi
+curl -s http://localhost:8080/health | jq .
+```
+
+Configuration errors are fatal and accumulate: the server reports every invalid variable at
+once, each naming its remedy, rather than starting in a degraded state.
 
 ### Running tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,10 +36,18 @@ without it get sent back.
 ### Prerequisites
 
 - **Go 1.26+** ([install](https://go.dev/dl/))
-- **Docker** (for testcontainers and the local stack)
+- **Docker** (only for integration tests and the local stack — unit tests need none)
 - **Atlas CLI** ([install](https://atlasgo.io/getting-started#installation)) — database migration tool
+- **Python 3** — `make preflight` runs `scripts/check_doc_config_consistency.py`
 - **golangci-lint v2.11.0** — `go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.0`
-- **Node.js 20+** (only if working on the UI)
+- **goimports v0.42.0** — `go install golang.org/x/tools/cmd/goimports@v0.42.0` (used by `make fmt`)
+- **govulncheck v1.1.4** — `go install golang.org/x/vuln/cmd/govulncheck@v1.1.4` (used by `make ci`)
+- **Node.js 22** (only if working on the UI — matches CI and the Dockerfile)
+
+The three `go install` tools land in `$(go env GOPATH)/bin`, usually `~/go/bin`. Put it on your
+`PATH` or `make lint` will report the tool as missing rather than the code as clean. The pinned
+versions are the ones CI installs (`.github/workflows/ci.yml`); a different golangci-lint minor
+can report findings CI does not, and vice versa.
 
 ### Starting the test database
 
@@ -139,43 +147,57 @@ SDK integration tests that hit a live server require `AKASHI_URL` and `AKASHI_AP
 
 ## Writing a migration
 
-1. Create `migrations/NNN_description.sql` where `NNN` is the next sequential number (check the `migrations/` directory for the current highest).
-2. Start the file with a comment: `-- NNN: Brief description of what this migration does.`
-3. Regenerate the checksum file:
-   ```sh
-   atlas migrate hash --dir file://migrations
-   ```
-4. Validate:
-   ```sh
-   atlas migrate validate --dir file://migrations
-   ```
-5. Stage both the `.sql` file and `migrations/atlas.sum` in your commit.
+```sh
+make new-migration name=add_foo_index
+```
+
+That picks the next sequential number, writes the `-- NNN: description.` header, and rehashes
+`atlas.sum` — the three steps most easily got wrong by hand. Write your SQL into the created
+file, then:
+
+```sh
+make migrate-validate
+```
+
+Stage both the `.sql` file and `migrations/atlas.sum`. If validation fails after you edit the
+file, `make migrate-hash` regenerates the checksum.
 
 **Never edit an existing migration** — always create a new one. Applied migrations are immutable.
 
+Two mechanisms apply migrations, and they are not the same one. The server runs a simple
+forward-only runner over the embedded files at startup, tracking what it has applied in
+`schema_migrations` (`internal/storage/migrate.go`); set `AKASHI_SKIP_EMBEDDED_MIGRATIONS=true`
+to suppress it. Atlas owns checksum integrity, linting, and production application — `make
+migrate-apply` is the operator path, not part of local development.
+
 ## Pre-commit checklist
 
-Run these before every commit. CI rejects failures on all of them.
-
 ```sh
-go mod tidy && git diff --exit-code go.mod go.sum
-go build ./...
-go vet ./...
-golangci-lint run ./...
-atlas migrate validate --dir file://migrations
+make preflight
 ```
+
+That is the whole gate, and it is the same list CI runs in its build job — tidy plus a
+`go.mod`/`go.sum` diff, doc/config consistency, Atlas migration validation, `go build`, the
+lite build, lint, and vet. It needs no Docker, no database, and no API keys.
+
+The target is the single definition on purpose. This file used to carry a hand-copied
+five-command version that had drifted: it omitted `scripts/check_doc_config_consistency.py`
+and the `-tags lite` build, both of which CI enforces on every push. If you want the raw
+commands, they are kept as a comment directly above the `preflight` target in the `Makefile`.
 
 If `go mod tidy` changes `go.mod` or `go.sum`, stage them in the commit.
 
-If `atlas migrate validate` fails, regenerate the checksum with `atlas migrate hash --dir file://migrations` and stage `migrations/atlas.sum`.
+If migration validation fails, regenerate the checksum with `make migrate-hash` and stage
+`migrations/atlas.sum`.
 
-Before pushing, also run:
+Before pushing:
 
 ```sh
-go test -race -count=1 ./...
+make test-unit    # fast, no containers
+make test         # full suite, requires Docker
 ```
 
-Or run the full CI mirror locally:
+Or the full CI mirror, which is `preflight` plus govulncheck and the test suite:
 
 ```sh
 make ci

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,35 @@
 
 This guide covers local development setup, common workflows, and the architecture you'll encounter when contributing to Akashi.
 
+[AGENTS.md](AGENTS.md) is normative for conventions and project structure. This file is the
+human-facing subset; where the two disagree, AGENTS.md wins.
+
+## Architecture invariants
+
+Two rules are load-bearing enough that a PR violating either will be sent back, and neither is
+visible from the code you are editing. Quoting AGENTS.md:
+
+> **Multi-tenancy via org_id.** Every query MUST include `AND org_id = $N`. There are 400+
+> org_id references across the storage layer. Missing one is a data leak. When adding a new
+> query, always scope by org_id.
+
+> **Bi-temporal model.** Decisions have `valid_from`/`valid_to` (business time) and
+> `transaction_time` (system time). Active records have `valid_to IS NULL`. Always include this
+> filter in queries that should return current state.
+
+Nothing mechanical enforces either one — `go vet`, the linter, and the type system are all blind
+to a dropped `WHERE` clause. Review is the only check, so make it easy: keep storage queries in
+the one-file-per-entity layout `internal/storage/` already uses.
+
+Some changes need a maintainer conversation before the code, not after. From AGENTS.md's
+"Ask first" list: changing the RBAC role required by an endpoint, adding a direct dependency to
+`go.mod`, modifying the MCP tool definitions, and any schema change that widens access.
+
+Finally, a house rule that surprises people: **every PR description must end with a blockquote
+about Marvel, DC, Harry Potter, Star Wars, Star Trek, or Tolkien** — an argument for one universe
+over another, or an original haiku. See AGENTS.md for the format. This is not a joke entry; PRs
+without it get sent back.
+
 ## Local dev setup
 
 ### Prerequisites
@@ -39,7 +68,7 @@ For the complete stack (database + Qdrant + Ollama + Akashi server):
 docker compose -f docker-compose.complete.yml up -d
 ```
 
-First launch downloads Ollama models (~7 GB total) and takes 10–20 minutes. Track progress with:
+First launch downloads Ollama models (~7 GB total) and takes 15–25 minutes. Track progress with:
 
 ```sh
 docker compose -f docker-compose.complete.yml logs -f ollama-init
@@ -203,3 +232,4 @@ For deeper context on the codebase, see:
 - [subsystems.md](docs/subsystems.md) — Embedding providers, rate limiting, search pipeline
 - [diagrams.md](docs/diagrams.md) — Mermaid diagrams of all major data flows
 - [configuration.md](docs/configuration.md) — Full environment variable reference
+- [faq.md](docs/faq.md) — Concepts, auth, integrity; includes the five-level RBAC role table

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build build-local build-ui build-with-ui test test-unit test-integration lint fmt vet clean docker-up docker-down ci security tidy \
+.PHONY: all build build-local build-ui build-with-ui test test-unit test-integration lint fmt vet clean docker-up docker-down ci preflight security tidy \
        dev-ui migrate-apply migrate-lint migrate-hash migrate-diff migrate-status migrate-validate new-migration \
        check-doc-consistency verify-restore reconcile-qdrant reconcile-qdrant-repair \
        archive-events-dry-run archive-events verify-exit-criteria install-hooks clean-hooks coverage
@@ -11,8 +11,29 @@ LDFLAGS := -ldflags "-X main.version=$(VERSION)"
 
 all: fmt lint vet test build
 
-# Run the full CI pipeline locally (mirrors .github/workflows/ci.yml)
-ci: tidy check-doc-consistency build lint vet security test migrate-validate
+# The local gate, and the ONLY definition of it. Exactly ci.yml's build job
+# minus the test suite: no Docker, no database, no API keys, seconds to run.
+#
+# AGENTS.md and CONTRIBUTING.md point here instead of restating the list.
+# Three hand-maintained copies is how the documented checklist came to omit
+# check-doc-consistency and the lite build while CI ran both on every push.
+#
+# The equivalent raw commands, in the order CI runs them, kept copy-pasteable:
+#   go mod tidy && git diff --exit-code go.mod go.sum
+#   python3 scripts/check_doc_config_consistency.py
+#   atlas migrate validate --dir file://migrations
+#   go build ./...
+#   go build -tags lite -o /dev/null ./cmd/akashi-local
+#   golangci-lint run ./...
+#   go vet ./...
+preflight: tidy check-doc-consistency migrate-validate build build-local lint vet
+	@echo "preflight passed"
+
+# Run the full CI pipeline locally (mirrors .github/workflows/ci.yml).
+# A strict superset of preflight, so the two cannot drift apart.
+# Deliberately NOT included, because they need Node or a live service:
+# build-with-ui, the three SDK test suites, and the coverage gate.
+ci: preflight security test
 	@echo "CI passed"
 
 check-doc-consistency:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,26 @@ Decisions are written atomically with reasoning, alternatives, and evidence. Con
 
 See [Conflict Detection](docs/conflicts.md) and [Subsystems](docs/subsystems.md) for internals.
 
-## Quick start
+## Try it in 60 seconds
+
+No Docker, no database, no API keys. `akashi-local` is a single binary that speaks MCP over
+stdio and stores everything in SQLite (see [ADR-009](adrs/)):
+
+```bash
+make build-local
+./bin/akashi-local          # database created at ~/.akashi/local.db
+```
+
+Point an MCP client at it — for Claude Code:
+
+```bash
+claude mcp add akashi -- /absolute/path/to/bin/akashi-local
+```
+
+`akashi_check` and `akashi_trace` work immediately. Conflict detection in this mode is
+text-based rather than semantic; see [Conflict Detection](docs/conflicts.md).
+
+## Quick start (full stack)
 
 ```bash
 docker compose -f docker-compose.complete.yml up -d

--- a/README.md
+++ b/README.md
@@ -97,8 +97,23 @@ claude mcp add --transport http --scope user akashi http://localhost:8080/mcp \
 | [Subsystems](docs/subsystems.md) | Embeddings, rate limiting, Qdrant pipeline |
 | [Runbook](docs/runbook.md) | Health checks, monitoring, troubleshooting |
 | [Diagrams](docs/diagrams.md) | Write path, read path, auth flow, schema |
-| [ADRs](adrs/) | 15 architecture decision records |
+| [ADRs](adrs/) | Architecture decision records |
 | [OpenAPI](api/openapi.yaml) | Full API spec (also at `GET /openapi.yaml`) |
+| [Contributing](CONTRIBUTING.md) | Local setup, the pre-commit gate, and the invariants a PR is judged against |
+
+## Contributing
+
+Contributions are welcome. The fast path needs no Docker, no database, and no API keys:
+
+```bash
+go build ./...
+go test -race ./...     # unit tests only; every container-backed test is behind a build tag
+```
+
+That is the whole loop for most changes, and it takes seconds. Read
+[CONTRIBUTING.md](CONTRIBUTING.md) before opening a PR — it names the two invariants
+(`org_id` scoping and `valid_to IS NULL`) that a reviewer will check first, and points at
+[AGENTS.md](AGENTS.md), which is normative for conventions.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ claude mcp add --transport http --scope user akashi http://localhost:8080/mcp \
 | [Self-Hosting](docs/self-hosting.md) | Postgres-only through full stack with Qdrant and Ollama |
 | [Configuration](docs/configuration.md) | Every environment variable |
 | [Conflict Detection](docs/conflicts.md) | Scoring, LLM validation, resolution |
+| [Detector Internals](docs/conflict-detection.md) | Operating point, judge models, evaluation, rejected alternatives |
 | [Quality Scoring](docs/quality-scoring.md) | Completeness scores and anti-gaming |
 | [GDPR Erasure](docs/erasure.md) | Tombstone erasure for right-to-be-forgotten |
 | [IDE Hooks](docs/hooks.md) | Claude Code and Cursor integration |

--- a/docker-compose.complete.yml
+++ b/docker-compose.complete.yml
@@ -45,6 +45,13 @@ services:
   postgres:
     image: timescale/timescaledb-ha:pg18
     restart: unless-stopped
+    # Published so `psql`, `make migrate-lint`, and a server run from source can
+    # reach it — Makefile's ATLAS_DEV_URL already assumes localhost:5432.
+    # Loopback only, never 0.0.0.0: this Postgres ships default credentials.
+    # Set POSTGRES_PORT if you already run Postgres on 5432; the bind fails
+    # loudly rather than silently attaching to the wrong database.
+    ports:
+      - "127.0.0.1:${POSTGRES_PORT:-5432}:5432"
     environment:
       POSTGRES_USER: akashi
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-akashi}
@@ -70,6 +77,9 @@ services:
   qdrant:
     image: qdrant/qdrant:v1.13.6
     restart: unless-stopped
+    # Loopback only — see the note on postgres above.
+    ports:
+      - "127.0.0.1:${QDRANT_PORT:-6333}:6333"
     volumes:
       - qdrant_data:/qdrant/storage
     healthcheck:

--- a/docs/conflict-detection.md
+++ b/docs/conflict-detection.md
@@ -201,6 +201,39 @@ Related knobs: `AKASHI_CONFLICT_LLM_MODEL` (Ollama text model), `AKASHI_CONFLICT
 
 ## 3. How to evaluate a change
 
+> **Read this before you start: the gold corpus is not distributed, and you cannot run
+> `--mode=gold` without building your own.**
+>
+> `conflict_gold_labels` (migration 107) has exactly one write path in this repository, and it
+> is inside a test (`internal/conflicts/goldset_protection_test.go`). There is no endpoint, no
+> CLI subcommand, no seed script, and no fixture that populates it. The 2,772 labelled pairs
+> behind every number in this document are real decision texts from the maintainer's own
+> deployment — they carry ticket references, service names, and customer-adjacent identifiers,
+> and they are not published.
+>
+> So on a fresh clone, `--mode=gold` connects, finds an empty table, and reports nothing. It
+> does this *after* you have provisioned a Postgres, set `AKASHI_DB_DSN`, and supplied an
+> `OPENAI_API_KEY`. That is a bad way to find out, which is why it is written here first.
+>
+> **What an outside contributor can offer instead**, in descending order of strength:
+>
+> 1. **Your own labelled corpus.** Run the detector against your own decision trail, label the
+>    scored pairs blind against the four-way taxonomy in §3.2, and report precision the way §3.3
+>    describes — re-weighted onto true class sizes, with the sample size and interval attached.
+>    This is the strongest evidence available and it does not require our data.
+> 2. **A counter-example with a mechanism.** A concrete pair the detector gets wrong, plus which
+>    stage produced the error (structural suppressor, significance threshold, judge verdict, or
+>    parser contract) and the reasoning for the fix. Structural suppressors are individually
+>    unit-testable with no database at all — see the `*_filter_test.go` files in
+>    `internal/conflicts/`.
+> 3. **A pure-code change with tests.** Parser contracts, prompt structure, and the suppressors
+>    are all testable offline. `go test ./internal/conflicts/...` needs no Docker.
+>
+> What is *not* useful, and has been tried and measured: threshold tuning, new regex
+> suppressors, and hand-written eval sets. §3.2 explains why a hand-written set cannot falsify
+> the prompt it was written alongside, and §5 records the alternatives already rejected with
+> their numbers. Read both before proposing one.
+
 ### 3.1 Run the gold eval
 
 ```bash

--- a/docs/conflicts.md
+++ b/docs/conflicts.md
@@ -4,6 +4,11 @@ Akashi automatically detects when AI agents make contradictory decisions. This d
 covers the full conflict pipeline: how conflicts are found, how they're scored, and how
 to resolve them.
 
+> This page describes the mechanism. For the detector's **measured** behaviour — its operating
+> point, base rate, judge-model comparison, how to evaluate a change, and the alternatives
+> already tried and rejected — see [conflict-detection.md](conflict-detection.md) and ADR-017.
+> Read those before changing detection logic.
+
 ## Overview
 
 When a decision is recorded via `POST /v1/trace`, Akashi asynchronously:

--- a/docs/conflicts.md
+++ b/docs/conflicts.md
@@ -8,14 +8,23 @@ to resolve them.
 
 When a decision is recorded via `POST /v1/trace`, Akashi asynchronously:
 
-1. **Retrieves candidates** — finds semantically similar past decisions via Qdrant (or
-   brute-force cosine similarity in local-lite mode — coming soon, see issue #312).
+1. **Retrieves candidates** — finds semantically similar past decisions via Qdrant, falling
+   back to PostgreSQL text search when Qdrant is not configured.
 2. **Scores significance** — computes a composite score from topic similarity, outcome
    divergence, confidence, and temporal decay.
 3. **Validates via LLM** (optional) — classifies the relationship as contradiction,
    supersession, complementary, refinement, or unrelated.
 4. **Persists conflicts** — only contradictions and supersessions are stored.
 5. **Notifies** — fires a `LISTEN/NOTIFY` event on the `akashi_conflicts` channel.
+
+Everything below this line describes the full pipeline. **Local-lite mode
+(`cmd/akashi-local`) runs a different, much simpler detector** — `LiteScorer` in
+`internal/conflicts/lite_scorer.go`. It compares decisions within the same org and
+`decision_type`, extracts claims from their outcomes, and measures text overlap; no embeddings,
+no vector store, and no LLM are involved. It catches obvious contradictions between agents
+writing about the same topic and will miss anything that needs semantic similarity. Treat the
+scoring, validation, and cross-encoder sections below as describing the server, not the lite
+binary.
 
 ## Significance scoring
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -30,7 +30,7 @@ Three modes, from most to least infrastructure:
 |------|---------------|--------|
 | **Complete local stack** | Docker Compose with TimescaleDB, Qdrant, Ollama | Available |
 | **Binary only** | Bring your own PostgreSQL (with pgvector + TimescaleDB) | Available |
-| **Local-lite** | Zero-dependency binary with SQLite | Coming soon ([#312](https://github.com/ashita-ai/akashi/issues/312)) |
+| **Local-lite** | Zero-dependency binary with SQLite | Available (`make build-local`; see ADR-009) |
 
 ### How do I get started quickly?
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -145,11 +145,29 @@ Check server health:
 curl -s http://localhost:8080/health | jq .
 ```
 
-Expected response:
+Expected response (`qdrant` and `sse_broker` appear only when those subsystems are configured):
 
 ```json
-{"status":"healthy"}
+{
+  "status": "healthy",
+  "version": "1.0.0",
+  "postgres": "connected",
+  "qdrant": "connected",
+  "buffer_depth": 0,
+  "buffer_status": "ok",
+  "sse_broker": "running",
+  "uptime_seconds": 42
+}
 ```
+
+`status` has three values. `healthy` is the normal case. `degraded` means the trace event buffer
+is over 75% of capacity — the server is still serving, but ingest is outrunning the flush, and
+`buffer_status` will read `critical`. `unhealthy` means the Postgres ping failed, and the
+endpoint returns 503 alongside it.
+
+`/health` is a liveness probe and reports 200 while degraded. For orchestrators deciding whether
+to route traffic, use `GET /readyz` instead: it returns 503 when any dependency required to serve
+requests is unreachable, with a per-dependency `checks` map.
 
 Record a test decision:
 

--- a/docs/subsystems.md
+++ b/docs/subsystems.md
@@ -185,17 +185,15 @@ WHERE attempts >= 10;
 
 Raw Qdrant similarity scores are adjusted before returning results:
 
-```
-outcome_weight =
-    0.40 * assessment_score    (explicit feedback; 0 if no assessments)
-    0.25 * log1p(citations)/log(6)  (logarithmic, saturates at 5 citations)
-    0.15 * stability_score     (0 if superseded within 48h)
-    0.10 * agreement_score     (min(AgreementCount/3, 1))
-    0.10 * conflict_win_rate   (0 if no conflict history)
+Five outcome signals are combined into a weight that scales raw similarity, alongside a recency
+decay. Assessment feedback dominates at 40%, then citations, stability, agreement, and conflict
+win rate.
 
-relevance = similarity × (0.5 + 0.5×outcome_weight) × recency_decay
-recency_decay = 1 / (1 + age_days/90)
-```
+**The authoritative formula is the doc comment on `ReScore` in `internal/search/search.go`** —
+read it there rather than trusting a copy. The version this page used to carry had already
+drifted: it showed citations as a fixed logarithmic cap, when they are percentile-normalized
+within the org whenever percentile data is available, falling back to the log form only when it
+is not.
 
 - **Assessment (primary, 40%)**: Explicit correctness feedback from `akashi_assess`. Contributes 0 when no assessments exist.
 - **Citations (25%)**: Logarithmic — first citation worth more than later ones.

--- a/internal/server/conventions_test.go
+++ b/internal/server/conventions_test.go
@@ -1,0 +1,114 @@
+package server
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// decodersExemptFromCheck lists handler files allowed to construct a JSON
+// decoder directly. Each entry must have a reason. There are none today, and an
+// entry added without a reason should not survive review.
+//
+// middleware.go is not listed because it is not scanned: the check covers
+// handlers*.go only, and middleware.go is where the two legal helpers are
+// defined.
+var decodersExemptFromCheck = map[string]string{}
+
+// rawDecoderPattern matches a JSON decoder constructed directly over a request
+// body — json.NewDecoder(r.Body), json.NewDecoder(req.Body), and so on.
+var rawDecoderPattern = regexp.MustCompile(`json\.NewDecoder\(\s*\w+\.Body\s*\)`)
+
+// helperCallPattern matches a call to either sanctioned decode helper.
+var helperCallPattern = regexp.MustCompile(`\bdecodeJSON(?:Lenient)?\(`)
+
+// TestHandlersUseDecodeJSONHelpers verifies that no HTTP handler decodes a
+// request body with the standard library decoder directly.
+//
+// This is a security property, not a style preference. decodeJSON and
+// decodeJSONLenient (middleware.go) both wrap the body in
+// http.MaxBytesReader(w, r.Body, maxBytes) before decoding. A bare
+// json.NewDecoder(r.Body) has no such bound, so a single request can stream an
+// arbitrary amount of data into the process — a denial-of-service regression
+// that no other check in this repo can see. .golangci.yml runs govet,
+// staticcheck, unused, ineffassign, errcheck, gosec and gocritic; none of them
+// model this rule. Before this test, only human review enforced it, and human
+// review is exactly the round that loses a first-time contributor.
+//
+// BOTH helpers are legal, deliberately. decodeJSON rejects unknown fields;
+// decodeJSONLenient does not, because it handles payloads from external senders
+// (e.g. Claude Code hooks) that may add fields at any time. A flat "always use
+// decodeJSON" rule would push a contributor to tighten the hooks endpoints and
+// silently break ingest from any sender that adds a field.
+//
+// Source-level analysis, following the same approach and reasoning as
+// TestOpenAPISpecMatchesRoutes in openapi_test.go: it inspects the text of the
+// handler files rather than runtime behaviour, so a handler behind a feature
+// flag is still covered.
+func TestHandlersUseDecodeJSONHelpers(t *testing.T) {
+	dir := sourceRelative(".")
+
+	matches, err := filepath.Glob(filepath.Join(dir, "handlers*.go"))
+	require.NoError(t, err, "globbing handler files")
+	require.NotEmpty(t, matches, "found no handlers*.go files — the glob is wrong, not the code")
+
+	var violations []string
+	helperCallSites := 0
+	scanned := 0
+
+	for _, path := range matches {
+		base := filepath.Base(path)
+		if strings.HasSuffix(base, "_test.go") {
+			continue
+		}
+		if _, exempt := decodersExemptFromCheck[base]; exempt {
+			continue
+		}
+		scanned++
+
+		data, readErr := os.ReadFile(filepath.Clean(path))
+		require.NoError(t, readErr, "reading %s", base)
+
+		for i, line := range strings.Split(string(data), "\n") {
+			if rawDecoderPattern.MatchString(line) {
+				// 1-indexed to match what an editor shows.
+				violations = append(violations,
+					fmt.Sprintf("%s:%d  %s", base, i+1, strings.TrimSpace(line)))
+			}
+			helperCallSites += len(helperCallPattern.FindAllString(line, -1))
+		}
+	}
+
+	require.NotZero(t, scanned, "no handler files scanned")
+
+	// Defensive, in the same spirit as openapi_test.go asserting it parsed a
+	// non-empty route set: if the helpers are renamed and this pattern stops
+	// matching, the check above would pass vacuously on a package that had
+	// stopped using them entirely. Fail loudly instead.
+	require.NotZero(t, helperCallSites,
+		"found no decodeJSON/decodeJSONLenient call sites in handlers*.go — the helpers were "+
+			"probably renamed, and this guard is now checking nothing. Update helperCallPattern.")
+
+	sort.Strings(violations)
+	if len(violations) > 0 {
+		assert.Failf(t, "handler decodes a request body without a size bound",
+			"These sites construct json.NewDecoder over a request body directly:\n  %s\n\n"+
+				"Use one of the helpers in middleware.go instead:\n"+
+				"  decodeJSON(w, r, &req, h.maxRequestBodyBytes)         // strict; rejects unknown fields\n"+
+				"  decodeJSONLenient(w, r, &req, h.maxRequestBodyBytes)  // for external senders that may add fields\n\n"+
+				"Both apply http.MaxBytesReader first. Without it the request body is unbounded, "+
+				"which is a denial-of-service regression rather than a style issue.\n"+
+				"If a file genuinely must be excluded, add it to decodersExemptFromCheck with a reason.",
+			strings.Join(violations, "\n  "))
+	}
+
+	t.Logf("scanned %d handler files, %d sanctioned decode call sites, %d violations",
+		scanned, helperCallSites, len(violations))
+}

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -530,7 +530,14 @@ func verifyAPIKey(ctx context.Context, db *storage.DB, credential, orgHeader str
 }
 
 // requireRole returns middleware that enforces a minimum role level.
-// Uses the role hierarchy: admin > agent > reader.
+//
+// The hierarchy has five levels, not three (model.RoleRank):
+//
+//	platform_admin (5) > org_owner (4) > admin (3) > agent (2) > reader (1)
+//
+// Pick the lowest role that is still correct. admin is NOT the ceiling: erasure
+// is gated on org_owner (server.go:172) because it is irreversible, and a
+// destructive endpoint documented as "admin-only" is under-gated by two levels.
 func requireRole(minRole model.AgentRole) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Six commits. No production code moves; one comment-only change to `middleware.go`, one new test file, everything else is docs, compose, and the Makefile.

The repo's engineering is in better shape than its on-ramp. Build-tag hygiene is correct, every internal package has a doc comment, `api/openapi.yaml` has zero drift against 72 routes with a test enforcing it. None of that is what a first-time contributor meets. They meet a documented setup that produces an unreachable database, and a PR contract they cannot see.

### What was actually broken

**The documented setup never worked.** `CONTRIBUTING.md` said the dev stack "starts TimescaleDB (with pgvector) on port 5432 and Qdrant on port 6333". Neither compose file published either port — `docker-compose.complete.yml` declared exactly one `ports` block, for the `akashi` service. The containers report healthy and `psql` refuses the connection, so it reads as a broken laptop rather than a broken instruction. `git log -S'5432:5432'` returns nothing: the claim has never been true. `Makefile`'s `ATLAS_DEV_URL` independently assumed `localhost:5432`, so `make migrate-lint` and `make migrate-diff` were broken for anyone who followed the docs exactly.

**The contract was invisible.** `rg -n 'AGENTS|CLAUDE|org_id|valid_to' README.md CONTRIBUTING.md` returned zero matches in both files. The `org_id` invariant, `valid_to IS NULL`, the ask-first list, and the mandatory universe blockquote all lived only in `AGENTS.md`, which is agent-facing. A contributor could satisfy every instruction they could find and still get bounced.

**The endpoint recipe did not compile.** `AGENTS.md` step 1 handed you `AgentIDFromContext(r.Context())` as the second line of the only handler skeleton in the repo. That identifier does not exist. The accessor is `ClaimsFromContext`.

**The checklist had drifted in triplicate.** The five "mandatory" pre-commit checks were hand-copied into two contributor docs, and every copy omitted the same two gates CI actually runs: `check_doc_config_consistency.py` and the `-tags lite` build. That lite step's own comment records that it rots silently and once did, undetected. `make preflight` is now the single definition, and `ci` is a strict superset of it.

**Local-lite shipped and the docs denied it.** ADR-009 reads "Accepted — implemented", `make build-local` exists, CI builds it every push, and `internal/storage/sqlite/` has 20 files — while the FAQ said "Coming soon (#312)". Verified the binary by running it: it starts with no environment at all and answers MCP `initialize`. `docs/conflicts.md` was wrong twice, also describing lite mode as cosine similarity when `LiteScorer` does text overlap and says so in its own doc comment.

**The gold eval cannot be run by anyone outside this deployment.** `conflict_gold_labels` has exactly one write path in the tree and it is inside a test. So `--mode=gold` finds an empty table — *after* the contributor has provisioned Postgres, set a DSN, and spent OpenAI credits. Section 3 now says so first, and says what evidence to bring instead.

### Also here

`middleware.go` documented the RBAC ladder as "admin > agent > reader", hiding `org_owner` and `platform_admin` — worse than silence, since it tells someone adding a destructive endpoint that `admin` is the ceiling, the opposite of the call already made for erasure. Comment-only, verified with `git diff -U0`.

`TestHandlersUseDecodeJSONHelpers` converts the strongest unwritten convention in the HTTP layer into a failing test. Both `decodeJSON` and `decodeJSONLenient` are permitted deliberately — a flat rule would push someone to tighten the hooks endpoints and break external ingest. Verified by mutation, not by reading: a first attempt only produced a build failure, which would have proved nothing.

### Verification

`make preflight` passes clean on a clean tree with no Docker, 0 lint issues. `python3 scripts/check_doc_config_consistency.py` passes. `grep -ri 'coming soon' docs/*.md README.md` returns nothing.

One pre-existing failure, unrelated and unchanged: `TestGitCommitSubject_CurrentRepo` fails identically on `main` — it shells out to `git` from the test process.

> Moon-letters, unread —
> the door was always right here
> under the wrong light

🤖 Generated with [Claude Code](https://claude.com/claude-code)