### PR TITLE
Correct the docs against the code they describe

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,11 +80,12 @@ internal/
   ratelimit/         Pluggable token bucket rate limiter.
   telemetry/         OpenTelemetry setup (traces + metrics).
   testutil/          Shared test helpers (testcontainers, test DB, test logger).
-migrations/          SQL files (001, 022..108). Atlas-managed checksums.
-adrs/                Technical architecture decision records (ADR-001 through ADR-017).
+migrations/          SQL files (001, 022..111). Atlas-managed checksums.
+adrs/                Technical architecture decision records (ADR-001 through ADR-018).
 sdk/                 Go, Python, TypeScript client SDKs.
 ui/                  React 19 SPA (audit dashboard). Embedded via go:embed when built with -tags ui.
-docs/                Configuration reference; conflict-detection operator guide.
+docs/                Configuration reference, runbook, conflict-detection operator guide,
+                     quality scoring, GDPR erasure, diagrams. README's Docs table is the index.
 ```
 
 ## Architecture patterns

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ See [Conflict Detection](docs/conflicts.md) and [Subsystems](docs/subsystems.md)
 ## Try it in 60 seconds
 
 No Docker, no database, no API keys. `akashi-local` is a single binary that speaks MCP over
-stdio and stores everything in SQLite (see [ADR-009](adrs/)):
+stdio and stores everything in SQLite (see [ADR-009](adrs/ADR-009-distribution-local-lite-and-cloud-mcp.md)):
 
 ```bash
 make build-local
@@ -90,8 +90,11 @@ claude mcp add --transport http --scope user akashi http://localhost:8080/mcp \
 | `akashi_check` | Find precedents and conflicts before deciding |
 | `akashi_trace` | Record a decision with reasoning and confidence |
 | `akashi_assess` | Record whether a past decision was correct |
+| `akashi_pending_assessments` | List decisions still awaiting an assessment |
 | `akashi_query` | Search decisions by filters or semantics |
 | `akashi_conflicts` | List open conflicts between agents |
+| `akashi_resolve` | Resolve a conflict, or mark it a false positive |
+| `akashi_reconcile` | Resolve a conflict with a synthesis decision that retires both sides |
 | `akashi_stats` | Decision trail health metrics |
 
 ## SDKs
@@ -114,8 +117,10 @@ claude mcp add --transport http --scope user akashi http://localhost:8080/mcp \
 | [Quality Scoring](docs/quality-scoring.md) | Completeness scores and anti-gaming |
 | [GDPR Erasure](docs/erasure.md) | Tombstone erasure for right-to-be-forgotten |
 | [IDE Hooks](docs/hooks.md) | Claude Code and Cursor integration |
+| [Decisions](docs/decisions.md) | The decision model, trace flow, and embeddings |
 | [Subsystems](docs/subsystems.md) | Embeddings, rate limiting, Qdrant pipeline |
 | [Runbook](docs/runbook.md) | Health checks, monitoring, troubleshooting |
+| [Data Lifecycle](docs/operations/data-lifecycle.md) | Retention, archival, reconciliation, restore drills |
 | [Diagrams](docs/diagrams.md) | Write path, read path, auth flow, schema |
 | [ADRs](adrs/) | Architecture decision records |
 | [OpenAPI](api/openapi.yaml) | Full API spec (also at `GET /openapi.yaml`) |

--- a/adrs/ADR-017-conflict-detection-operating-point.md
+++ b/adrs/ADR-017-conflict-detection-operating-point.md
@@ -9,8 +9,8 @@ Accepted, 2026-08-10
 Akashi's conflict detection pipeline (`internal/conflicts/`) takes pairs of decisions that are
 semantically close and asks whether they contradict each other. Candidates come from Qdrant top-20
 retrieval during the trace pipeline (`internal/service/decisions/service.go` calls `ScoreForDecision`);
-`scorer.go:527` sends any pair with topic similarity ≥ 0.70 straight to the scorer, and an LLM validator
-then classifies it.
+the `directToScorer` bypass in `scorer.go` sends any pair with topic similarity ≥ 0.70 straight to the
+scorer, and an LLM validator then classifies it.
 
 We had no measurement of whether this worked. To get one, we blind-labelled the production corpus.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -257,7 +257,7 @@ Operational idempotency settings:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `AKASHI_COMPLETENESS_PROFILES` | _(empty)_ | JSON map of decision_type → profile overrides for completeness scoring. Each profile has `min_evidence` (int), `alternatives_expected` (bool), `max_confidence_no_evidence` (float). See [quality-scoring.md](quality-scoring.md) for details |
+| `AKASHI_COMPLETENESS_PROFILES` | _(empty)_ | **Currently inert — setting it has no effect.** Intended as a JSON map of decision_type → profile overrides (`min_evidence`, `alternatives_expected`, `max_confidence_no_evidence`) for the completeness tips. The value is parsed at startup and never consumed; the only caller of `quality.ProfileFor` passes `nil`. Tracked in [#765](https://github.com/ashita-ai/akashi/issues/765). See [quality-scoring.md](quality-scoring.md) |
 | `AKASHI_STANDARD_DECISION_TYPES` | _(built-in 12)_ | Comma-separated list of decision types considered "standard" for suggestion tips. Replaces the built-in defaults when set. Example: `architecture,security,data_pipeline,access_control` |
 
 Hook endpoints (`/hooks/session-start`, `/hooks/pre-tool-use`, `/hooks/post-tool-use`) are unauthenticated but restricted to localhost by default. They enable IDE agents to receive context injection, edit gating, and automatic decision tracing without shell-script marker files.
@@ -310,7 +310,7 @@ In `reject` mode the HTTP API returns `422 Unprocessable Entity` with the `COMPL
 
 ## Data retention
 
-Akashi supports per-org data retention policies that automatically delete decisions older than a configured threshold. Policies are set via `PUT /v1/retention` (admin-only). Legal holds (`POST /v1/retention/hold`) exempt matching decisions from both automated and GDPR deletion. All deletion operations are recorded in the `deletion_log` table.
+Akashi supports per-org data retention policies that automatically delete decisions older than a configured threshold. Policies are set via `PUT /v1/retention` (admin-only). Legal holds (`POST /v1/retention/hold`) exempt matching decisions from both automated and GDPR deletion. All deletion operations are recorded in the `deletion_audit_log` table.
 
 | Variable | Default | Description |
 |----------|---------|-------------|

--- a/docs/conflict-detection.md
+++ b/docs/conflict-detection.md
@@ -1,7 +1,8 @@
 # Conflict Detection: Operator and Contributor Reference
 
-> **Requires PR #740.** `conflict_gold_labels` (migration 107), `--mode=gold`,
-> `AKASHI_CONFLICT_OPENAI_MODEL` and `AKASHI_CONFLICT_LLM_TIMEOUT` do not exist before it.
+> `conflict_gold_labels` (migration 107), `--mode=gold`, `AKASHI_CONFLICT_OPENAI_MODEL` and
+> `AKASHI_CONFLICT_LLM_TIMEOUT` arrived in PR #740 and are on `main`. On an older checkout,
+> none of this page's evaluation instructions apply.
 
 This document is about **tuning and evaluating** conflict detection quality. For the
 mechanism reference — significance formula, claim extraction, metrics, admin endpoints —
@@ -24,8 +25,8 @@ default (`gpt-4o-mini`) runs at roughly 8% queue precision. A stronger judge get
 ### 1.1 Trigger and candidate generation
 
 `POST /v1/trace` persists the decision, then fires conflict scoring asynchronously —
-`internal/service/decisions/service.go` (e.g. line 763) calls `ScoreForDecision`,
-implemented in `internal/conflicts/scorer.go:285`. Candidates come from a Qdrant vector
+`internal/service/decisions/service.go` calls `ScoreForDecision`, implemented in
+`internal/conflicts/scorer.go` (`ScoreForDecision` → `scoreForDecision`). Candidates come from a Qdrant vector
 search over decision embeddings (`internal/search/qdrant.go`), capped at the top 20 nearest
 neighbours (`AKASHI_CONFLICT_CANDIDATE_LIMIT`, default `20`).
 
@@ -43,7 +44,7 @@ confidence weight × temporal decay). Candidates below `AKASHI_CONFLICT_EARLY_EX
 (default `0.25`) are pruned — *unless* they qualify for the direct-to-scorer bypass:
 
 ```go
-// internal/conflicts/scorer.go:527
+// internal/conflicts/scorer.go — grep for directToScorer
 directToScorer := hasScorer && sc.topicSim >= s.decisionTopicSimFloor
 ```
 
@@ -64,8 +65,11 @@ note — figures of 0.500/0.587 published before 2026-08-12 do not reproduce.
 ### 1.3 Structural suppressors (pre-LLM)
 
 Before any LLM call, `scoreForDecision` applies a family of deterministic filters, each
-incrementing its own counter (Go field names on `s.metrics`, greppable in `scorer.go`) so
-you can see which one is doing the work:
+incrementing its own counter so you can see which one is doing the work. The counters are Go
+field names on `s.metrics`, all declared in `internal/conflicts/metrics.go`; the predicates
+themselves live in the per-filter files alongside `scorer.go` (`branch_filters.go`,
+`cross_agent_precedent.go`, `disjoint_resource.go`, `disjoint_work_item.go`,
+`operational_progression.go`, `temporal_filter.go`, `workflow_filters.go`):
 
 | Filter | Counter | What it kills |
 |---|---|---|
@@ -84,9 +88,10 @@ you can see which one is doing the work:
 
 Measured on the live candidate stream (2026-08-11), these rules together suppress **~56%**
 of candidate pairs before any judge sees them — 990 of 1,779 in the trailing window. Their
-false-negative rate is what migration 111's deterministic 5% sample
-(`suppressed_pair_samples`) exists to measure; until that sample accumulates labels, the
-56% is a throughput fact, not a safety one.
+false-negative rate is what migration 111's `suppressed_pair_samples` table exists to
+measure, via the deterministic sample enabled by `AKASHI_CONFLICT_SUPPRESSION_SAMPLE_RATE`
+(default `0` — off; `0.05` is the intended dogfood setting). Until that sample accumulates
+labels, the 56% is a throughput fact, not a safety one.
 
 These are cheap and they cut LLM cost, but **do not expect them to buy precision.** Every
 deterministic gate measured against the gold labels sits on the diagonal — it removes
@@ -118,8 +123,9 @@ moved measured precision:
    no shared question. (2) Timeline test. (3) Are both positions still live and
    incompatible?
 2. **A parser-enforced disputed-question contract.** A `contradiction` verdict that names
-   no question is downgraded to `complementary` at `validator.go:450`. The verdict is not
-   trusted unless the model can state what is in dispute.
+   no question is downgraded to `complementary` in `ParseValidatorResponse`
+   (`internal/conflicts/validator.go`). The verdict is not trusted unless the model can state
+   what is in dispute.
 
 The wording is fragile in a specific, measured way. An intermediate version framed step 2
 as "a timeline is SUPERSESSION, never CONTRADICTION" and **inverted the failure**:
@@ -139,10 +145,12 @@ collapsed to 1.1%. If you edit this prompt, run the gold eval (§3). Do not eyeb
   applies transitive dedup: if both decisions already participate in conflicts inside the
   same group, the pair is dropped (`transitiveGroupFiltered`). This is what prevents the
   O(n²) explosion from supersession chains.
-- **Supersession routing.** At `scorer.go:896` a `supersession` verdict is recorded as a
-  row in `supersedes_suggestions` instead of opening a conflict (shipped in #729). The
-  validator still *returns* `supersession`, so precision/recall evals are unaffected —
-  only the scorer's handling changes.
+- **Supersession routing.** A `supersession` verdict is recorded as a row in
+  `supersedes_suggestions` instead of opening a conflict — the scorer intercepts the verdict
+  before `IsConflict()` and hands it to `internal/conflicts/supersedes_suggestions.go`
+  (shipped in #729; direction taken from the judge rather than the clock since #749). The
+  validator still *returns* `supersession`, so precision/recall evals are unaffected — only
+  the scorer's handling changes.
 
 Auto-resolution policy lives in `internal/conflicts/autoresolve.go` (`ClassifyTier`,
 `ShouldAutoResolve`, `DetermineWinner`).
@@ -224,8 +232,9 @@ Related knobs: `AKASHI_CONFLICT_LLM_MODEL` (Ollama text model), `AKASHI_CONFLICT
 > 2. **A counter-example with a mechanism.** A concrete pair the detector gets wrong, plus which
 >    stage produced the error (structural suppressor, significance threshold, judge verdict, or
 >    parser contract) and the reasoning for the fix. Structural suppressors are individually
->    unit-testable with no database at all — see the `*_filter_test.go` files in
->    `internal/conflicts/`.
+>    unit-testable with no database at all — see the per-filter tests in `internal/conflicts/`
+>    (`branch_filters_test.go`, `disjoint_resource_test.go`, `disjoint_work_item_test.go`,
+>    `operational_progression_test.go`, `temporal_filter_test.go`, `cross_agent_precedent_test.go`).
 > 3. **A pure-code change with tests.** Parser contracts, prompt structure, and the suppressors
 >    are all testable offline. `go test ./internal/conflicts/...` needs no Docker.
 >
@@ -451,7 +460,7 @@ firm restrictions, and are meant as a help or guidance to the editor"
 
 | Approach | Result |
 |---|---|
-| Threshold tuning on scorer features | significance AUC 0.500, topic similarity 0.587 |
+| Threshold tuning on scorer features | no separating threshold; significance AUC 0.601 (0.54–0.66), topic similarity 0.616 (0.55–0.68) — see §1.2 |
 | Deterministic gates | all on the diagonal (§1.3) |
 | Fine-tuned DeBERTa cross-encoder | held-out AUC 0.494 at 67 training positives |
 | Embedding-pair classifier (1024-d, \|a−b\| and a·b, PCA-64) | AUC 0.611 — worse than metadata alone (0.730) |

--- a/docs/conflicts.md
+++ b/docs/conflicts.md
@@ -90,19 +90,44 @@ significance threshold are classified into relationship types:
 | Relationship | Meaning | Creates conflict? |
 |-------------|---------|-------------------|
 | `contradiction` | Incompatible positions on the same question | Yes |
-| `supersession` | One decision explicitly replaces the other | Yes |
+| `supersession` | One decision explicitly replaces the other | No — routed to `supersedes_suggestions` |
 | `complementary` | Different findings about different aspects | No |
 | `refinement` | One deepens the other without contradicting | No |
 | `unrelated` | Different topics despite surface similarity | No |
 
+`IsConflict()` still returns true for both `contradiction` and `supersession`, so evals are
+unaffected — but the scorer intercepts a `supersession` verdict before that check and records
+it as a row in `supersedes_suggestions` rather than opening a conflict. Supersession is a
+lifecycle event, not a standing disagreement. The suggestion surfaces in `akashi_check`; you
+confirm it by re-tracing the newer decision with `supersedes_id` set, or ignore it and let
+retention prune it.
+
 The validator also assigns:
 
 - **Category**: `factual`, `assessment`, `strategic`, or `temporal`
-- **Severity**: `critical`, `high`, `medium`, or `low`
+- **Severity**: `high`, `medium`, or `low`. `critical` is never assigned by scoring — it is
+  reserved for precedent escalation, when a conflict reopens the winning side of a
+  previously resolved one.
+
+A `contradiction` verdict that does not name the disputed question is downgraded to
+`complementary` by the response parser: the judge is not trusted to claim a disagreement it
+cannot state.
 
 ### False positive reduction
 
-The LLM prompt includes contextual signals that reduce false positives:
+Two layers, in order.
+
+**Structural suppressors run before any LLM call.** Twelve deterministic filters drop
+candidate pairs that cannot be genuine disagreements — different PR or ticket references,
+different `connector_`/`org_` resources, one agent revising itself on one branch, the same
+mechanical operation on two branches, operational state that legitimately mutates,
+iterative refinement within a ticket, and so on. Each increments its own OTel counter.
+Together they suppress roughly 56% of candidates. The full table, the counter names, and the
+measured caveat — these buy throughput and LLM cost, **not** precision, because they remove
+true and false positives in the same proportion — are in
+[conflict-detection.md §1.3](conflict-detection.md).
+
+**The LLM prompt then includes contextual signals:**
 
 - **Cross-project**: Decisions from different projects are flagged as almost certainly unrelated.
 - **Same session**: Sequential decisions in the same session (e.g., review → fix) are
@@ -119,18 +144,20 @@ pre-computed significance in descending order. Candidates below the floor are sk
 unless they qualify for "direct-to-scorer" bypass (high topic similarity pairs that only
 an LLM can properly classify).
 
-### Cross-encoder reranking
+### NLI / cross-encoder reranking
 
-An optional cross-encoder can pre-filter candidates before LLM validation, reducing LLM
-calls by 50–80%. Configure with:
+An optional sidecar can pre-filter candidates before LLM validation, reducing LLM calls by
+50–80%. Two implementations share one `POST /score` contract
+(`{"text_a":…,"text_b":…}` → `{"score":0.0-1.0}`):
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `AKASHI_CONFLICT_CROSS_ENCODER_URL` | _(empty)_ | Cross-encoder service endpoint. Empty = disabled. |
-| `AKASHI_CONFLICT_CROSS_ENCODER_THRESHOLD` | `0.50` | Minimum cross-encoder score to proceed to LLM. |
+| `AKASHI_CONFLICT_NLI_URL` | _(empty)_ | DeBERTa-v3-base NLI sidecar (`services/nli/`). Stance-aware, so more accurate here than a generic cross-encoder. **Takes precedence when both are set.** |
+| `AKASHI_CONFLICT_CROSS_ENCODER_URL` | _(empty)_ | Generic cross-encoder service endpoint. Empty = disabled. |
+| `AKASHI_CONFLICT_CROSS_ENCODER_THRESHOLD` | `0.50` | Minimum contradiction score to proceed to LLM. Applies to both. |
 
-Pairs below the threshold are skipped without an LLM call. If the cross-encoder service
-is unreachable, the system falls open to LLM validation (no silent suppression).
+Pairs below the threshold are skipped without an LLM call. If the service is unreachable,
+the system falls open to LLM validation (no silent suppression).
 
 ### Revision chain exclusion
 
@@ -292,8 +319,14 @@ When OpenTelemetry is configured, the conflict pipeline emits these metrics:
 | `AKASHI_CONFLICT_EARLY_EXIT_FLOOR` | `0.25` | Min pre-LLM significance for early exit (0 disables) |
 | `AKASHI_CONFLICT_DECAY_LAMBDA` | `0.01` | Temporal decay rate (0 disables; ~70 days to half significance) |
 | `AKASHI_CONFLICT_BACKFILL_WORKERS` | `4` | Parallel workers for batch scoring |
-| `AKASHI_CONFLICT_LLM_MODEL` | _(empty)_ | LLM model for validation (e.g., `qwen3.5:9b`) |
+| `AKASHI_CONFLICT_LLM_MODEL` | _(empty)_ | Ollama model for validation (e.g., `qwen3.5:9b`) |
+| `AKASHI_CONFLICT_OPENAI_MODEL` | `gpt-4o-mini` | OpenAI judge when `_LLM_MODEL` is unset. **The highest-leverage knob in the pipeline** — see [conflict-detection.md §2](conflict-detection.md) |
+| `AKASHI_CONFLICT_LLM_TIMEOUT` | `15s` | Per-call deadline. Raise to 120s+ for reasoning models; a timeout is fail-safe and presents as a silent drop in detections |
 | `AKASHI_CONFLICT_LLM_THREADS` | `floor(NumCPU/3)` | CPU threads for Ollama |
+| `AKASHI_CONFLICT_OUTCOME_SIM_FLOOR` | `0.85` | Outcome-embedding similarity above which a pair is suppressed as complementary |
+| `AKASHI_CONFLICT_NLI_URL` | _(empty)_ | NLI sidecar for stance-aware pre-filtering |
+| `AKASHI_CONFLICT_SUPPRESSION_SAMPLE_RATE` | `0.0` | Fraction of structurally-suppressed pairs recorded for blind labelling |
+| `AKASHI_CONFLICT_BACKFILL_WINDOW` | `0` (unbounded) | How far back a rescore reaches. Bound this before a forced rescore |
 | `AKASHI_CONFLICT_CLAIM_TOPIC_SIM_FLOOR` | `0.60` | Min cosine similarity for claim pairs |
 | `AKASHI_CONFLICT_CLAIM_DIV_FLOOR` | `0.15` | Min outcome divergence for claim pairs |
 | `AKASHI_CONFLICT_DECISION_TOPIC_SIM_FLOOR` | `0.70` | Min decision similarity to activate claim scoring |
@@ -328,4 +361,8 @@ POST /v1/admin/conflicts/eval
 ```
 
 Runs the built-in evaluation dataset and returns precision, recall, F1, and accuracy.
-Use this after changing the LLM model or tuning thresholds to verify detection quality.
+
+This is a smoke test, not a quality measurement: the dataset was written alongside the prompt
+it tests and scored 1.000/1.000 while the shipped detector was at 3.4% precision in
+production. For a number worth acting on, use `cmd/eval-conflicts --mode=gold` against a
+blind-labelled corpus — see [conflict-detection.md §3](conflict-detection.md).

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -16,6 +16,7 @@ A decision records what an agent decided and why:
 | `confidence` | 0–1 score. |
 | `alternatives` | Other options considered (labels, scores, rejection reasons). |
 | `evidence` | References used (URIs, content, relevance). |
+| `bindings` | Named parameters this decision *sets*, and the values it sets them to. The one field where conflict detection is an exact join rather than an inference — two decisions binding the same parameter to different values conflict by lookup, no model involved. |
 
 Decisions are bi-temporal: `valid_from`/`valid_to` (business time) and `transaction_time` (when recorded). Revising a decision sets `valid_to` on the old row and inserts a new row with `supersedes_id` pointing to it.
 
@@ -23,17 +24,33 @@ Decisions are bi-temporal: `valid_from`/`valid_to` (business time) and `transact
 
 ## Trace Flow
 
-`POST /v1/trace` records a decision:
+`POST /v1/trace` records a decision, in this order:
 
-1. **Embeddings** — Two vectors computed (full + outcome-only). See [subsystems.md](subsystems.md#what-gets-embedded).
+1. **Type canonicalization** — `decision_type` is lowercased, then mapped through the org's
+   alias table or Levenshtein-matched to a standard type. The submitted spelling is kept in
+   `metadata.original_decision_type`. See [quality-scoring.md](quality-scoring.md#type-canonicalization-this-rewrites-your-input).
 
-2. **Quality score** — Completeness heuristic (alternatives, evidence, reasoning length).
+2. **Completeness score** — Structural heuristic over reasoning, alternatives, evidence,
+   confidence, outcome, and precedent ref. Computed on what the agent submitted.
 
-3. **Transactional write** — Decision, alternatives, evidence, and search outbox entry in one transaction.
+3. **Ingest gate** (optional, off by default) — Refuses or warns when the score is below the
+   configured floor for that type. Runs before any embedding work so a reject costs nothing.
 
-4. **Conflict scoring** — Async goroutine finds similar decisions and inserts into `scored_conflicts` when significance ≥ threshold.
+4. **Embeddings** — Two vectors computed concurrently (full + outcome-only), plus one per
+   evidence item. See [subsystems.md](subsystems.md#what-gets-embedded).
 
-5. **Notifications** — `akashi_decisions` (LISTEN/NOTIFY) for real-time subscribers.
+5. **Confidence deflation** — Self-reported confidence is reduced when unsupported by
+   evidence, alternatives, or reasoning; the original is kept in metadata. See
+   [quality-scoring.md](quality-scoring.md#confidence-deflation).
+
+6. **Transactional write** — Decision, alternatives, evidence, bindings, and the search
+   outbox entry in one transaction.
+
+7. **Notifications** — `akashi_decisions` (LISTEN/NOTIFY) for real-time subscribers.
+
+8. **Claims and conflict scoring** — Async, post-commit. Claims are extracted and embedded,
+   then the scorer finds similar decisions and inserts into `scored_conflicts` when
+   significance ≥ threshold and the judge confirms.
 
 ---
 
@@ -57,7 +74,14 @@ Key points relevant to the decision model:
 
 ## Storage
 
-- **decisions** — Source of truth; `embedding`, `outcome_embedding` nullable.
-- **scored_conflicts** — Detected conflict pairs. See [conflicts.md](conflicts.md) for schema details.
+- **decisions** — Current-state table read by every query path; `embedding`,
+  `outcome_embedding` nullable. Derived from `agent_events`, which is the append-only source
+  of truth (see [ADR-003](../adrs/ADR-003-event-sourced-bitemporal-model.md)).
+- **alternatives**, **evidence** — Child rows written in the same transaction.
+- **decision_bindings** — Named parameter/value pairs the decision sets, with canonicalized
+  join keys.
 - **decision_claims** — Sentence-level claims extracted from decision outcomes, with per-claim embeddings.
+- **scored_conflicts** — Detected conflict pairs. See [conflicts.md](conflicts.md) for schema details.
+- **decision_supersedes** — Confirmed and detector-suggested supersession links.
+- **decision_type_aliases** — Per-org mapping from submitted type spellings to canonical types.
 - **search_outbox** — Syncs decisions to Qdrant for semantic search (when configured).

--- a/docs/diagrams.md
+++ b/docs/diagrams.md
@@ -10,10 +10,14 @@ of the Akashi decision trace layer.
 A client records a decision by posting to `/v1/trace`. The request passes through
 the middleware chain (request ID, security headers, CORS, tracing, logging, JWT
 auth, panic recovery), then through `requireRole(agent)` authorization before
-reaching the handler. The handler delegates to the shared `decisions.Service`,
-which orchestrates embedding generation, quality scoring, and
-an atomic transactional write. Notification and conflict scoring happen after the
-transaction commits and are non-fatal on failure.
+reaching the handler. The handler delegates to the shared `decisions.Service`.
+
+Order matters here and is easy to get backwards. The completeness score is computed
+**first**, on exactly what the agent submitted, so the optional ingest gate can refuse a
+thin trace before any embedding latency or quota is spent. Confidence deflation runs
+**after** the gate, so the gate judges the submitted value, not the deflated one.
+Notification and conflict scoring happen after the transaction commits and are non-fatal on
+failure.
 
 ```mermaid
 sequenceDiagram
@@ -24,7 +28,7 @@ sequenceDiagram
     participant H as HandleTrace
     participant DS as decisionSvc.Trace()
     participant E as embedder.Embed()
-    participant Q as quality.Score()
+    participant Q as quality pkg
     participant DB as storage.CreateTraceTx()
     participant N as storage.Notify()
 
@@ -37,14 +41,34 @@ sequenceDiagram
     H->>H: decodeJSON (MaxBytesReader), validate fields
     H->>H: verify agent_id exists in caller's org
     H->>DS: Trace(ctx, orgID, TraceInput)
-    DS->>E: Embed(decisionType + ": " + outcome + reasoning)
-    E-->>DS: full embedding vector(1024) or warning
-    DS->>E: Embed(outcome)
-    E-->>DS: outcome embedding vector(1024) or warning
-    DS->>E: Embed(evidence[i].content) for each evidence
-    E-->>DS: evidence vectors
+
+    DS->>DS: normalize decision_type; resolve alias<br/>or Levenshtein-canonicalize (dist <= 2),<br/>keep original in metadata
     DS->>Q: Score(decision)
     Q-->>DS: completeness_score (0.0-1.0)
+    DS->>Q: completenessGate.Evaluate(score, decision_type)
+    alt Below threshold, mode=reject
+        Q-->>DS: Below
+        DS->>DB: INSERT mutation_audit_log (trace_decision_rejected)
+        DS-->>H: CompletenessRejection
+        H-->>C: 422 COMPLETENESS_BELOW_THRESHOLD
+    else Pass, or mode=warn/off
+        Q-->>DS: proceed (warn appends to warnings[])
+    end
+
+    par Concurrent
+        DS->>E: Embed(decisionType + ": " + outcome + reasoning)
+        E-->>DS: full embedding vector(1024) or nil + warning
+    and
+        DS->>E: Embed(outcome)
+        E-->>DS: outcome embedding vector(1024) or nil
+    end
+    DS->>E: Embed(evidence[i].content) for each evidence
+    E-->>DS: evidence vectors
+
+    DS->>Q: AdjustConfidence(confidence, evidence, alts, reasoningLen)
+    Q-->>DS: deflated confidence; original kept in metadata
+    DS->>DS: bootstrap metadata; canonicalize bindings
+
     DS->>DB: CreateTraceTx(params)
 
     rect rgb(235, 245, 255)
@@ -53,6 +77,7 @@ sequenceDiagram
         DB->>DB: INSERT INTO decisions (embedding, outcome_embedding, completeness_score)
         DB->>DB: COPY INTO alternatives
         DB->>DB: COPY INTO evidence
+        DB->>DB: INSERT INTO decision_bindings (canonicalized parameter/value pairs)
         DB->>DB: INSERT INTO search_outbox (always, regardless of embedding)
         DB->>DB: UPDATE agent_runs SET status=completed
         DB->>DB: COMMIT
@@ -61,7 +86,8 @@ sequenceDiagram
     DB-->>DS: (run, decision)
     DS->>N: pg_notify('akashi_decisions', payload)
     N-->>DS: OK (non-fatal on error)
-    DS-->>H: TraceResult{RunID, DecisionID, EventCount}
+    Note over DS: async, post-commit: claim extraction + embedding,<br/>then conflictScorer.ScoreForDecision
+    DS-->>H: TraceResult{RunID, DecisionID, EventCount, Warnings}
     H-->>C: 201 Created {run_id, decision_id, event_count}
 ```
 
@@ -113,9 +139,10 @@ Qdrant. The outbox row is inserted inside the same transaction that writes the
 decision, so the two are atomically consistent. A background worker polls the
 outbox on a configurable interval, processes entries in batches using
 `SELECT ... FOR UPDATE SKIP LOCKED` for concurrency safety, and uses exponential
-backoff on failure. Entries that exceed 10 attempts are logged as dead letters
-and cleaned up after 7 days. Decisions without embeddings are deferred (not
-upserted) until a backfill provides an embedding.
+backoff on failure. Entries that exceed 10 attempts are logged as dead letters; after 7 days
+they are archived into `search_outbox_dead_letters` and removed from `search_outbox`, so a
+reset that targets `search_outbox` no longer reaches them. Decisions without embeddings are
+deferred (not upserted) until a backfill provides an embedding.
 
 ```mermaid
 sequenceDiagram
@@ -150,7 +177,7 @@ sequenceDiagram
         end
 
         alt attempts >= 10
-            Note over W: Log dead-letter warning<br/>Periodic cleanup deletes entries<br/>older than 7 days
+            Note over W: Log dead-letter warning<br/>Hourly cleanup archives entries older than 7 days<br/>into search_outbox_dead_letters, then deletes<br/>them from search_outbox
         end
     end
 ```
@@ -491,6 +518,48 @@ erDiagram
         timestamptz created_at
     }
 
+    decision_bindings {
+        uuid id PK
+        uuid decision_id FK
+        uuid org_id FK
+        text parameter "as written, for display"
+        text parameter_key "canonical form the join runs on"
+        text value "as written; compared literally, never interpreted"
+        text value_key "canonical form"
+        timestamptz created_at
+    }
+
+    decision_erasures {
+        uuid id PK
+        uuid decision_id FK
+        uuid org_id FK
+        text erased_by
+        text original_hash "pre-scrub content hash"
+        text erased_hash "post-scrub content hash"
+        text reason "nullable"
+        timestamptz erased_at
+    }
+
+    decision_supersedes {
+        uuid superseding_id PK "composite PK with superseded_id"
+        uuid superseded_id PK
+        uuid org_id FK
+        text relationship "supersedes | reconciles"
+        bool is_primary
+        text suggested_by "nullable; set when detector-inferred"
+        real suggested_confidence "nullable"
+        text suggested_reason "nullable"
+        timestamptz recorded_at
+    }
+
+    decision_type_aliases {
+        uuid org_id PK "composite PK with alias"
+        text alias PK "the spelling agents sent"
+        text canonical "the standard type it maps to"
+        text created_by "default system"
+        timestamptz created_at
+    }
+
     organizations ||--o{ agents : "has"
     organizations ||--o{ api_keys : "has"
     organizations ||--o{ agent_runs : "has"
@@ -514,5 +583,26 @@ erDiagram
     decisions ||--o{ scored_conflicts : "decision_a"
     decisions ||--o{ scored_conflicts : "decision_b"
     decisions ||--o{ search_outbox : "queues sync"
+    decisions ||--o{ decision_bindings : "binds parameters"
+    decisions ||--o| decision_erasures : "erased by (GDPR tombstone)"
+    decisions ||--o{ decision_supersedes : "superseding"
+    decisions ||--o{ decision_supersedes : "superseded"
+    organizations ||--o{ decision_type_aliases : "canonicalizes types for"
     scored_conflicts }o--|| conflict_groups : "grouped into"
 ```
+
+### Tables not shown
+
+The diagram covers the decision graph. These exist and matter operationally, but are
+standalone ledgers or buffers with no interesting relationships to draw:
+
+| Table | Purpose | Reference |
+|---|---|---|
+| `mutation_audit_log` | Append-only paper trail for every API mutation, including gate rejections | [runbook.md](runbook.md) |
+| `deletion_audit_log` | Row-level archive for destructive admin deletes | [data-lifecycle.md](operations/data-lifecycle.md) |
+| `search_outbox_dead_letters` | Archive for outbox entries past 10 attempts and 7 days | [subsystems.md](subsystems.md) |
+| `agent_events_archive` | Historical events moved out of the hot hypertable | [data-lifecycle.md](operations/data-lifecycle.md) |
+| `integrity_proofs`, `proof_leaves`, `integrity_violations` | Merkle batch proofs and audit results | [ADR-013](../adrs/ADR-013-merkle-integrity-proofs.md) |
+| `conflict_gold_labels` | Blind four-way labels used by `--mode=gold` | [conflict-detection.md](conflict-detection.md) |
+| `suppressed_pair_samples` | Sampled structurally-suppressed pairs, for measuring suppressor recall | [conflict-detection.md](conflict-detection.md) |
+| `idempotency_keys` | Replay safety for write APIs | [configuration.md](configuration.md#write-idempotency) |

--- a/docs/erasure.md
+++ b/docs/erasure.md
@@ -34,6 +34,29 @@ POST /v1/decisions/{id}/erase
 | Evidence `content` | `"[erased]"` |
 | Evidence `source_uri` | `NULL` |
 | Evidence `embedding` | `NULL` |
+| Claim `claim_text` | `"[erased]"` |
+| Claim `embedding` | `NULL` |
+
+Claims (`decision_claims`) are sentence-level statements derived from the outcome and
+reasoning, so they carry the same PII as the text they were extracted from and are scrubbed
+in the same transaction. The response reports how many rows of each kind were affected.
+
+### Response
+
+```json
+{
+  "decision_id": "…",
+  "erased_at": "2026-08-13T04:21:00Z",
+  "original_hash": "…",
+  "erased_hash": "…",
+  "alternatives_erased": 3,
+  "evidence_erased": 2,
+  "claims_erased": 5
+}
+```
+
+Like every JSON response, this arrives wrapped in the standard `{"data": …, "meta": …}`
+envelope.
 
 ### What is preserved
 
@@ -79,14 +102,20 @@ After erasure, `GET /v1/verify/{id}` returns:
 
 ```json
 {
+  "decision_id": "…",
   "status": "erased",
-  "original_hash": "sha256:abc...",
-  "erased_hash": "sha256:def...",
-  "verified": true
+  "valid": true,
+  "content_hash": "…",
+  "original_hash": "…",
+  "erased_at": "2026-08-13T04:21:00Z",
+  "erased_by": "compliance-agent"
 }
 ```
 
-This confirms the erasure was applied correctly and the content hash chain is intact.
+`content_hash` is the hash recomputed over the scrubbed fields; `original_hash` is what it
+was before. `valid: true` means the stored hash still matches the stored (scrubbed) content
+— the erasure was applied correctly and the chain is intact. Note the erased branch reports
+`valid`, not the `verified` field used by the non-erased branches.
 
 ## Operational notes
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -16,7 +16,7 @@ Yes. Akashi is released under the Apache 2.0 license.
 
 ### What AI agents and frameworks does Akashi work with?
 
-Akashi is agent-agnostic. Any agent that can make HTTP calls or use MCP (Model Context Protocol) can integrate. SDKs are available for Go, Python, and TypeScript. The MCP interface works with Claude Code, Cursor, Windsurf, and any other MCP-compatible client. Framework integrations for LangChain, CrewAI, and Vercel AI SDK are planned.
+Akashi is agent-agnostic. Any agent that can make HTTP calls or use MCP (Model Context Protocol) can integrate. SDKs are available for Go, Python, and TypeScript. The MCP interface works with Claude Code, Cursor, Windsurf, and any other MCP-compatible client. End-to-end walkthroughs for LangChain, CrewAI, and the Vercel AI SDK live in [`examples/`](../examples/).
 
 ---
 
@@ -106,10 +106,14 @@ Every traced decision receives a quality score (0.0–1.0) based on how much con
 | Alternatives with rejection reasons | 0.20 |
 | Confidence (penalizes extremes of 0 or 1) | 0.15 |
 | Evidence items | 0.15 |
-| Outcome length | 0.10 |
+| Outcome length (full credit at 21–300 chars, less above) | 0.10 |
 | Precedent reference | 0.10 |
 
-Higher-quality decisions surface higher in precedent search results. The scoring has anti-gaming measures — padding fields with filler text does not help.
+The scoring has anti-gaming measures — padding fields with filler text does not help, and an over-long `outcome` scores worse than a concise one.
+
+Completeness does **not** affect search ranking. It measures how thorough a trace is, not whether the decision was right; what surfaces a precedent higher is assessment feedback, citations, and stability. Its uses are the trace-health report and the optional ingest gate. See [quality-scoring.md](quality-scoring.md).
+
+Confidence is also adjusted downward at write time when it is not backed by evidence, alternatives, or reasoning — see [quality-scoring.md § Confidence deflation](quality-scoring.md#confidence-deflation).
 
 ### What is `akashi_assess`?
 
@@ -123,7 +127,7 @@ After a decision plays out, an agent (or human) can call `akashi_assess` to reco
 
 Two mechanisms:
 
-- **API keys** — `ApiKey <agent_id>:<key>` header. Never expire, survive server restarts. Recommended for configuration files and long-running integrations. Keys are hashed with Argon2id (memory-hard, GPU-resistant).
+- **API keys** — `ApiKey <agent_id>:<key>` header. Survive server restarts, and never expire unless you set `expires_at` when creating the key. Recommended for configuration files and long-running integrations. Keys are hashed with Argon2id (memory-hard, GPU-resistant) and can be rotated or revoked.
 - **JWT tokens** — `Bearer <token>` header. Ed25519-signed, expire after 24 hours by default. Obtained by exchanging an API key at `POST /auth/token`.
 
 ### What are the RBAC roles?
@@ -140,7 +144,7 @@ Five roles in descending privilege order:
 
 ### How does multi-tenancy work?
 
-Every query is scoped by `org_id`. Agents belong to exactly one organization, and all data access is filtered by the agent's org. There are over 230 org_id filters across the storage layer. Within an org, fine-grained access grants let one agent share its decisions with specific other agents.
+Every query is scoped by `org_id`. Agents belong to exactly one organization, and all data access is filtered by the agent's org. There are over 500 `org_id` references across the storage layer. Within an org, fine-grained access grants let one agent share its decisions with specific other agents.
 
 ---
 
@@ -164,7 +168,7 @@ Yes. Decisions can be erased via tombstone erasure, which scrubs the content but
 
 ### What happens if Qdrant goes down?
 
-Akashi degrades gracefully. Semantic vector search falls back to PostgreSQL full-text search (BM25-style). Decisions are still stored and queryable — you lose semantic similarity ranking until Qdrant recovers. Failed Qdrant syncs retry with exponential backoff and dead-letter after 10 attempts.
+Akashi degrades gracefully. Semantic vector search falls back to PostgreSQL full-text search (`tsvector`/`tsquery` with `ts_rank`, plus ILIKE matching). Decisions are still stored and queryable — you lose semantic similarity ranking until Qdrant recovers. Failed Qdrant syncs retry with exponential backoff and dead-letter after 10 attempts.
 
 ### What happens if the embedding provider is unavailable?
 
@@ -187,7 +191,7 @@ Akashi tries providers in order: Ollama → OpenAI → noop. If all are unavaila
 | Python | `pip install akashi` | Async and sync clients, requires Python 3.10+ |
 | TypeScript | `npm install akashi` | Zero runtime dependencies, native `fetch` |
 
-All three SDKs expose the same methods: `Check`, `Trace`, `Query`, `Search`, `Recent`, and `Assess`.
+All three cover the same core workflow — `check`, `trace`, `assess`, `query`, `search`, `recent` — and each carries roughly 75 methods spanning conflicts, agents, grants, runs, retention, and admin endpoints. Coverage is close but not identical across languages, and neither is a complete mapping of the OpenAPI spec; check the SDK source for the method you need.
 
 ### Can I use Akashi without an SDK?
 

--- a/docs/quality-scoring.md
+++ b/docs/quality-scoring.md
@@ -20,10 +20,15 @@ comparability and prevents stored score discontinuities.
 | **Reasoning** | 0.30 | 0.30 if > 100 chars; 0.24 if > 50; 0.12 if > 20; 0.0 otherwise |
 | **Alternatives** | 0.20 | Counts non-selected alternatives with substantive rejection reasons (> 20 chars). 0.20 for ≥ 3; 0.15 for 2; 0.10 for 1; 0.0 for none |
 | **Evidence** | 0.15 | 0.15 for ≥ 2 items; 0.10 for 1; 0.0 for none |
-| **Outcome** | 0.10 | 0.10 if > 20 chars; 0.0 otherwise |
+| **Outcome** | 0.10 | 0.10 for 21–300 chars; 0.07 for 301–500; 0.04 above 500; 0.0 for ≤ 20 |
 | **Precedent ref** | 0.10 | 0.10 if precedent_ref set; 0.0 otherwise |
 
 **Maximum possible score: 1.00** (0.90 from content + 0.10 from precedent_ref)
+
+The outcome factor is the one tier that goes **down** as the field gets longer. An `outcome`
+is meant to be the decision stated as a fact; past ~300 characters it is almost always a
+change log pasted into the wrong field, so it earns less. Put the narrative in `reasoning`,
+which is rewarded for length.
 
 ### Per-type differentiation
 
@@ -40,14 +45,16 @@ will get evidence nudges because evidence matters for security decisions.
 |---|---|---|---|
 | `investigation` | suppressed | suppressed | if > 0.90 without evidence |
 | `planning` | suppressed | suppressed | if > 0.85 without evidence |
-| `code_review` | shown | shown | if > 0.85 without evidence |
-| `architecture` | shown | shown | if > 0.80 without evidence |
-| `security` | shown | shown | if > 0.75 without evidence |
+| `code_review` | shown (min 1 item) | shown | if > 0.85 without evidence |
+| `architecture` | shown (min 2 items) | shown | if > 0.80 without evidence |
+| `security` | shown (min 2 items) | shown | if > 0.75 without evidence |
+| _any other type_ | shown (min 1 item) | shown | never |
 
-Override via `AKASHI_COMPLETENESS_PROFILES` env var (JSON map):
-```
-AKASHI_COMPLETENESS_PROFILES='{"security":{"min_evidence":3,"alternatives_expected":true,"max_confidence_no_evidence":0.70}}'
-```
+> **`AKASHI_COMPLETENESS_PROFILES` is currently inert.** The variable is parsed at startup
+> into `config.CompletenessProfilesJSON` and then never read: the only caller of
+> `quality.ProfileFor` passes `nil` overrides (`internal/mcp/tools.go`). Setting it changes
+> nothing today. Tracked in [#765](https://github.com/ashita-ai/akashi/issues/765) — either
+> wire it through or delete it. Until then, the table above is the whole story.
 
 #### 2. Per-type health thresholds
 
@@ -74,10 +81,26 @@ The following types are considered "standard" for suggestion purposes: `model_se
 `architecture`, `data_source`, `error_handling`, `feature_scope`, `trade_off`, `deployment`,
 `security`, `code_review`, `investigation`, `planning`, `assessment`.
 
-Custom types are fully supported with no scoring penalty. When a non-standard type is close
-to a standard one (e.g. `trade-off` vs `trade_off`), a suggestion tip is shown.
+Custom types are fully supported with no scoring penalty. Override the standard list per org
+via `AKASHI_STANDARD_DECISION_TYPES` (comma-separated).
 
-Override the standard list per org via `AKASHI_STANDARD_DECISION_TYPES` (comma-separated).
+### Type canonicalization (this rewrites your input)
+
+Before scoring, `decision_type` is lowercased, trimmed, and then canonicalized:
+
+1. If the org has a stored alias for the value (`decision_type_aliases`), the canonical type
+   replaces it.
+2. Otherwise, if the value is within Levenshtein distance 2 of a standard type, the standard
+   type replaces it **and a durable alias is created** once the trace commits, so every later
+   trace using that spelling is redirected the same way.
+
+Either way the original string is preserved on the decision as
+`metadata.original_decision_type`. So `trade-off` is not merely flagged — it is stored as
+`trade_off`. If you want a genuinely distinct custom type, keep it more than two edits away
+from every entry in the standard list above, or add it to `AKASHI_STANDARD_DECISION_TYPES`.
+
+A suggestion tip is separately shown for near-misses at distance ≤ 3, which is wider than the
+rewrite threshold: distance-3 types are named in a tip but left alone.
 
 ### Anti-gaming measures
 
@@ -89,6 +112,8 @@ The scoring formula includes deliberate anti-gaming rules:
   everything is not rewarded.
 - **Confidence boundaries penalized**: Exactly 0.05 or 0.95 falls to a lower tier than
   the mid-range, discouraging mechanical boundary values.
+- **Outcome length capped**: Past 300 characters the outcome factor decreases, so pasting a
+  commit message into `outcome` costs score rather than earning it.
 - **Whitespace trimmed**: All character counts apply after trimming.
 
 ### Calibration status
@@ -96,6 +121,39 @@ The scoring formula includes deliberate anti-gaming rules:
 All weights are currently uncalibrated — chosen by hand without empirical basis. A future
 iteration will fit weights against assessed decision data. See the factor table as a
 guide to what Akashi values in a decision trace, not as a precise quality metric.
+
+## Confidence deflation
+
+Completeness is not the only thing computed at write time. The `confidence` you send is
+**adjusted before it is stored**, because agents systematically over-report it (mean 0.867
+across the 824 decisions the rule was fit on). Three rules apply independently and stack:
+
+| Condition | Adjustment |
+|---|---|
+| `confidence ≥ 0.80` and zero evidence items | −0.15 |
+| `confidence ≥ 0.85` and zero alternatives | −0.10 |
+| `confidence ≥ 0.80` and reasoning under 50 chars | −0.10 |
+
+The result is floored at 0.30, so a sparse trace lands at 0.30 rather than 0.00. Values
+outside `[0, 1]` pass through untouched so the database CHECK constraint catches them.
+
+Nothing is lost: the submitted value is preserved on the decision as
+`metadata.original_confidence`, with `metadata.confidence_adjustment_reasons` naming which
+rules fired. The MCP `akashi_trace` response also returns `confidence_adjusted`,
+`original_confidence`, `stored_confidence`, and `confidence_reasons` when an adjustment
+happened, so an agent can see it in the same turn.
+
+Two consequences worth knowing:
+
+- Deflation runs **after** the completeness score and the ingest gate below, so neither sees
+  the deflated value — the gate judges what you submitted.
+- Downstream consumers read the **stored** value, so they see the deflated one — the
+  conflict scorer's `confidence_weight` term, the `confidence_min` query filter, and the
+  Qdrant `confidence` payload index. (Search re-ranking does not use confidence at all; see
+  below.)
+
+The only way to keep a high confidence is to support it: attach evidence, list alternatives,
+and write more than 50 characters of reasoning.
 
 ## Ingest gate (#715)
 
@@ -137,9 +195,17 @@ outcome_score = (correct + 0.5 × partially_correct) / total_assessments
 
 ### How it influences search
 
-The outcome score feeds into the search re-ranking formula as the **assessment signal**
-(weight: 40%). Decisions assessed as correct rank higher in `akashi_check` results,
-creating a feedback loop: good decisions surface more often as precedents.
+The outcome score feeds into the search re-ranking formula as the **assessment signal**, the
+largest of the five outcome signals at 40%. Decisions assessed as correct rank higher in
+`akashi_check` results, creating a feedback loop: decisions that turned out to be right
+surface more often as precedents. An unassessed decision contributes 0 here rather than a
+neutral score — absence of feedback is not a middling grade.
+
+**Completeness does not affect ranking.** It was deliberately removed from the relevance
+formula: filling in evidence and alternatives says how thorough a trace is, not whether the
+decision was correct, and rewarding it in search would have let a well-formatted wrong answer
+outrank a terse right one. The authoritative formula is the doc comment on `ReScore` in
+`internal/search/search.go`.
 
 ## Recording assessments
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -645,7 +645,14 @@ psql "$DATABASE_URL" -c "
 
 ## 10. Conflict Detection Evaluation
 
-Akashi detects conflicts between agent decisions using an embedding-based scorer followed by an optional LLM validator. Two evaluation modes let you measure detection quality against ground truth.
+Akashi detects conflicts between agent decisions using an embedding-based scorer followed by an optional LLM validator.
+
+> **Read [conflict-detection.md](conflict-detection.md) and [ADR-017](../adrs/ADR-017-conflict-detection-operating-point.md) before acting on anything in this section.** They carry the measured behaviour, and two of the instincts this section supports have been measured and rejected on the production corpus:
+>
+> - **Tuning scorer thresholds does not buy precision.** Contradictions are 3.35% of scored pairs, and no scorer feature separates them (best AUC 0.601, CI 0.54–0.66). Thresholds change throughput and cost, not the precision of what survives. The judge model is the discriminating component: `gpt-4o-mini` runs at ~8% queue precision, `gpt-5` at ~41.5%.
+> - **The hand-written validator dataset cannot falsify the detector.** `DefaultEvalDataset` scored 1.000 precision / 1.000 recall while the shipped detector was running at 3.4% precision in production. An eval set written from the same intuitions as the prompt will always pass.
+>
+> The authoritative measurement is `--mode=gold` against `conflict_gold_labels`, described in [conflict-detection.md §3](conflict-detection.md). The label-based scorer eval below remains useful for one thing only: telling you how noisy *your* queue is right now.
 
 ### Concepts
 
@@ -723,18 +730,33 @@ Open conflicts return `400`; resolve or mark them false-positive first.
 
 ### Reducing False Positives
 
-For a noisy deployment, switch to the high-precision profile and force one
-rescore:
+**Change the judge model first.** It is the only lever measured to move precision, and by a
+factor of five:
+
+```sh
+export AKASHI_CONFLICT_OPENAI_MODEL=gpt-5   # default gpt-4o-mini: ~8% queue precision
+export AKASHI_CONFLICT_LLM_TIMEOUT=120s     # MANDATORY: at the 15s default, gpt-5 failed 159/200 calls
+```
+
+The timeout is not optional. A validation timeout is fail-safe — the candidate is skipped, not
+flagged — so too low a value produces no error and no alert, only a quiet drop in detections
+that reads exactly like "the new model is more precise." After switching, check
+`akashi.conflicts.llm_calls{result="timeout"}` before concluding anything.
+
+The `high_precision` profile is a throughput and cost lever, not a precision lever — its
+thresholds sit on the diagonal, removing true and false positives in the same proportion. Use
+it to shrink the queue, not to clean it:
 
 ```sh
 export AKASHI_CONFLICT_PROFILE=high_precision
 export AKASHI_FORCE_CONFLICT_RESCORE=true
 ```
 
-Restart once with both variables set, wait for rescore to complete, then remove
-`AKASHI_FORCE_CONFLICT_RESCORE` so future restarts do not clear and rebuild the
-conflict table again. Keep `AKASHI_CONFLICT_PROFILE=high_precision` if the
-deployment favors reviewer time over marginal recall.
+Restart once with both variables set, wait for the rescore to complete, then remove
+`AKASHI_FORCE_CONFLICT_RESCORE` so future restarts do not clear and rebuild the conflict
+table again. On a large corpus, bound the cost first with `AKASHI_CONFLICT_BACKFILL_WINDOW`
+(e.g. `720h`) — a forced rescore re-judges every surviving candidate pair at one LLM call
+each.
 
 ### Running Scorer Eval (Precision from Labels)
 
@@ -770,7 +792,13 @@ Scorer Precision: 85.7% (6 TP, 1 FP, 7 labeled)
 
 ### Running Validator Eval (LLM Accuracy)
 
-The validator eval runs a hardcoded dataset of 27 decision pairs through the LLM validator and measures precision and recall of the LLM's conflict/no-conflict judgments.
+The validator eval runs a hardcoded dataset of decision pairs through the LLM validator and reports precision and recall of the LLM's conflict/no-conflict judgments.
+
+> **This number is not evidence of detection quality.** The dataset was written alongside the
+> prompt it tests, and it scored a perfect 1.000/1.000 while the shipped detector was running
+> at 3.4% precision in production. Treat it as a smoke test that the validator is wired up and
+> parsing responses — nothing more. For a number you can act on, use `--mode=gold`
+> ([conflict-detection.md §3](conflict-detection.md)).
 
 ```sh
 export AKASHI_URL=http://localhost:8081
@@ -821,7 +849,17 @@ This is useful for verifying that threshold changes don't break the scorer's abi
 1. Run your akashi instance locally on port 8081.
 2. Exercise the system — trace decisions, let the scorer detect conflicts.
 3. Review detected conflicts via the UI or `GET /v1/conflicts`.
-4. Label 20+ conflicts across all three categories for a meaningful precision measurement.
-5. Run `go run ./cmd/eval-conflicts --mode=scorer --save` to compute precision.
-6. Tune scorer thresholds (`AKASHI_CONFLICT_SIGNIFICANCE_THRESHOLD`, early exit floor) and re-evaluate.
-7. Repeat after model or embedding changes to catch regressions.
+4. Label 20+ conflicts across all three categories.
+5. Run `go run ./cmd/eval-conflicts --mode=scorer --save` to get your queue's current precision.
+6. If it is low, **change the judge model** (see "Reducing False Positives" above). Do not
+   reach for `AKASHI_CONFLICT_SIGNIFICANCE_THRESHOLD` or the early-exit floor — measured
+   against 2,772 blind gold labels, no scorer-feature threshold separates contradictions from
+   the rest, so tuning them shrinks the queue without cleaning it.
+7. Re-run the scorer eval after the model change, and after any embedding change, to catch
+   regressions.
+
+To go further than "how noisy is my queue" — comparing judges, measuring majority-class
+false-positive rate, or choosing an operating point against your own miss:false-alarm cost
+ratio — build a blind-labelled corpus and use `--mode=gold`. The procedure, including what an
+outside contributor can offer without access to the maintainer's corpus, is in
+[conflict-detection.md §3](conflict-detection.md).

--- a/docs/subsystems.md
+++ b/docs/subsystems.md
@@ -170,7 +170,7 @@ Tenant isolation: every query includes `org_id` as a required filter.
 |----------|-------|
 | Max attempts | 10 |
 | Backoff | Exponential: `2^attempts` seconds, capped at 5 minutes |
-| Dead-letter cleanup | Entries with `attempts >= 10` and older than 7 days are deleted hourly |
+| Dead-letter cleanup | Entries with `attempts >= 10` and older than 7 days are archived to `search_outbox_dead_letters`, then deleted from `search_outbox` (checked hourly) |
 | Lock duration | 60 seconds per batch (prevents double-processing) |
 
 Dead-lettered entries remain in PostgreSQL and are queryable via SQL. They are not indexed in Qdrant until manually reset:
@@ -179,6 +179,19 @@ Dead-lettered entries remain in PostgreSQL and are queryable via SQL. They are n
 UPDATE search_outbox
 SET attempts = 0, locked_until = NULL, last_error = NULL
 WHERE attempts >= 10;
+```
+
+**This only works within the 7-day window.** After the hourly cleanup archives an entry, it
+is no longer in `search_outbox` and the `UPDATE` above matches nothing — it succeeds and does
+nothing, which is the worst way to find out. To replay an archived entry, re-queue it:
+
+```sql
+INSERT INTO search_outbox (decision_id, org_id, operation)
+SELECT decision_id, org_id, operation
+FROM search_outbox_dead_letters
+WHERE outbox_id = <id>
+ON CONFLICT (decision_id, operation) DO UPDATE
+   SET attempts = 0, locked_until = NULL, last_error = NULL, created_at = now();
 ```
 
 ### Re-Scoring
@@ -196,10 +209,11 @@ within the org whenever percentile data is available, falling back to the log fo
 is not.
 
 - **Assessment (primary, 40%)**: Explicit correctness feedback from `akashi_assess`. Contributes 0 when no assessments exist.
-- **Citations (25%)**: Logarithmic — first citation worth more than later ones.
+- **Citations (25%)**: Percentile-normalized within the org when percentile data is available; falls back to a logarithmic cap (saturating at 5 citations) when it is not.
 - **Stability (15%)**: Decisions superseded within 48h of creation score 0.
-- **Agreement / conflict win rate**: Minor boosts based on consensus signals.
-- **Recency decay**: Decisions lose relevance with a 90-day half-life.
+- **Agreement (10%) / conflict win rate (10%)**: Minor boosts based on consensus signals. Win rate contributes 0 when there is no conflict history.
+- **Recency decay**: `1 / (1 + age_days/90)` — halved at 90 days, but hyperbolic rather than exponential, so it keeps flattening rather than halving again (one third at 180 days, not one quarter).
+- **Completeness**: not a factor. It was removed deliberately — a thoroughly filled-out trace is not a correct one.
 - **Over-fetch**: Qdrant returns `limit * 3` results; re-scoring and truncation happen in Go.
 
 ### Graceful Shutdown


### PR DESCRIPTION
A full accuracy pass over `docs/`, `adrs/`, `README.md` and `AGENTS.md`. Every claim was checked at the call site rather than read for plausibility. Docs only — no code changes.

Two findings are internal contradictions rather than drift, and they are why this is a fix rather than a cleanup.

## The two that could cost someone real time

**`runbook.md` §10 recommended the two approaches ADR-017 measured and rejected.** It told operators to tune `AKASHI_CONFLICT_SIGNIFICANCE_THRESHOLD` and the early-exit floor, and to measure quality with the built-in validator dataset. Against 2,772 blind gold labels no scorer feature separates contradictions (best AUC 0.601, CI 0.54–0.66), so thresholds change throughput and cost but not the precision of what survives — and `DefaultEvalDataset` scored 1.000 precision / 1.000 recall while the shipped detector was running at **3.4%** in production, because an eval set written alongside the prompt it tests cannot falsify that prompt. Meanwhile §10 never mentioned `--mode=gold` or the judge model, which is the one lever measured to move the number and moves it roughly 5× (`gpt-4o-mini` ~8% queue precision → `gpt-5` ~41.5%). An operator following this page did the wrong thing carefully. §10 now leads with a pointer to the measured behaviour, reframes the label-based eval as "how noisy is my queue right now," and puts the judge-model swap — with its mandatory `AKASHI_CONFLICT_LLM_TIMEOUT=120s`, since a timeout is fail-safe and presents as a silent drop in detections — first under "Reducing False Positives."

**`conflict-detection.md` §5 republished the AUCs its own §1.2 retracts.** §1.2 states plainly that "figures of 0.500/0.587 published before 2026-08-12 do not reproduce." Sixty lines later the rejected-alternatives table still read `significance AUC 0.500, topic similarity 0.587`. `e869266` corrected ADR-017 and §1.2 and missed the table.

## The rest, by consequence

- **`erasure.md` omitted `decision_claims` from the GDPR scrub inventory.** `EraseDecision` scrubs `claim_text` and nulls the claim embedding in the same transaction, and the response reports `claims_erased`. An incomplete "what gets scrubbed" table is the single error a compliance doc cannot afford. The `GET /v1/verify/{id}` example also had the wrong field names — the erased branch returns `valid` and `content_hash`, not `verified` and `erased_hash`. Both fixed, and the erase response shape is now documented.
- **`subsystems.md` gave a dead-letter reset that silently does nothing.** `UPDATE search_outbox … WHERE attempts >= 10` matches no rows once the hourly job archives them into `search_outbox_dead_letters` — it succeeds and accomplishes nothing, which is the worst way to find out. The doc also said entries were "deleted hourly" and never named the archive table. `runbook.md` had this right; the two contradicted each other. Now both agree, and there is a re-queue statement that works after archival.
- **`quality-scoring.md`** documented the outcome factor as binary (`0.10 if > 20 chars`) when it is four tiers with a deliberate length penalty (0.10 → 0.07 → 0.04 at 300 and 500 chars), and documented `AKASHI_COMPLETENESS_PROFILES` as a working override when it is parsed into config and never read — **#765**.
- **Confidence deflation and `decision_type` canonicalization were documented nowhere**, in `docs/` or `adrs/`, despite both rewriting agent input on every trace. Confidence is reduced by up to 0.35 and floored at 0.30; `decision_type` is *replaced* at Levenshtein distance ≤ 2 and a durable alias is created. The old text said only that "a suggestion tip is shown." Both now have sections, including the ordering that matters: the ingest gate judges what you submitted, not what we deflated it to.
- **`faq.md` claimed completeness raises search ranking.** `ReScore` removed it deliberately — "field-filling quality ≠ decision correctness" — so a well-formatted wrong answer cannot outrank a terse right one. Also stale there: "over 230 org_id filters" (actual 523), framework integrations "planned" (shipped in `examples/`), and "all three SDKs expose the same methods: Check, Trace, Query, Search, Recent, Assess" (each carries ~75).
- **Six source line references were rotted by the #764 file split.** Five in `conflict-detection.md`, one in ADR-017; every one pointed at unrelated code. `scorer.go:285` landed on a `const`, `scorer.go:527` mid-loop, `validator.go:450` on a parser case. They now name symbols and files, which do not renumber. The `*_filter_test.go` glob and "greppable in `scorer.go`" were both wrong after the split too — the suppressors live in seven per-filter files and their counters in `metrics.go`.
- **The write-path diagram had the pipeline backwards and was missing four stages.** Scoring runs *before* embedding, not after — deliberately, so a rejected trace costs no embedding quota. The gate, confidence deflation, type aliasing and bindings were all absent. The ERD gained `decision_bindings`, `decision_erasures`, `decision_supersedes` and `decision_type_aliases` (columns read off the DDL, not guessed) plus an index of eight ledgers it does not draw.
- **`conflicts.md` was missing its whole first stage.** No mention of the twelve structural suppressors that drop ~56% of candidates before any LLM call, the NLI sidecar that takes precedence over the cross-encoder, or supersession being routed to `supersedes_suggestions` rather than opening a conflict. It also listed `critical` as a severity the scorer assigns; `ComputeSeverity` never returns it.
- Smaller: `deletion_log` → `deletion_audit_log`; README's 6-of-9 MCP tools; `AGENTS.md` migration and ADR counts (108→111, 017→018).

## Verification

`make preflight` passes. The doc/config consistency gate passes — and worth noting for reviewers, that gate only asserts every env var *name* appears somewhere in the doc; it never compares defaults and permits extras, which is why it was green throughout the period `AKASHI_COMPLETENESS_PROFILES` was documented as functional. I diffed all 98 defaults against `config.go` separately: 98/98 match. A link check over every relative link and every anchor introduced in `docs/`, `adrs/`, `README.md` and `AGENTS.md` resolves clean.

Two caveats on coverage. The 18 ADRs got targeted verification against their load-bearing claims rather than line-by-line reading. The ERD gaps were derived from the migration list rather than a live schema diff, so the four added tables are right but the set may not be exhaustive.

## Follow-ups filed

- **#765** — `AKASHI_COMPLETENESS_PROFILES` is inert. A half-landed requirement from #471, which specified profiles as tunable config. Wire it or delete it; both docs carry an explicit warning pointing there until then.
- **#766** — completeness tips report percentages the scorer does not award: "+up to 65%" for reasoning on `investigation`/`planning` against a real cap of 30%, and +15% for the first three alternatives when it is +20%.

> Faramir gets Boromir's assignment, Boromir's city, and Boromir's father, and the thing he does with them is refuse the Ring in a sentence — "I would not take this thing, if it lay by the highway" — where his brother needed a river and a death to get there. Denethor reads that as the lesser son failing the same test. It is the opposite: Faramir had read enough to know what he was holding before it was in his hand. Gondor's archive was never decoration. It is the only reason one steward could tell a weapon from an heirloom while the other went to the palantír and saw exactly what he was shown.
