### PR TITLE
Report conflict precision as an interval: the label protocol cannot resolve a 3.35% base rate

### DIFF
--- a/adrs/ADR-017-conflict-detection-operating-point.md
+++ b/adrs/ADR-017-conflict-detection-operating-point.md
@@ -90,6 +90,24 @@ the 2,733 not rescored since labelling, `blind_llm_stratified_v1` (212), and `bl
 unchanged; the "pure noise" characterisation was wrong. Feature columns are mutable and 39 labelled rows
 were rescored after the 2026-08-10 labelling run, so any published AUC must name its snapshot date.
 
+**Correction (2026-08-13). Every precision figure in this document is conditional on a base rate the
+labelling protocol cannot resolve.** See ADR-019. Pushing this document's own reported label-reliability
+constants (sensitivity 0.817, false-flag rate 5.7%, Measurements below) back through the Rogan–Gladen
+misclassification correction gives a corrected prevalence of **-3.09%** — negative, therefore
+inadmissible. The estimator is positive only when the labeller's false-flag rate is below the base rate
+it is measuring, i.e. below 3.355%; the measured value is 5.7%. This does *not* mean there are no
+contradictions. It means the 3.35% base rate is not established, and every number downstream of it —
+3.4% for the shipped detector, the 8.1% / 26.9% / 28.7% / 41.5% judge table, 74.2% for the cascade, the
+1.39:1 break-even ratio — is a point estimate whose interval was never computed. At the gpt-5 operating
+point that interval spans 20.3% to 46.7% precision over a prevalence range this evidence cannot narrow.
+The numbers below are not retracted and remain the best available estimates and the current operating
+point; they are no longer quotable without that band. ADR-019 decision 3 specifies the fix (a
+human-labelled calibration subset of 480 labels — a census of all 93 gold contradictions plus a
+387-row sample of the gold negatives, drawn 29:1 toward the negative class — with the raw per-pair
+agreement rows retained). Note also that the 0.817 / 5.7% constants exist only as prose in the
+Measurements section — the per-pair agreement rows were never persisted — so they are
+sensitivity-analysis inputs, not measurements.
+
 It is worth being clear about why systems that appear to have solved conflict detection have not solved
 ours. Kubernetes server-side apply can raise a conflict cheaply and exactly because identity is a JSON
 field path — two writers touching the same path is a decidable syntactic fact
@@ -320,6 +338,7 @@ false-positive rate that precision is this sensitive to.
 - `scorer.go:527` — `directToScorer` for topic similarity ≥ 0.70; `scorer.go:896` — supersession routing (#729)
 - `cmd/eval-conflicts --mode=gold` — gold-set evaluation (PR #740); migration 107 — `conflict_gold_labels`
 - ADR-015 — separation of conflict severity from confidence scoring
+- ADR-019 — label-noise floor and prefilter routing; re-scopes every precision figure in this document
 - Nie et al., "I like fish, especially dolphins: Addressing Contradictions in Dialogue Modeling" (DECODE),
   ACL 2021. <https://aclanthology.org/2021.acl-long.134/>
 - de Marneffe, Rafferty & Manning, "Finding Contradictions in Text", ACL 2008.

--- a/adrs/ADR-019-label-noise-floor-and-prefilter-routing.md
+++ b/adrs/ADR-019-label-noise-floor-and-prefilter-routing.md
@@ -1,0 +1,366 @@
+# ADR-019: The label protocol cannot resolve a 3% base rate, so precision for this component is reported as an interval, and type-pair routing is the next candidate
+
+## Status
+
+Proposed, 2026-08-13
+
+Extends ADR-017 (Accepted 2026-08-10, corrected 2026-08-12). Nothing in ADR-017 is retracted here.
+Its numbers are re-scoped: they remain the best available estimates and they stop being quotable as
+point values.
+
+## Context
+
+On 2026-08-12 the labelled corpus behind ADR-017 was published as `conflict-labels.csv` — 2,772 rows,
+one per scored decision pair, every scorer feature and every gold label, no decision text — under
+CC BY 4.0. That publication is what makes this ADR possible: the arithmetic in ADR-017 can now be
+checked from outside the database, by anyone, against a frozen artifact. This is the first such check.
+
+**Everything in ADR-017 reproduces.** Recomputed from the published CSV (snapshot 2026-08-12), rank AUC
+with midrank ties, Hanley–McNeil intervals:
+
+| Published claim | Recomputed | Match |
+|---|---|---|
+| base rate 3.35% | 93/2,772 = 3.355% (Wilson 95% CI 2.75%–4.09%) | yes |
+| detector flagged 97.8% | 2,711/2,772 = 97.83% | yes |
+| detector precision 3.4% | 92/2,711 = 3.394% | yes |
+| detector recall 98.9% | 92/93 = 98.92% | yes |
+| said "supersession" 61 times vs 627 real | 61 vs 627 | yes |
+| `temporal_decay` AUC 0.728 | 0.728 (0.669–0.787) | yes |
+| `topic_similarity` AUC 0.616 | 0.616 (0.554–0.678) | yes |
+| `significance` AUC 0.601 | 0.601 (0.540–0.663) | yes |
+| `confidence_weight` AUC 0.584 | 0.584 (0.522–0.646) | yes |
+| `outcome_divergence` AUC 0.434 | 0.434 (0.378–0.491) | yes |
+
+All five AUCs match to three decimals. The published data is honest and self-consistent, and the
+2026-08-12 correction note in ADR-017 caught the one figure that was not. State this plainly: the
+finding below is not that ADR-017 was careless with its arithmetic. It is that the arithmetic rests on
+a base rate the labelling protocol is not strong enough to establish.
+
+The reference for every number in ADR-017 is a single blind LLM rater. ADR-017 measured that rater
+against an independent 200-pair re-rate and reported the result honestly in its Consequences section:
+kappa 0.766, 88.4% raw agreement, 81.7% recall of pass-1 contradictions, 5.7% false-flag rate on
+non-contradictions. What it did not do is push those constants back through the base rate they
+qualify. Doing that is what this ADR records.
+
+## Decision
+
+**1. Precision figures for conflict detection are reported with a label-noise correction, and the
+correction currently available is inadmissible.** Applying Rogan–Gladen misclassification correction —
+the form Lee et al. (arXiv:2511.21140) use for LLM-as-a-judge evaluation — to the observed base rate:
+
+    theta = (p + Sp - 1) / (Se + Sp - 1)
+
+with p = 0.03355, Se = 0.817, Sp = 1 - 0.057 = 0.943:
+
+    numerator   0.03355 + 0.943 - 1 = -0.0235
+    denominator 0.817   + 0.943 - 1 =  0.7600
+    theta = -3.09%
+
+Negative. A prevalence cannot be negative, so the point estimate is inadmissible and no corrected
+precision can be computed from it. The estimator is positive if and only if
+
+    (1 - Sp) < p
+
+that is, the labeller's false-flag rate on non-contradictions must be **below the base rate it is
+measuring**, below 3.355%. The measured value is 5.7%. The observed 3.355% flag rate is lower than what
+this labeller's false-flag rate alone would produce on a corpus containing no contradictions at all.
+
+**2. State what that does and does not mean, every time it is quoted.** It does **not** mean there are
+no contradictions in the corpus; 93 pairs were labelled as contradictions and the ones that have been
+read are real. It means this labelling protocol cannot resolve a prevalence this low, so the base rate
+every downstream number rests on is **not established**. The correct object is an interval over
+plausible prevalence, not a point.
+
+**3. The calibration constants are prose-derived, and the fix is human labels with the raw rows
+retained.** Se = 0.817 and Sp = 0.943 come from ADR-017's Measurements section (lines 204–207). The
+per-pair agreement rows behind them were never persisted — there is no table, no CSV, no artifact.
+They are therefore **sensitivity-analysis inputs, not measurements**, and must be described that way
+wherever they appear. Every use of them in this ADR carries that caveat.
+
+The fix is a human-labelled calibration subset drawn from the same population as the corpus, with the
+per-pair agreement rows stored in a table (a new migration), not summarised into a paragraph. Lee et
+al. state that a calibration set should be allocated adaptively rather than uniformly — "it uses an
+adaptive strategy to allocate calibration samples for tighter intervals". They support allocating
+adaptively; they do not supply a formula for this corpus. The one we adopt is standard Neyman-style
+stratified allocation, stated here on our own authority:
+
+    m0 / m1  ≈  (1/p - 1) · sqrt(kappa)
+
+where m1 is the positive-class (contradiction) stratum, m0 the negative-class stratum, and kappa the
+relative per-label cost of the two strata. Both strata cost the same to read here, so kappa = 1 and
+the ratio is 1/p - 1 = 28.8 — roughly **29 negative labels for every positive one**. That ratio sizes
+the negative stratum. It does not license *sampling* the positive stratum, because there are only 93
+positives in the whole corpus and the allocation is a guide to proportions, not a cap on a census.
+
+**The subset is 480 labels: a 387-row sample of the gold negatives, plus a census of all 93 gold
+contradictions.**
+
+| Stratum | Labels | Drawn how |
+|---|---|---|
+| `related_not_contradicting` (plus the other non-contradiction classes) | 387 | random sample of 2,679 |
+| `contradiction` | 93 | **census — every gold contradiction in the corpus** |
+
+The specificity leg is what the budget is really buying. Precision at a 3% base rate is bounded by the
+false-positive rate on a class that is 96.65% of the data, and it is the specificity leg that the
+positivity condition `(1 - Sp) < p` turns on. 387 negatives settle that condition — the Wilson upper
+bound on the observed false-flag rate clears 3.355% at up to 6 false flags in 387, i.e. whenever the
+true rate is at or below about 1.5%.
+
+The sensitivity leg does not get to be a sample. At the measured Se = 0.817, thirteen positives means
+11 of 13 recalled, and the Wilson 95% interval on that is **57.8%–95.7%** — a 38-point band on a term
+that multiplies straight through every corrected prevalence and every precision projection downstream.
+That is not a measurement. Censusing all 93 gives 76 of 93 and a Wilson interval of **72.7%–88.3%**,
+which is 15.6 points wide and is the narrowest this corpus can ever produce. There is no larger
+positive stratum to buy; 93 is the ceiling, so take it.
+
+If a hard 400-label cap is imposed, the census is not what gives way — the split degrades to 93 + 307,
+and 307 negatives settle positivity only at up to 4 false flags, i.e. only if the true false-flag rate
+is at or below about 1%. Take the 400 knowing that is the trade; do not spend it as 387/13.
+
+**4. Until that calibration subset exists, report precision as a band over prevalence.** At the gpt-5
+operating point ADR-017 fixes (s = 0.505, f = 0.0200), queue precision and the break-even
+miss-to-false-alarm cost ratio move as follows:
+
+| Assumed true prevalence pi | Queue precision | Break-even cost ratio |
+|---|---|---|
+| 3.35% (ADR-017's assumption) | 46.7% | 1.14 : 1 |
+| 3.00% | 43.8% | 1.28 : 1 |
+| 2.00% | 34.0% | 1.94 : 1 |
+| 1.50% | 27.8% | 2.60 : 1 |
+| 1.00% | 20.3% | 3.92 : 1 |
+| 0.50% | 11.3% | 7.88 : 1 |
+
+The 46.7% top row and ADR-017's published 41.5% are the same estimate under two false-positive rates:
+this table uses the 300-pair majority-class f = 2.00%, ADR-017's corpus projection uses the
+class-weighted f = 2.44% across all non-contradiction classes, which gives 41.8%. Both assume
+pi = 3.35%. The published 41.5% sits inside this band; it is not pinned by it. An operator whose miss
+cost is 2:1 is above break-even at pi = 3.35% and below it at pi = 1.5%, and nothing measured so far
+distinguishes those two worlds.
+
+**5. The scorer-feature line of work is closed.** Two results confirm ADR-017 decision 2 rather than
+overturning it, and together they end the search for signal in the continuous features:
+
+- `temporal_decay` is the clock. Spearman(temporal_decay, -days_apart) = +0.999999, and -days_apart
+  has AUC 0.728 — identical to `temporal_decay`'s 0.728 to three decimals. The strongest feature in
+  the scorer carries no information the raw timestamp difference does not already carry.
+- There is no multivariate signal to recover. Pooled out-of-fold AUC from 5-fold cross-validated L2
+  logistic regression: the 5 scorer features together reach 0.681, structure-only features (log gap,
+  text lengths, `same_agent`/`same_project`/`same_type`) reach 0.726, everything together 0.731 —
+  against 0.728 for the single best feature alone. Combining buys nothing over the clock.
+
+Do not re-open feature engineering on the scorer without a new feature that is not a function of the
+timestamp gap.
+
+**6. Decision-type-pair routing is a provisional prioritisation candidate. It does not ship yet.**
+Unordered decision-type pairs, 25 cells with >= 30 pairs tested:
+
+`architecture` x `code_review` has a 15.5% contradiction rate (20/129, Wilson 95% CI 10.3%–22.7%),
+lift 4.62x over the 3.355% corpus rate, capturing 21.5% of all contradictions in 4.7% of pairs. It
+survives Bonferroni correction over the 25 tested cells and survives split-half replication (half A
+10/75 = 13.3%, half B 10/54 = 18.5%). It composes with ADR-017 decision 5's temporal window:
+`architecture` x `code_review` **and** cross-agent **and** gap < 72h gives 19/75 = 25.3%, lift 7.55x.
+
+ADR-017 missed this because it tested single *continuous* features by AUC and tested deterministic
+*suppression* gates. `decision_type` is categorical, was never tested as a pair interaction, and this
+is a **prioritisation** signal — it routes and ranks, it does not suppress. Nothing is discarded by it.
+
+Three caveats travel with it always, and all three are blocking conditions on shipping:
+
+  i. **It was found by search over 25 cells on the same corpus that scores it.** Split-half is weak
+     replication, not a held-out test. Pre-register the rule and measure it on pairs scored after
+     2026-08-12 before it changes any queue.
+  ii. **Its subgroup rates inherit the decision-1 label bias.** The effect could partly be a rater
+      effect — the blind rater may call `architecture`-versus-`code_review` pairs contradictions more
+      readily. That alternative explanation cannot be ruled out without the human labels in decision 3.
+  iii. **`decision_type` is caller-supplied free text on the trace call.** It is a claim by the agent,
+       not a verified property. Any rule keyed to it is gameable and will drift as agents change their
+       type vocabulary.
+
+Caveat (ii) means decision 3 is a prerequisite for decision 6, not a parallel track.
+
+**7. ADR-017's headline numbers are re-scoped, not retracted.** 41.5% precision / 50.5% recall / 113-pair
+queue remain the best available estimates and remain the default operating point. They are no longer
+quotable without the prevalence band from decision 4 attached. A dated correction note pointing here has
+been appended to ADR-017.
+
+## Measurements
+
+Everything below is computed from `conflict-labels.csv`, snapshot 2026-08-12, 2,772 rows, 93 positives.
+Feature columns are mutable in the source system and 39 of these rows were rescored after the labelling
+run, so these are properties of the snapshot, not of the pipeline in general.
+
+**Sensitivity of the corrected base rate to the labeller's false-flag rate** (Se held at 0.817):
+
+| Labeller false-flag rate | Sp | Corrected prevalence | 95% CI |
+|---|---|---|---|
+| 5.700% (measured) | 0.943 | **-3.086%** | -7.40% .. +1.23% |
+| 5.000% | 0.950 | -2.145% | -6.18% .. +1.89% |
+| 4.000% | 0.960 | -0.830% | -4.43% .. +2.77% |
+| 3.350% (break-even) | 0.967 | 0.006% | -3.29% .. +3.30% |
+| 3.000% | 0.970 | 0.451% | -2.66% .. +3.56% |
+| 2.000% | 0.980 | 1.700% | -0.84% .. +4.24% |
+| 1.000% | 0.990 | 2.918% | +1.05% .. +4.78% |
+| 0.500% | 0.995 | 3.516% | +2.07% .. +4.96% |
+| 0.000% | 1.000 | 4.106% | +3.24% .. +4.97% |
+
+The interval covers zero until the false-flag rate is under about 1%. Variance amplification from the
+correction is 1/(Se + Sp - 1)^2 = **1.73x**: correcting a weak reference labeller widens the interval
+as well as moving the point. Chen et al. (arXiv:2601.05420) identify this as the reason to prefer
+prediction-powered inference (Angelopoulos et al., arXiv:2301.09633) or efficient-influence-function
+estimators over direct Rogan–Gladen correction — but those estimators consume a small trusted label
+set alongside the cheap ones, which is exactly the artifact decision 3 buys and the current protocol
+does not have.
+
+**Multivariate feature search** (5-fold cross-validated L2 logistic regression, pooled out-of-fold AUC):
+
+| Feature set | Pooled OOF AUC | 95% CI |
+|---|---|---|
+| 5 scorer features | 0.681 | 0.620–0.742 |
+| structure only (log gap, lengths, `same_*`) | 0.726 | 0.667–0.786 |
+| all of the above | 0.731 | 0.672–0.790 |
+| *best single feature, for comparison* | *0.728* | *0.669–0.787* |
+
+**Decision-type-pair base rates**, unordered pairs, cells with >= 30 pairs (25 cells tested,
+Bonferroni z = 3.02):
+
+| Type pair | Pairs | Contradictions | Rate | 95% CI | Lift | Survives Bonferroni |
+|---|---|---|---|---|---|---|
+| `architecture` x `code_review` | 129 | 20 | 15.5% | 10.3%–22.7% | 4.62x | yes |
+| `assessment` x `code_review` | 46 | 4 | 8.7% | 3.4%–20.3% | 2.59x | no (weak) |
+| `architecture` x `error_handling` | 33 | 2 | 6.1% | 1.7%–19.6% | 1.81x | no |
+| `code_review` x `code_review` | 255 | 11 | 4.3% | 2.4%–7.6% | 1.29x | no |
+| `architecture` x `investigation` | 71 | 3 | 4.2% | 1.4%–11.7% | 1.26x | no |
+
+One cell survives. Twenty-four do not.
+
+**Composed filters and their projection at the gpt-5 operating point** (s = 0.505, f = 0.0200). The
+projections assume the subgroup label rate is the true prevalence, which is exactly the assumption
+decision 1 says is unsupported — read them as relative, not absolute:
+
+| Filter | Pairs kept | Base rate | Contradictions kept | Lift | Projected precision | Queue | Corpus recall |
+|---|---|---|---|---|---|---|---|
+| all scored pairs | 2,772 | 3.35% | 93 | 1.00x | 46.7% | 101 | 50.5% |
+| cross-agent and gap < 24h | 726 | 7.99% | 58 | 2.38x | 68.7% | 43 | 31.5% |
+| `architecture` x `code_review` | 129 | 15.50% | 20 | 4.62x | 82.2% | 12 | 10.9% |
+| `architecture` x `code_review`, cross-agent | 124 | 16.13% | 20 | 4.81x | 82.9% | 12 | 10.9% |
+| `architecture` x `code_review`, cross-agent, gap < 72h | 75 | 25.33% | 19 | 7.55x | 89.5% | 11 | 10.3% |
+| (`architecture` x `code_review`) OR (cross-agent and gap < 12h) | 634 | 8.52% | 54 | 2.54x | 70.2% | 39 | 29.3% |
+
+The trade is explicit: the tightest filter projects an 11-item queue at 10.3% corpus recall. That is a
+routing decision — which pairs a reviewer sees first — not a suppression decision.
+
+## Rejected alternatives
+
+**Widening retrieval inside the high-yield window.** An earlier version of this analysis recommended
+raising `AKASHI_CONFLICT_CANDIDATE_LIMIT` above 20 inside the cross-agent / gap < 72h window to attack
+the ~22% funnel recall. That recommendation is withdrawn and must not be re-proposed on the current
+evidence. ADR-017's own funnel measurement is the reason: blind-labelling 200 never-scored candidates
+above the 0.70 similarity floor found a **1.0% contradiction rate (2/200)**, *below* the 3.355% rate of
+the already-scored pool. Widening therefore draws from a lower-prevalence pool and dilutes queue
+precision — it buys recall by spending the exact quantity ADR-017 establishes is scarcest. The right
+response to low funnel recall is prioritised routing (decision 6) and better measurement (decision 3).
+Issue #758 (a second blind-label batch of never-scored pairs) is what would change this; a wider
+candidate limit is not. If funnel recall is attacked at all, the lever is a retrieval objective trained
+for contradiction rather than for similarity — Xu et al.'s SparseCL (arXiv:2406.10746) is the published
+form of that idea — not more results from the same similarity ranking. That is unmeasured here and is
+not proposed by this ADR.
+
+**Clamping the corrected prevalence to zero and carrying on.** A negative theta is the estimator
+reporting that its inputs are outside its domain. Clamping to zero would turn a loud, informative
+failure into a plausible-looking 0% base rate and an infinite break-even cost ratio, both of which are
+wrong in a way nobody downstream could detect. The correction reports inadmissible and stops.
+
+**Re-labelling more of the scored corpus with the same LLM protocol.** More labels from the same rater
+shrink the sampling interval and leave the bias untouched. The binding constraint is (1 - Sp) < p, and
+no volume of same-protocol labels moves Sp.
+
+**Suppressing pairs outside the high-yield type cells.** Decision 6 is deliberately a routing rule.
+Turning it into a suppressor discards 78.5% of known contradictions on a rule found by search over 25
+cells on the corpus that scores it, keyed to a caller-supplied string. ADR-017's rejected-alternatives
+list already records that every deterministic gate measured on this corpus sits on the diagonal.
+
+**Judge ensembles as a route around label noise.** Kohli (arXiv:2605.29800) measures nine frontier
+judges as carrying roughly two independent votes' worth of information because their errors are
+correlated, which is consistent with ADR-017's own measured null result on two-model agreement
+ensembles. Averaging correlated judges does not manufacture a reference standard.
+
+## Consequences
+
+Every precision figure this project has published for conflict detection — 3.4% for the shipped
+detector, 8.1% / 26.9% / 28.7% / 41.5% by judge model, 74.2% for the cascade — is conditional on a
+base rate that the labelling protocol cannot resolve. They are not wrong. They are estimates whose
+interval was never computed, and the interval is wide: at the gpt-5 point, 20.3% to 46.7% over a
+prevalence range this evidence cannot narrow. Anyone quoting them, including us, quotes the band.
+
+This does not change the operating point. gpt-5 at the default remains the right choice on the
+available evidence, ADR-017 decision 7's rule (do not run the single-judge point unless a miss costs
+at least 1.4x a false alarm) still holds at its own stated prevalence, and conflicts remain advisory.
+What changes is that the cost-ratio rule now has a prevalence argument, and operators near break-even
+should treat the feature as unproven for their cost structure rather than proven.
+
+The 480-label calibration subset in decision 3 is the unblocking work for everything else in this
+document. It is the prerequisite for a defensible precision number, for distinguishing decision 6's
+type-pair effect from a rater artifact, and for the efficient estimators Chen et al. describe. Scope it
+as 387 sampled gold negatives plus a census of all 93 gold contradictions. Two parts of that will look
+wrong to anyone who has not read decision 3 and need their justification attached wherever the work is
+scoped: the negative stratum is sized 29:1 against the positive one, and the positive stratum is not
+sampled at all. Sampling it is what a 400-label budget tempts you into, and 13 positives put a
+57.8%–95.7% Wilson interval on the sensitivity term, which is no measurement. Under a hard 400 cap the
+split is 93 + 307, and 307 negatives resolve the positivity condition only if the true false-flag rate
+is at or below about 1%.
+
+Two further consequences worth naming. First, the published CC BY 4.0 corpus is now load-bearing
+infrastructure, not a marketing artifact: it is what made this check possible from outside the
+database, and any future correction to it must be dated and announced the way the 2026-08-12 AUC
+correction was. Second, the reproduction scripts behind this ADR read only that public CSV but are not
+in this repository; they must be committed alongside the calibration work so a contributor can re-run
+the check rather than trust it.
+
+The conformal-abstention direction in issue #760 is where a tunable precision dial would come from —
+SCOPE (Badshah, Emami & Sajjad, arXiv:2602.13110) calibrates an acceptance threshold so that queue
+error is bounded, which is a better answer than picking a judge from a menu of four fixed operating
+points. It shares decision 3's blocker: a conformal guarantee calibrated against a reference that
+cannot resolve the prevalence inherits that reference's bias.
+
+Decision 6's third caveat generalises past `decision_type`. Every structured field the detector can key
+on today — `decision_type`, and the `bindings` that drive exact binding-collision detection in
+`internal/conflicts/bindings.go` — is supplied by the calling agent and written verbatim; there is no
+extraction from text anywhere in the pipeline. That is a deliberate design, and it means the precision
+of any structural channel is the honesty of the caller. The escape is extraction at write time with an
+explicit refusal path: Metropolitansky & Larson's Claimify (arXiv:2502.10855) is built around declining
+to extract a claim under ambiguity rather than guessing, which is the property a second detection
+channel would need to have an error profile independent of the LLM judge. Not scoped here; recorded so
+the caveat is not read as being about one field.
+
+## References
+
+- ADR-017 — conflict detection operating point; the numbers this ADR re-scopes. See its 2026-08-13
+  correction note.
+- ADR-015 — separation of conflict severity from confidence scoring.
+- `internal/conflicts/` — `scorer.go`, `validator.go`, `goldset.go`, `cost.go` (break-even and
+  normalized expected cost arithmetic).
+- `cmd/eval-conflicts --mode=gold` — gold-set evaluation; migration 107 — `conflict_gold_labels`.
+- `docs/conflict-detection.md` §3.3 — operator reading of the label-noise correction flags.
+- `conflict-labels.csv`, 2,772 rows, snapshot 2026-08-12, CC BY 4.0
+  (<https://ashita.ai/assets/data/conflict-detection/>) — the artifact every reproduction above runs
+  against. Companion to <https://ashita.ai/blog/the-detector-that-said-yes/>.
+- `label_noise_analysis.py`, `followup.py` — the reproduction and follow-up scripts for this ADR. They
+  read only the published CSV. **Not currently in this repository**; commit them with the decision 3
+  calibration work.
+- Issue #758 — second blind-label batch of never-scored high-similarity pairs.
+- Issue #760 — two-stage detection: tension screen then classification; the conformal-abstention work
+  extends it.
+- Lee, Zeng, Jeong, Sohn & Lee, "How to Correctly Report LLM-as-a-Judge Evaluations", arXiv:2511.21140.
+  <https://arxiv.org/abs/2511.21140>
+- Chen, Lu, Li, Guo & Li, "Efficient Inference for Noisy LLM-as-a-Judge Evaluation", arXiv:2601.05420.
+  <https://arxiv.org/abs/2601.05420>
+- Angelopoulos, Bates, Fannjiang, Jordan & Zrnic, "Prediction-Powered Inference", arXiv:2301.09633.
+  <https://arxiv.org/abs/2301.09633>
+- Badshah, Emami & Sajjad, "SCOPE: Selective Conformal Optimized Pairwise LLM Judging", arXiv:2602.13110
+  (ICML 2026). <https://arxiv.org/abs/2602.13110>
+- Kohli, "Nine Judges, Two Effective Votes: Correlated Errors Undermine LLM Evaluation Panels",
+  arXiv:2605.29800. <https://arxiv.org/abs/2605.29800>
+- Xu, Lin, Sun, Chang & Indyk, "SparseCL: Sparse Contrastive Learning for Contradiction Retrieval",
+  arXiv:2406.10746. <https://arxiv.org/abs/2406.10746>
+- Metropolitansky & Larson, "Towards Effective Extraction and Evaluation of Factual Claims",
+  arXiv:2502.10855. <https://arxiv.org/abs/2502.10855>

--- a/cmd/eval-conflicts/main.go
+++ b/cmd/eval-conflicts/main.go
@@ -64,7 +64,22 @@ func run() int {
 	save := flag.Bool("save", false, "save results to ./eval-results/{timestamp}.json")
 	costRatio := flag.Float64("cost-ratio", 0, "cost of a missed contradiction relative to one false alarm. When set with --prevalence, reports normalized expected cost, which answers whether the detector beats not running it at all.")
 	prevalence := flag.Float64("prevalence", 0, "share of evaluated pairs that are genuine contradictions IN PRODUCTION (not in the eval sample). Required with --cost-ratio; precision moves with prevalence and a stratified sample's own rate would flatter the detector.")
+	labelSens := flag.Float64("label-sensitivity", 0, "gold mode: measured sensitivity of the blind labeller that produced the gold corpus. Set together with --label-specificity to report a misclassification-corrected base rate. There is no default and there must not be one: these constants are a property of your labelling protocol, and a borrowed one silently rewrites every precision figure downstream.")
+	labelSpec := flag.Float64("label-specificity", 0, "gold mode: measured specificity of the same labeller. Its complement is the labeller's false-flag rate, which must be below the observed base rate or the correction has no admissible answer at all.")
+	labelN := flag.Int("label-calibration-n", 0, "gold mode: size of the re-rate sample --label-sensitivity and --label-specificity were measured on. Printed with the correction so a reader can tell a measurement from an assumption.")
 	flag.Parse()
+
+	cal, err := parseLabelCalibration(*labelSens, *labelSpec, *labelN)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	if cal != nil && *mode != "gold" {
+		// Accepting and ignoring them would let an operator believe a run was
+		// noise-corrected when it was not.
+		fmt.Fprintf(os.Stderr, "--label-sensitivity/--label-specificity apply to --mode=gold only (got --mode=%s)\n", *mode)
+		return 1
+	}
 
 	// Benchmark mode runs locally — no server or auth required.
 	if *mode == "benchmark" {
@@ -73,7 +88,7 @@ func run() int {
 
 	// Gold mode talks to the database directly, not the server.
 	if *mode == "gold" {
-		return runGoldMode(*goldLimit, *goldConc, *goldModel, *goldTimeout, *goldClasses, *save)
+		return runGoldMode(*goldLimit, *goldConc, *goldModel, *goldTimeout, *goldClasses, *save, cal)
 	}
 
 	baseURL := os.Getenv("AKASHI_URL")
@@ -432,7 +447,7 @@ func callScorerEval(baseURL, token string) (scorerEvalResult, error) {
 // cannot falsify that prompt.
 //
 // Requires AKASHI_DB_DSN (direct database access) and OPENAI_API_KEY.
-func runGoldMode(limit, conc int, model string, timeout time.Duration, classes string, save bool) int {
+func runGoldMode(limit, conc int, model string, timeout time.Duration, classes string, save bool, cal *conflicts.LabelCalibration) int {
 	dsn := os.Getenv("AKASHI_DB_DSN")
 	if dsn == "" {
 		fmt.Fprintln(os.Stderr, "gold mode requires AKASHI_DB_DSN")
@@ -471,7 +486,7 @@ func runGoldMode(limit, conc int, model string, timeout time.Duration, classes s
 	// constant. The projection below divides by these, so a frozen snapshot
 	// would silently misreport precision the moment the label set changed —
 	// and the label set is expected to grow.
-	corpusSizes := map[string]float64{}
+	corpusSizes := map[string]int{}
 	for _, p := range pairs {
 		corpusSizes[p.ExpectedRelationship]++
 	}
@@ -527,7 +542,7 @@ func runGoldMode(limit, conc int, model string, timeout time.Duration, classes s
 	}
 	wg.Wait()
 
-	reportGold(results, model, corpusSizes)
+	reportGold(results, model, corpusSizes, cal)
 	if save {
 		if err := saveResults("gold", results); err != nil {
 			fmt.Fprintln(os.Stderr, "save:", err)
@@ -613,7 +628,7 @@ func parseGoldClasses(arg string) (map[string]bool, error) {
 	return want, nil
 }
 
-func reportGold(results []conflicts.EvalResult, model string, corpusSizes map[string]float64) {
+func reportGold(results []conflicts.EvalResult, model string, corpusSizes map[string]int, cal *conflicts.LabelCalibration) {
 	m := conflicts.ComputeMetrics(results)
 	fmt.Printf("\n=== gold-set eval (model=%s, n=%d, errors=%d) ===\n", model, m.TotalPairs, m.Errors)
 	fmt.Printf("relationship accuracy  : %.1f%%\n", m.RelationshipAcc*100)
@@ -633,60 +648,27 @@ func reportGold(results []conflicts.EvalResult, model string, corpusSizes map[st
 
 	// Sample precision flatters the judge because contradictions are
 	// oversampled. Re-weight per-class flag rates by true corpus sizes.
-	var flagged, tp float64
-	for expected, acts := range conf {
-		total := 0
-		for _, n := range acts {
-			total += n
-		}
-		if total == 0 {
-			continue
-		}
-		n := corpusSizes[expected] * float64(acts["contradiction"]) / float64(total)
-		flagged += n
-		if expected == "contradiction" {
-			tp = n
-		}
-	}
-	if flagged > 0 {
-		base := corpusSizes["contradiction"]
-		var totalCorpus float64
-		for _, n := range corpusSizes {
-			totalCorpus += n
-		}
-		// The guard is on the SAMPLE, not the corpus: a --gold-classes run that
-		// evaluated no contradiction-class pairs has no true positives to be
-		// precise about, however many the corpus holds.
-		_, sampledContradictions := conf["contradiction"]
-		if base == 0 || !sampledContradictions {
+	proj := conflicts.ProjectCorpusPrecision(conf, corpusSizes)
+	if proj.Flagged > 0 {
+		if proj.Measurable {
+			fmt.Printf("corpus-projected queue : %.0f pairs, precision %.1f%% (base rate %.1f%%, lift %.1fx)\n",
+				proj.Flagged, proj.Precision*100, proj.BaseRate*100, proj.Lift)
+			// The queue is small enough that the point estimate alone has
+			// misled once already: a 47-pair sample put gpt-5 at 65.2%
+			// precision before a 300-pair run corrected it to 41.5%.
+			fmt.Printf("                         95%% CI %.1f%%-%.1f%% (queue-size sampling only; the per-class flag rates are estimates too)\n",
+				proj.PrecisionLo*100, proj.PrecisionHi*100)
+		} else if proj.SampleEvaluated > 0 {
 			// Measuring one negative class in isolation (the point of
 			// --gold-classes) leaves nothing to be precise about. Report the
 			// false-positive rate, which is what such a run actually measures,
 			// instead of printing "precision 0.0%" as if the judge failed.
-			var evaluated float64
-			for expected, acts := range conf {
-				if expected == "contradiction" {
-					continue
-				}
-				for _, n := range acts {
-					evaluated += float64(n)
-				}
-			}
-			var falseFlags float64
-			for expected, acts := range conf {
-				if expected != "contradiction" {
-					falseFlags += float64(acts["contradiction"])
-				}
-			}
-			if evaluated > 0 {
-				fmt.Printf("no contradiction-class pairs evaluated — this run measures the false-positive rate: %.2f%% (%.0f of %.0f)\n",
-					falseFlags/evaluated*100, falseFlags, evaluated)
-			}
-		} else {
-			baseRate := base / totalCorpus
-			fmt.Printf("corpus-projected queue : %.0f pairs, precision %.1f%% (base rate %.1f%%, lift %.1fx)\n",
-				flagged, tp/flagged*100, baseRate*100, (tp/flagged)/baseRate)
+			fmt.Printf("no contradiction-class pairs evaluated — this run measures the false-positive rate: %.2f%% (%.0f of %.0f)\n",
+				proj.SampleFalseFlagRate*100, proj.SampleFalseFlags, proj.SampleEvaluated)
 		}
+	}
+	if cal != nil && proj.BaseRate > 0 {
+		printLabelNoiseCorrection(proj.BaseRate, *cal)
 	}
 
 	fmt.Println("\ngold (row) \u2192 validator (col):")
@@ -709,4 +691,54 @@ func reportGold(results []conflicts.EvalResult, model string, corpusSizes map[st
 		}
 		fmt.Println()
 	}
+}
+
+// parseLabelCalibration turns the --label-* flags into a calibration, or nil
+// when the operator did not ask for the correction.
+//
+// The constants are deliberately not defaulted. Akashi's own 0.817/0.943 pair
+// is prose-derived from a 200-pair re-rate whose per-pair agreement rows were
+// never published; baking it in would turn a sensitivity-analysis input into
+// something a reader would take for a measurement. A half-specified
+// calibration is an error rather than a skipped report, because a gold run
+// costs money and an operator who asked for the correction should find out
+// before the bill, not after.
+func parseLabelCalibration(sens, spec float64, n int) (*conflicts.LabelCalibration, error) {
+	if sens == 0 && spec == 0 {
+		if n != 0 {
+			return nil, fmt.Errorf("--label-calibration-n given without --label-sensitivity and --label-specificity")
+		}
+		return nil, nil
+	}
+	if sens <= 0 || sens > 1 {
+		return nil, fmt.Errorf("--label-sensitivity must be in (0,1], got %v", sens)
+	}
+	if spec <= 0 || spec > 1 {
+		return nil, fmt.Errorf("--label-specificity must be in (0,1], got %v", spec)
+	}
+	if n < 0 {
+		return nil, fmt.Errorf("--label-calibration-n must not be negative, got %d", n)
+	}
+	return &conflicts.LabelCalibration{Sensitivity: sens, Specificity: spec, N: n}, nil
+}
+
+// printLabelNoiseCorrection reports what the corpus base rate becomes once the
+// noise in the reference labels is accounted for — including, and especially,
+// when the answer is that it cannot be established at all.
+func printLabelNoiseCorrection(observed float64, cal conflicts.LabelCalibration) {
+	fmt.Printf("\n=== label-noise correction (labeller Se %.1f%%, Sp %.1f%%", cal.Sensitivity*100, cal.Specificity*100)
+	if cal.N > 0 {
+		fmt.Printf(", re-rated on n=%d", cal.N)
+	}
+	fmt.Println(") ===")
+
+	corrected, err := conflicts.CorrectedBaseRate(observed, cal)
+	if err != nil {
+		fmt.Printf("WARNING: the observed base rate of %.3f%% cannot be corrected with this calibration.\n", observed*100)
+		fmt.Printf("  %v\n", err)
+		fmt.Println("  Every precision, lift and cost-ratio figure above rests on that base rate. Treat them as unestablished.")
+		return
+	}
+	fmt.Printf("observed base rate %.3f%% → corrected %.3f%% (Rogan-Gladen; this calibration widens the interval %.2fx)\n",
+		observed*100, corrected*100, cal.VarianceAmplification())
 }

--- a/cmd/eval-conflicts/main.go
+++ b/cmd/eval-conflicts/main.go
@@ -672,10 +672,29 @@ func reportGold(results []conflicts.EvalResult, model string, corpusSizes map[st
 	// Sample precision flatters the judge because contradictions are
 	// oversampled. Re-weight per-class flag rates by true corpus sizes.
 	proj := conflicts.ProjectCorpusPrecision(conf, corpusSizes)
+
+	// Resolve the correction before printing anything it invalidates. The
+	// headline queue line is the one that gets screenshotted, grepped and
+	// pasted into a dashboard; a caveat printed below it does not travel with
+	// it. If the base rate cannot be established, that has to be on the same
+	// line as the number it disqualifies.
+	var (
+		corrected     float64
+		correctionErr error
+	)
+	correctable := cal != nil && proj.BaseRate > 0
+	if correctable {
+		corrected, correctionErr = conflicts.CorrectedBaseRate(proj.BaseRate, *cal)
+	}
+	unestablished := ""
+	if correctionErr != nil {
+		unestablished = "  [BASE RATE UNESTABLISHED - see label-noise correction below]"
+	}
+
 	if proj.Flagged > 0 {
 		if proj.Measurable {
-			fmt.Printf("corpus-projected queue : %.0f pairs, precision %.1f%% (base rate %.1f%%, lift %.1fx)\n",
-				proj.Flagged, proj.Precision*100, proj.BaseRate*100, proj.Lift)
+			fmt.Printf("corpus-projected queue : %.0f pairs, precision %.1f%% (base rate %.1f%%, lift %.1fx)%s\n",
+				proj.Flagged, proj.Precision*100, proj.BaseRate*100, proj.Lift, unestablished)
 			// The queue is small enough that the point estimate alone has
 			// misled once already: a 47-pair sample put gpt-5 at 65.2%
 			// precision before a 300-pair run corrected it to 41.5%.
@@ -690,10 +709,9 @@ func reportGold(results []conflicts.EvalResult, model string, corpusSizes map[st
 				proj.SampleFalseFlagRate*100, proj.SampleFalseFlags, proj.SampleEvaluated)
 		}
 	}
-	var correctionErr error
 	if cal != nil {
-		if proj.BaseRate > 0 {
-			correctionErr = printLabelNoiseCorrection(proj.BaseRate, *cal)
+		if correctable {
+			printLabelNoiseCorrection(proj.BaseRate, *cal, corrected, correctionErr)
 		} else {
 			// The operator passed the calibration flags and paid for the run.
 			// Skipping the correction without saying so leaves them believing
@@ -728,7 +746,10 @@ func reportGold(results []conflicts.EvalResult, model string, corpusSizes map[st
 		}
 		fmt.Println()
 	}
-	return correctionErr
+	if correctionErr != nil {
+		return fmt.Errorf("label-noise correction is inadmissible, so the base rate is not established: %w", correctionErr)
+	}
+	return nil
 }
 
 // parseLabelCalibration turns the --label-* flags into a calibration, or nil
@@ -764,18 +785,17 @@ func parseLabelCalibration(sens, spec float64, n int) (*conflicts.LabelCalibrati
 // noise in the reference labels is accounted for — including, and especially,
 // when the answer is that it cannot be established at all.
 //
-// An inadmissible correction is returned as an error, not merely printed. The
-// figures above it are all divided by a base rate the correction has just
-// refused to certify, and a caller that exits 0 on that would hand a CI job a
-// green run on an unestablished number.
-func printLabelNoiseCorrection(observed float64, cal conflicts.LabelCalibration) error {
+// The correction is resolved by the caller, before the projection figures are
+// printed, so that the headline queue line can be marked inline rather than
+// contradicted several lines later. This function only renders that result;
+// reportGold owns the error and the non-zero exit that follows from it.
+func printLabelNoiseCorrection(observed float64, cal conflicts.LabelCalibration, corrected float64, err error) {
 	fmt.Printf("\n=== label-noise correction (labeller Se %.1f%%, Sp %.1f%%", cal.Sensitivity*100, cal.Specificity*100)
 	if cal.N > 0 {
 		fmt.Printf(", re-rated on n=%d", cal.N)
 	}
 	fmt.Println(") ===")
 
-	corrected, err := conflicts.CorrectedBaseRate(observed, cal)
 	if err != nil {
 		fmt.Printf("WARNING: the observed base rate of %.3f%% cannot be corrected with this calibration.\n", observed*100)
 		fmt.Printf("  %v\n", err)
@@ -784,11 +804,11 @@ func printLabelNoiseCorrection(observed float64, cal conflicts.LabelCalibration)
 		// reason a run can arrive at no admissible answer.
 		fmt.Printf("  Positivity condition: the labeller's false-flag rate (1 - specificity = %.3f%%) must be below the observed base rate (%.3f%%).\n",
 			(1-cal.Specificity)*100, observed*100)
-		fmt.Println("  Every precision, lift and cost-ratio figure above rests on that base rate. Treat them as unestablished.")
+		fmt.Println("  Every precision, lift and cost-ratio figure above rests on that base rate. Treat them as unestablished;")
+		fmt.Println("  the queue line above is marked [BASE RATE UNESTABLISHED] for that reason.")
 		fmt.Printf("  The rest of the report still prints; this run will exit %d.\n", exitBaseRateUnestablished)
-		return fmt.Errorf("label-noise correction is inadmissible, so the base rate is not established: %w", err)
+		return
 	}
 	fmt.Printf("observed base rate %.3f%% → corrected %.3f%% (Rogan-Gladen; this calibration widens the interval %.2fx)\n",
 		observed*100, corrected*100, cal.VarianceAmplification())
-	return nil
 }

--- a/cmd/eval-conflicts/main.go
+++ b/cmd/eval-conflicts/main.go
@@ -542,15 +542,31 @@ func runGoldMode(limit, conc int, model string, timeout time.Duration, classes s
 	}
 	wg.Wait()
 
-	reportGold(results, model, corpusSizes, cal)
+	// The full report is printed regardless: the operator paid for this run and
+	// must see every number. reportGold's error only decides the exit code.
+	reportErr := reportGold(results, model, corpusSizes, cal)
 	if save {
 		if err := saveResults("gold", results); err != nil {
 			fmt.Fprintln(os.Stderr, "save:", err)
 			return 1
 		}
 	}
+	if reportErr != nil {
+		fmt.Fprintf(os.Stderr, "\nFAIL: %v\n", reportErr)
+		return exitBaseRateUnestablished
+	}
 	return 0
 }
+
+// exitBaseRateUnestablished is the exit code of a gold run whose label-noise
+// correction came out inadmissible.
+//
+// It is distinct from 1 because nothing about the run failed: every figure was
+// computed and printed. What the code says is narrower — do not trust the base
+// rate those figures divide by. A CI job checking $? must not read a green run
+// off a base rate the tool has just declared unestablished, which is what
+// happened while this path only printed a warning.
+const exitBaseRateUnestablished = 2
 
 // stratifyGold oversamples the rare, decision-relevant classes so a bounded run
 // still measures contradiction recall. reportGold re-weights back to true class
@@ -628,7 +644,14 @@ func parseGoldClasses(arg string) (map[string]bool, error) {
 	return want, nil
 }
 
-func reportGold(results []conflicts.EvalResult, model string, corpusSizes map[string]int, cal *conflicts.LabelCalibration) {
+// reportGold prints the gold-set report and returns a non-nil error when a
+// requested label-noise correction was inadmissible.
+//
+// The error is returned rather than printed and swallowed so the caller can
+// fail the run. It is produced mid-report and returned at the end, never early:
+// an inadmissible correction invalidates the base rate, not the run, and the
+// operator still gets the confusion matrix.
+func reportGold(results []conflicts.EvalResult, model string, corpusSizes map[string]int, cal *conflicts.LabelCalibration) error {
 	m := conflicts.ComputeMetrics(results)
 	fmt.Printf("\n=== gold-set eval (model=%s, n=%d, errors=%d) ===\n", model, m.TotalPairs, m.Errors)
 	fmt.Printf("relationship accuracy  : %.1f%%\n", m.RelationshipAcc*100)
@@ -667,8 +690,22 @@ func reportGold(results []conflicts.EvalResult, model string, corpusSizes map[st
 				proj.SampleFalseFlagRate*100, proj.SampleFalseFlags, proj.SampleEvaluated)
 		}
 	}
-	if cal != nil && proj.BaseRate > 0 {
-		printLabelNoiseCorrection(proj.BaseRate, *cal)
+	var correctionErr error
+	if cal != nil {
+		if proj.BaseRate > 0 {
+			correctionErr = printLabelNoiseCorrection(proj.BaseRate, *cal)
+		} else {
+			// The operator passed the calibration flags and paid for the run.
+			// Skipping the correction without saying so leaves them believing
+			// the printed figures were noise-corrected when they were not.
+			// Rogan-Gladen corrects an observed base rate, and there is none:
+			// nothing in the loaded corpus carries the contradiction label.
+			fmt.Println("\n=== label-noise correction: SKIPPED ===")
+			fmt.Printf("No correction was applied. The loaded gold corpus holds %d pairs and none are labelled %q,\n",
+				proj.CorpusSize, conflicts.GoldContradiction)
+			fmt.Println("so the observed base rate is 0% and there is nothing for the correction to divide.")
+			fmt.Println("Load a corpus containing contradiction-labelled rows, or drop the --label-* flags.")
+		}
 	}
 
 	fmt.Println("\ngold (row) \u2192 validator (col):")
@@ -691,6 +728,7 @@ func reportGold(results []conflicts.EvalResult, model string, corpusSizes map[st
 		}
 		fmt.Println()
 	}
+	return correctionErr
 }
 
 // parseLabelCalibration turns the --label-* flags into a calibration, or nil
@@ -725,7 +763,12 @@ func parseLabelCalibration(sens, spec float64, n int) (*conflicts.LabelCalibrati
 // printLabelNoiseCorrection reports what the corpus base rate becomes once the
 // noise in the reference labels is accounted for — including, and especially,
 // when the answer is that it cannot be established at all.
-func printLabelNoiseCorrection(observed float64, cal conflicts.LabelCalibration) {
+//
+// An inadmissible correction is returned as an error, not merely printed. The
+// figures above it are all divided by a base rate the correction has just
+// refused to certify, and a caller that exits 0 on that would hand a CI job a
+// green run on an unestablished number.
+func printLabelNoiseCorrection(observed float64, cal conflicts.LabelCalibration) error {
 	fmt.Printf("\n=== label-noise correction (labeller Se %.1f%%, Sp %.1f%%", cal.Sensitivity*100, cal.Specificity*100)
 	if cal.N > 0 {
 		fmt.Printf(", re-rated on n=%d", cal.N)
@@ -736,9 +779,16 @@ func printLabelNoiseCorrection(observed float64, cal conflicts.LabelCalibration)
 	if err != nil {
 		fmt.Printf("WARNING: the observed base rate of %.3f%% cannot be corrected with this calibration.\n", observed*100)
 		fmt.Printf("  %v\n", err)
+		// Stated here as well as inside the error: the degenerate-denominator
+		// path does not mention it, and the positivity condition is the whole
+		// reason a run can arrive at no admissible answer.
+		fmt.Printf("  Positivity condition: the labeller's false-flag rate (1 - specificity = %.3f%%) must be below the observed base rate (%.3f%%).\n",
+			(1-cal.Specificity)*100, observed*100)
 		fmt.Println("  Every precision, lift and cost-ratio figure above rests on that base rate. Treat them as unestablished.")
-		return
+		fmt.Printf("  The rest of the report still prints; this run will exit %d.\n", exitBaseRateUnestablished)
+		return fmt.Errorf("label-noise correction is inadmissible, so the base rate is not established: %w", err)
 	}
 	fmt.Printf("observed base rate %.3f%% → corrected %.3f%% (Rogan-Gladen; this calibration widens the interval %.2fx)\n",
 		observed*100, corrected*100, cal.VarianceAmplification())
+	return nil
 }

--- a/cmd/eval-conflicts/main_test.go
+++ b/cmd/eval-conflicts/main_test.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ashita-ai/akashi/internal/conflicts"
+)
+
+// akashiCorpus is the labelled gold corpus as it stands: 93 contradictions in
+// 2772 pairs, an observed base rate of 3.355%. The label-noise correction is
+// inadmissible against it for any labeller whose false-flag rate exceeds that.
+func akashiCorpus() map[string]int {
+	return map[string]int{
+		conflicts.GoldRelated:       2017,
+		"supersession":              627,
+		conflicts.GoldContradiction: 93,
+		"unrelated":                 35,
+	}
+}
+
+// goldResults is a minimal stratified sample: both a contradiction row and a
+// negative row, so ProjectCorpusPrecision has something to project.
+func goldResults() []conflicts.EvalResult {
+	return []conflicts.EvalResult{
+		{ExpectedRelationship: conflicts.GoldContradiction, ActualRelationship: conflicts.GoldContradiction},
+		{ExpectedRelationship: conflicts.GoldContradiction, ActualRelationship: "complementary"},
+		{ExpectedRelationship: conflicts.GoldRelated, ActualRelationship: "complementary"},
+		{ExpectedRelationship: conflicts.GoldRelated, ActualRelationship: conflicts.GoldContradiction},
+	}
+}
+
+// captureStdout runs fn with os.Stdout redirected and returns what it printed.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	orig := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	done := make(chan string, 1)
+	go func() {
+		b, _ := io.ReadAll(r)
+		done <- string(b)
+	}()
+
+	fn()
+	require.NoError(t, w.Close())
+	return <-done
+}
+
+// The behaviour docs/conflict-detection.md promises operators: an inadmissible
+// correction fails the run. Before this, reportGold printed a WARNING and
+// returned nothing, so a CI job checking $? saw a green run on a base rate the
+// tool had just declared unestablished.
+func TestReportGold_InadmissibleCorrectionReturnsError(t *testing.T) {
+	// Akashi's own 200-pair re-rate: false-flag rate 5.7% against a 3.355%
+	// observed base rate, so the positivity condition fails.
+	cal := &conflicts.LabelCalibration{Sensitivity: 0.817, Specificity: 0.943, N: 200}
+
+	var err error
+	out := captureStdout(t, func() {
+		err = reportGold(goldResults(), "gpt-5", akashiCorpus(), cal)
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not established")
+	assert.NotZero(t, exitBaseRateUnestablished, "the error must map to a non-zero exit code")
+
+	// The message names the positivity condition in the operator's terms.
+	assert.Contains(t, out, "Positivity condition")
+	assert.Contains(t, out, "false-flag rate")
+
+	// The operator paid for the run: the full report prints anyway, and the
+	// confusion matrix comes after the warning rather than being suppressed
+	// by it.
+	warn := strings.Index(out, "WARNING")
+	matrix := strings.Index(out, "gold (row)")
+	require.NotEqual(t, -1, warn)
+	require.NotEqual(t, -1, matrix)
+	assert.Less(t, warn, matrix, "exit code signals distrust; it must not truncate the report")
+}
+
+func TestReportGold_AdmissibleCorrectionReturnsNil(t *testing.T) {
+	// A labeller whose false-flag rate (0.5%) sits below the 3.355% base rate.
+	cal := &conflicts.LabelCalibration{Sensitivity: 0.90, Specificity: 0.995, N: 200}
+
+	var err error
+	out := captureStdout(t, func() {
+		err = reportGold(goldResults(), "gpt-5", akashiCorpus(), cal)
+	})
+
+	require.NoError(t, err)
+	assert.Contains(t, out, "corrected")
+	assert.NotContains(t, out, "WARNING")
+}
+
+func TestReportGold_NoCalibrationReturnsNil(t *testing.T) {
+	var err error
+	out := captureStdout(t, func() {
+		err = reportGold(goldResults(), "gpt-5", akashiCorpus(), nil)
+	})
+
+	require.NoError(t, err)
+	assert.NotContains(t, out, "label-noise correction")
+}
+
+// A corpus with no contradiction-labelled rows has no observed base rate to
+// correct. That is not a failure, but silence would let an operator who passed
+// the flags believe the figures were corrected.
+func TestReportGold_ZeroBaseRateExplainsTheSkip(t *testing.T) {
+	corpus := map[string]int{conflicts.GoldRelated: 400, "supersession": 100}
+	cal := &conflicts.LabelCalibration{Sensitivity: 0.817, Specificity: 0.943, N: 200}
+
+	var err error
+	out := captureStdout(t, func() {
+		err = reportGold(goldResults(), "gpt-5", corpus, cal)
+	})
+
+	require.NoError(t, err, "an absent base rate is not an inadmissible one")
+	assert.Contains(t, out, "label-noise correction: SKIPPED")
+	assert.Contains(t, out, "none are labelled")
+	assert.Contains(t, out, "500 pairs")
+}

--- a/cmd/eval-conflicts/main_test.go
+++ b/cmd/eval-conflicts/main_test.go
@@ -87,6 +87,45 @@ func TestReportGold_InadmissibleCorrectionReturnsError(t *testing.T) {
 	assert.Less(t, warn, matrix, "exit code signals distrust; it must not truncate the report")
 }
 
+// The queue line is the one that gets screenshotted, grepped and pasted into a
+// dashboard. A caveat printed below it does not travel with it, so the
+// disqualification has to be on the same line as the number it disqualifies —
+// which means the correction must be resolved before that line is printed.
+func TestReportGold_InadmissibleCorrectionMarksTheQueueLineItself(t *testing.T) {
+	cal := &conflicts.LabelCalibration{Sensitivity: 0.817, Specificity: 0.943, N: 200}
+
+	out := captureStdout(t, func() {
+		_ = reportGold(goldResults(), "gpt-5", akashiCorpus(), cal)
+	})
+
+	var queueLine string
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "corpus-projected queue") {
+			queueLine = line
+			break
+		}
+	}
+	require.NotEmpty(t, queueLine, "the projection headline must still print")
+	assert.Contains(t, queueLine, "BASE RATE UNESTABLISHED",
+		"the headline carries the precision figure, so it must carry the disqualification too")
+
+	// And the marker must appear before the correction block, not only inside
+	// it — otherwise it has not travelled with the number.
+	assert.Less(t, strings.Index(out, "BASE RATE UNESTABLISHED"), strings.Index(out, "label-noise correction"))
+}
+
+// The converse: an admissible correction must leave the headline clean, or the
+// marker becomes noise operators learn to ignore.
+func TestReportGold_AdmissibleCorrectionLeavesTheQueueLineUnmarked(t *testing.T) {
+	cal := &conflicts.LabelCalibration{Sensitivity: 0.90, Specificity: 0.995, N: 200}
+
+	out := captureStdout(t, func() {
+		_ = reportGold(goldResults(), "gpt-5", akashiCorpus(), cal)
+	})
+
+	assert.NotContains(t, out, "BASE RATE UNESTABLISHED")
+}
+
 func TestReportGold_AdmissibleCorrectionReturnsNil(t *testing.T) {
 	// A labeller whose false-flag rate (0.5%) sits below the 3.355% base rate.
 	cal := &conflicts.LabelCalibration{Sensitivity: 0.90, Specificity: 0.995, N: 200}

--- a/docs/conflict-detection.md
+++ b/docs/conflict-detection.md
@@ -337,6 +337,62 @@ confidence intervals too wide to act on (the 47-pair run read 0%).
 Also available: `POST /v1/admin/conflicts/validate-pair` for a single ad-hoc pair, and
 `--mode=benchmark` for local scorer changes with no server or API key.
 
+#### Correcting for label noise: `--label-sensitivity` and `--label-specificity`
+
+Added with ADR-019. If `--help` on your build does not list them, you are on an older build and every
+precision figure it prints is uncorrected.
+
+The gold labels are LLM-generated, so the 3.35% base rate that every projection above divides by is
+itself an estimate from a noisy rater. These two flags supply that rater's reliability and apply the
+Rogan–Gladen correction to the base rate before precision is projected:
+
+```bash
+go run ./cmd/eval-conflicts --mode=gold --gold-model=gpt-5 --gold-timeout=120s \
+  --label-sensitivity=0.817 \
+  --label-specificity=0.943
+```
+
+`--label-sensitivity` is the rater's recall of true contradictions; `--label-specificity` is
+`1 - (the rater's false-flag rate on non-contradictions)`. Both flags are required together and both
+default to unset, in which case no correction is applied and the printed base rate is the raw 3.35%.
+
+The 0.817 / 0.943 above come from the 200-pair re-rate reported in ADR-017 §Measurements. **The
+per-pair agreement rows behind them were never persisted**, so treat them as sensitivity-analysis
+inputs and sweep them rather than trusting either digit.
+
+**Reading an inadmissible result.** The correction is `theta = (p + Sp - 1) / (Se + Sp - 1)`, and it
+returns a positive prevalence only when `(1 - Sp) < p` — the rater's false-flag rate must be below the
+base rate it is measuring. At the constants above it is not (5.7% against a 3.35% base rate), so
+`theta` comes out at **-3.09%**. A negative prevalence is not a number the run can use, and it is not
+clamped to zero: the correction reports the failure, names the positivity condition it violated, and
+the run exits non-zero.
+
+Three things this does **not** mean:
+
+- It does not mean the corpus has no contradictions. It means this labelling protocol cannot resolve a
+  prevalence this low, so the base rate is not established.
+- It is not a bug in the run, and it is not fixed by supplying different constants. Only a better
+  reference labeller moves `Sp`.
+- It does not invalidate the operating point. gpt-5 at 41.5% is still the default.
+
+**What to do with it.** Report precision as a band over prevalence rather than a point. At the gpt-5
+operating point (s = 0.505, f = 2.00%):
+
+| Assumed prevalence | Queue precision | Break-even miss:false-alarm ratio |
+|---|---|---|
+| 3.35% | 46.7% | 1.14 : 1 |
+| 2.00% | 34.0% | 1.94 : 1 |
+| 1.00% | 20.3% | 3.92 : 1 |
+
+The 46.7% top row and the 41.5% default above are the same operating point at the same 3.35%
+prevalence, differing only in the false-positive rate: this table uses the majority-class f = 2.00%
+measured on 300 pairs, while 41.5% comes from ADR-017's class-weighted f = 2.44% across all
+non-contradiction classes.
+
+If your cost ratio sits inside that band, the feature is unproven for your cost structure — treat §4's
+break-even arithmetic as unresolved rather than passed. ADR-019 has the full sweep, the positivity
+condition, and the calibration work that would close it.
+
 ---
 
 ## 4. Choosing an operating point from a cost ratio

--- a/internal/conflicts/projection.go
+++ b/internal/conflicts/projection.go
@@ -1,0 +1,287 @@
+//go:build !lite
+
+package conflicts
+
+import (
+	"fmt"
+	"math"
+)
+
+// Projecting an eval sample onto the corpus, and correcting the corpus base
+// rate for the noise in the reference labels.
+//
+// Two things happen here, and they are separate on purpose.
+//
+// First, projection. A gold-set run oversamples contradictions by design —
+// there are only 93 of them in 2,772 pairs, so a bounded run that sampled
+// uniformly would measure almost nothing about recall. Sample precision from
+// such a run is meaningless: it describes a population that does not exist.
+// ProjectCorpusPrecision re-weights each class's measured flag rate by that
+// class's true size in the corpus, which is the only precision figure that
+// predicts what an operator's review queue will look like.
+//
+// Second, correction. Every one of those corpus labels came from a single
+// blind LLM rater, and the projection above silently treats them as truth.
+// They are not truth; they are a noisy measurement, and at a 3.35% base rate
+// the noise floor can exceed the signal. Rogan-Gladen (Am J Public Health
+// 1978;68(1):71-76) corrects an observed prevalence for a reference test of
+// known sensitivity and specificity:
+//
+//	theta = (p + Sp - 1) / (Se + Sp - 1)
+//
+// The correction has a positivity condition that is easy to miss and brutal
+// when violated: theta > 0 requires (1 - Sp) < p, i.e. the labeller's
+// false-flag rate must be below the base rate being measured. Akashi's own
+// re-rate reliability figures put the labeller's false-flag rate at 5.7%
+// against a 3.355% observed base rate, which yields theta = -3.09%. That is
+// not "there are no contradictions". It is "this labelling protocol cannot
+// resolve a prevalence this low, so the base rate every downstream number
+// rests on is not established".
+//
+// CorrectedBaseRate therefore returns an error rather than a floor of zero
+// when the estimate is inadmissible. Clamping would hand the caller a number
+// that looks like a measurement and is not one, and every precision, lift and
+// cost-ratio figure downstream inherits that lie. The operator has to see it.
+//
+// The calibration constants are inputs, never defaults. Akashi's own
+// 0.817/0.943 pair is prose-derived from a 200-pair re-rate whose per-pair
+// agreement rows were never published, so it is a sensitivity-analysis input,
+// not a measurement. Nothing in this package supplies it.
+
+// CorpusProjection is a gold-set eval sample re-weighted onto the true corpus.
+//
+// The counts are fractional because they are projections, not observations:
+// Flagged is "how many pairs this judge would put in the queue if it ran on
+// the whole corpus", derived from per-class flag rates measured on a sample
+// that deliberately does not match the corpus mix.
+type CorpusProjection struct {
+	// Flagged is the projected review-queue size over the whole corpus.
+	Flagged float64 `json:"flagged"`
+
+	// TruePositives is the share of Flagged drawn from the contradiction class.
+	TruePositives float64 `json:"true_positives"`
+
+	// Precision is TruePositives/Flagged: the fraction of the projected queue
+	// an operator would find worth reading. NaN when Measurable is false.
+	Precision float64 `json:"precision"`
+
+	// PrecisionLo and PrecisionHi are a Wilson 95% interval computed by
+	// treating the rounded projection as a binomial sample. It captures only
+	// the queue-size sampling term; the per-class flag rates are themselves
+	// estimates, so the true interval is wider than this one. NaN when
+	// Measurable is false.
+	PrecisionLo float64 `json:"precision_lo"`
+	PrecisionHi float64 `json:"precision_hi"`
+
+	// BaseRate is the contradiction share of the corpus as labelled. It is an
+	// observed rate against a noisy reference — see CorrectedBaseRate.
+	BaseRate float64 `json:"base_rate"`
+
+	// Lift is Precision/BaseRate: how much better than random draw the queue
+	// is. NaN when Measurable is false.
+	Lift float64 `json:"lift"`
+
+	// CorpusSize is the total labelled corpus the projection re-weights onto.
+	CorpusSize int `json:"corpus_size"`
+
+	// Measurable is false when the sample contained no contradiction-class
+	// pairs — the intended shape of a run that deliberately evaluates one
+	// negative class to measure its false-positive rate. Such a run has no
+	// true positives to be precise about, and reporting "precision 0.0%" would
+	// read as a judge failure rather than as a question that was not asked.
+	Measurable bool `json:"measurable"`
+
+	// SampleFalseFlags, SampleEvaluated and SampleFalseFlagRate describe what a
+	// non-measurable run does measure. These are raw sample counts over the
+	// non-contradiction classes, not corpus projections.
+	SampleFalseFlags    float64 `json:"sample_false_flags"`
+	SampleEvaluated     float64 `json:"sample_evaluated"`
+	SampleFalseFlagRate float64 `json:"sample_false_flag_rate"`
+}
+
+// ProjectCorpusPrecision re-weights a sampled confusion matrix onto the corpus.
+//
+// conf is indexed conf[expectedRelationship][actualRelationship]; corpusSizes
+// gives the true number of pairs per expected relationship in the full labelled
+// corpus. Classes present in conf but absent from corpusSizes contribute
+// nothing, which is correct: a class the corpus does not contain cannot put
+// pairs in the queue.
+//
+// Only GoldContradiction is a reserved key. The two maps must agree on how the
+// other classes are spelled — gold vocabulary or validator vocabulary, either
+// works, but not one of each.
+func ProjectCorpusPrecision(conf map[string]map[string]int, corpusSizes map[string]int) CorpusProjection {
+	p := CorpusProjection{
+		Precision:   math.NaN(),
+		PrecisionLo: math.NaN(),
+		PrecisionHi: math.NaN(),
+		Lift:        math.NaN(),
+	}
+	for _, n := range corpusSizes {
+		p.CorpusSize += n
+	}
+	if p.CorpusSize > 0 {
+		p.BaseRate = float64(corpusSizes[GoldContradiction]) / float64(p.CorpusSize)
+	}
+
+	for expected, acts := range conf {
+		total := 0
+		for _, n := range acts {
+			total += n
+		}
+		if total == 0 {
+			continue
+		}
+		projected := float64(corpusSizes[expected]) * float64(acts[GoldContradiction]) / float64(total)
+		p.Flagged += projected
+		if expected == GoldContradiction {
+			p.TruePositives = projected
+			continue
+		}
+		p.SampleEvaluated += float64(total)
+		p.SampleFalseFlags += float64(acts[GoldContradiction])
+	}
+	if p.SampleEvaluated > 0 {
+		p.SampleFalseFlagRate = p.SampleFalseFlags / p.SampleEvaluated
+	}
+
+	// The guard is on the SAMPLE, not the corpus: a run that evaluated no
+	// contradiction-class pairs has no true positives to be precise about,
+	// however many the corpus holds.
+	_, sampledContradictions := conf[GoldContradiction]
+	p.Measurable = sampledContradictions && corpusSizes[GoldContradiction] > 0 && p.Flagged > 0
+	if !p.Measurable {
+		return p
+	}
+
+	p.Precision = p.TruePositives / p.Flagged
+	if p.BaseRate > 0 {
+		p.Lift = p.Precision / p.BaseRate
+	}
+	// Round the projection to integers for the interval. A fractional queue has
+	// no binomial interpretation, and rounding is the honest way to say "an
+	// interval this construction can only approximate".
+	if lo, hi, err := WilsonInterval(int(math.Round(p.TruePositives)), int(math.Round(p.Flagged)), 1.96); err == nil {
+		p.PrecisionLo, p.PrecisionHi = lo, hi
+	}
+	return p
+}
+
+// LabelCalibration is the measured reliability of the reference labeller whose
+// output the corpus base rate was computed from.
+//
+// There is no default and there must not be one. Akashi's own figures are
+// derived from a 200-pair re-rate whose per-pair agreement rows were never
+// published; treating them as constants would launder a sensitivity-analysis
+// input into a measurement.
+type LabelCalibration struct {
+	// Sensitivity is the labeller's true-positive rate: the share of genuine
+	// contradictions it labels as contradictions.
+	Sensitivity float64
+
+	// Specificity is the labeller's true-negative rate. Its complement,
+	// 1 - Specificity, is the false-flag rate that drives the positivity
+	// condition below.
+	Specificity float64
+
+	// N is the size of the re-rate sample the two constants came from. It does
+	// not enter the arithmetic; it is carried so a report can state the
+	// provenance of numbers that otherwise look authoritative.
+	N int
+}
+
+// VarianceAmplification is the factor by which Rogan-Gladen widens the interval
+// around the corrected estimate relative to the observed one: 1/(Se+Sp-1)^2.
+// A weak reference labeller does not merely shift the estimate, it destroys the
+// precision of it.
+func (c LabelCalibration) VarianceAmplification() float64 {
+	d := c.Sensitivity + c.Specificity - 1
+	if d <= 0 {
+		return math.Inf(1)
+	}
+	return 1 / (d * d)
+}
+
+// minCorrectionDenominator is the smallest Se+Sp-1 this package will divide by.
+// Below it the correction is arithmetic noise amplification: at 0.05 the
+// variance is already 400x the uncorrected variance, so the point estimate is
+// meaningless whatever sign it carries.
+const minCorrectionDenominator = 0.05
+
+// CorrectedBaseRate applies the Rogan-Gladen misclassification correction to an
+// observed prevalence measured against a noisy reference labeller:
+//
+//	theta = (p + Sp - 1) / (Se + Sp - 1)
+//
+// It returns an error, never a clamped or defaulted value, when the estimate is
+// inadmissible. A negative theta is a real result and the caller must see it:
+// it says the observed flag rate is below what the labeller's own false-flag
+// rate alone would produce on a corpus containing zero positives, so the
+// protocol cannot resolve a prevalence this low.
+func CorrectedBaseRate(observed float64, cal LabelCalibration) (float64, error) {
+	if math.IsNaN(observed) || observed < 0 || observed > 1 {
+		return 0, fmt.Errorf("observed base rate %v is not a probability", observed)
+	}
+	if cal.Sensitivity < 0 || cal.Sensitivity > 1 {
+		return 0, fmt.Errorf("label sensitivity %v is not a probability", cal.Sensitivity)
+	}
+	if cal.Specificity < 0 || cal.Specificity > 1 {
+		return 0, fmt.Errorf("label specificity %v is not a probability", cal.Specificity)
+	}
+	if cal.N < 0 {
+		return 0, fmt.Errorf("label calibration sample size %d is negative", cal.N)
+	}
+
+	denom := cal.Sensitivity + cal.Specificity - 1
+	if denom <= minCorrectionDenominator {
+		return 0, fmt.Errorf(
+			"label calibration is degenerate: sensitivity %.3f + specificity %.3f - 1 = %.3f, at or below the %.2f floor; "+
+				"a labeller this close to chance carries no recoverable signal (variance amplification %.0fx)",
+			cal.Sensitivity, cal.Specificity, denom, minCorrectionDenominator, cal.VarianceAmplification())
+	}
+
+	theta := (observed + cal.Specificity - 1) / denom
+	if theta <= 0 {
+		return 0, fmt.Errorf(
+			"Rogan-Gladen correction is inadmissible: theta = %.4f%% <= 0. "+
+				"The positivity condition is (1 - specificity) < observed base rate: the labeller's false-flag rate "+
+				"of %.3f%% must be below the observed base rate of %.3f%%, and it is not. "+
+				"This does not mean the true rate is zero — it means this labelling protocol cannot resolve a "+
+				"prevalence this low, so the observed base rate is not established",
+			theta*100, (1-cal.Specificity)*100, observed*100)
+	}
+	if theta > 1 {
+		return 0, fmt.Errorf(
+			"Rogan-Gladen correction is inadmissible: theta = %.4f%% > 100%%. "+
+				"The observed base rate of %.3f%% exceeds the labeller's sensitivity of %.3f%%, which no prevalence can produce",
+			theta*100, observed*100, cal.Sensitivity*100)
+	}
+	return theta, nil
+}
+
+// WilsonInterval returns the Wilson score interval for k successes in n trials
+// at the given z. Wilson rather than the normal approximation because the rates
+// here sit near zero, where the normal interval runs below it and stops meaning
+// anything.
+//
+// The interval is exact at the boundaries: k=0 gives a lower bound of exactly 0
+// and k=n an upper bound of exactly 1, which is the behaviour the boundary
+// tests pin.
+func WilsonInterval(k, n int, z float64) (lo, hi float64, err error) {
+	if n <= 0 {
+		return 0, 0, fmt.Errorf("wilson interval needs at least one trial, got n=%d", n)
+	}
+	if k < 0 || k > n {
+		return 0, 0, fmt.Errorf("wilson interval needs 0 <= k <= n, got k=%d n=%d", k, n)
+	}
+	if z <= 0 {
+		return 0, 0, fmt.Errorf("wilson interval needs a positive z, got %v", z)
+	}
+	fn := float64(n)
+	p := float64(k) / fn
+	z2 := z * z
+	denom := 1 + z2/fn
+	center := (p + z2/(2*fn)) / denom
+	half := z / denom * math.Sqrt(p*(1-p)/fn+z2/(4*fn*fn))
+	return math.Max(0, center-half), math.Min(1, center+half), nil
+}

--- a/internal/conflicts/projection_test.go
+++ b/internal/conflicts/projection_test.go
@@ -1,0 +1,283 @@
+//go:build !lite
+
+package conflicts
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The 2,772-pair blind-labelled corpus, by gold class. Every published figure
+// for this detector is projected onto these counts, so they are pinned here
+// rather than recomputed.
+var publishedCorpus = map[string]int{
+	GoldContradiction: 93,
+	GoldSupersession:  627,
+	GoldRelated:       2017,
+	GoldUnrelated:     35,
+}
+
+const publishedBaseRate = 93.0 / 2772.0 // 3.355%
+
+// TestProjectCorpusPrecision_ReproducesPublishedGPT5Point is a characterization
+// test. ADR-017 quotes gpt-5 at a 113-pair review queue, 41.5% precision and
+// 12.4x lift over the base rate, and the operating point in production was
+// chosen from those three numbers. The arithmetic that produces them used to
+// live inline in package main where nothing could hold it still. It is pinned
+// here so a refactor cannot move a number an operator already acted on.
+//
+// The per-class flag rates below reproduce the published aggregate: 50.5%
+// recall on the contradiction class and a 2.5% flag rate on each of the two
+// large negative classes, which weights to the published 2.44% overall FPR.
+func TestProjectCorpusPrecision_ReproducesPublishedGPT5Point(t *testing.T) {
+	conf := map[string]map[string]int{
+		GoldContradiction: {GoldContradiction: 47, "complementary": 46},
+		GoldRelated:       {GoldContradiction: 5, "complementary": 195},
+		GoldSupersession:  {GoldContradiction: 5, GoldSupersession: 195},
+		GoldUnrelated:     {GoldUnrelated: 35},
+	}
+
+	p := ProjectCorpusPrecision(conf, publishedCorpus)
+
+	require.True(t, p.Measurable, "a run that sampled contradictions must be measurable")
+	assert.Equal(t, 2772, p.CorpusSize)
+	assert.InDelta(t, publishedBaseRate, p.BaseRate, 1e-6)
+
+	assert.InDelta(t, 113, p.Flagged, 0.5, "ADR-017 quotes a 113-pair review queue")
+	assert.InDelta(t, 0.415, p.Precision, 0.005, "ADR-017 quotes 41.5%% precision")
+	assert.InDelta(t, 12.4, p.Lift, 0.05, "ADR-017 quotes 12.4x lift")
+
+	// Recall falls out of the contradiction-class flag rate and is the third
+	// leg of the published point.
+	assert.InDelta(t, 0.505, p.TruePositives/float64(publishedCorpus[GoldContradiction]), 0.005)
+
+	// The interval must bracket the point estimate and stay well inside (0,1):
+	// 113 pairs is a small queue and the honest interval is wide.
+	assert.Less(t, p.PrecisionLo, p.Precision)
+	assert.Greater(t, p.PrecisionHi, p.Precision)
+	assert.InDelta(t, 0.3293, p.PrecisionLo, 1e-3)
+	assert.InDelta(t, 0.5081, p.PrecisionHi, 1e-3)
+}
+
+// A --gold-classes run that deliberately evaluates one negative class has no
+// true positives to be precise about. Reporting "precision 0.0%" would read as
+// a judge failure rather than as a question that was never asked, so the
+// projection reports the false-positive rate instead.
+func TestProjectCorpusPrecision_NegativeClassOnlyRunIsNotMeasurable(t *testing.T) {
+	conf := map[string]map[string]int{
+		GoldRelated: {GoldContradiction: 4, "complementary": 196},
+	}
+
+	p := ProjectCorpusPrecision(conf, publishedCorpus)
+
+	assert.False(t, p.Measurable)
+	assert.True(t, math.IsNaN(p.Precision), "precision must be NaN, not 0, when nothing was measured")
+	assert.True(t, math.IsNaN(p.Lift))
+	assert.InDelta(t, 0.02, p.SampleFalseFlagRate, 1e-9)
+	assert.InDelta(t, 4, p.SampleFalseFlags, 1e-9)
+	assert.InDelta(t, 200, p.SampleEvaluated, 1e-9)
+}
+
+// A judge that flags nothing produces an empty queue, not a division by zero.
+func TestProjectCorpusPrecision_EmptyQueueIsNotMeasurable(t *testing.T) {
+	conf := map[string]map[string]int{
+		GoldContradiction: {"complementary": 93},
+		GoldRelated:       {"complementary": 200},
+	}
+
+	p := ProjectCorpusPrecision(conf, publishedCorpus)
+
+	assert.False(t, p.Measurable)
+	assert.Zero(t, p.Flagged)
+	assert.True(t, math.IsNaN(p.Precision))
+}
+
+// TestCorrectedBaseRate_AkashiLabellerIsInadmissible is the finding this file
+// exists for. Akashi's own re-rate reliability figures put the labeller's
+// false-flag rate at 5.7% against a 3.355% observed base rate. Rogan-Gladen
+// then returns a negative prevalence, and the caller must be told so rather
+// than handed a floor of zero — the corrected estimate is not "about zero
+// contradictions", it is "this protocol cannot resolve a prevalence this low".
+func TestCorrectedBaseRate_AkashiLabellerIsInadmissible(t *testing.T) {
+	_, err := CorrectedBaseRate(publishedBaseRate, LabelCalibration{
+		Sensitivity: 0.817,
+		Specificity: 0.943,
+		N:           200,
+	})
+
+	require.Error(t, err, "a negative Rogan-Gladen estimate must be an error, never a clamped zero")
+	assert.Contains(t, err.Error(), "positivity condition",
+		"the operator has to be told which condition failed")
+	assert.Contains(t, err.Error(), "(1 - specificity) < observed base rate")
+	assert.Contains(t, err.Error(), "5.700%", "the labeller's false-flag rate belongs in the message")
+	assert.Contains(t, err.Error(), "3.355%", "the observed base rate belongs in the message")
+	assert.Contains(t, err.Error(), "cannot resolve a prevalence this low",
+		"the message must rule out the 'there are no contradictions' misreading")
+}
+
+// The sensitivity sweep over the labeller's false-flag rate, holding its
+// sensitivity at the reported 0.817. Break-even sits exactly at the observed
+// base rate, which is the positivity condition stated as a number.
+func TestCorrectedBaseRate_FalseFlagSweep(t *testing.T) {
+	cases := []struct {
+		name      string
+		falseFlag float64
+		want      float64
+	}{
+		{"false-flag 2.0%", 0.020, 0.01700},
+		{"false-flag 1.0%", 0.010, 0.02918},
+		{"false-flag 0.5%", 0.005, 0.03516},
+		{"perfect specificity", 0.000, 0.04106},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := CorrectedBaseRate(publishedBaseRate, LabelCalibration{
+				Sensitivity: 0.817,
+				Specificity: 1 - tc.falseFlag,
+				N:           200,
+			})
+			require.NoError(t, err)
+			assert.InDelta(t, tc.want, got, 1e-3)
+		})
+	}
+}
+
+// The positivity condition is a knife edge at the observed base rate itself:
+// a labeller whose false-flag rate sits a whisker above 3.355% is inadmissible,
+// and one a whisker below yields an admissible but useless estimate near zero.
+// Both sides are pinned because the whole finding is that Akashi's labeller is
+// on the wrong side of this line by a factor of 1.7.
+func TestCorrectedBaseRate_PositivityKnifeEdge(t *testing.T) {
+	_, err := CorrectedBaseRate(publishedBaseRate, LabelCalibration{
+		Sensitivity: 0.817, Specificity: 1 - 0.0340, N: 200,
+	})
+	require.Error(t, err, "false-flag rate just above the base rate must be inadmissible")
+	assert.Contains(t, err.Error(), "positivity condition")
+
+	got, err := CorrectedBaseRate(publishedBaseRate, LabelCalibration{
+		Sensitivity: 0.817, Specificity: 1 - 0.0330, N: 200,
+	})
+	require.NoError(t, err, "false-flag rate just below the base rate is admissible")
+	assert.InDelta(t, 0.0007, got, 1e-4, "and worth almost nothing: 0.07%% against an observed 3.355%%")
+}
+
+func TestCorrectedBaseRate_RejectsDegenerateCalibration(t *testing.T) {
+	cases := []struct {
+		name    string
+		obs     float64
+		cal     LabelCalibration
+		wantMsg string
+	}{
+		{
+			name:    "coin-flip labeller",
+			obs:     0.5,
+			cal:     LabelCalibration{Sensitivity: 0.5, Specificity: 0.5},
+			wantMsg: "degenerate",
+		},
+		{
+			name:    "denominator just under the floor",
+			obs:     0.5,
+			cal:     LabelCalibration{Sensitivity: 0.90, Specificity: 0.14},
+			wantMsg: "degenerate",
+		},
+		{
+			name:    "observed rate is not a probability",
+			obs:     1.4,
+			cal:     LabelCalibration{Sensitivity: 0.9, Specificity: 0.9},
+			wantMsg: "not a probability",
+		},
+		{
+			name:    "sensitivity is not a probability",
+			obs:     0.03,
+			cal:     LabelCalibration{Sensitivity: 1.2, Specificity: 0.9},
+			wantMsg: "sensitivity",
+		},
+		{
+			name:    "specificity is not a probability",
+			obs:     0.03,
+			cal:     LabelCalibration{Sensitivity: 0.9, Specificity: -0.1},
+			wantMsg: "specificity",
+		},
+		{
+			name:    "observed rate above the labeller's sensitivity",
+			obs:     0.95,
+			cal:     LabelCalibration{Sensitivity: 0.80, Specificity: 0.99},
+			wantMsg: "> 100%",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := CorrectedBaseRate(tc.obs, tc.cal)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantMsg)
+		})
+	}
+}
+
+// A perfect labeller changes nothing, which is the identity that says the
+// correction is applied in the right direction.
+func TestCorrectedBaseRate_PerfectLabellerIsIdentity(t *testing.T) {
+	got, err := CorrectedBaseRate(publishedBaseRate, LabelCalibration{Sensitivity: 1, Specificity: 1, N: 200})
+	require.NoError(t, err)
+	assert.InDelta(t, publishedBaseRate, got, 1e-12)
+}
+
+// The reason the corrected estimate cannot simply be quoted with the observed
+// interval: Akashi's own calibration widens it by 1.73x.
+func TestLabelCalibration_VarianceAmplification(t *testing.T) {
+	cal := LabelCalibration{Sensitivity: 0.817, Specificity: 0.943, N: 200}
+	assert.InDelta(t, 1.73, cal.VarianceAmplification(), 0.01)
+	assert.Equal(t, 1.0, LabelCalibration{Sensitivity: 1, Specificity: 1}.VarianceAmplification())
+	assert.True(t, math.IsInf(LabelCalibration{Sensitivity: 0.5, Specificity: 0.5}.VarianceAmplification(), 1))
+}
+
+func TestWilsonInterval(t *testing.T) {
+	cases := []struct {
+		name   string
+		k, n   int
+		wantLo float64
+		wantHi float64
+	}{
+		// Boundary cases are the reason for Wilson over the normal
+		// approximation: the interval stays inside [0,1] and is exact at the
+		// ends.
+		{"zero successes", 0, 100, 0, 0.0370},
+		{"all successes", 100, 100, 0.9630, 1},
+		{"single trial, zero", 0, 1, 0, 0.7935},
+		{"single trial, one", 1, 1, 0.2065, 1},
+		// Textbook midpoint: 50/100 is symmetric about 0.5.
+		{"half", 50, 100, 0.4038, 0.5962},
+		// The published gold-set base rate, as an observed proportion.
+		{"corpus base rate", 93, 2772, 0.0275, 0.0409},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			lo, hi, err := WilsonInterval(tc.k, tc.n, 1.96)
+			require.NoError(t, err)
+			assert.InDelta(t, tc.wantLo, lo, 1e-3)
+			assert.InDelta(t, tc.wantHi, hi, 1e-3)
+			assert.LessOrEqual(t, lo, hi)
+		})
+	}
+}
+
+func TestWilsonInterval_Rejects(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		k, n int
+		z    float64
+	}{
+		{"no trials", 0, 0, 1.96},
+		{"negative successes", -1, 10, 1.96},
+		{"more successes than trials", 11, 10, 1.96},
+		{"non-positive z", 5, 10, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := WilsonInterval(tc.k, tc.n, tc.z)
+			require.Error(t, err)
+		})
+	}
+}


### PR DESCRIPTION
## What this is

The published conflict corpus (`conflict-labels.csv`, CC BY 4.0) reproduces **exactly** — base rate 93/2772 = 3.355%, shipped-detector precision 92/2711 = 3.394%, and all five feature AUCs to three decimals. That reproduction is what made the next problem visible.

Applying the Rogan-Gladen misclassification correction to ADR-017's own reported label reliability (sensitivity 0.817, false-flag rate 5.7%) gives a corrected base rate of **−3.09%**. Negative, therefore inadmissible.

```
theta = (p + Sp - 1) / (Se + Sp - 1) = (0.0335 + 0.943 - 1) / 0.760 = -0.0309
```

The positivity condition is `(1 - Sp) < p`: the labeller's false-flag rate has to be below the base rate itself, below 3.355%. The measured value is 5.7%.

**This does not say there are no contradictions, and it does not retract 3.4% → 41.5%.** It says the base rate every downstream number divides by is not established, so those numbers carry an unquantified band. At the gpt-5 operating point, queue precision is 46.7% if π = 3.35%, 34.0% if π = 2.0%, 20.3% if π = 1.0% — and the break-even miss:false-alarm ratio moves 1.14:1 → 1.94:1 → 3.92:1 across that range.

## Changes

- **`internal/conflicts/projection.go`** (new) — corpus-projected precision moves out of `package main`, where it was inline and untestable, into a tested package. Adds Wilson intervals and `CorrectedBaseRate`, which **returns an error rather than clamping** when the correction is degenerate or inadmissible. No soft floor at zero: an operator who cannot trust the base rate has to be told so.
- **`internal/conflicts/projection_test.go`** (new) — characterization tests pin the published gpt-5 figures (113-pair queue, 41.5%, 12.4× lift) so a refactor cannot move them silently, plus the inadmissible case and the sensitivity sweep.
- **`cmd/eval-conflicts/main.go`** — `reportGold` calls the package; new `--label-sensitivity` / `--label-specificity` flags, both defaulting to 0 (correction off). The constants 0.817/0.943 are **not** baked in anywhere: they exist only as prose in ADR-017 and are sensitivity-analysis inputs, not measurements. An inadmissible correction prints the full report and then exits 2.
- **`cmd/eval-conflicts/main.go`** (second pass) — the correction now resolves *before* the projection prints, so an inadmissible result marks the headline queue line itself rather than being contradicted three lines below it. The first version printed `precision 41.5%` clean and then said "every figure above rests on that base rate; treat them as unestablished" — correct, and useless to anyone who screenshots, greps, or pipes the headline. A caveat that does not travel with the number is the exact failure this PR is about.
- **`adrs/ADR-019-*.md`** (new) — records the finding, the 480-label calibration ask (93-row census + 387 sampled), and a provisional decision-type-pair routing signal with its three blocking caveats.
- **`adrs/ADR-017-*.md`** — dated correction note, appended not rewritten, per the house pattern.
- **`docs/conflict-detection.md`** — operator guidance for the new flags.

## Verification

`go build ./...`, `go test -race -count=1 ./internal/conflicts/... ./cmd/...`, and `make preflight` all pass; all seven CI checks green including integration tests. Six `reportGold` tests cover the exit path, the inline marker, its absence on an admissible correction, the no-calibration case and the zero-base-rate case. `go.mod`, `go.sum` and `migrations/atlas.sum` untouched. Every interval in the ADR was recomputed independently against the public CSV.

## Not in this PR

Widening retrieval was considered and **rejected**: the never-scored pool blind-labelled at 1.0% (2/200), below the scored pool's 3.355%, so raising `AKASHI_CONFLICT_CANDIDATE_LIMIT` draws from a lower-prevalence pool and dilutes the queue. Follow-up issues for calibrated abstention, type-pair routing, and automatic binding extraction are drafted separately.

> Gandalf spends the whole of Moria certain the Balrog is the danger, and he is right, and it still costs him the bridge. The thing that nearly ends the quest is Boromir, who was measured wrong from the start — the Council read him as strong and read strength as reliable. Saruman falls the same way, by having the finest instrument in Middle-earth and pointing it somewhere that answered back. A palantír is not wrong. It is unresolved, and it does not say so.

